### PR TITLE
GROOVY-7563: Make InvokerHelper output self-consistent

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -583,9 +583,13 @@ public class InvokerHelper {
             return (String) nullObject.getMetaClass().invokeMethod(nullObject, "toString", EMPTY_ARGS);
         }
         if (arguments.getClass().isArray()) {
+            if (arguments instanceof Object[]) {
+                return toArrayString((Object[]) arguments, maxSize, false);
+            }
             if (arguments instanceof char[]) {
                 return new String((char[]) arguments);
             }
+            // other primitives
             return formatCollection(DefaultTypeTransformation.arrayAsCollection(arguments), verbose, maxSize);
         }
         if (arguments instanceof Range) {

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -593,10 +593,18 @@ public class InvokerHelper {
         }
         if (arguments instanceof Range) {
             Range range = (Range) arguments;
-            if (verbose) {
-                return range.inspect();
-            } else {
-                return range.toString();
+            try {
+                if (verbose) {
+                    return range.inspect();
+                } else {
+                    return range.toString();
+                }
+            } catch (RuntimeException ex) {
+                if (!safe) throw ex;
+                return handleFormattingException(arguments, ex);
+            } catch (Exception ex) {
+                if (!safe) throw new GroovyRuntimeException(ex);
+                return handleFormattingException(arguments, ex);
             }
         }
         if (arguments instanceof Collection) {

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -124,11 +124,6 @@ public class InvokerHelper {
     }
 
     public static String toString(Object arguments) {
-        if (arguments instanceof Range) {
-            // for historic reasons, toString() formats Ranges by printing
-            // them as a list, whereas format prints them in .. notation
-            return toListString((Collection) arguments);
-        }
         return format(arguments, false);
     }
 

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -579,7 +579,7 @@ public class InvokerHelper {
         }
         if (arguments.getClass().isArray()) {
             if (arguments instanceof Object[]) {
-                return toArrayString((Object[]) arguments, maxSize, false);
+                return toArrayString((Object[]) arguments, verbose, maxSize, false);
             }
             if (arguments instanceof char[]) {
                 return new String((char[]) arguments);
@@ -796,16 +796,45 @@ public class InvokerHelper {
      * @return the string representation of the array
      */
     public static String toArrayString(Object[] arguments) {
-        if (arguments == null) {
+        return toArrayString(arguments, false, -1, false);
+    }
+
+    private static String toArrayString(Object[] collection, boolean verbose, int maxSize, boolean safe) {
+        if (collection == null) {
             return "null";
         }
-        StringBuilder argBuf = new StringBuilder(arguments.length);
+        boolean first = true;
+        StringBuilder argBuf = new StringBuilder(collection.length);
         argBuf.append('[');
-        for (int i = 0; i < arguments.length; i++) {
-            if (i > 0) {
+
+        for (Object item : collection) {
+            if (first) {
+                first = false;
+            } else {
                 argBuf.append(", ");
             }
-            argBuf.append(format(arguments[i], false));
+            if (maxSize != -1 && argBuf.length() > maxSize) {
+                argBuf.append("...");
+                break;
+            }
+            if (item == collection) {
+                argBuf.append("(this Collection)");
+            } else {
+                String str;
+                try {
+                    str = format(item, verbose, sizeLeft(maxSize, argBuf));
+                } catch (Exception ex) {
+                    if (!safe) throw new GroovyRuntimeException(ex);
+                    String hash;
+                    try {
+                        hash = Integer.toHexString(item.hashCode());
+                    } catch (Exception ignored) {
+                        hash = "????";
+                    }
+                    str = "<" + item.getClass().getName() + "@" + hash + ">";
+                }
+                argBuf.append(str);
+            }
         }
         argBuf.append(']');
         return argBuf.toString();
@@ -821,7 +850,7 @@ public class InvokerHelper {
      * @return the string representation of the array
      */
     public static String toArrayString(Object[] arguments, int maxSize, boolean safe) {
-        return toListString(DefaultTypeTransformation.asCollection(arguments), maxSize, safe);
+        return toArrayString(arguments, false, maxSize, safe);
     }
 
     public static List createRange(Object from, Object to, boolean inclusive) {

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -680,7 +680,11 @@ public class InvokerHelper {
                 break;
             }
             Map.Entry entry = (Map.Entry) o;
-            buffer.append(format(entry.getKey(), verbose));
+            if (entry.getKey() == map) {
+                buffer.append("(this Map)");
+            } else {
+                buffer.append(format(entry.getKey(), verbose, sizeLeft(maxSize, buffer), safe));
+            }
             buffer.append(":");
             if (entry.getValue() == map) {
                 buffer.append("(this Map)");

--- a/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
@@ -127,9 +127,8 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
     }
 
     public void testToStringRanges() {
-        assert '[1, 2, 3, 4]' == InvokerHelper.toString(1..4)
-        assert "[a'b, a'c, a'd]" == InvokerHelper.toString('a\'b'..'a\'d')
-        // within other lists, ranges get ToStringed in code form
+        assert '1..4' == InvokerHelper.toString(1..4)
+        assert "a'b..a'd" == InvokerHelper.toString('a\'b'..'a\'d')
         assert "[1..4]" == InvokerHelper.toString([1..4])
         assert "[a'b..a'd]" == InvokerHelper.toString(['a\'b'..'a\'d'])
     }

--- a/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
@@ -208,14 +208,8 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         assert '[(this Collection)]' == InvokerHelper.toString(l)
 
         Map m = [:]
-        m.put('x', m)
-        assert '[x:(this Map)]' == InvokerHelper.toString(m)
-
-        Map m2 = [:]
-        m2.put(m2, m2)
-        shouldFail(StackOverflowError) {
-            InvokerHelper.toString(m2)
-        }
+        m.put(m, m)
+        assert '[(this Map):(this Map)]' == InvokerHelper.toString(m)
     }
 
 }

--- a/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
@@ -92,6 +92,8 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         shouldFail(UnsupportedOperationException) {
             InvokerHelper.format(eObject..eObject2)
         }
+
+        assert InvokerHelper.format(eObject..eObject, false, -1, true) == '<groovy.lang.ObjectRange@????>'
     }
 
     public void testToStringLists() {

--- a/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/InvokerHelperFormattingTest.groovy
@@ -72,6 +72,7 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         shouldFail(UnsupportedOperationException) {
             InvokerHelper.format(eObject, false)
         }
+        assert InvokerHelper.format(new ExceptionOnToString(), false, -1, true) =~ (ExceptionOnToString.MATCHER)
     }
 
     public void testFormatRanges() {
@@ -79,6 +80,7 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         assert "a'b..a'd" == InvokerHelper.format('a\'b'..'a\'d', false)
         assert "[1..4]" == InvokerHelper.format([1..4], false)
         assert "[a'b..a'd]" == InvokerHelper.format(['a\'b'..'a\'d'], false)
+
         // verbose
         assert '1..4' == InvokerHelper.format(1..4, true)
         assert "'a\\'b'..'a\\'d'" == InvokerHelper.format('a\'b'..'a\'d', true)
@@ -104,16 +106,16 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         Object eObject = new ExceptionOnToString()
         assert InvokerHelper.toListString([eObject], -1, true) =~ "\\[${ExceptionOnToString.MATCHER}\\]"
         List list = [[z: eObject]]
-        assert InvokerHelper.toListString(list, -1, true) == '[<java.util.LinkedHashMap@' + Integer.toHexString(list[0].hashCode()) +'>]'
+        assert InvokerHelper.toListString(list, -1, true) =~ "\\[\\[z:${ExceptionOnToString.MATCHER}\\]\\]"
         // even when throwing object is deeply nested, exception handling only happens in Collection
         list = [[x: [y: [z: eObject, a: 2, b: 4]]]]
-        assert InvokerHelper.toListString(list, -1, true) == '[<java.util.LinkedHashMap@' + Integer.toHexString(list[0].hashCode()) + '>]'
+        assert InvokerHelper.toListString(list, -1, true) =~ "\\[\\[x:\\[y:\\[z:${ExceptionOnToString.MATCHER}, a:2, b:4\\]\\]\\]\\]"
 
         list = [[eObject, 1, 2]]
         // safe argument is not passed on recursively
-        assert InvokerHelper.toListString(list, -1, true) == '[<java.util.ArrayList@' + Integer.toHexString(list[0].hashCode()) + '>]'
+        assert InvokerHelper.toListString(list, -1, true) =~ "\\[\\[${ExceptionOnToString.MATCHER}, 1, 2\\]\\]"
         list = [[[[[eObject, 1, 2]]]]]
-        assert InvokerHelper.toListString(list, -1, true) == '[<java.util.ArrayList@' + Integer.toHexString(list[0].hashCode()) + '>]'
+        assert InvokerHelper.toListString(list, -1, true) =~ "\\[\\[\\[\\[\\[${ExceptionOnToString.MATCHER}, 1, 2\\]\\]\\]\\]\\]"
 
         shouldFail(UnsupportedOperationException) {
             InvokerHelper.toListString([eObject], -1, false)
@@ -147,6 +149,8 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         shouldFail(UnsupportedOperationException) {
             InvokerHelper.format([eObject] as ExceptionOnToString[], false)
         }
+
+        assert InvokerHelper.format([new ExceptionOnToString()] as Object[], false, -1, true) =~ "\\[${ExceptionOnToString.MATCHER}\\]"
     }
 
     public void testToStringMaps() {
@@ -157,12 +161,18 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
     public void testFormatMaps() {
         assert '[:]' == InvokerHelper.format([:], false)
         assert "[a'b:1, 2:b'c]" == InvokerHelper.format(['a\'b':1, 2:'b\'c'], false)
+        assert "['a\\'b':1, 2:'b\\'c']" == InvokerHelper.format(['a\'b':1, 2:'b\'c'], true, -1, true)
 
         Object eObject = new ExceptionOnToString()
         shouldFail(UnsupportedOperationException) {
             InvokerHelper.format([foo: eObject], false)
         }
 
+        assert InvokerHelper.format([foo: eObject], false, -1, true) =~ "\\[foo:${ExceptionOnToString.MATCHER}\\]"
+        assert InvokerHelper.format([foo: eObject], true, -1, true) =~ "\\['foo':${ExceptionOnToString.MATCHER}\\]"
+        Map m = [:]
+        m.put(eObject, eObject)
+        assert InvokerHelper.format(m, false, -1, true) =~ "\\[${ExceptionOnToString.MATCHER}:${ExceptionOnToString.MATCHER}\\]"
     }
 
     public void testToMapString() {
@@ -188,6 +198,8 @@ class InvokerHelperFormattingTest extends GroovyTestCase {
         list.add(['h', 'i'] as String[])
         list.add([10, 11] as int[])
         assert "[key:[[a'b:c'd], [e, f, g], 5..9, fog..fop, [h, i], [10, 11]]]" == InvokerHelper.toString([key: list])
+
+        assert "['key':[['a\\'b':'c\\'d'], ['e', 'f', 'g'], 5..9, 'fog'..'fop', ['h', 'i'], [10, 11]]]" == InvokerHelper.format([key:list], true, -1, false)
     }
 
     public void testToStringSelfContained() {


### PR DESCRIPTION
Changes the internal API of the formatting methods in InvokerHelper and also the output in some cases when using verbose or safe arguments.

This PR contains currently controversial changes to the formatting methods in InvokerHelper that could break client code.

Further analysis and discussion required.

This currently contains the commits from #96 (until that one is merged).

(This supercedes #111, which had the wrong JIRA number in commit messages)