### PR TITLE
GROOVY-7717 StaticTypeCheckingTestCase#shouldFailWithMessages erroneo…

### DIFF
--- a/src/test/groovy/transform/stc/PrecompiledExtensionNotExtendingDSL.groovy
+++ b/src/test/groovy/transform/stc/PrecompiledExtensionNotExtendingDSL.groovy
@@ -39,7 +39,7 @@ class PrecompiledExtensionNotExtendingDSL extends AbstractTypeCheckingExtension 
     @Override
     void onMethodSelection(final Expression expression, final MethodNode target) {
         if (target.name=='println') {
-            addStaticTypeError('Error thrown from extension in onMethodSelection', expression.parameters[0])
+            addStaticTypeError('Error thrown from extension in onMethodSelection', expression.arguments[0])
         }
     }
 }

--- a/src/test/groovy/transform/stc/StaticTypeCheckingTestCase.groovy
+++ b/src/test/groovy/transform/stc/StaticTypeCheckingTestCase.groovy
@@ -78,14 +78,13 @@ abstract class StaticTypeCheckingTestCase extends GroovyTestCase {
         try {
             shell.evaluate(code, getTestClassName())
         } catch (MultipleCompilationErrorsException mce) {
-            mce.errorCollector.errors.each {
-                messages.each { message ->
-                    success = success || (it instanceof SyntaxErrorMessage && it.cause.message.contains(message))
+            success = messages.every { message ->
+                mce.errorCollector.errors.any {
+                    it instanceof SyntaxErrorMessage && it.cause.message.contains(message)
                 }
             }
-            if (!success) throw mce;
             if (success && mce.errorCollector.errorCount!=messages.length) {
-                throw new AssertionError("Expected error message was found, but compiler thrown more than one error : "+mce.toString())
+                throw new AssertionError("Expected error messages were found, but compiler threw additional errors : " + mce.toString())
             }
         }
         if (!success) throw new AssertionError("Test should have failed with messages [$messages]")


### PR DESCRIPTION
…usly passes

*StaticTypeCheckingTestCase: shouldFailWithMessages should only pass if all and only the expected error messages occur
*PrecompiledExtensionNotExtendingDSL:  fix ASTNode associated with error added in onMethodSelection method