### PR TITLE
GROOVY-7630 - JsonSlurper LAX parser with invalid number

### DIFF
--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
@@ -121,4 +121,31 @@ class JsonSlurperLaxTest extends JsonSlurperTest {
         assert map["he said"] == '"fire all your guns at once baby, and explode into the night"'
         assert map.the == "end"
     }
+
+    @Override
+    void testInvalidNumbers() {
+        // should be parsed as Strings
+        assert parser.parseText('{"num": 1a}').num == '1a'
+        assert parser.parseText('{"num": -1a}').num == '-1a'
+        assert parser.parseText('[98ab9]')[0] == '98ab9'
+        assert parser.parseText('[12/25/1980]')[0] == '12/25/1980'
+        assert parser.parseText('{"num": 1980-12-25}').num == '1980-12-25'
+        assert parser.parseText('{"num": 1.2ee5}').num == '1.2ee5'
+        assert parser.parseText('{"num": 1.2EE5}').num == '1.2EE5'
+        assert parser.parseText('{"num": 1.2Ee5}').num == '1.2Ee5'
+        assert parser.parseText('{"num": 1.2e++5}').num == '1.2e++5'
+        assert parser.parseText('{"num": 1.2e--5}').num == '1.2e--5'
+        assert parser.parseText('{"num": 1.2e+-5}').num == '1.2e+-5'
+        assert parser.parseText('{"num": 1.2+e5}').num == '1.2+e5'
+        assert parser.parseText('{"num": 1.2E5+}').num == '1.2E5+'
+        assert parser.parseText('{"num": 1.2e5+}').num == '1.2e5+'
+        assert parser.parseText('{"num": 37e-5.5}').num == '37e-5.5'
+        assert parser.parseText('{"num": 6.92e}').num == '6.92e'
+        assert parser.parseText('{"num": 6.92E}').num == '6.92E'
+        assert parser.parseText('{"num": 6.92e-}').num == '6.92e-'
+        assert parser.parseText('{"num": 6.92e+}').num == '6.92e+'
+        assert parser.parseText('{"num": 6+}').num == '6+'
+        assert parser.parseText('{"num": 6-}').num == '6-'
+    }
+
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -274,7 +274,6 @@ class JsonSlurperTest extends GroovyTestCase {
         shouldFail(JsonException) { parser.parseText('["a"')        }
         shouldFail(JsonException) { parser.parseText('["a", ')      }
         shouldFail(JsonException) { parser.parseText('["a", true')  }
-        shouldFail(JsonException) { parser.parseText('[1.1.1]')     }
     }
 
     void testBackSlashEscaping() {
@@ -317,4 +316,40 @@ class JsonSlurperTest extends GroovyTestCase {
 
         assertEquals(Date.class, o.a.class)
     }
+
+    void testInvalidNumbers() {
+        shouldFail(JsonException) { parser.parseText('[1.1.1]') }
+        shouldFail(JsonException) { parser.parseText('{"num": 1a}') }
+        shouldFail(JsonException) { parser.parseText('{"num": 1A}') }
+        shouldFail(JsonException) { parser.parseText('{"num": -1a}') }
+        shouldFail(JsonException) { parser.parseText('[98ab9]') }
+        shouldFail(JsonException) { parser.parseText('[-98ab9]') }
+        shouldFail(JsonException) { parser.parseText('[12/25/1980]') }
+
+        // TODO: Exception class differs from this point by parser type
+        // Probably something to be addressed at some point.
+        Class exceptional = JsonException
+        if (parser.type == JsonParserType.CHAR_BUFFER) {
+            exceptional = NumberFormatException
+        }
+
+        shouldFail(exceptional) { parser.parseText('{"num": 1980-12-25}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2ee5}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2EE5}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2Ee5}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2e++5}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2e--5}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2e+-5}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2+e5}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2E5+}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 1.2e5+}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 37e-5.5}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 6.92e}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 6.92E}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 6.92e-}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 6.92e+}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 6+}') }
+        shouldFail(exceptional) { parser.parseText('{"num": 6-}') }
+    }
+
 }


### PR DESCRIPTION
Breaking changes proposed here, but current behavior appears incorrect even in terms of relaxed parsing.  In addition to addressing GROOVY-7630, also found some missing cases around decimal parsing which were partially addressed by commit 8063a9dec07329804f3e1770aa31984bc38a694d for GROOVY-7344.

There seems to be quite a bit of duplication between the LAX and INDEX_OVERLAY parsers that I didn't address in this PR (actually adding more duplication :smile:).  I didn't want to introduce too much change, but at some point would like to come back and remove the duplication.