### PR TITLE
GROOVY-7683 - Memory leak when using Groovy as JSR-223 scripting language

### DIFF
--- a/src/main/org/codehaus/groovy/reflection/ClassInfo.java
+++ b/src/main/org/codehaus/groovy/reflection/ClassInfo.java
@@ -25,6 +25,7 @@ import org.codehaus.groovy.reflection.stdclasses.*;
 import org.codehaus.groovy.util.*;
 import org.codehaus.groovy.vmplugin.VMPluginFactory;
 
+import java.lang.ref.WeakReference;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
@@ -32,16 +33,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Handle for all information we want to keep about the class
+ * <p>
+ * This class handles caching internally and its advisable to not store
+ * references directly to objects of this class.  The static factory method
+ * {@link ClassInfo#getClassInfo(Class)} should be used to retrieve an instance
+ * from the cache.  Internally the {@code Class} associated with a {@code ClassInfo}
+ * instance is kept as {@link WeakReference}, so it not safe to reference
+ * and instance without the Class being either strongly or softly reachable.
  *
  * @author Alex.Tkachman
  */
-public class ClassInfo {
+public class ClassInfo implements Finalizable {
 
     private final LazyCachedClassRef cachedClassRef;
     private final LazyClassLoaderRef artifactClassLoader;
     private final LockableObject lock = new LockableObject();
     public final int hash = -1;
-    private final Class klazz;
+    private final WeakReference<Class<?>> klazz;
 
     private final AtomicInteger version = new AtomicInteger();
 
@@ -68,11 +76,7 @@ public class ClassInfo {
     private static final GlobalClassSet globalClassSet = new GlobalClassSet();
 
     ClassInfo(Class klazz) {
-    	this.klazz = klazz;
-        if (ClassInfo.DebugRef.debug)
-          new DebugRef(klazz);
-        new ClassInfoCleanup(this);
-
+    	this.klazz = new WeakReference<Class<?>>(klazz);
         cachedClassRef = new LazyCachedClassRef(softBundle, this);
         artifactClassLoader = new LazyClassLoaderRef(softBundle, this);
     }
@@ -101,6 +105,19 @@ public class ClassInfo {
 	            info.setStrongMetaClass(null);
 	        }
 	    }
+    }
+
+    /**
+     * Returns the {@code Class} associated with this {@code ClassInfo}.
+     * <p>
+     * This method can return {@code null} if the {@code Class} is no longer reachable
+     * through any strong or soft references.  A non-null return value indicates that this
+     * {@code ClassInfo} is valid.
+     *
+     * @return the {@code Class} associated with this {@code ClassInfo}, else {@code null}
+     */
+    public final Class<?> getTheClass() {
+        return klazz.get();
     }
 
     public CachedClass getCachedClass() {
@@ -222,7 +239,7 @@ public class ClassInfo {
             return answer;
         }
 
-        answer = mccHandle.create(klazz, metaClassRegistry);
+        answer = mccHandle.create(klazz.get(), metaClassRegistry);
         answer.initialize();
 
         if (GroovySystem.isKeepJavaMetaClasses()) {
@@ -248,6 +265,17 @@ public class ClassInfo {
         return (!enableGloballyOn || cachedAnswerIsEMC);
     }
 
+    /**
+     * Returns the {@code MetaClass} for the {@code Class} associated with this {@code ClassInfo}.
+     * If no {@code MetaClass} exists one will be created.
+     * <p>
+     * It is not safe to call this method without a {@code Class} associated with this {@code ClassInfo}.
+     * It is advisable to aways retrieve a ClassInfo instance from the cache by using the static
+     * factory method {@link ClassInfo#getClassInfo(Class)} to ensure the referenced Class is
+     * strongly reachable.
+     *
+     * @return a {@code MetaClass} instance
+     */
     public final MetaClass getMetaClass() {
         MetaClass answer = getMetaClassForClass();
         if (answer != null) return answer;
@@ -375,7 +403,7 @@ public class ClassInfo {
         }
 
         public CachedClass initValue() {
-            return createCachedClass(info.klazz, info);
+            return createCachedClass(info.klazz.get(), info);
         }
     }
 
@@ -388,43 +416,17 @@ public class ClassInfo {
         }
 
         public ClassLoaderForClassArtifacts initValue() {
-            return new ClassLoaderForClassArtifacts(info.klazz);
-        }
-    }
-    
-    private static class ClassInfoCleanup extends ManagedReference<ClassInfo> {
-
-        public ClassInfoCleanup(ClassInfo classInfo) {
-            super(weakBundle, classInfo);
-        }
-
-        public void finalizeRef() {
-        	ClassInfo classInfo = get();
-        	classInfo.setStrongMetaClass(null);
-        	classInfo.cachedClassRef.clear();
-        	classInfo.artifactClassLoader.clear();
+            return new ClassLoaderForClassArtifacts(info.klazz.get());
         }
     }
 
-    private static class DebugRef extends ManagedReference<Class> {
-        public static final boolean debug = false;
-
-        private static final AtomicInteger count = new AtomicInteger();
-
-        final String name;
-
-        public DebugRef(Class klazz) {
-            super(softBundle, klazz);
-            name = klazz == null ? "<null>" : klazz.getName();
-            count.incrementAndGet();
-        }
-
-        public void finalizeRef() {
-            //System.out.println(name + " unloaded " + count.decrementAndGet() + " classes kept");
-            super.finalizeReference();
-        }
+    @Override
+    public void finalizeReference() {
+        setStrongMetaClass(null);
+        cachedClassRef.clear();
+        artifactClassLoader.clear();
     }
-    
+
     private static class GlobalClassSet {
     	
     	private final ManagedLinkedList<ClassInfo> items = new ManagedLinkedList<ClassInfo>(weakBundle);

--- a/src/main/org/codehaus/groovy/reflection/GroovyClassValuePreJava7.java
+++ b/src/main/org/codehaus/groovy/reflection/GroovyClassValuePreJava7.java
@@ -18,6 +18,7 @@
  */
 package org.codehaus.groovy.reflection;
 
+import org.codehaus.groovy.util.Finalizable;
 import org.codehaus.groovy.util.ManagedConcurrentMap;
 import org.codehaus.groovy.util.ReferenceBundle;
 
@@ -39,6 +40,15 @@ class GroovyClassValuePreJava7<T> implements GroovyClassValue<T> {
 		@Override
 		public void setValue(T value) {
 			if(value!=null) super.setValue(value);
+		}
+
+		@Override
+		public void finalizeReference() {
+			T value = getValue();
+			if (value instanceof Finalizable) {
+				((Finalizable) value).finalizeReference();
+			}
+			super.finalizeReference();
 		}
 	}
 

--- a/src/test/groovy/bugs/Groovy7683Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7683Bug.groovy
@@ -1,0 +1,76 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import org.codehaus.groovy.reflection.ClassInfo
+
+import java.lang.ref.PhantomReference
+import java.lang.ref.ReferenceQueue
+
+/**
+ * NOTE: Test uses multiple calls to System.gc() and throws an OutOfMemoryError in attempt to
+ * demonstrate changes fix the issue.  This test should not be included if the PR is accepted.
+ */
+class Groovy7683Bug extends GroovyTestCase {
+
+    private static final int NUM_OBJECTS = 31
+
+    ReferenceQueue<ClassLoader> classLoaderQueue = new ReferenceQueue<ClassLoader>()
+    ReferenceQueue<Class<?>> classQueue = new ReferenceQueue<Class<?>>()
+    ReferenceQueue<ClassInfo> classInfoQueue = new ReferenceQueue<ClassInfo>()
+
+    // Used to keep a hard reference to the PhantomReferences so they are not collected
+    List<Object> refList = new ArrayList<Object>(NUM_OBJECTS)
+
+    void testLeak() {
+        assert !Boolean.getBoolean('groovy.use.classvalue')
+        for (int i = 0; i < NUM_OBJECTS; i++) {
+            GroovyClassLoader gcl = new GroovyClassLoader()
+            Class scriptClass = gcl.parseClass("int myvar = " + i)
+            ClassInfo ci = ClassInfo.getClassInfo(scriptClass)
+            PhantomReference<ClassLoader> classLoaderRef = new PhantomReference<>(gcl, classLoaderQueue)
+            PhantomReference<Class<?>> classRef = new PhantomReference<Class<?>>(scriptClass, classQueue)
+            PhantomReference<ClassInfo> classInfoRef = new PhantomReference<ClassInfo>(ci, classInfoQueue)
+            refList.add(classLoaderRef)
+            refList.add(classRef)
+            refList.add(classInfoRef)
+            System.gc()
+        }
+        System.gc()
+        // Encourage GC to collect soft references
+        try { throw new OutOfMemoryError() } catch(OutOfMemoryError oom) { }
+        System.gc()
+
+        // Ensure that at least 90% of objects should have been collected, we can't guarantee 100% because
+        // System.gc() is not guaranteed to run on each call.
+        int targetCollectedCount = Math.floor(NUM_OBJECTS * 0.9f)
+        assert queueSize(classLoaderQueue) >= targetCollectedCount //GroovyClassLoaders not collected by GC
+        assert queueSize(classQueue) >= targetCollectedCount //Script Classes not collected by GC
+        assert queueSize(classInfoQueue) >= targetCollectedCount //ClassInfo objects not collected by GC
+    }
+
+    private int queueSize(ReferenceQueue<?> queue) {
+        int size = 0
+        while (queue.poll() != null) {
+            ++size
+        }
+        return size
+    }
+
+}


### PR DESCRIPTION
I am unsure what if any problems making the Class a `WeakReference` might have but thought I'd put this out there for review. 

I also tested against [GROOVY-7646](https://issues.apache.org/jira/browse/GROOVY-7646) which was consistently throwing OOME after <2 mins prior to these changes and ran to completion with changes.

Another thing I noticed in looking at this class is that [uses a `PhantomReference`](https://github.com/apache/groovy/blob/73f5979a468f1508134eba20ce503630b0fe0cc7/src/main/org/codehaus/groovy/reflection/ClassInfo.java#L405) and attempts [to use the value from `get()`](https://github.com/apache/groovy/blob/73f5979a468f1508134eba20ce503630b0fe0cc7/src/main/org/codehaus/groovy/reflection/ClassInfo.java#L435).  However, this will always return `null` so the code path never executes.