### PR TITLE
GROOVY-7709 - ConvertedClosure/ConvertedMap do not work with interface extending GroovyObject

### DIFF
--- a/src/test/groovy/bugs/Groovy7709Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7709Bug.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+class Groovy7709Bug extends GroovyTestCase {
+
+    void testConvertedClosureAsGroovyObject() {
+        def closure = { 43 }
+        def proxy = closure as Groovy7709BugY
+        assert proxy instanceof GroovyObject
+        assert proxy.foo() == 43
+    }
+
+    void testConvertedMapAsGroovyObject() {
+        def map = [foo: { 43 }]
+        def proxy = map as Groovy7709BugY
+        assert proxy instanceof GroovyObject
+        assert proxy.foo() == 43
+    }
+
+}
+
+interface Groovy7709BugY extends GroovyObject {
+    int foo()
+}


### PR DESCRIPTION
Just posting for discussion and acknowledge that there is probably a better fix and lots here is not being addressed other the immediate issue.  For this fix I borrowed from what was done in `GroovyResultSetProxy`.

Assuming this is even somewhat close to the right way to address it, it might make sense for the `ConvertedMap` to handle the metaClass in case the map has a `getMetaClass` key.