### PR TITLE
Map#removeAll(Closure) and Map#retainAll(Closure)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     commonsHttpClientVersion = '3.1'
     eclipseOsgiVersion = '3.9.1-v20140110-1610'
     gparsVersion = '1.2.1'
-    gradleVersion = '2.8'
+    gradleVersion = '2.10'
     ivyVersion = '2.4.0'
     jansiVersion = '1.11'
     jarjarVersion = '1.3'

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -4434,6 +4434,10 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * specified closure condition. If the closure takes one parameter then it will be
      * passed the Map.Entry. Otherwise the closure should take two parameters, which
      * will be the key and the value.
+     * 
+     * <pre class="groovyTestCase">def map = [a:1, b:2]
+     * map.removeAll { k,v -> k == 'b' }
+     * assert map == [a:1]</pre>
      *
      * See also <code>findAll</code> when wanting to produce a new map containing items
      * which don't match some criteria while leaving the original map unchanged.

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -4379,6 +4379,10 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * that are matched according to the specified closure condition.  In other words,
      * removes from this collection all of its elements that don't match.
      *
+     * <pre class="groovyTestCase">def list = ['a', 'b']
+     * list.retainAll { it == 'b' }
+     * assert list == ['b']</pre>
+     *
      * See also <code>findAll</code> and <code>grep</code> when wanting to produce a new list
      * containing items which match some criteria but leaving the original collection unchanged.
      *
