### PR TITLE
Function same as `with`, but returns the incoming object

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -218,6 +218,48 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Allows the closure to be called for the object reference self (similar
+     * to <code>with</code> and always returns self.
+     * <p>
+     * Any method invoked inside the closure will first be invoked on the
+     * self reference. For instance, the following method calls to the append()
+     * method are invoked on the StringBuilder instance:
+     * <pre>
+     * def b = new StringBuilder().tap {
+     *   append('foo')
+     *   append('bar')
+     * }
+     * assert b.toString() == 'foobar'
+     * </pre>
+     * This is commonly used to simplify object creation, such as this example:
+     * <pre>
+     * def p = new Person().tap {
+     *   firstName = 'John'
+     *   lastName = 'Doe'
+     * }
+     * </pre>
+     *
+     * @param self    the object to have a closure act upon
+     * @param closure the closure to call on the object
+     * @return self
+     * @since 2.5.0
+     */
+    public static <T,U> U tap(
+            @DelegatesTo.Target("self") U self,
+            @DelegatesTo(value=DelegatesTo.Target.class,
+                    target="self",
+                    strategy=Closure.DELEGATE_FIRST)
+            @ClosureParams(FirstParam.class)
+            Closure<T> closure) {
+        @SuppressWarnings("unchecked")
+        final Closure<T> clonedClosure = (Closure<T>) closure.clone();
+        clonedClosure.setResolveStrategy(Closure.DELEGATE_FIRST);
+        clonedClosure.setDelegate(self);
+        clonedClosure.call(self);
+        return self;
+    }
+
+    /**
      * Allows the subscript operator to be used to lookup dynamic property values.
      * <code>bean[somePropertyNameExpression]</code>. The normal property notation
      * of groovy is neater and more concise but only works with compile-time known

--- a/src/spec/doc/style-guide.adoc
+++ b/src/spec/doc/style-guide.adoc
@@ -313,11 +313,11 @@ You can use named parameters with the default constructor (first the constructor
 def server = new Server(name: "Obelix", cluster: aCluster)
 ----
 
-== Using with() for repeated operations on the same bean
+== Using `with()` and `tap()` for repeated operations on the same bean
 
 Named-parameters with the default constructor is interesting when creating new instances,
 but what if you are updating an instance that was given to you, do you have to repeat the 'server' prefix again and again?
-No, thanks to the with() method that Groovy adds on all objects of any kind:
+No, thanks to the `with()` and `tap()` methods that Groovy adds on all objects of any kind:
 
 [source,groovy]
 ----
@@ -338,6 +338,25 @@ server.with {
     sessionCount = 3
     start()
     stop()
+}
+----
+
+As with any closure in Groovy, the last statement is considered the return value.  In the example above this is the result of `stop()`.  To use this as a builder, that just returns the incoming object, there is also `tap()`:
+
+[source,groovy]
+----
+def person = new Person().with {
+    name = "Ada Lovelace"
+    it // Note the explicit return
+}
+----
+
+vs:
+
+[source,groovy]
+----
+def person = new Person().tap {
+    name = "Ada Lovelace"
 }
 ----
 

--- a/src/test/groovy/lang/TapMethodTest.groovy
+++ b/src/test/groovy/lang/TapMethodTest.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2003-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package groovy.lang
+
+/**
+ * Tests the .tap method
+ *
+ */
+class TapMethodTest extends GroovyTestCase {
+
+    void testTapReturnsSelf() {
+        def m1 = [:]
+        def m2 = m1.tap{
+            put("a",1)
+        }
+        assertSame("Outgoing object of tap is not the same as the ingoing", m1, m2)
+        assertEquals("Outgoing object of tap is changed", m2, [a: 1])
+    }
+
+    void testDelegateGetsFirstOpportunity() {
+        def sb = new StringBuffer()
+
+        sb.tap {
+            // this should call append() on the
+            // delegate not, the owner
+            append 'some text'
+        }
+
+        assertEquals 'delegate had wrong value', 'some text', sb.toString()
+    }
+
+    void testOwnerGetsOpportunityIfDelegateCannotRespond() {
+        def sb = new StringBuffer()
+
+        def returnValue
+
+        sb.tap {
+            // this should call ownerMethod() on the owner
+            returnValue = ownerMethod()
+        }
+
+        assertEquals 'owner should have responded to method call',
+                     42,
+                     returnValue
+    }
+
+    void testCallingNonExistentMethod() {
+        def sb = new StringBuffer()
+
+        shouldFail(MissingMethodException) {
+            sb.tap {
+                someNoneExistentMethod()
+            }
+        }
+    }
+
+    void testClosureWithResolveStrategyExplicitlySet() {
+        def closure = {
+            append 'some text'
+        }
+        closure.resolveStrategy = Closure.OWNER_ONLY
+
+        def sb = new StringBuffer()
+
+        // .tap should use DELEGATE_FIRST, even though
+        // the closure has another strategy set
+        sb.tap closure
+
+        assertEquals 'delegate had wrong value', 'some text', sb.toString()
+    }
+
+    def ownerMethod() {
+        42
+    }
+
+    void append(String s) {
+        fail 'this should never have been called'
+    }
+}


### PR DESCRIPTION
My usecase for `with` is >80% to (ab)use it as some sort of builder.  Since I end up putting close to always `(return) it` at the end of my closure: ~~`doto`~~ `tap` is a slight variation of `with`, that just returns the incoming object.  ~~[`doto` is a loanword from clojure](http://clojuredocs.org/clojure.core/doto),~~ `tap` is a loanword from Ruby (see comments below) where it does the same and I could not find a naming scheme for groovy, that would not involve renaming `with` (which is impossible).
