### PR TITLE
Added check for NONSTOP_KERNEL to bypass ulimit.

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -30,6 +30,7 @@ die ( ) {
 cygwin=false
 msys=false
 darwin=false
+nonstop=false
 case "`uname`" in
   CYGWIN* )
     cygwin=true
@@ -39,6 +40,9 @@ case "`uname`" in
     ;;
   MINGW* )
     msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
     ;;
 esac
 
@@ -85,7 +89,7 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`
     if [ $? -eq 0 ] ; then
         if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then

--- a/src/bin/startGroovy
+++ b/src/bin/startGroovy
@@ -66,6 +66,7 @@ earlyInit
 cygwin=false
 msys=false
 darwin=false
+nonstop=false
 case "`uname`" in
   CYGWIN* )
     cygwin=true
@@ -75,6 +76,9 @@ case "`uname`" in
     ;;
   MINGW* )
     msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
     ;;
 esac
 
@@ -179,7 +183,7 @@ if [ -z "$JAVA_HOME" ] ; then
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`
     if [ $? -eq 0 ] ; then
         if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then


### PR DESCRIPTION
The change is analogous to how cygwin and darwin are handled.

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>