### PR TITLE
Fix for the issue GROOVY-7542

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
@@ -651,6 +651,11 @@ public class StaticTypesCallSiteWriter extends CallSiteWriter implements Opcodes
                 writeModCall(receiver, arguments, rType, aType);
                 return true;
             }
+            else if("rightShiftUnsigned".equals(message))
+            {
+                writeShiftOperatorCall(receiver, arguments, rType, aType);
+                return true;
+            }
         } else if (STRING_TYPE.equals(rType) && "plus".equals(message)) {
             writeStringPlusCall(receiver, message, arguments);
             return true;
@@ -750,7 +755,17 @@ public class StaticTypesCallSiteWriter extends CallSiteWriter implements Opcodes
         mv.visitMethodInsn(INVOKESTATIC, "org/codehaus/groovy/runtime/typehandling/NumberMath", "mod", "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;", false);
         controller.getOperandStack().replace(Number_TYPE, 2);
     }
-    
+
+    private void writeShiftOperatorCall(Expression receiver, Expression arguments, ClassNode rType, ClassNode aType) {
+        prepareSiteAndReceiver(receiver, "rightShiftUnsigned", false, controller.getCompileStack().isLHS());
+        controller.getOperandStack().doGroovyCast(Number_TYPE);
+        visitBoxedArgument(arguments);
+        controller.getOperandStack().doGroovyCast(Number_TYPE);
+        MethodVisitor mv = controller.getMethodVisitor();
+        mv.visitMethodInsn(INVOKESTATIC, "org/codehaus/groovy/runtime/typehandling/NumberMath", "rightShiftUnsigned", "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;", false);
+        controller.getOperandStack().replace(Number_TYPE, 2);
+    }
+
     private void writePowerCall(Expression receiver, Expression arguments, final ClassNode rType, ClassNode aType) {
         OperandStack operandStack = controller.getOperandStack();
         int m1 = operandStack.getStackLength();


### PR DESCRIPTION
Hi @melix,
 
I guess I have understood the problem for this issue (kindly correct me if I'm wrong here). Looks like there is no method to handle `rightShiftUnsigned` operation for writing the bytecode in the compile static mode. Actually there is no methods for other bitwise operations as well; After this fix, I have tested the code with and without `@CompileStatic`. Then did `groovyc`, could able to see the the difference in the generated byte code. 

Sample program that I have used, (same as given in the issue):

```
import groovy.transform.CompileStatic 

test()

@CompileStatic
def test() {
  long register = 0xfac432b10cd5e44aL  
  
  [1,2,3].each { int element -> 
    int t = (int) (register >>> 56 ^ (long) element) & 0xff
    println t
  }  
}
```

doing `javap` on the compiled groovy class, I could able to get 

```
  public java.lang.Object test();
    Code:
       0: getstatic     #59                 // Field $const$0:J
       3: invokestatic  #65                 // Method java/lang/Long.valueOf:(J)Ljava/lang/Long;
       6: new           #67                 // class groovy/lang/Reference
       9: dup_x1        
      10: swap          
      11: invokespecial #70                 // Method groovy/lang/Reference."<init>":(Ljava/lang/Object;)V
      14: astore_1      
      15: aload_1       
      16: pop           
      17: iconst_3      
      18: anewarray     #72                 // class java/lang/Object
      21: dup           
      22: iconst_0      
      23: iconst_1      
      24: invokestatic  #77                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
      27: aastore       
      28: dup           
      29: iconst_1      
      30: iconst_2      
      31: invokestatic  #77                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
      34: aastore       
      35: dup           
      36: iconst_2      
      37: iconst_3      
      38: invokestatic  #77                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
      41: aastore       
      42: invokestatic  #83                 // Method org/codehaus/groovy/runtime/ScriptBytecodeAdapter.createList:([Ljava/lang/Object;)Ljava/util/List;
      45: new           #85                 // class "GROOVY-7542$_test_closure1"
      48: dup           
      49: aload_0       
      50: aload_0       
      51: aload_1       
      52: invokespecial #88                 // Method "GROOVY-7542$_test_closure1"."<init>":(Ljava/lang/Object;Ljava/lang/Object;Lgroovy/lang/Reference;)V
      55: invokestatic  #94                 // Method org/codehaus/groovy/runtime/DefaultGroovyMethods.each:(Ljava/util/List;Lgroovy/lang/Closure;)Ljava/util/List;
      58: areturn       
      59: aconst_null   
      60: areturn      
```

(only for `test` method)

where as removing the `@CompileStatic` does gives the following bytecode:

```
public java.lang.Object test();
    Code:
       0: invokestatic  #19                 // Method $getCallSiteArray:()[Lorg/codehaus/groovy/runtime/callsite/CallSite;
       3: astore_1      
       4: getstatic     #59                 // Field $const$0:J
       7: invokestatic  #65                 // Method java/lang/Long.valueOf:(J)Ljava/lang/Long;
      10: new           #67                 // class groovy/lang/Reference
      13: dup_x1        
      14: swap          
      15: invokespecial #70                 // Method groovy/lang/Reference."<init>":(Ljava/lang/Object;)V
      18: astore_2      
      19: aload_2       
      20: pop           
      21: aload_1       
      22: ldc           #71                 // int 2
      24: aaload        
      25: iconst_3      
      26: anewarray     #73                 // class java/lang/Object
      29: dup           
      30: iconst_0      
      31: iconst_1      
      32: invokestatic  #78                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
      35: aastore       
      36: dup           
      37: iconst_1      
      38: iconst_2      
      39: invokestatic  #78                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
      42: aastore       
      43: dup           
      44: iconst_2      
      45: iconst_3      
      46: invokestatic  #78                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
      49: aastore       
      50: invokestatic  #84                 // Method org/codehaus/groovy/runtime/ScriptBytecodeAdapter.createList:([Ljava/lang/Object;)Ljava/util/List;
      53: new           #86                 // class "GROOVY-7542$_test_closure1"
      56: dup           
      57: aload_0       
      58: aload_0       
      59: aload_2       
      60: invokespecial #89                 // Method "GROOVY-7542$_test_closure1"."<init>":(Ljava/lang/Object;Ljava/lang/Object;Lgroovy/lang/Reference;)V
      63: invokeinterface #92,  3           // InterfaceMethod org/codehaus/groovy/runtime/callsite/CallSite.call:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
      68: areturn       
      69: aconst_null   
      70: areturn       
```

I guess I'm in right path; I'm no-where an byte code engineer, so in case if I have missed any of the cases, let me know. So that I can write an generic method for handling other bit-wise operators on the compile static mode!

After this fix, the sample code was running perfectly fine and giving the expected results. 

Thanks for your response. 