### PR TITLE
Two branches in the same conditional structure should not have exactly the same implementation

### DIFF
--- a/src/main/org/codehaus/groovy/antlr/java/Java2GroovyConverter.java
+++ b/src/main/org/codehaus/groovy/antlr/java/Java2GroovyConverter.java
@@ -214,10 +214,8 @@ public class Java2GroovyConverter extends VisitorAdapter{
             // as groovy AST doesn't expect to have them
             if (t.getType() == GroovyTokenTypes.STRING_LITERAL) {
                 String text = t.getText();
-                if (isSingleQuoted(text)) {
+                if (isSingleQuoted(text) || isDoubleQuoted(text)) {
                     t.setText(text.substring(1, text.length() - 1)); // chop off the single quotes at start and end
-                } else if (isDoubleQuoted(text)) {
-                    t.setText(text.substring(1, text.length() - 1)); // chop off the double quotes at start and end
                 }
             }
         }

--- a/src/main/org/codehaus/groovy/classgen/asm/OperandStack.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/OperandStack.java
@@ -336,14 +336,12 @@ public class OperandStack {
                 return;
             }
             box();
-        } else if (primTop) {
-            // top is primitive, target is not
-            // so box and do groovy cast
-            controller.getInvocationWriter().castToNonPrimitiveIfNecessary(top, targetType);
         } else if (primTarget) {
             // top is not primitive so unbox
             // leave that BH#doCast later
         } else {
+            // top is primitive, target is not
+            // so box and do groovy cast
             controller.getInvocationWriter().castToNonPrimitiveIfNecessary(top, targetType);
         }
 

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
@@ -602,7 +602,7 @@ public class StaticInvocationWriter extends InvocationWriter {
         boolean isInt = ClassHelper.int_TYPE.equals(type);
         boolean isShort = ClassHelper.short_TYPE.equals(type);
         boolean isByte = ClassHelper.byte_TYPE.equals(type);
-        if (isInt || isShort || isByte) {
+        if (isInt || isShort || isByte || ClassHelper.boolean_TYPE.equals(type)) {
             mv.visitInsn(ICONST_0);
         } else if (ClassHelper.long_TYPE.equals(type)) {
             mv.visitInsn(LCONST_0);
@@ -610,8 +610,6 @@ public class StaticInvocationWriter extends InvocationWriter {
             mv.visitInsn(FCONST_0);
         } else if (ClassHelper.double_TYPE.equals(type)) {
             mv.visitInsn(DCONST_0);
-        } else if (ClassHelper.boolean_TYPE.equals(type)) {
-            mv.visitInsn(ICONST_0);
         } else {
             mv.visitLdcInsn(0);
         }

--- a/src/main/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/org/codehaus/groovy/control/CompilationUnit.java
@@ -1020,9 +1020,7 @@ public class CompilationUnit extends ProcessingUnit {
             int min = -1;
             for (int j = 0; j < unsorted.size(); j++) {
                 if (index[j] == -1) continue;
-                if (min == -1) {
-                    min = j;
-                } else if (index[j] < index[min]) {
+                if (min == -1 || index[j] < index[min]) {
                     min = j;
                 }
             }

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDocAssembler.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDocAssembler.java
@@ -749,10 +749,7 @@ public class SimpleGroovyClassDocAssembler extends VisitorAdapter implements Gro
                 StringBuilder dot = new StringBuilder();
                 GroovySourceAST dotChild = (GroovySourceAST) node.getFirstChild();
                 while (dotChild != null) {
-                    if (dotChild.getType() == IDENT) {
-                        if (dot.length() > 0) dot.append("/");
-                        dot.append(getAsTextCurrent(dotChild, defaultText));
-                    } else if (dotChild.getType() == DOT) {
+                    if (dotChild.getType() == IDENT || dotChild.getType() == DOT) {
                         if (dot.length() > 0) dot.append("/");
                         dot.append(getAsTextCurrent(dotChild, defaultText));
                     } else if (dotChild.getType() == TYPE_ARGUMENTS) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1871 - Two branches in the same conditional structure should not have exactly the same implementation
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1871
Please let me know if you have any questions.
Kirill Vlasov