### PR TITLE
GROOVY-7420 Prefer a method signature without boxing or unboxing

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -816,7 +816,9 @@ public abstract class StaticTypeCheckingSupport {
                 && unwrapReceiver!=unwrapCompare) {
             dist = getPrimitiveDistance(unwrapReceiver, unwrapCompare);
         }
-        if (isPrimitiveType(receiver) && !isPrimitiveType(compare)) {
+        // Add a penalty against boxing or unboxing, to get a resolution similar to JLS 15.12.2
+        // (http://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.12.2).
+        if (isPrimitiveType(receiver) ^ isPrimitiveType(compare)) {
             dist = (dist+1)<<1;
         }
         if (unwrapCompare.equals(unwrapReceiver)) return dist;

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy7420Bug.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy7420Bug.groovy
@@ -18,12 +18,10 @@
  */
 package org.codehaus.groovy.classgen.asm.sc.bugs
 
-import groovy.transform.NotYetImplemented
 import groovy.transform.stc.StaticTypeCheckingTestCase
 import org.codehaus.groovy.classgen.asm.sc.StaticCompilationTestSupport
 
 class Groovy7420Bug extends StaticTypeCheckingTestCase implements StaticCompilationTestSupport {
-    @NotYetImplemented
     void testOverloadedMethodWithPrimitiveOrObjectParameter() {
         assertScript '''
             class A {
@@ -38,6 +36,9 @@ class Groovy7420Bug extends StaticTypeCheckingTestCase implements StaticCompilat
 
             Long l = 42L
             assert A.m(l) == "object"
+            assert A.m(l.longValue()) == "primitive"
+            int i = 42
+            assert A.m(i) == "primitive" // Primitive widening
         '''
     }
 }


### PR DESCRIPTION
The method resolution mechanism is closer to what is done when following the
Java Language Specification ([JLS 15.2.2](http://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.12.2)), and removes the ambiguity when
calling a method having both primitive and object overloads with an object.
