### PR TITLE
StreamingJsonBuilder - fix IllegalStateException when writing unescaped output

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
@@ -643,6 +643,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
          */
         public void call(String name, JsonOutput.JsonUnescaped json) throws IOException {
             writeName(name);
+            verifyValue();
             writer.write(json.toString());
         }
 

--- a/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
@@ -616,11 +616,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
             writeObject(writer, value, callable);
         }
         /**
-<<<<<<< c9db44a9f71be65a92ae9e03e04e97eb7f491df1
          * Writes the name and another JSON object
-=======
-         * Writes the name and another JSON boject
->>>>>>> Support for Array and Iterable not just Collection in StreamingJsonBuilder
          *
          * @param name The attribute name
          * @param value The value

--- a/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
@@ -616,7 +616,11 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
             writeObject(writer, value, callable);
         }
         /**
+<<<<<<< c9db44a9f71be65a92ae9e03e04e97eb7f491df1
          * Writes the name and another JSON object
+=======
+         * Writes the name and another JSON boject
+>>>>>>> Support for Array and Iterable not just Collection in StreamingJsonBuilder
          *
          * @param name The attribute name
          * @param value The value

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/StreamingJsonBuilderTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/StreamingJsonBuilderTest.groovy
@@ -77,8 +77,22 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
             new StreamingJsonBuilder(w).call {
                 a 1
                 b JsonOutput.unescaped('{"name":"Fred"}')
+                c 3
             }
-            assert w.toString() == '{"a":1,"b":{"name":"Fred"}}'
+            assert w.toString() == '{"a":1,"b":{"name":"Fred"},"c":3}'
+        }
+    }
+
+
+    @CompileStatic
+    void testUnescapedJsonCompileStatic() {
+        new StringWriter().with { w ->
+            new StreamingJsonBuilder(w).call {
+                call 'a', 1
+                call 'b', JsonOutput.unescaped('{"name":"Fred"}')
+                call 'c', 3
+            }
+            assert w.toString() == '{"a":1,"b":{"name":"Fred"},"c":3}'
         }
     }
 


### PR DESCRIPTION
When writing unescaped JSON the state is not reset, resulting in an exception if another entry is written.