### PR TITLE
GROOVY-6514: GrapeIvy Classloader selection change, Groovysh :grab and rescan commands

### DIFF
--- a/src/main/groovy/grape/GrapeIvy.groovy
+++ b/src/main/groovy/grape/GrapeIvy.groovy
@@ -185,14 +185,20 @@ class GrapeIvy implements GrapeEngine {
                 throw new RuntimeException("No suitable ClassLoader found for grab")
             }
         }
+        // use the highest available valid loader in hierarchy
+        // (assuming they are all connected), so that
+        // e.g. Groovysh can pick up new classes for import tab completion
+        while (isValidTargetClassLoaderClass(loader.getParent()?.class)) {
+            loader = loader.parent
+        }
         return loader
     }
 
-    private boolean isValidTargetClassLoader(loader) {
+    private static boolean isValidTargetClassLoader(ClassLoader loader) {
         return isValidTargetClassLoaderClass(loader?.class)
     }
 
-    private boolean isValidTargetClassLoaderClass(Class loaderClass) {
+    private static boolean isValidTargetClassLoaderClass(Class loaderClass) {
         return (loaderClass != null) &&
             (
              (loaderClass.name == 'groovy.lang.GroovyClassLoader') ||

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommand.groovy
@@ -1,0 +1,83 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.shell.commands
+
+import jline.console.completer.Completer
+import org.codehaus.groovy.tools.shell.CommandSupport
+import org.codehaus.groovy.tools.shell.Groovysh
+
+/**
+ * The 'grab' command.
+ *
+ * @author Thibault Kruse
+ */
+class GrabCommand
+    extends CommandSupport
+{
+    public static final String COMMAND_NAME = ':grab'
+
+    GrabCommand(final Groovysh shell) {
+        super(shell, COMMAND_NAME, ':g')
+    }
+
+    @Override
+    protected List<Completer> createCompleters() {
+        return []
+    }
+
+    @Override
+    Object execute(final List<String> args) {
+        assert args != null
+
+        if (args.size() == 0) {
+            fail("Command '$COMMAND_NAME' requires at least one argument") // TODO: i18n
+        }
+        String specString = buildSpec(args)
+
+        log.debug("Attempting to grab: \"$specString\"")
+        shell.execute("groovy.grape.Grape.grab($specString)")
+        shell.packageHelper.reset()
+    }
+
+    protected String buildSpec(List<String> args) {
+        Map<String, String> spec = [:]
+        List<String> splitArgs
+        if (args.size() == 1 && args[0].contains(':')) {
+            splitArgs = args[0].split(':')
+        } else {
+            splitArgs = args
+        }
+        if (splitArgs.size() == 1) {
+            spec['group'] = ''
+            spec['module'] = splitArgs[0]
+            spec['version'] = ''
+        } else if (splitArgs.size() == 2) {
+            spec['group'] = splitArgs[0]
+            spec['module'] = splitArgs[1]
+            spec['version'] = ''
+        } else if (splitArgs.size() == 3) {
+            spec['group'] = splitArgs[0]
+            spec['module'] = splitArgs[1]
+            spec['version'] = splitArgs[2]
+        } else {
+            fail("Command '$COMMAND_NAME' takes one to three arguments") // TODO: i18n
+        }
+        return spec.collect({String k, String v -> "$k:'$v'"}).join(', ')
+    }
+}

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/RescanCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/RescanCommand.groovy
@@ -16,13 +16,38 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.codehaus.groovy.tools.shell.util
+package org.codehaus.groovy.tools.shell.commands
 
-interface PackageHelper {
+import jline.console.completer.Completer
+import org.codehaus.groovy.tools.shell.CommandSupport
+import org.codehaus.groovy.tools.shell.Groovysh
 
-    public static final String IMPORT_COMPLETION_PREFERENCE_KEY = 'disable-import-completion'
+/**
+ * The 'rescan' command.
+ *
+ * @author Thibault Kruse
+ */
+class RescanCommand
+    extends CommandSupport
+{
+    public static final String COMMAND_NAME = ':rescan'
 
-    Set<String> getContents(final String packagename)
+    RescanCommand(final Groovysh shell) {
+        super(shell, COMMAND_NAME, ':+')
+    }
 
-    void reset()
+    @Override
+    protected List<Completer> createCompleters() {
+        return []
+    }
+
+    @Override
+    Object execute(final List<String> args) {
+        assert args != null
+
+        if (args.size() > 0) {
+            fail("Command '$COMMAND_NAME' requires no arguments") // TODO: i18n
+        }
+        shell.packageHelper.reset()
+    }
 }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/DefaultCommandsRegistrar.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/DefaultCommandsRegistrar.groovy
@@ -20,23 +20,7 @@ package org.codehaus.groovy.tools.shell.util
 
 import org.codehaus.groovy.tools.shell.Command
 import org.codehaus.groovy.tools.shell.Shell
-import org.codehaus.groovy.tools.shell.commands.AliasCommand
-import org.codehaus.groovy.tools.shell.commands.ClearCommand
-import org.codehaus.groovy.tools.shell.commands.DisplayCommand
-import org.codehaus.groovy.tools.shell.commands.DocCommand
-import org.codehaus.groovy.tools.shell.commands.EditCommand
-import org.codehaus.groovy.tools.shell.commands.ExitCommand
-import org.codehaus.groovy.tools.shell.commands.HelpCommand
-import org.codehaus.groovy.tools.shell.commands.HistoryCommand
-import org.codehaus.groovy.tools.shell.commands.ImportCommand
-import org.codehaus.groovy.tools.shell.commands.InspectCommand
-import org.codehaus.groovy.tools.shell.commands.LoadCommand
-import org.codehaus.groovy.tools.shell.commands.PurgeCommand
-import org.codehaus.groovy.tools.shell.commands.RecordCommand
-import org.codehaus.groovy.tools.shell.commands.RegisterCommand
-import org.codehaus.groovy.tools.shell.commands.SaveCommand
-import org.codehaus.groovy.tools.shell.commands.SetCommand
-import org.codehaus.groovy.tools.shell.commands.ShowCommand
+import org.codehaus.groovy.tools.shell.commands.*
 
 /**
  * Registers {@link Command} classes from an XML file like:
@@ -76,6 +60,8 @@ class DefaultCommandsRegistrar
                 new HistoryCommand(shell),
                 new AliasCommand(shell),
                 new SetCommand(shell),
+                new GrabCommand(shell),
+                new RescanCommand(shell),
                 // does not do anything
                 //new ShadowCommand(shell),
                 new RegisterCommand(shell),

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/PackageHelperImpl.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/PackageHelperImpl.groovy
@@ -45,7 +45,7 @@ class PackageHelperImpl implements PreferenceChangeListener, PackageHelper {
     PackageHelperImpl(final ClassLoader groovyClassLoader=null) {
         this.groovyClassLoader = groovyClassLoader
         if (! Boolean.valueOf(Preferences.get(IMPORT_COMPLETION_PREFERENCE_KEY))) {
-            rootPackages = initializePackages(groovyClassLoader)
+            reset()
         }
         Preferences.addChangeListener(this)
     }
@@ -56,9 +56,13 @@ class PackageHelperImpl implements PreferenceChangeListener, PackageHelper {
             if (Boolean.valueOf(evt.getNewValue())) {
                 rootPackages = null
             } else if (rootPackages == null) {
-                rootPackages = initializePackages(groovyClassLoader)
+                reset()
             }
         }
+    }
+
+    void reset() {
+        rootPackages = initializePackages(groovyClassLoader)
     }
 
     static Map<String, CachedPackage> initializePackages(final ClassLoader groovyClassLoader) throws IOException {

--- a/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/GrabCommand.properties
+++ b/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/GrabCommand.properties
@@ -1,0 +1,21 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+command.description=Fetches a dependency using Grapes
+command.usage=[[<group>]? <module> [<version>]? | g:m:v]
+command.help=Fetch dependency

--- a/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/RescanCommand.properties
+++ b/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/RescanCommand.properties
@@ -1,0 +1,21 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+command.description=Scans the classpath for new classes after using grapes
+command.usage=
+command.help=Rescan classpath

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ImportCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ImportCompletorTest.groovy
@@ -39,6 +39,9 @@ class MockPackageHelper implements PackageHelper {
     Set<String> getContents(String packagename) {
         return mockContents
     }
+
+    void reset() {
+    }
 }
 
 class ImportCompleterUnitTest extends GroovyTestCase {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommandTest.groovy
@@ -1,0 +1,42 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.shell.commands
+
+/**
+ * Tests for the {@link GrabCommand} class.
+ *
+ */
+class GrabCommandTest
+    extends CommandTestSupport
+{
+    void testDisplay() {
+        shell.execute(GrabCommand.COMMAND_NAME)
+    }
+
+    void testBuildSpec() {
+        GrabCommand grabCommand = new GrabCommand(shell)
+        assert 'group:\'\', module:\'foo\', version:\'\'' == grabCommand.buildSpec(['foo'])
+        assert 'group:\'foo\', module:\'bar\', version:\'\'' == grabCommand.buildSpec(['foo', 'bar'])
+        assert 'group:\'foo\', module:\'bar\', version:\'baz\'' == grabCommand.buildSpec(['foo', 'bar', 'baz'])
+        assert 'group:\'\', module:\'foo\', version:\'\'' == grabCommand.buildSpec([':foo'])
+        assert 'group:\'\', module:\'foo\', version:\'\'' == grabCommand.buildSpec([':foo:'])
+        assert 'group:\'foo\', module:\'bar\', version:\'\'' == grabCommand.buildSpec(['foo:bar'])
+        assert 'group:\'foo\', module:\'bar\', version:\'baz\'' == grabCommand.buildSpec(['foo:bar:baz'])
+    }
+}


### PR DESCRIPTION
This PR allows to grab Grapes via a new ```:grab``` command. Classes from the new jar are available ia the import command completion. 

To allow the completion to work, I had to change the selection of the classLoader in GrapeIvy. I do not know if that will break anything. Grabbing without completion is already possible in groovysh in a cumbersome way using the grapes code API. Merely adding a command to hide that would also be nice, but the real benefit would be to have import completion, as manually typing import commands is very tiring.