### PR TITLE
GROOVY-7105 Add try/catch for NoClassDefFoundError

### DIFF
--- a/src/main/org/codehaus/groovy/reflection/stdclasses/CachedSAMClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/CachedSAMClass.java
@@ -153,6 +153,14 @@ public class CachedSAMClass extends CachedClass {
      * @return null if nothing was found, the method otherwise
      */
     public static Method getSAMMethod(Class<?> c) {
+      try {
+        return getSAMMethodImpl(c);
+      } catch (NoClassDefFoundError ignore) {
+        return null;
+      }
+    }
+
+    private static Method getSAMMethodImpl(Class<?> c) {
         // SAM = single public abstract method
         // if the class is not abstract there is no abstract method
         if (!Modifier.isAbstract(c.getModifiers())) return null;


### PR DESCRIPTION
SAM method resolution can cause loading of classes used in method
arguments (or as a return type).
When such a class is not present on a CLASSPATH, it causes a
NoClassDefFoundError even though the class may actually not be needed
for program execution.

This is the naive sollution, but I think it may work. It suppresses the NoClassDefFoundError when resolving SAM method, but in the case when the class is really needed for execution, it will throw the exception then.