### PR TITLE
GROOVY-4698 - Possible memory leak in Tomcat (GroovyScriptEngine ThreadLocal)

### DIFF
--- a/src/main/groovy/util/GroovyScriptEngine.java
+++ b/src/main/groovy/util/GroovyScriptEngine.java
@@ -236,12 +236,6 @@ public class GroovyScriptEngine implements ResourceConnector {
 
         @Override
         public Class parseClass(GroovyCodeSource codeSource, boolean shouldCacheSource) throws CompilationFailedException {
-            synchronized (sourceCache) {
-                return doParseClass(codeSource);
-            }
-        }
-
-        private Class<?> doParseClass(GroovyCodeSource codeSource) {
             LocalData localData = localDataCache.get();
             StringSetMap cache = localData.dependencyCache;
             Class<?> answer = null;

--- a/src/test/groovy/util/GroovyScriptEngineReloadingTest.groovy
+++ b/src/test/groovy/util/GroovyScriptEngineReloadingTest.groovy
@@ -410,7 +410,7 @@ class GroovyScriptEngineReloadingTest extends GroovyTestCase {
     void testThreadLocalCleanup() {
         MapFileSystem.instance.modFile('Groovy4698.groovy', 'x = 7', 0)
         gse.run('Groovy4698.groovy', new Binding())
-        def gseThreadLocal = GroovyScriptEngine.@localData.get()
+        def gseThreadLocal = GroovyScriptEngine.@localDataCache
         def gseThreadLocalEntry = Thread.currentThread().threadLocals.table.find { entry ->
             entry?.get()?.is(gseThreadLocal)
         }
@@ -424,7 +424,7 @@ class GroovyScriptEngineReloadingTest extends GroovyTestCase {
             gse.run('Groovy4698Bad.groovy', new Binding())
             fail('Groovy4698Bad.groovy script should have failed')
         } catch (ignore) { }
-        def gseThreadLocal = GroovyScriptEngine.@localData.get()
+        def gseThreadLocal = GroovyScriptEngine.@localDataCache
         def gseThreadLocalEntry = Thread.currentThread().threadLocals.table.find { entry ->
             entry?.get()?.is(gseThreadLocal)
         }

--- a/src/test/groovy/util/GroovyScriptEngineReloadingTest.groovy
+++ b/src/test/groovy/util/GroovyScriptEngineReloadingTest.groovy
@@ -407,7 +407,31 @@ class GroovyScriptEngineReloadingTest extends GroovyTestCase {
        assert gse.run(scriptName, binding) == 123
    }
 
-    
+    void testThreadLocalCleanup() {
+        MapFileSystem.instance.modFile('Groovy4698.groovy', 'x = 7', 0)
+        gse.run('Groovy4698.groovy', new Binding())
+        def gseThreadLocal = GroovyScriptEngine.@localData.get()
+        def gseThreadLocalEntry = Thread.currentThread().threadLocals.table.find { entry ->
+            entry?.get()?.is(gseThreadLocal)
+        }
+        assert gseThreadLocal instanceof ThreadLocal
+        assert gseThreadLocalEntry == null
+    }
+
+    void testThreadLocalCleanupOnException() {
+        MapFileSystem.instance.modFile('Groovy4698Bad.groovy', 'class 1BadFoo4698 {}', 0)
+        try {
+            gse.run('Groovy4698Bad.groovy', new Binding())
+            fail('Groovy4698Bad.groovy script should have failed')
+        } catch (ignore) { }
+        def gseThreadLocal = GroovyScriptEngine.@localData.get()
+        def gseThreadLocalEntry = Thread.currentThread().threadLocals.table.find { entry ->
+            entry?.get()?.is(gseThreadLocal)
+        }
+        assert gseThreadLocal instanceof ThreadLocal
+        assert gseThreadLocalEntry == null
+    }
+
     class MapFileEntry {
         String content
         long lutime


### PR DESCRIPTION
Recommend reviewing each commit separately.  The first commit I think is fairly safe and addresses the issue reported.  The others I'm a little less sure about.

863247f - main fix is ensuring that `localTh.remove()` (changed from `localTh.set(null)`) is always called even if an exception occurs.  Did some refactoring by pulling out the code used to update dependencies and the script cache.  Even though some changes have been made to the ThreadLocal's in this class since that JIRA, the problem remains because `set(null)` will not be called if `super.parseClass` throws.  I think this is a fairly safe change.

dbfa026- If we always clean up the ThreadLocal by calling remove, I think things can be simplified by removing the `WeakReference` holder and synchronized `getLocalData` method.

c32722a- Since `super.parseClass` is synchronized and the other code in that method just updates thread confined (ThreadLocal) data and ConcurrentHashMap scriptCache, it seemed like that could be done outside of synchronization.  I don't know if there might be a potential problem with ordering of the `scriptCache.put` calls.  However, if it is supposed to be synchronized, then I'm not sure a ThreadLocal is needed since that would mean all access to the ThreadLocal is synchronized.  In that case why not just have a `private LocalData localData;` field and set it with a `new LocalData()` each time `parseClass` is called?

**UNIT TEST NOTE**: I'm not sure how good the added test methods are.  They were helpful in showing the issue before the changes (commit 863247f).  However, they might be brittle since they rely on poking into package-private/private members.