### PR TITLE
Changed the Range's step to Number instead of int

### DIFF
--- a/src/main/groovy/lang/EmptyRange.java
+++ b/src/main/groovy/lang/EmptyRange.java
@@ -179,16 +179,28 @@ public class EmptyRange extends AbstractList implements Range {
         throw new UnsupportedOperationException("cannot set in Empty Ranges");
     }
 
+    @Override
+    public void step(int step, Closure closure) {
+        step((Number) step, closure);
+    }
+
     /**
      * Always does nothing for an empty range.
      */
-    public void step(int step, Closure closure) {
+    @Override
+    public void step(Number step, Closure closure) {
+    }
+
+    @Override
+    public List step(int step) {
+        return step((Number) step);
     }
 
     /**
      * Always returns an empty list for an empty range.
      */
-    public List step(int step) {
+    @Override
+    public List step(Number step) {
         return new ArrayList();
     }
 }

--- a/src/main/groovy/lang/IntRange.java
+++ b/src/main/groovy/lang/IntRange.java
@@ -27,6 +27,10 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.codehaus.groovy.runtime.ScriptBytecodeAdapter.*;
+import static org.codehaus.groovy.runtime.dgmimpl.NumberNumberMinus.*;
+import static org.codehaus.groovy.runtime.dgmimpl.NumberNumberMultiply.multiply;
+import static org.codehaus.groovy.runtime.dgmimpl.NumberNumberPlus.*;
 /**
  * Represents a list of Integer objects starting at a specified {@code from} value up (or down)
  * to and potentially including a given {@code to} value.
@@ -356,40 +360,50 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer> {
         return super.containsAll(other);
     }
 
+    @Override
     public void step(int step, Closure closure) {
-        if (step == 0) {
-            if (!getFrom().equals(getTo())) {
-                throw new GroovyRuntimeException("Infinite loop detected due to step size of 0");
-            } else {
-                return; // from == to and step == 0, nothing to do, so return
-            }
-        }
-
-        if (isReverse()) {
-            step = -step;
-        }
-        if (step > 0) {
-            int value = getFrom();
-            while (value <= getTo()) {
-                closure.call(Integer.valueOf(value));
-                if ((0L + value + step) >= Integer.MAX_VALUE) {
-                    break;
-                }
-                value = value + step;
-            }
-        } else {
-            int value = getTo();
-            while (value >= getFrom()) {
-                closure.call(Integer.valueOf(value));
-                if ((0L + value + step) <= Integer.MIN_VALUE) {
-                    break;
-                }
-                value = value + step;
-            }
-        }
+        step((Number) step, closure);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void step(Number step, Closure closure) {
+        Long from = getFrom().longValue();
+        Long to = getTo().longValue();
+
+        if (compareEqual(step, 0))
+            if (compareNotEqual(from, to))
+                throw new GroovyRuntimeException("Infinite loop detected due to step size of 0");
+            else
+                return; // from == to and step == 0, nothing to do, so return
+
+        boolean isAscending = !isReverse();
+        if (compareLessThan(step, 0)) {
+            step = multiply(step, -1);
+            isAscending = !isAscending;
+        }
+
+        if (isAscending)
+            for (Long value = from; value <= to; value = (Long) plus(value, step))
+                closure.call(value);
+        else
+            for (Long value = to; value >= from; value = (Long) minus(value, step))
+                closure.call(value);
+    }
+
+
+    @Override
     public List<Integer> step(int step) {
+        return step((Number) step);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Integer> step(Number step) {
         IteratorClosureAdapter<Integer> adapter = new IteratorClosureAdapter<Integer>(this);
         step(step, adapter);
         return adapter.asList();

--- a/src/main/groovy/lang/Range.java
+++ b/src/main/groovy/lang/Range.java
@@ -73,23 +73,32 @@ public interface Range<T extends Comparable> extends List<T> {
     boolean containsWithinBounds(Object o);
 
     /**
-     * Steps through the range, calling a closure for each number.
-     *
-     * @param step    the amount by which to step. If negative, steps through the
-     *                range backwards.
-     * @param closure the {@link Closure} to call
+     * Replaced by <code>step(Number, Closure)</code>
      */
     void step(int step, Closure closure);
 
     /**
-     * Forms a list by stepping through the range by the indicated interval.
+     * Steps through the range, calling a closure for each number.
      *
-     * @param step the amount by which to step. If negative, steps through the
-     *             range backwards.
-     * @return the list formed by stepping through the range by the indicated
-     *         interval.
+     * @param step    the amount by which to step.
+     *                If negative, steps through the range backwards.
+     * @param closure the {@link Closure} to call
+     */
+    void step(Number step, Closure closure);
+
+    /**
+     * Replaced by <code>step(Number)</code>
      */
     List<T> step(int step);
+
+    /**
+     * Forms a list by stepping through the range by the indicated interval.
+     *
+     * @param step the amount by which to step.
+     *             If negative, steps through the range backwards.
+     * @return the list formed by stepping through the range by the indicated interval.
+     */
+    List<T> step(Number step);
 
     /**
      * @return the verbose {@link String} representation of this {@link Range} as would be typed into a console

--- a/src/test/groovy/lang/EmptyRangeTest.java
+++ b/src/test/groovy/lang/EmptyRangeTest.java
@@ -384,7 +384,7 @@ public class EmptyRangeTest extends GroovyTestCase {
     }
 
     /**
-     * Test method for {@link groovy.lang.EmptyRange#step(int,groovy.lang.Closure)}.
+     * Test method for {@link groovy.lang.EmptyRange#step(Number,groovy.lang.Closure)}.
      */
     public void testStepIntClosure() {
         final List callLog = new ArrayList();
@@ -394,7 +394,7 @@ public class EmptyRangeTest extends GroovyTestCase {
     }
 
     /**
-     * Test method for {@link groovy.lang.EmptyRange#step(int)}.
+     * Test method for {@link groovy.lang.EmptyRange#step(Number)}.
      */
     public void testStepInt() {
         List result = range.step(1);


### PR DESCRIPTION
Until now a `Range` could only step by an integer value, even if its elements had other types, e.g. doubles.
This made stepping over ranges like `0.1..0.9`strange, as that resulted in a single element.

Also, stepping over `ObjectRange` instances (like the above one) called the `next`/`previous` method reflectively, even if the range had a numeric type (the most common case).
This made it ~10x slower than e.g. `IntRange`.

The new implementation changed the `step` type to `Number` and unified the way stepping is done in
`ObjectRange` and `IntRange`, making them as fast as the original `IntRange` for numeric cases.

Also, `IntRange` treats the overflow issue by storing the intermediary value in a `Long` directly.

At the boundaries, the `next` and `previous` methods may now wrap to the other extreme - or return null.

-------------------

I tested the speed via the following trivial method:

```Groovy
void testSpeed() {
    for (def i = 0; i < 10; i++)
        run()
}

private void run() {
    def time = System.currentTimeMillis()
    def size = 0G
    for (def i = 0; i < 100; i++) { // changed to `i = 0G` when testing ObjectRange
        for (def j = 0; j < 100; j++) {
            def range = i..j
            def inverseRange = j..i
            for (def k = 1; k < 100; k++) {
                size += range.step(k).size()
                size += range.step(-k).size()

                size += inverseRange.step(k).size()
                size += inverseRange.step(-k).size()
            }
        }
    }
    println "size = ${size} in ${(System.currentTimeMillis() - time) / 1000.0}s"
}
```

resulting in
```
* Old impl for ObjectRange: `66.30s`
* New impl for ObjectRange: `5.52s` (12x faster)
```
and
```
* Old impl for IntRange: `4.54s`
* New impl for IntRange: `4.52s` (same speed as before)
```