### PR TITLE
Remove duplicate ReferenceBundle definitions

### DIFF
--- a/src/main/org/codehaus/groovy/util/ReferenceBundle.java
+++ b/src/main/org/codehaus/groovy/util/ReferenceBundle.java
@@ -38,7 +38,7 @@ public class ReferenceBundle{
     static {
         ReferenceQueue queue = new ReferenceQueue();
         ReferenceManager callBack = ReferenceManager.createCallBackedManager(queue);
-        ReferenceManager manager  = ReferenceManager.createThresholdedIdlingManager(queue, callBack, 5000);
+        ReferenceManager manager  = ReferenceManager.createThresholdedIdlingManager(queue, callBack, 500);
         softReferences = new ReferenceBundle(manager, ReferenceType.SOFT);
         weakReferences = new ReferenceBundle(manager, ReferenceType.WEAK);
         phantomReferences = new ReferenceBundle(manager, ReferenceType.PHANTOM);

--- a/src/main/org/codehaus/groovy/util/ReferenceManager.java
+++ b/src/main/org/codehaus/groovy/util/ReferenceManager.java
@@ -156,21 +156,20 @@ public class ReferenceManager {
     public String toString() {
         return "ReferenceManager(idling)";
     }
-    
-    private static final ReferenceBundle SOFT_BUNDLE, WEAK_BUNDLE;
-    static {
-        ReferenceQueue queue = new ReferenceQueue();
-        ReferenceManager callBack = ReferenceManager.createCallBackedManager(queue);
-        ReferenceManager manager  = ReferenceManager.createThresholdedIdlingManager(queue, callBack, 500);
-        SOFT_BUNDLE = new ReferenceBundle(manager, ReferenceType.SOFT);
-        WEAK_BUNDLE = new ReferenceBundle(manager, ReferenceType.WEAK);
-    }
-    
+
+    /**
+     * @deprecated use {@link ReferenceBundle#getSoftBundle()}
+     */
+    @Deprecated
     public static ReferenceBundle getDefaultSoftBundle() {
-        return SOFT_BUNDLE;
+        return ReferenceBundle.getSoftBundle();
     }
-    
+
+    /**
+     * @deprecated use {@link ReferenceBundle#getWeakBundle()}
+     */
+    @Deprecated
     public static ReferenceBundle getDefaultWeakBundle() {
-        return WEAK_BUNDLE;
+        return ReferenceBundle.getWeakBundle();
     }
 }


### PR DESCRIPTION
Removed static initialization of default Soft/Weak bundles in ReferenceManager class.  The methods in that class were not used in the codebase.  Looking at the history of those static bundle references it appeared that 500 was the original threshold setting.  Typical startup creates roughly 1000 managed references, so 500 seems like a more appropriate value than 5000.

Note: the deprecated methods are in the `org.codehaus.groovy.util` package which might be considered non-public even though the methods are public.  But just to be safe left them in place just in case they may be referenced in others code.