### PR TITLE
Generate closures as public classes

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/ClosureWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/ClosureWriter.java
@@ -77,8 +77,10 @@ public class ClosureWriter {
         MethodVisitor mv = controller.getMethodVisitor();
         ClassNode classNode = controller.getClassNode();
         AsmClassGenerator acg = controller.getAcg();
-        
-        ClassNode closureClass = getOrAddClosureClass(expression, 0);
+
+        // generate closure as public class to make sure it can be properly invoked by classes of the
+        // Groovy runtime without circumventing JVM access checks (see CachedMethod for example).
+        ClassNode closureClass = getOrAddClosureClass(expression, ACC_PUBLIC);
         String closureClassinternalName = BytecodeHelper.getClassInternalName(closureClass);
         List constructors = closureClass.getDeclaredConstructors();
         ConstructorNode node = (ConstructorNode) constructors.get(0);


### PR DESCRIPTION
Groovy is the default scripting language in Elasticsearch, used to evaluate custom expressions. In Elasticsearch 2.0 we introduced the Java security manager as a key component to secure our software. We spent a lot of effort on getting Groovy to run under the security manager with a conservative set of permissions. We have currently hit a road block with the `suppressAccessCheck` which allows suppressing the standard language access checks and expose information that would normally be unavailable to malicious code. Unfortunately, not providing this permission to Groovy breaks the use of Groovy closures in our scripts.

The reason is that in the Groovy framework:

- Closures are generated as package private classes.
- Access to closures is cached by the Groovy runtime using the class `CachedMethod`.

Invoking a closure thus fails without the `suppressAccessCheck` permission as the class of the closure is package private but accessed from the Groovy runtime class `CachedMethod` in the `org.codehaus.groovy.reflection` package.

This one-line PR changes the access modifier of the classes generated for Groovy closures from package-private to public.