### PR TITLE
Fix finalizeReference method override for ManagedReference subclasses

### DIFF
--- a/src/main/org/codehaus/groovy/util/ManagedConcurrentMap.java
+++ b/src/main/org/codehaus/groovy/util/ManagedConcurrentMap.java
@@ -76,9 +76,18 @@ public class ManagedConcurrentMap<K,V> extends AbstractConcurrentMap<K,V> {
             return hash;
         }
 
-        public void finalizeRef() {
-            super.finalizeReference();
+        @Override
+        public void finalizeReference() {
             segment.removeEntry(this);
+            super.finalizeReference();
+        }
+
+        /**
+         * @deprecated use finalizeReference
+         */
+        @Deprecated
+        public void finalizeRef() {
+            finalizeReference();
         }
     }
 
@@ -90,18 +99,20 @@ public class ManagedConcurrentMap<K,V> extends AbstractConcurrentMap<K,V> {
             setValue(value);
         }
 
+        @Override
         public V getValue() {
             return value;
         }
 
+        @Override
         public void setValue(V value) {
             this.value = value;
         }
 
-
-        public void finalizeRef() {
+        @Override
+        public void finalizeReference() {
             value = null;
-            super.finalizeRef();
+            super.finalizeReference();
         }
     }
 }

--- a/src/main/org/codehaus/groovy/util/ManagedConcurrentValueMap.java
+++ b/src/main/org/codehaus/groovy/util/ManagedConcurrentValueMap.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This is a basic implementation of a map able to forget its values. This
- * map uses internally a ConcurrentHashMap, thus should be save for concurrency.
+ * map uses internally a ConcurrentHashMap, thus should be safe for concurrency.
  * hashcode and equals are used to find the entries and should thus be implemented
  * properly for the keys. This map does not support null keys.
  * @author <a href="mailto:blackdrag@gmx.org">Jochen "blackdrag" Theodorou</a>
@@ -67,8 +67,8 @@ public class ManagedConcurrentValueMap<K,V> {
         ManagedReference<V> ref = new ManagedReference<V>(bundle, value) {
             @Override
             public void finalizeReference() {
+                internalMap.remove(key, this);
                 super.finalizeReference();
-                internalMap.remove(key, get());
             }
         };
         internalMap.put(key, ref);

--- a/src/main/org/codehaus/groovy/util/ManagedDoubleKeyMap.java
+++ b/src/main/org/codehaus/groovy/util/ManagedDoubleKeyMap.java
@@ -48,8 +48,10 @@ public class ManagedDoubleKeyMap<K1,K2,V> extends AbstractConcurrentDoubleKeyMap
             this.entry = entry;
         }
 
-        public void finalizeRef() {
+        @Override
+        public void finalizeReference() {
             this.entry.clean();
+            super.finalizeReference();
         }
     }
 
@@ -87,8 +89,6 @@ public class ManagedDoubleKeyMap<K1,K2,V> extends AbstractConcurrentDoubleKeyMap
 
         public void clean() {
             segment.removeEntry(this);
-            ref1.clear();
-            ref2.clear();
         }
     }
 
@@ -99,17 +99,20 @@ public class ManagedDoubleKeyMap<K1,K2,V> extends AbstractConcurrentDoubleKeyMap
             super(bundle, key1, key2, hash, segment);
         }
 
+        @Override
         public V getValue() {
             return value;
         }
 
+        @Override
         public void setValue(V value) {
             this.value = value;
         }
 
+        @Override
         public void clean() {
-            super.clean();
             value = null;
+            super.clean();
         }
     }
 }

--- a/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
+++ b/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
@@ -40,6 +40,7 @@ public class ManagedLinkedList<T> {
             super(bundle, value);
         }
 
+        @Override
         public void finalizeReference() {
             if (previous != null && previous.next != null) {
                 previous.next = next;

--- a/src/test/org/codehaus/groovy/util/ManagedConcurrentMapTest.groovy
+++ b/src/test/org/codehaus/groovy/util/ManagedConcurrentMapTest.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.util
+
+class ManagedConcurrentMapTest extends GroovyTestCase {
+
+    ManagedConcurrentMap<Object, String> map =
+            new ManagedConcurrentMap<Object, String>(ReferenceBundle.getHardBundle())
+
+    void testEntriesRemoveSelfFromMapWhenFinalized() {
+        List<ManagedReference<Object>> entries = []
+        for (int i = 0; i < 5; i++) {
+            entries << map.getOrPut(new Object(), "Object ${i}")
+        }
+
+        assert map.size() == 5
+        assert map.fullSize() == 5
+
+        entries*.finalizeReference()
+
+        assert map.size() == 0
+        assert map.fullSize() == 0
+    }
+
+}

--- a/src/test/org/codehaus/groovy/util/ManagedConcurrentValueMapTest.groovy
+++ b/src/test/org/codehaus/groovy/util/ManagedConcurrentValueMapTest.groovy
@@ -1,0 +1,38 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.util
+
+class ManagedConcurrentValueMapTest extends GroovyTestCase {
+
+    ManagedConcurrentValueMap<String, Object> map =
+            new ManagedConcurrentValueMap<String, Object>(ReferenceBundle.getHardBundle())
+
+    void testEntriesRemoveSelfFromMapWhenFinalized() {
+        for (int i = 0; i < 5; i++) {
+            map.put("Key${i}", new Object())
+        }
+
+        assert map.@internalMap.size() == 5
+
+        Collection<ManagedReference<Object>> values = map.@internalMap.values()
+        values*.finalizeReference()
+
+        assert map.@internalMap.size() == 0
+    }
+}

--- a/src/test/org/codehaus/groovy/util/ManagedDoubleKeyMapTest.groovy
+++ b/src/test/org/codehaus/groovy/util/ManagedDoubleKeyMapTest.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.util
+
+class ManagedDoubleKeyMapTest extends GroovyTestCase {
+
+    ManagedDoubleKeyMap<Object, Object, String> map =
+            new ManagedDoubleKeyMap<Object, Object, String>(ReferenceBundle.getHardBundle())
+
+    void testEntriesRemoveSelfFromMapWhenFinalized() {
+        def entries = []
+        for (int i = 0; i < 5; i++) {
+            entries << map.getOrPut(new Object(), new Object(), "Value${i}")
+        }
+
+        assert map.size() == 5
+        assert map.fullSize() == 5
+
+        entries*.clean()
+
+        assert map.size() == 0
+        assert map.fullSize() == 0
+    }
+
+}


### PR DESCRIPTION
In working on PR #219 I ran across an issue with `ManagedConcurrentMap` not cleaning up `ManagedReference`'s.  It looked like the intent to was to override the `finalizeReference()` method but instead was named `finalizeRef()`.