### PR TITLE
GROOVY-7710 GROOVY-7711 Apply the rules to resolve method consistently

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -973,61 +973,16 @@ public abstract class StaticTypeCheckingSupport {
              */
 
             Parameter[] params = makeRawTypes(safeNode.getParameters());
-            if (params.length == safeArgs.length) {
-                int allPMatch = allParametersAndArgumentsMatch(params, safeArgs);
-                int firstParamDist = firstParametersAndArgumentsMatch(params, safeArgs);
-                int lastArgMatch = isVargs(params) && firstParamDist >= 0?lastArgMatchesVarg(params, safeArgs):-1;
-                if (lastArgMatch>=0) {
-                    lastArgMatch += getVarargsDistance(params);
-                }
-                int dist = allPMatch>=0?Math.max(allPMatch, lastArgMatch):lastArgMatch;
-                if (dist >= 0) {
-                    dist += getClassDistance(declaringClassForDistance, actualReceiverForDistance);
-                    dist += getExtensionDistance(isExtensionMethodNode);
-                    if (dist < bestDist) {
-                        bestChoices.clear();
-                        bestChoices.add(candidateNode);
-                        bestDist = dist;
-                    } else if (dist == bestDist) {
-                        bestChoices.add(candidateNode);
-                    }
-                }
-            } else if (isVargs(params)) {
-                int dist = firstParametersAndArgumentsMatch(params, safeArgs);
-                if (dist >= 0) {
-                    // there are three case for vargs
-                    // (1) varg part is left out
-                    if (params.length == safeArgs.length + 1) {
-                        dist += getVarargsDistance(params);
-                        dist++; // increment to discriminate foo(Object,String) vs foo(Object,String, Object...)
-                        if (dist < bestDist) {
-                            bestChoices.clear();
-                            bestChoices.add(candidateNode);
-                            bestDist = dist;
-                        }
-                    } else {
-                        // (2) last argument is put in the vargs array
-                        //      that case is handled above already
-                        // (3) there is more than one argument for the vargs array
-                        int excessArgumentsDistance = excessArgumentsMatchesVargsParameter(params, safeArgs);
-                        if (excessArgumentsDistance < 0) continue;
-                        dist += excessArgumentsDistance;
-                        dist += getClassDistance(declaringClassForDistance, actualReceiverForDistance);
-                        // varargs methods must not be preferred to methods without varargs
-                        // for example :
-                        // int sum(int x) should be preferred to int sum(int x, int... y)
-                        dist += getVarargsDistance(params);
-                        dist += getExtensionDistance(isExtensionMethodNode);
-                        if (params.length < safeArgs.length) {
-                            if (dist < bestDist) {
-                                bestChoices.clear();
-                                bestChoices.add(candidateNode);
-                                bestDist = dist;
-                            } else if (dist == bestDist) {
-                                bestChoices.add(candidateNode);
-                            }
-                        }
-                    }
+            int dist = measureParametersAndArgumentsDistance(params, safeArgs);
+            if (dist >= 0) {
+                dist += getClassDistance(declaringClassForDistance, actualReceiverForDistance);
+                dist += getExtensionDistance(isExtensionMethodNode);
+                if (dist < bestDist) {
+                    bestChoices.clear();
+                    bestChoices.add(candidateNode);
+                    bestDist = dist;
+                } else if (dist == bestDist) {
+                    bestChoices.add(candidateNode);
                 }
             }
         }
@@ -1044,6 +999,41 @@ public abstract class StaticTypeCheckingSupport {
             }
         }
         return bestChoices;
+    }
+
+    private static int measureParametersAndArgumentsDistance(Parameter[] params, ClassNode[] args) {
+        int dist = -1;
+        if (params.length == args.length) {
+            int allPMatch = allParametersAndArgumentsMatch(params, args);
+            int firstParamDist = firstParametersAndArgumentsMatch(params, args);
+            int lastArgMatch = isVargs(params) && firstParamDist >= 0 ? lastArgMatchesVarg(params, args) : -1;
+            if (lastArgMatch >= 0) {
+                lastArgMatch += getVarargsDistance(params);
+            }
+            dist = allPMatch >= 0 ? Math.max(allPMatch, lastArgMatch) : lastArgMatch;
+        } else if (isVargs(params)) {
+            dist = firstParametersAndArgumentsMatch(params, args);
+            if (dist >= 0) {
+                // varargs methods must not be preferred to methods without varargs
+                // for example :
+                // int sum(int x) should be preferred to int sum(int x, int... y)
+                dist += getVarargsDistance(params);
+                // there are three case for vargs
+                // (1) varg part is left out (there's one less argument than there are parameters)
+                // (2) last argument is put in the vargs array
+                //     that case is handled above already when params and args have the same length
+                if (params.length < args.length) {
+                    // (3) there is more than one argument for the vargs array
+                    int excessArgumentsDistance = excessArgumentsMatchesVargsParameter(params, args);
+                    if (excessArgumentsDistance < 0) {
+                        dist = -1;
+                    } else {
+                        dist += excessArgumentsDistance;
+                    }
+                }
+            }
+        }
+        return dist;
     }
 
     private static int firstParametersAndArgumentsMatch(Parameter[] params, ClassNode[] safeArgs) {

--- a/src/test/groovy/transform/stc/BugsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/BugsSTCTest.groovy
@@ -648,6 +648,30 @@ Printer
         '''
     }
 
+    void testAmbiguousMethodResolutionGroovy7710NoArgsOverloaded() {
+        shouldFailWithMessages '''
+            Arrays.sort()
+        ''', 'Reference to method is ambiguous. Cannot choose between '
+    }
+
+    void testAmbiguousMethodResolutionGroovy7711NoArgsCovariantOverride() {
+        assertScript '''
+            class A {}
+            class B {
+                Object m(Object[] args) {
+                    new Object()
+                }
+            }
+            class C extends B {
+                A m(Object[] args) {
+                    new A()
+                }
+            }
+            C c = new C()
+            A a = c.m()
+        '''
+    }
+
     // GROOVY-6911
     void testShouldNotThrowArrayIndexOfOutBoundsException() {
         assertScript '''


### PR DESCRIPTION
A no-arg call to a varargs method needs to be resolved with the same rules
as when there are exactly the same number of parameters, or even more, by
applying the class distance and extension method biases.