### PR TITLE
Provide static reference for indy setting

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/WriterController.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/WriterController.java
@@ -94,7 +94,7 @@ public class WriterController {
             optimizeForInt=false;
             // set other optimizations options to false here
         } else {
-            if (Boolean.TRUE.equals(optOptions.get("indy"))) invokedynamic=true;
+            if (Boolean.TRUE.equals(optOptions.get(CompilerConfiguration.INVOKEDYNAMIC))) invokedynamic=true;
             if (Boolean.FALSE.equals(optOptions.get("int"))) optimizeForInt=false;
             if (invokedynamic) optimizeForInt=false;
             // set other optimizations options to false here

--- a/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -39,6 +39,9 @@ public class CompilerConfiguration {
 
     private static final String JDK5_CLASSNAME_CHECK = "java.lang.annotation.Annotation";
 
+    /** This (<code>"indy"</code>) is the Optimization Option value for enabling <code>invokedynamic</code> complilation. */
+    public static final String INVOKEDYNAMIC = "indy";
+
     /** This (<code>"1.4"</code>) is the value for targetBytecode to compile for a JDK 1.4. **/
     public static final String JDK4 = "1.4";
     /** This (<code>"1.5"</code>) is the value for targetBytecode to compile for a JDK 1.5. **/
@@ -214,12 +217,12 @@ public class CompilerConfiguration {
         } catch (Exception e) {
             // IGNORE
         }
-        if (DEFAULT!=null && Boolean.TRUE.equals(DEFAULT.getOptimizationOptions().get("indy"))) {
+        if (DEFAULT!=null && Boolean.TRUE.equals(DEFAULT.getOptimizationOptions().get(INVOKEDYNAMIC))) {
             indy = true;
         }
         Map options = new HashMap<String,Boolean>(3);
         if (indy) {
-            options.put("indy", Boolean.TRUE);
+            options.put(INVOKEDYNAMIC, Boolean.TRUE);
         }
         setOptimizationOptions(options);
     }


### PR DESCRIPTION
This enables developers to avoid using a "magic string" in their code and to use the known-to-be-right version of it when setting up `CompilerConfiguration`s to use invokedynamic (aka indy).