### PR TITLE
StreamingJsonBuilder should handle nested closures

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
@@ -487,6 +487,9 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
             this.first = first;
         }
 
+        /**
+         * @return Obtains the current writer
+         */
         public Writer getWriter() {
             return writer;
         }
@@ -500,7 +503,12 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
                     switch (len) {
                         case 1:
                             final Object value = arr[0];
-                            call(name, value);
+                            if(value instanceof Closure) {
+                                call(name, (Closure)value);
+                            }
+                            else {
+                                call(name, value);
+                            }
                             return null;
                         case 2:
                             if(arr[len -1] instanceof Closure) {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/StreamingJsonBuilderTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/StreamingJsonBuilderTest.groovy
@@ -65,6 +65,22 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
         }
     }
 
+    void testJsonBuilderWithNestedClosures() {
+        new StringWriter().with { w ->
+            def builder = new StreamingJsonBuilder(w)
+
+            builder.response {
+                status "ok"
+                results {
+                    sectionId "world"
+                    assert delegate instanceof StreamingJsonBuilder.StreamingJsonDelegate
+                }
+            }
+
+            assert w.toString() == '{"response":{"status":"ok","results":{"sectionId":"world"}}}'
+        }
+    }
+
     void testJsonBuilderConstructor() {
         new StringWriter().with { w ->
             new StreamingJsonBuilder(w, [a: 1, b: true])


### PR DESCRIPTION
Currently StreamingJsonBuilder doesn't handle nested closures properly and instead these are delegated to `JsonOutput.toJson` which is not streaming and leads to an unexpected change of delegate in the nested closure. This pull request fixes that erroneous behaviour.