@@ -4405,7 +4409,9 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     /**
      * Modifies this map so that it retains only its elements that are matched
      * according to the specified closure condition.  In other words, removes from
-     * this map all of its elements that don't match.
+     * this map all of its elements that don't match. If the closure takes one
+     * parameter then it will be passed the Map.Entry. Otherwise the closure should
+     * take two parameters, which will be the key and the value.
      *
      * <pre class="groovyTestCase">def map = [a:1, b:2]
      * map.retainAll { k,v -> k == 'b' }
@@ -4437,6 +4443,10 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * Modifies this collection by removing the elements that are matched according
      * to the specified closure condition.
      *
+     * <pre class="groovyTestCase">def list = ['a', 'b']
+     * list.removeAll { it == 'b' }
+     * assert list == ['a']</pre>
+     *
      * See also <code>findAll</code> and <code>grep</code> when wanting to produce a new list
      * containing items which match some criteria but leaving the original collection unchanged.
      *
@@ -4465,7 +4475,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * specified closure condition. If the closure takes one parameter then it will be
      * passed the Map.Entry. Otherwise the closure should take two parameters, which
      * will be the key and the value.
-     * 
+     *
      * <pre class="groovyTestCase">def map = [a:1, b:2]
      * map.removeAll { k,v -> k == 'b' }
      * assert map == [a:1]</pre>

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -4407,7 +4407,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * to the specified closure condition.
      *
      * See also <code>findAll</code> and <code>grep</code> when wanting to produce a new list
-     * containing items which don't match some criteria while leaving the original collection unchanged.
+     * containing items which match some criteria but leaving the original collection unchanged.
      *
      * @param  self a Collection to be modified
      * @param  condition a closure condition
@@ -4440,7 +4440,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert map == [a:1]</pre>
      *
      * See also <code>findAll</code> when wanting to produce a new map containing items
-     * which don't match some criteria while leaving the original map unchanged.
+     * which match some criteria but leaving the original map unchanged.
      *
      * @param self a Map to be modified
      * @param condition a 1 or 2 arg Closure condition applying on the entries

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -4403,6 +4403,37 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Modifies this map so that it retains only its elements that are matched
+     * according to the specified closure condition.  In other words, removes from
+     * this map all of its elements that don't match.
+     *
+     * <pre class="groovyTestCase">def map = [a:1, b:2]
+     * map.retainAll { k,v -> k == 'b' }
+     * assert map == [b:2]</pre>
+     *
+     * See also <code>findAll</code> when wanting to produce a new map containing items
+     * which match some criteria but leaving the original map unchanged.
+     *
+     * @param self a Map to be modified
+     * @param condition a 1 or 2 arg Closure condition applying on the entries
+     * @return <tt>true</tt> if this map changed as a result of the call
+     * @since 2.5
+     */
+    public static <K, V> boolean retainAll(Map<K, V> self, @ClosureParams(MapEntryOrKeyValue.class) Closure condition) {
+        Iterator<Map.Entry<K, V>> iter = self.entrySet().iterator();
+        BooleanClosureWrapper bcw = new BooleanClosureWrapper(condition);
+        boolean result = false;
+        while (iter.hasNext()) {
+            Map.Entry<K, V> entry = iter.next();
+            if (!bcw.callForMap(entry)) {
+                iter.remove();
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    /**
      * Modifies this collection by removing the elements that are matched according
      * to the specified closure condition.
      *

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -4430,6 +4430,34 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Modifies this map by removing the elements that are matched according to the
+     * specified closure condition. If the closure takes one parameter then it will be
+     * passed the Map.Entry. Otherwise the closure should take two parameters, which
+     * will be the key and the value.
+     *
+     * See also <code>findAll</code> when wanting to produce a new map containing items
+     * which don't match some criteria while leaving the original map unchanged.
+     *
+     * @param self a Map to be modified
+     * @param condition a 1 or 2 arg Closure condition applying on the entries
+     * @return <tt>true</tt> if this map changed as a result of the call
+     * @since 2.5
+     */
+    public static <K, V> boolean removeAll(Map<K, V> self, @ClosureParams(MapEntryOrKeyValue.class) Closure condition) {
+        Iterator<Map.Entry<K, V>> iter = self.entrySet().iterator();
+        BooleanClosureWrapper bcw = new BooleanClosureWrapper(condition);
+        boolean result = false;
+        while (iter.hasNext()) {
+            Map.Entry<K, V> entry = iter.next();
+            if (bcw.callForMap(entry)) {
+                iter.remove();
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    /**
      * Modifies the collection by adding all of the elements in the specified array to the collection.
      * The behavior of this operation is undefined if
      * the specified array is modified while the operation is in progress.

--- a/src/test/groovy/MapTest.groovy
+++ b/src/test/groovy/MapTest.groovy
@@ -166,6 +166,26 @@ class MapTest extends GroovyTestCase {
         assert map2 == [d:4]
     }
 
+    void testRetainAll() {
+        // given:
+        def map1 = [a:1, b:2]
+        def map2 = [c:3, d:4]
+
+        // when: 'two parameters = key,value'
+        map1.retainAll { k,v ->
+            k == 'a'
+        }
+        // then:
+        assert map1 == [a:1]
+
+        // when: 'one parameter = entry'
+        map2.retainAll { e ->
+            e.value == 3
+        }
+        // then:
+        assert map2 == [c:3]
+    }
+
     void testPlusCollectionMapEntry() {
         def map1 = [a:1, b:2]
         def map2 = [c:3, d:4]

--- a/src/test/groovy/MapTest.groovy
+++ b/src/test/groovy/MapTest.groovy
@@ -146,6 +146,26 @@ class MapTest extends GroovyTestCase {
         assert map1 == control
     }
 
+    void testRemoveAll() {
+        // given:
+        def map1 = [a:1, b:2]
+        def map2 = [c:3, d:4]
+
+        // when: 'two parameters = key,value'
+        map1.removeAll { k,v ->
+            k == 'a'
+        }
+        // then:
+        assert map1 == [b:2]
+
+        // when: 'one parameter = entry'
+        map2.removeAll { e ->
+            e.value == 3
+        }
+        // then:
+        assert map2 == [d:4]
+    }
+
     void testPlusCollectionMapEntry() {
         def map1 = [a:1, b:2]
         def map2 = [c:3, d:4]


### PR DESCRIPTION
I added support for a method I missed more than once: `Map.removeAll(Closure)`, which behaves exactly like `Collection.removeAll(Closure)` and takes the same parameters as `Map.findAll(Closure)`. This enables convenient use of key/value parameters in contrast to the workaround of `Map.entrySet().removeAll(Closure)`.