### PR TITLE
ConversionHandler improvements

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/ConversionHandler.java
+++ b/src/main/org/codehaus/groovy/runtime/ConversionHandler.java
@@ -42,11 +42,15 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author <a href="mailto:blackdrag@gmx.org">Jochen Theodorou</a>
  */
 public abstract class ConversionHandler implements InvocationHandler, Serializable {
-    private Object delegate;
+    private final Object delegate;
     private static final long serialVersionUID = 1162833717190835227L;
-    private ConcurrentHashMap handleCache;
+    private final ConcurrentHashMap<Method, Object> handleCache;
     {
-        if (VMPluginFactory.getPlugin().getVersion()>=7) handleCache = new ConcurrentHashMap();
+        if (VMPluginFactory.getPlugin().getVersion() >= 7) {
+            handleCache = new ConcurrentHashMap<Method, Object>(16, 0.9f, 2);
+        } else {
+            handleCache = null;
+        }
     }
 
     private MetaClass metaClass;
@@ -58,7 +62,9 @@ public abstract class ConversionHandler implements InvocationHandler, Serializab
      * @throws IllegalArgumentException if the given delegate is null
      */
     public ConversionHandler(Object delegate) {
-        if (delegate == null) throw new IllegalArgumentException("delegate must not be null");
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate must not be null");
+        }
         this.delegate = delegate;
     }
 
@@ -96,8 +102,8 @@ public abstract class ConversionHandler implements InvocationHandler, Serializab
      * @see InvocationHandler#invoke(java.lang.Object, java.lang.reflect.Method, java.lang.Object[])
      */
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        VMPlugin plugin = VMPluginFactory.getPlugin();
-        if (plugin.getVersion()>=7 && isDefaultMethod(method)) {
+        if (handleCache != null && isDefaultMethod(method)) {
+            VMPlugin plugin = VMPluginFactory.getPlugin();
             Object handle = handleCache.get(method);
             if (handle == null) {
                 handle = plugin.getInvokeSpecialHandle(method, proxy);

--- a/src/main/org/codehaus/groovy/runtime/ConvertedClosure.java
+++ b/src/main/org/codehaus/groovy/runtime/ConvertedClosure.java
@@ -31,7 +31,7 @@ import java.lang.reflect.Method;
  * Jul 27, 2006 3:50:51 PM
  */
 public class ConvertedClosure extends ConversionHandler implements Serializable {
-    private String methodName;
+    private final String methodName;
     private static final long serialVersionUID = 1162833713450835227L;
 
     /**
@@ -46,7 +46,8 @@ public class ConvertedClosure extends ConversionHandler implements Serializable 
     public ConvertedClosure(Closure closure) {
         this(closure,null);
     }
-    
+
+    @Override
     public Object invokeCustom(Object proxy, Method method, Object[] args)
     throws Throwable {
         if (methodName!=null && !methodName.equals(method.getName())) return null;

--- a/src/main/org/codehaus/groovy/runtime/ConvertedMap.java
+++ b/src/main/org/codehaus/groovy/runtime/ConvertedMap.java
@@ -40,6 +40,7 @@ public class ConvertedMap extends ConversionHandler {
         super(closures);
     }
 
+    @Override
     public Object invokeCustom(Object proxy, Method method, Object[] args)
             throws Throwable {
         Map m = (Map) getDelegate();
@@ -53,10 +54,12 @@ public class ConvertedMap extends ConversionHandler {
         return cl.call(args);
     }
 
+    @Override
     public String toString() {
         return DefaultGroovyMethods.toString(getDelegate());
     }
 
+    @Override
     protected boolean checkMethod(Method method) {
         return isCoreObjectMethod(method);
     }


### PR DESCRIPTION
Added final where appropriate and limited plugin variable scope in invoke method.

Related to PR #226 (GROOVY-7709), while full synchronization may not be required the lazily initialized `metaClass` should probably be `volatile`.