### PR TITLE
Allow security managers to prevent system property access for Indy

### DIFF
--- a/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
@@ -72,13 +72,20 @@ public class IndyInterface {
         /** boolean to indicate if logging for indy is enabled */
         protected static final boolean LOG_ENABLED;
         static {
+            boolean enableLogger = false;
+
             LOG = Logger.getLogger(IndyInterface.class.getName());
-            if (System.getProperty("groovy.indy.logging")!=null) {
-                LOG.setLevel(Level.ALL);
-                LOG_ENABLED = true;
-            } else {
-                LOG_ENABLED = false;
+
+            try {
+                if (System.getProperty("groovy.indy.logging")!=null) {
+                    LOG.setLevel(Level.ALL);
+                    enableLogger = true;
+                }
+            } catch (SecurityException e) {
+                // Allow security managers to prevent system property access
             }
+
+            LOG_ENABLED = enableLogger;
         }
         /** LOOKUP constant used for for example unreflect calls */
         public static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();


### PR DESCRIPTION
When using the `"indy"` setting, it tries to read a system property to enable logging.

This change enables a JVM Security Manager to block this setting and therefore simply ignore the setting to use the default: do not log.

From a security manager, you might otherwise catch a `SecurityException` containing:

> access denied ("java.util.PropertyPermission" "groovy.indy.logging" "read")

Not only is this not recoverable, but the `IndyInterface` class will be inaccessible thereafter due to it being in a `static` block that fails (the dreaded `NoClassDefFoundError`).