### PR TITLE
Refactor InvokerHelper formatting methods

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -62,6 +62,9 @@ public class InvokerHelper {
     protected static final Object[] EMPTY_ARGUMENTS = EMPTY_ARGS;
     protected static final Class[] EMPTY_TYPES = {};
 
+    // heuristic size to pre-alocate stringbuffers for collections of items
+    private static final int ITEM_ALLOCATE_SIZE = 5;
+
     public static final MetaClassRegistry metaRegistry = GroovySystem.getMetaClassRegistry();
 
     public static void removeClass(Class clazz) {
@@ -645,7 +648,8 @@ public class InvokerHelper {
         if (map.isEmpty()) {
             return "[:]";
         }
-        StringBuilder buffer = new StringBuilder("[");
+        StringBuilder buffer = new StringBuilder(ITEM_ALLOCATE_SIZE * map.size() * 2);
+        buffer.append('[');
         boolean first = true;
         for (Object o : map.entrySet()) {
             if (first) {
@@ -666,7 +670,7 @@ public class InvokerHelper {
                 buffer.append(format(entry.getValue(), verbose, sizeLeft(maxSize, buffer)));
             }
         }
-        buffer.append("]");
+        buffer.append(']');
         return buffer.toString();
     }
 
@@ -679,7 +683,8 @@ public class InvokerHelper {
     }
 
     private static String formatList(Collection collection, boolean verbose, int maxSize, boolean safe) {
-        StringBuilder buffer = new StringBuilder("[");
+        StringBuilder buffer = new StringBuilder(ITEM_ALLOCATE_SIZE * collection.size());
+        buffer.append('[');
         boolean first = true;
         for (Object item : collection) {
             if (first) {
@@ -710,7 +715,7 @@ public class InvokerHelper {
                 buffer.append(str);
             }
         }
-        buffer.append("]");
+        buffer.append(']');
         return buffer.toString();
     }
 
@@ -799,16 +804,15 @@ public class InvokerHelper {
         if (arguments == null) {
             return "null";
         }
-        String sbdry = "[";
-        String ebdry = "]";
-        StringBuilder argBuf = new StringBuilder(sbdry);
+        StringBuilder argBuf = new StringBuilder(arguments.length);
+        argBuf.append('[');
         for (int i = 0; i < arguments.length; i++) {
             if (i > 0) {
                 argBuf.append(", ");
             }
             argBuf.append(format(arguments[i], false));
         }
-        argBuf.append(ebdry);
+        argBuf.append(']');
         return argBuf.toString();
     }
 

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -124,14 +124,10 @@ public class InvokerHelper {
     }
 
     public static String toString(Object arguments) {
-        if (arguments instanceof Object[]) {
-            return toArrayString((Object[]) arguments);
-        }
-        if (arguments instanceof Collection) {
+        if (arguments instanceof Range) {
+            // for historic reasons, toString() formats Ranges by printing
+            // them as a list, whereas format prints them in .. notation
             return toListString((Collection) arguments);
-        }
-        if (arguments instanceof Map) {
-            return toMapString((Map) arguments);
         }
         return format(arguments, false);
     }

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -590,7 +590,7 @@ public class InvokerHelper {
             if (arguments instanceof char[]) {
                 return new String((char[]) arguments);
             }
-            return format(DefaultTypeTransformation.asCollection(arguments), verbose, maxSize);
+            return formatCollection(DefaultTypeTransformation.arrayAsCollection(arguments), verbose, maxSize);
         }
         if (arguments instanceof Range) {
             Range range = (Range) arguments;

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -601,7 +601,7 @@ public class InvokerHelper {
             }
         }
         if (arguments instanceof Collection) {
-            return formatList((Collection) arguments, verbose, maxSize);
+            return formatCollection((Collection) arguments, verbose, maxSize);
         }
         if (arguments instanceof Map) {
             return formatMap((Map) arguments, verbose, maxSize);
@@ -678,11 +678,11 @@ public class InvokerHelper {
         return maxSize == -1 ? maxSize : Math.max(0, maxSize - buffer.length());
     }
 
-    private static String formatList(Collection collection, boolean verbose, int maxSize) {
-        return formatList(collection, verbose, maxSize, false);
+    private static String formatCollection(Collection collection, boolean verbose, int maxSize) {
+        return formatCollection(collection, verbose, maxSize, false);
     }
 
-    private static String formatList(Collection collection, boolean verbose, int maxSize, boolean safe) {
+    private static String formatCollection(Collection collection, boolean verbose, int maxSize, boolean safe) {
         StringBuilder buffer = new StringBuilder(ITEM_ALLOCATE_SIZE * collection.size());
         buffer.append('[');
         boolean first = true;
@@ -790,7 +790,7 @@ public class InvokerHelper {
      * @return the string representation of the collection
      */
     public static String toListString(Collection arg, int maxSize, boolean safe) {
-        return formatList(arg, false, maxSize, safe);
+        return formatCollection(arg, false, maxSize, safe);
     }
 
     /**

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -121,12 +121,15 @@ public class InvokerHelper {
     }
 
     public static String toString(Object arguments) {
-        if (arguments instanceof Object[])
+        if (arguments instanceof Object[]) {
             return toArrayString((Object[]) arguments);
-        if (arguments instanceof Collection)
+        }
+        if (arguments instanceof Collection) {
             return toListString((Collection) arguments);
-        if (arguments instanceof Map)
+        }
+        if (arguments instanceof Map) {
             return toMapString((Map) arguments);
+        }
         return format(arguments, false);
     }
 

--- a/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
@@ -20,7 +20,37 @@ package org.codehaus.groovy.runtime
 
 class InvokerHelperFormattingTest extends GroovyTestCase {
 
-    public void testFormatLiterals() {
+    private static class ExceptionOnToString implements Comparable {
+        public static final String MATCHER = '<org.codehaus.groovy.runtime.InvokerHelperFormattingTest\\$ExceptionOnToString@[0-9a-z]+>'
+
+        @Override
+        String toString() {
+            throw new UnsupportedOperationException("toString() throws Exception for Testing")
+        }
+
+        @Override
+        int compareTo(Object o) {
+            throw new UnsupportedOperationException("compareTo() throws Exception for Testing")
+        }
+    }
+
+    public void testToStringLiterals() {
+        assert 'null' == InvokerHelper.toString(null)
+        assert '0.5' == InvokerHelper.toString(0.5)
+        assert '2' == InvokerHelper.toString(2)
+        assert '2' == InvokerHelper.toString(2L)
+        assert 'a' == InvokerHelper.toString('a')
+        assert 'a\'b' == InvokerHelper.toString('a\'b')
+
+    }
+
+    public void testToStringThrows() {
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.toString(new ExceptionOnToString())
+        }
+    }
+
+    public void testFormat() {
         assert 'null' == InvokerHelper.format(null, false)
         assert '0.5' == InvokerHelper.format(0.5, false)
         assert '2' == InvokerHelper.format(2, false)
@@ -28,7 +58,8 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         assert 'a' == InvokerHelper.format('a', false)
         assert 'a\'b' == InvokerHelper.format('a\'b', false)
         assert 'a\\b' + '' == InvokerHelper.format('a\\b', false)
-
+        assert '\'a\\\'b\'' == InvokerHelper.format('a\'b', true)
+        
         assert 'null' == InvokerHelper.format(null, true)
         assert '0.5' == InvokerHelper.format(0.5, true)
         assert '2' == InvokerHelper.format(2, true)
@@ -36,16 +67,144 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         assert '\'a\'' == InvokerHelper.format('a', true)
         assert '\'a\\\'b\'' + '' == InvokerHelper.format('a\'b', true)
         assert '\'a\\\\b\'' + '' == InvokerHelper.format('a\\b', true)
+        
+        Object eObject = new ExceptionOnToString()
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.format(eObject, false)
+        }
     }
 
-    public void testPrintSelfContained() {
+    public void testFormatRanges() {
+        assert '1..4' == InvokerHelper.format(1..4, false)
+        assert "a'b..a'd" == InvokerHelper.format('a\'b'..'a\'d', false)
+        assert "[1..4]" == InvokerHelper.format([1..4], false)
+        assert "[a'b..a'd]" == InvokerHelper.format(['a\'b'..'a\'d'], false)
+        // verbose
+        assert '1..4' == InvokerHelper.format(1..4, true)
+        assert "'a\\'b'..'a\\'d'" == InvokerHelper.format('a\'b'..'a\'d', true)
+        assert "[1..4]" == InvokerHelper.format([1..4], true)
+        assert "['a\\'b'..'a\\'d']" == InvokerHelper.format(['a\'b'..'a\'d'], true)
+
+        Object eObject = new ExceptionOnToString()
+        Object eObject2 = new ExceptionOnToString()
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.format(eObject..eObject2)
+        }
+    }
+
+    public void testToStringLists() {
+        assert '[]' == InvokerHelper.toString([])
+        assert '[1, true, a, \'b\']' == InvokerHelper.toString([1, true, 'a, \'b\''])
+    }
+
+    public void testToListString() {
+        assert '[]' == InvokerHelper.toString([])
+        assert '[1, true, a, \'b\']' == InvokerHelper.toListString([1, true, 'a, \'b\''])
+        assert '[1, ...]' == InvokerHelper.toListString([1, true, 'a, \'b\''], 2)
+        Object eObject = new ExceptionOnToString()
+        assert InvokerHelper.toListString([eObject], -1, true) =~ "\\[${ExceptionOnToString.MATCHER}\\]"
+        List list = [[z: eObject]]
+        assert InvokerHelper.toListString(list, -1, true) == '[<java.util.LinkedHashMap@' + Integer.toHexString(list[0].hashCode()) +'>]'
+        // even when throwing object is deeply nested, exception handling only happens in Collection
+        list = [[x: [y: [z: eObject, a: 2, b: 4]]]]
+        assert InvokerHelper.toListString(list, -1, true) == '[<java.util.LinkedHashMap@' + Integer.toHexString(list[0].hashCode()) + '>]'
+
+        list = [[eObject, 1, 2]]
+        // safe argument is not passed on recursively
+        assert InvokerHelper.toListString(list, -1, true) == '[<java.util.ArrayList@' + Integer.toHexString(list[0].hashCode()) + '>]'
+        list = [[[[[eObject, 1, 2]]]]]
+        assert InvokerHelper.toListString(list, -1, true) == '[<java.util.ArrayList@' + Integer.toHexString(list[0].hashCode()) + '>]'
+
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.toListString([eObject], -1, false)
+        }
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.toListString([eObject], -1)
+        }
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.toListString([eObject])
+        }
+    }
+
+    public void testToStringRanges() {
+        assert '[1, 2, 3, 4]' == InvokerHelper.toString(1..4)
+        assert "[a'b, a'c, a'd]" == InvokerHelper.toString('a\'b'..'a\'d')
+        // within other lists, ranges get ToStringed in code form
+        assert "[1..4]" == InvokerHelper.toString([1..4])
+        assert "[a'b..a'd]" == InvokerHelper.toString(['a\'b'..'a\'d'])
+    }
+
+    public void testToStringArrays() {
+        assert "[a, a'b]" == InvokerHelper.toString(['a', 'a\'b'] as String[])
+        assert "[a, a'b]" == InvokerHelper.toString(['a', 'a\'b'] as Object[])
+    }
+
+    public void testFormatArrays() {
+        assert "[a, a'b]" == InvokerHelper.format(['a', 'a\'b'] as String[], false)
+        assert "[a, a'b]" == InvokerHelper.format(['a', 'a\'b'] as Object[], false)
+        assert "['a', 'a\\'b']" == InvokerHelper.format(['a', 'a\'b'] as String[], true)
+        assert "['a', 'a\\'b']" == InvokerHelper.format(['a', 'a\'b'] as Object[], true)
+        Object eObject = new ExceptionOnToString()
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.format([eObject] as ExceptionOnToString[], false)
+        }
+    }
+
+    public void testToStringMaps() {
+        assert '[:]' == InvokerHelper.toString([:])
+        assert "[a'b:1, 2:b'c]" == InvokerHelper.toString(['a\'b':1, 2:'b\'c'])
+    }
+
+    public void testFormatMaps() {
+        assert '[:]' == InvokerHelper.format([:], false)
+        assert "[a'b:1, 2:b'c]" == InvokerHelper.format(['a\'b':1, 2:'b\'c'], false)
+
+        Object eObject = new ExceptionOnToString()
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.format([foo: eObject], false)
+        }
+
+    }
+
+    public void testToMapString() {
+        assert '[:]' == InvokerHelper.toMapString([:])
+        assert "[a'b:1, 2:b'c]" == InvokerHelper.toMapString(['a\'b':1, 2:'b\'c'])
+        assert "[a'b:1, ...]" == InvokerHelper.toMapString(['a\'b':1, 2:'b\'c'], 2)
+        Object eObject = new ExceptionOnToString()
+        // no safe / verbose toMapString method provided
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.toMapString([x: eObject])
+        }
+        shouldFail(UnsupportedOperationException) {
+            InvokerHelper.toMapString([x: eObject], 2)
+        }
+    }
+
+    public void testEmbedded() {
+        List list = []
+        list.add(['a\'b': 'c\'d'])
+        list.add(['e', 'f', 'g'])
+        list.add(5..9)
+        list.add('fog'..'fop')
+        list.add(['h', 'i'] as String[])
+        list.add([10, 11] as int[])
+        assert "[key:[[a'b:c'd], [e, f, g], 5..9, fog..fop, [h, i], [10, 11]]]" == InvokerHelper.toString([key: list])
+    }
+
+    public void testToStringSelfContained() {
         List l = [];
         l.add(l)
-        assert '[(this Collection)]' == InvokerHelper.toListString(l)
+        assert '[(this Collection)]' == InvokerHelper.toString(l)
 
         Map m = [:]
         m.put('x', m)
-        assert '[x:(this Map)]' == InvokerHelper.toMapString(m)
+        assert '[x:(this Map)]' == InvokerHelper.toString(m)
+
+        Map m2 = [:]
+        m2.put(m2, m2)
+        shouldFail(StackOverflowError) {
+            InvokerHelper.toString(m2)
+        }
     }
 
 }


### PR DESCRIPTION
These are some refactorings and minor enhancements of the formatting methods in InvokerHelper.

The formatting of maps, arrays, collections and ranges should be more consistent, allowing the same parameters (verbose, maxSize, safe) everywhere. The 'safe' parameter gets used in many more contexts (though default is still false).

I hope that existing behavior and API was not changed (too much). I believe I did not change any existing *public* method signature, though I added a few with more options.

The behavior should be the same, except for the case when an Object.toString() method throws a checked exception, then this will be rethrown wrapped in a GroovyRuntimeException, when a method is invoked with 'safe=true', which I believe is done by PowerAsserts.

Some changes might need further discussions. One thing annoying me still is that after this PR, the methods
```toArrayString(Object[] collection, boolean verbose, int maxSize, boolean safe)``` and ```formatCollection(Collection collection, boolean verbose, int maxSize, boolean safe)``` are syntactically equal, not sure if there is a nice way not to replicate code, yet also not transforming arrays to collections or vice versa.

The preAllocation of the StringBuffers might be too big, maybe a value like 3 or 4 might be nicer. It's always a heuristic value, maybe premature optimization.

I hope next to change the default printing in PowerAsserts and Groovysh to use the "verbose" flag.