### PR TITLE
make private methods static when they are pure functions

### DIFF
--- a/src/main/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
@@ -121,7 +121,7 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
         }
     }
 
-    private void mergeCollectedAnnotations(AnnotationCollectorMode mode, Map<Integer, List<AnnotationNode>> existing, List<AnnotationNode> replacements) {
+    private static void mergeCollectedAnnotations(AnnotationCollectorMode mode, Map<Integer, List<AnnotationNode>> existing, List<AnnotationNode> replacements) {
         switch(mode) {
             case PREFER_COLLECTOR:
                 deleteExisting(false, existing, replacements);
@@ -140,7 +140,7 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
         }
     }
 
-    private void deleteExisting(boolean mergeParams, Map<Integer, List<AnnotationNode>> existingMap, List<AnnotationNode> replacements) {
+    private static void deleteExisting(boolean mergeParams, Map<Integer, List<AnnotationNode>> existingMap, List<AnnotationNode> replacements) {
         for (AnnotationNode replacement : replacements) {
             for (Integer key : existingMap.keySet()) {
                 List<AnnotationNode> annotationNodes = new ArrayList<AnnotationNode>(existingMap.get(key));
@@ -159,7 +159,7 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
         }
     }
 
-    private void deleteReplacement(boolean mergeParams, Map<Integer, List<AnnotationNode>> existingMap, List<AnnotationNode> replacements) {
+    private static void deleteReplacement(boolean mergeParams, Map<Integer, List<AnnotationNode>> existingMap, List<AnnotationNode> replacements) {
         Iterator<AnnotationNode> nodeIterator = replacements.iterator();
         while (nodeIterator.hasNext()) {
             boolean remove = false;
@@ -180,7 +180,7 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
         }
     }
 
-    private void mergeParameters(AnnotationNode to, AnnotationNode from) {
+    private static void mergeParameters(AnnotationNode to, AnnotationNode from) {
         for (String name : from.getMembers().keySet()) {
             if (to.getMember(name) == null) {
                 to.setMember(name, from.getMember(name));
@@ -241,7 +241,7 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
         }
     }
 
-    private AnnotationCollectorMode getMode(AnnotationNode node) {
+    private static AnnotationCollectorMode getMode(AnnotationNode node) {
         final Expression member = node.getMember("mode");
         if (member != null && member instanceof PropertyExpression) {
             PropertyExpression prop = (PropertyExpression) member;

--- a/src/main/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
+++ b/src/main/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
@@ -177,13 +177,13 @@ public class AnnotationCollectorTransform {
         return ret;
     }
 
-    private List<AnnotationNode> getStoredTargetList(AnnotationNode aliasAnnotationUsage, SourceUnit source) {
+    private static List<AnnotationNode> getStoredTargetList(AnnotationNode aliasAnnotationUsage, SourceUnit source) {
         ClassNode alias = aliasAnnotationUsage.getClassNode().redirect();
         List<AnnotationNode> ret = getMeta(alias);
         return copy(ret, aliasAnnotationUsage);
     }
 
-    private List<AnnotationNode> copy(List<AnnotationNode> orig, AnnotationNode aliasAnnotationUsage) {
+    private static List<AnnotationNode> copy(List<AnnotationNode> orig, AnnotationNode aliasAnnotationUsage) {
         if (orig.isEmpty()) return orig;
         List<AnnotationNode> ret = new ArrayList<AnnotationNode>(orig.size());
         for (AnnotationNode an : orig) {

--- a/src/main/org/codehaus/groovy/transform/AutoCloneASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/AutoCloneASTTransformation.java
@@ -137,7 +137,7 @@ public class AutoCloneASTTransformation extends AbstractASTTransformation {
         cNode.addMethod("clone", ACC_PUBLIC, GenericsUtils.nonGeneric(cNode), Parameter.EMPTY_ARRAY, exceptions, body);
     }
 
-    private void createCloneCopyConstructor(ClassNode cNode, List<FieldNode> list, List<String> excludes) {
+    private static void createCloneCopyConstructor(ClassNode cNode, List<FieldNode> list, List<String> excludes) {
         if (cNode.getDeclaredConstructors().isEmpty()) {
             // add no-arg constructor
             BlockStatement noArgBody = new BlockStatement();
@@ -182,23 +182,23 @@ public class AutoCloneASTTransformation extends AbstractASTTransformation {
         cNode.addMethod("clone", ACC_PUBLIC, GenericsUtils.nonGeneric(cNode), Parameter.EMPTY_ARRAY, exceptions, block(stmt(ctorX(cNode, args(varX("this"))))));
     }
 
-    private boolean isCloneableType(ClassNode fieldType) {
+    private static boolean isCloneableType(ClassNode fieldType) {
         return isOrImplements(fieldType, CLONEABLE_TYPE) || !fieldType.getAnnotations(MY_TYPE).isEmpty();
     }
 
-    private boolean possiblyCloneable(ClassNode type) {
+    private static boolean possiblyCloneable(ClassNode type) {
         return !isPrimitiveType(type) && ((isCloneableType(type) || (type.getModifiers() & ACC_FINAL) == 0));
     }
 
-    private Expression callCloneDynamicX(Expression target) {
+    private static Expression callCloneDynamicX(Expression target) {
         return callX(INVOKER_TYPE, "invokeMethod", args(target, constX("clone"), ConstantExpression.NULL));
     }
 
-    private Expression callCloneDirectX(Expression direct) {
+    private static Expression callCloneDirectX(Expression direct) {
         return ternaryX(equalsNullX(direct), ConstantExpression.NULL, callX(direct, "clone"));
     }
 
-    private void createSimpleClone(ClassNode cNode, List<FieldNode> fieldNodes, List<String> excludes) {
+    private static void createSimpleClone(ClassNode cNode, List<FieldNode> fieldNodes, List<String> excludes) {
         if (cNode.getDeclaredConstructors().isEmpty()) {
             // add no-arg constructor
             cNode.addConstructor(ACC_PUBLIC, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, block(EmptyStatement.INSTANCE));
@@ -212,7 +212,7 @@ public class AutoCloneASTTransformation extends AbstractASTTransformation {
             returnS(result)));
     }
 
-    private void addSimpleCloneHelperMethod(ClassNode cNode, List<FieldNode> fieldNodes, List<String> excludes) {
+    private static void addSimpleCloneHelperMethod(ClassNode cNode, List<FieldNode> fieldNodes, List<String> excludes) {
         Parameter methodParam = new Parameter(GenericsUtils.nonGeneric(cNode), "other");
         final Expression other = varX(methodParam);
         boolean hasParent = cNode.getSuperClass() != ClassHelper.OBJECT_TYPE;
@@ -241,7 +241,7 @@ public class AutoCloneASTTransformation extends AbstractASTTransformation {
         cNode.addMethod("cloneOrCopyMembers", ACC_PROTECTED, ClassHelper.VOID_TYPE, params(methodParam), exceptions, methodBody);
     }
 
-    private void createClone(ClassNode cNode, List<FieldNode> fieldNodes, List<String> excludes) {
+    private static void createClone(ClassNode cNode, List<FieldNode> fieldNodes, List<String> excludes) {
         final BlockStatement body = new BlockStatement();
         final Expression result = varX("_result", cNode);
         body.addStatement(declS(result, castX(cNode, callSuperX("clone"))));
@@ -263,7 +263,7 @@ public class AutoCloneASTTransformation extends AbstractASTTransformation {
         cNode.addMethod("clone", ACC_PUBLIC, GenericsUtils.nonGeneric(cNode), Parameter.EMPTY_ARRAY, exceptions, body);
     }
 
-    private AutoCloneStyle getStyle(AnnotationNode node, String name) {
+    private static AutoCloneStyle getStyle(AnnotationNode node, String name) {
         final Expression member = node.getMember(name);
         if (member != null && member instanceof PropertyExpression) {
             PropertyExpression prop = (PropertyExpression) member;

--- a/src/main/org/codehaus/groovy/transform/BaseScriptASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/BaseScriptASTTransformation.java
@@ -158,7 +158,7 @@ public class BaseScriptASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    private boolean isCustomScriptBodyMethod(MethodNode node) {
+    private static boolean isCustomScriptBodyMethod(MethodNode node) {
         return node != null
             && !(node.getDeclaringClass().equals(ClassHelper.SCRIPT_TYPE)
                 && "run".equals(node.getName())

--- a/src/main/org/codehaus/groovy/transform/CategoryASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/CategoryASTTransformation.java
@@ -244,7 +244,7 @@ public class CategoryASTTransformation implements ASTTransformation, Opcodes {
         new VariableScopeVisitor(source, true).visitClass(parent);
     }
 
-    private boolean ensureNoInstanceFieldOrProperty(final SourceUnit source, final ClassNode parent) {
+    private static boolean ensureNoInstanceFieldOrProperty(final SourceUnit source, final ClassNode parent) {
         boolean valid = true;
         for (FieldNode fieldNode : parent.getFields()) {
             if (!fieldNode.isStatic() && fieldNode.getLineNumber()>0) {
@@ -282,7 +282,7 @@ public class CategoryASTTransformation implements ASTTransformation, Opcodes {
         return node.getText();
     }
 
-    private ClassNode getTargetClass(SourceUnit source, AnnotationNode annotation) {
+    private static ClassNode getTargetClass(SourceUnit source, AnnotationNode annotation) {
         Expression value = annotation.getMember("value");
         if (value == null || !(value instanceof ClassExpression)) {
             //noinspection ThrowableInstanceNeverThrown

--- a/src/main/org/codehaus/groovy/transform/DelegateASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/DelegateASTTransformation.java
@@ -155,7 +155,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    private void addSetterIfNeeded(FieldNode fieldNode, ClassNode owner, PropertyNode prop, String name, List<String> includes, List<String> excludes) {
+    private static void addSetterIfNeeded(FieldNode fieldNode, ClassNode owner, PropertyNode prop, String name, List<String> includes, List<String> excludes) {
         String setterName = "set" + Verifier.capitalize(name);
         if ((prop.getModifiers() & ACC_FINAL) == 0
                 && owner.getSetterMethod(setterName) == null
@@ -170,7 +170,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    private void addGetterIfNeeded(FieldNode fieldNode, ClassNode owner, PropertyNode prop, String name, List<String> includes, List<String> excludes) {
+    private static void addGetterIfNeeded(FieldNode fieldNode, ClassNode owner, PropertyNode prop, String name, List<String> includes, List<String> excludes) {
         String getterName = "get" + Verifier.capitalize(name);
         if (owner.getGetterMethod(getterName) == null
                 && !shouldSkipPropertyMethod(name, getterName, excludes, includes)) {
@@ -183,7 +183,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         }
     }
     
-    private boolean shouldSkipPropertyMethod(String propertyName, String methodName, List<String> excludes, List<String> includes) {
+    private static boolean shouldSkipPropertyMethod(String propertyName, String methodName, List<String> excludes, List<String> includes) {
         return (deemedInternalName(propertyName)
                     || excludes != null && (excludes.contains(propertyName) || excludes.contains(methodName)) 
                     || (includes != null && !includes.isEmpty() && !includes.contains(propertyName) && !includes.contains(methodName)));
@@ -273,7 +273,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    private List<String> genericPlaceholderNames(MethodNode candidate) {
+    private static List<String> genericPlaceholderNames(MethodNode candidate) {
         GenericsType[] candidateGenericsTypes = candidate.getGenericsTypes();
         List<String> names = new ArrayList<String>();
         if (candidateGenericsTypes != null) {
@@ -284,7 +284,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         return names;
     }
 
-    private String getParamName(Parameter[] params, int i, String fieldName) {
+    private static String getParamName(Parameter[] params, int i, String fieldName) {
         String name = params[i].getName();
         while(name.equals(fieldName) || clashesWithOtherParams(name, params, i)) {
             name = "_" + name;
@@ -292,7 +292,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         return name;
     }
 
-    private boolean clashesWithOtherParams(String name, Parameter[] params, int i) {
+    private static boolean clashesWithOtherParams(String name, Parameter[] params, int i) {
         for (int j = 0; j < params.length; j++) {
             if (i == j) continue;
             if (params[j].getName().equals(name)) return true;

--- a/src/main/org/codehaus/groovy/transform/ExternalizeMethodsASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ExternalizeMethodsASTTransformation.java
@@ -26,7 +26,6 @@ import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.Parameter;
-import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.tools.GenericsUtils;
@@ -86,7 +85,7 @@ public class ExternalizeMethodsASTTransformation extends AbstractASTTransformati
         }
     }
 
-    private void createWriteExternal(ClassNode cNode, List<String> excludes, List<FieldNode> list) {
+    private static void createWriteExternal(ClassNode cNode, List<String> excludes, List<FieldNode> list) {
         final BlockStatement body = new BlockStatement();
         Parameter out = param(OBJECTOUTPUT_TYPE, "out");
         for (FieldNode fNode : list) {
@@ -100,7 +99,7 @@ public class ExternalizeMethodsASTTransformation extends AbstractASTTransformati
         cNode.addMethod("writeExternal", ACC_PUBLIC, ClassHelper.VOID_TYPE, params(out), exceptions, body);
     }
 
-    private void createReadExternal(ClassNode cNode, List<String> excludes, List<FieldNode> list) {
+    private static void createReadExternal(ClassNode cNode, List<String> excludes, List<FieldNode> list) {
         final BlockStatement body = new BlockStatement();
         Parameter oin = param(OBJECTINPUT_TYPE, "oin");
         for (FieldNode fNode : list) {
@@ -114,7 +113,7 @@ public class ExternalizeMethodsASTTransformation extends AbstractASTTransformati
         cNode.addMethod("readExternal", ACC_PUBLIC, ClassHelper.VOID_TYPE, params(oin), ClassNode.EMPTY_ARRAY, body);
     }
 
-    private String suffixForField(FieldNode fNode) {
+    private static String suffixForField(FieldNode fNode) {
         // use primitives for efficiency
         if (fNode.getType() == ClassHelper.int_TYPE) return "Int";
         if (fNode.getType() == ClassHelper.boolean_TYPE) return "Boolean";

--- a/src/main/org/codehaus/groovy/transform/ExternalizeVerifierASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ExternalizeVerifierASTTransformation.java
@@ -86,15 +86,15 @@ public class ExternalizeVerifierASTTransformation extends AbstractASTTransformat
         }
     }
 
-    private boolean implementsExternalizable(ClassNode cNode) {
+    private static boolean implementsExternalizable(ClassNode cNode) {
         return cNode.implementsInterface(EXTERNALIZABLE_TYPE);
     }
 
-    private boolean implementsSerializable(ClassNode cNode) {
+    private static boolean implementsSerializable(ClassNode cNode) {
         return cNode.implementsInterface(SERIALIZABLE_TYPE);
     }
 
-    private boolean hasNoargConstructor(ClassNode cNode) {
+    private static boolean hasNoargConstructor(ClassNode cNode) {
         List<ConstructorNode> constructors = cNode.getDeclaredConstructors();
         for (ConstructorNode next : constructors) {
             if (next.getParameters().length == 0) {

--- a/src/main/org/codehaus/groovy/transform/FieldASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/FieldASTTransformation.java
@@ -122,7 +122,7 @@ public class FieldASTTransformation extends ClassCodeExpressionTransformer imple
         }
     }
 
-    private boolean acceptableTransform(AnnotationNode annotation) {
+    private static boolean acceptableTransform(AnnotationNode annotation) {
         // TODO also check for phase after sourceUnit.getPhase()? but will be ignored anyway?
         // TODO we should only copy those annotations with FIELD_TARGET but haven't visited annotations
         // and gathered target info at this phase, so we can't do this:
@@ -131,7 +131,7 @@ public class FieldASTTransformation extends ClassCodeExpressionTransformer imple
         return !annotation.getClassNode().equals(MY_TYPE);
     }
 
-    private boolean notTransform(ClassNode annotationClassNode) {
+    private static boolean notTransform(ClassNode annotationClassNode) {
         return annotationClassNode.getAnnotations(ASTTRANSFORMCLASS_TYPE).isEmpty();
     }
 

--- a/src/main/org/codehaus/groovy/transform/IndexedPropertyASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/IndexedPropertyASTTransformation.java
@@ -82,23 +82,23 @@ public class IndexedPropertyASTTransformation extends AbstractASTTransformation 
         }
     }
 
-    private void addListGetter(FieldNode fNode) {
+    private static void addListGetter(FieldNode fNode) {
         addGetter(fNode, getComponentTypeForList(fNode.getType()));
     }
 
-    private void addListSetter(FieldNode fNode) {
+    private static void addListSetter(FieldNode fNode) {
         addSetter(fNode, getComponentTypeForList(fNode.getType()));
     }
 
-    private void addArrayGetter(FieldNode fNode) {
+    private static void addArrayGetter(FieldNode fNode) {
         addGetter(fNode, fNode.getType().getComponentType());
     }
 
-    private void addArraySetter(FieldNode fNode) {
+    private static void addArraySetter(FieldNode fNode) {
         addSetter(fNode, fNode.getType().getComponentType());
     }
 
-    private void addGetter(FieldNode fNode, ClassNode componentType) {
+    private static void addGetter(FieldNode fNode, ClassNode componentType) {
         ClassNode cNode = fNode.getDeclaringClass();
         BlockStatement body = new BlockStatement();
         Parameter[] params = new Parameter[1];
@@ -107,7 +107,7 @@ public class IndexedPropertyASTTransformation extends AbstractASTTransformation 
         cNode.addMethod(makeName(fNode, "get"), getModifiers(fNode), componentType, params, null, body);
     }
 
-    private void addSetter(FieldNode fNode, ClassNode componentType) {
+    private static void addSetter(FieldNode fNode, ClassNode componentType) {
         ClassNode cNode = fNode.getDeclaringClass();
         BlockStatement body = new BlockStatement();
         Parameter[] theParams = params(
@@ -117,7 +117,7 @@ public class IndexedPropertyASTTransformation extends AbstractASTTransformation 
         cNode.addMethod(makeName(fNode, "set"), getModifiers(fNode), ClassHelper.VOID_TYPE, theParams, null, body);
     }
 
-    private ClassNode getComponentTypeForList(ClassNode fType) {
+    private static ClassNode getComponentTypeForList(ClassNode fType) {
         if (fType.isUsingGenerics() && fType.getGenericsTypes().length == 1) {
             return fType.getGenericsTypes()[0].getType();
         } else {
@@ -125,13 +125,13 @@ public class IndexedPropertyASTTransformation extends AbstractASTTransformation 
         }
     }
 
-    private int getModifiers(FieldNode fNode) {
+    private static int getModifiers(FieldNode fNode) {
         int mods = ACC_PUBLIC;
         if (fNode.isStatic()) mods |= ACC_STATIC;
         return mods;
     }
 
-    private String makeName(FieldNode fNode, String prefix) {
+    private static String makeName(FieldNode fNode, String prefix) {
         return prefix + MetaClassHelper.capitalize(fNode.getName());
     }
 }

--- a/src/main/org/codehaus/groovy/transform/InheritConstructorsASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/InheritConstructorsASTTransformation.java
@@ -116,7 +116,7 @@ public class InheritConstructorsASTTransformation extends AbstractASTTransformat
         return theArgs;
     }
 
-    private boolean isExisting(ClassNode classNode, Parameter[] params) {
+    private static boolean isExisting(ClassNode classNode, Parameter[] params) {
         for (ConstructorNode consNode : classNode.getDeclaredConstructors()) {
             if (matchingTypes(params, consNode.getParameters())) {
                 return true;
@@ -125,7 +125,7 @@ public class InheritConstructorsASTTransformation extends AbstractASTTransformat
         return false;
     }
 
-    private boolean matchingTypes(Parameter[] params, Parameter[] existingParams) {
+    private static boolean matchingTypes(Parameter[] params, Parameter[] existingParams) {
         if (params.length != existingParams.length) return false;
         for (int i = 0; i < params.length; i++) {
             if (!params[i].getType().equals(existingParams[i].getType())) {

--- a/src/main/org/codehaus/groovy/transform/LogASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/LogASTTransformation.java
@@ -161,7 +161,7 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
         new VariableScopeVisitor(sourceUnit, true).visitClass(classNode);
     }
 
-    private String lookupLogFieldName(AnnotationNode logAnnotation) {
+    private static String lookupLogFieldName(AnnotationNode logAnnotation) {
         Expression member = logAnnotation.getMember("value");
         if (member != null && member.getText() != null) {
             return member.getText();
@@ -170,7 +170,7 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
         }
     }
 
-    private String lookupCategoryName(AnnotationNode logAnnotation) {
+    private static String lookupCategoryName(AnnotationNode logAnnotation) {
         Expression member = logAnnotation.getMember("category");
         if (member != null && member.getText() != null) {
             return member.getText();
@@ -178,7 +178,7 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
         return DEFAULT_CATEGORY_NAME;
     }
 
-    private LoggingStrategy createLoggingStrategy(AnnotationNode logAnnotation, GroovyClassLoader loader) {
+    private static LoggingStrategy createLoggingStrategy(AnnotationNode logAnnotation, GroovyClassLoader loader) {
 
         String annotationName = logAnnotation.getClassNode().getName();
 

--- a/src/main/org/codehaus/groovy/transform/MemoizedASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/MemoizedASTTransformation.java
@@ -113,7 +113,7 @@ public class MemoizedASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    private MethodNode buildDelegatingMethod(final MethodNode annotatedMethod, final ClassNode ownerClassNode) {
+    private static MethodNode buildDelegatingMethod(final MethodNode annotatedMethod, final ClassNode ownerClassNode) {
         Statement code = annotatedMethod.getCode();
         int access = ACC_PROTECTED;
         if (annotatedMethod.isStatic()) {
@@ -137,7 +137,7 @@ public class MemoizedASTTransformation extends AbstractASTTransformation {
     private static final String MEMOIZE_AT_LEAST_METHOD_NAME = "memoizeAtLeast";
     private static final String MEMOIZE_BETWEEN_METHOD_NAME = "memoizeBetween";
 
-    private MethodCallExpression buildMemoizeClosureCallExpression(MethodNode privateMethod,
+    private static MethodCallExpression buildMemoizeClosureCallExpression(MethodNode privateMethod,
                                                                    int protectedCacheSize, int maxCacheSize) {
         Parameter[] srcParams = privateMethod.getParameters();
         Parameter[] newParams = cloneParams(srcParams);

--- a/src/main/org/codehaus/groovy/transform/NewifyASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/NewifyASTTransformation.java
@@ -100,7 +100,7 @@ public class NewifyASTTransformation extends ClassCodeExpressionTransformer impl
         auto = oldAuto;
     }
 
-    private boolean determineAutoFlag(Expression autoExpr) {
+    private static boolean determineAutoFlag(Expression autoExpr) {
         return !(autoExpr instanceof ConstantExpression && ((ConstantExpression) autoExpr).getValue().equals(false));
     }
 
@@ -271,7 +271,7 @@ public class NewifyASTTransformation extends ClassCodeExpressionTransformer impl
                 || (auto && isNewMethodStyle(mce));
     }
 
-    private boolean isNewMethodStyle(MethodCallExpression mce) {
+    private static boolean isNewMethodStyle(MethodCallExpression mce) {
         final Expression obj = mce.getObjectExpression();
         final Expression meth = mce.getMethod();
         return (obj instanceof ClassExpression && meth instanceof ConstantExpression
@@ -306,7 +306,7 @@ public class NewifyASTTransformation extends ClassCodeExpressionTransformer impl
         return null;
     }
 
-    private void internalError(String message) {
+    private static void internalError(String message) {
         throw new GroovyBugError("Internal error: " + message);
     }
 

--- a/src/main/org/codehaus/groovy/transform/PackageScopeASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/PackageScopeASTTransformation.java
@@ -134,7 +134,7 @@ public class PackageScopeASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    private void visitFieldNode(FieldNode fNode) {
+    private static void visitFieldNode(FieldNode fNode) {
         final ClassNode cNode = fNode.getDeclaringClass();
         final List<PropertyNode> pList = cNode.getProperties();
         PropertyNode foundProp = null;
@@ -150,19 +150,19 @@ public class PackageScopeASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    private void revertVisibility(FieldNode fNode) {
+    private static void revertVisibility(FieldNode fNode) {
         fNode.setModifiers(fNode.getModifiers() & ~ACC_PRIVATE);
     }
 
-    private void revertVisibility(MethodNode mNode) {
+    private static void revertVisibility(MethodNode mNode) {
         mNode.setModifiers(mNode.getModifiers() & ~ACC_PUBLIC);
     }
 
-    private void revertVisibility(ClassNode cNode) {
+    private static void revertVisibility(ClassNode cNode) {
         cNode.setModifiers(cNode.getModifiers() & ~ACC_PUBLIC);
     }
 
-    private List<groovy.transform.PackageScopeTarget> determineTargets(Expression expr) {
+    private static List<groovy.transform.PackageScopeTarget> determineTargets(Expression expr) {
         List<groovy.transform.PackageScopeTarget> list = new ArrayList<groovy.transform.PackageScopeTarget>();
         if (expr instanceof PropertyExpression) {
             list.add(extractTarget((PropertyExpression) expr));
@@ -178,7 +178,7 @@ public class PackageScopeASTTransformation extends AbstractASTTransformation {
         return list;
     }
 
-    private groovy.transform.PackageScopeTarget extractTarget(PropertyExpression expr) {
+    private static groovy.transform.PackageScopeTarget extractTarget(PropertyExpression expr) {
         Expression oe = expr.getObjectExpression();
         if (oe instanceof ClassExpression) {
             ClassExpression ce = (ClassExpression) oe;

--- a/src/main/org/codehaus/groovy/transform/ReadWriteLockASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ReadWriteLockASTTransformation.java
@@ -137,7 +137,7 @@ public class ReadWriteLockASTTransformation extends AbstractASTTransformation {
         return DEFAULT_INSTANCE_LOCKNAME;
     }
 
-    private Expression createLockObject() {
+    private static Expression createLockObject() {
         return ctorX(LOCK_TYPE);
     }
 }

--- a/src/main/org/codehaus/groovy/transform/SingletonASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/SingletonASTTransformation.java
@@ -81,11 +81,11 @@ public class SingletonASTTransformation extends AbstractASTTransformation {
         classNode.addMethod(getGetterName(propertyName), ACC_STATIC | ACC_PUBLIC, newClass(classNode), Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, body);
     }
 
-    private Statement nonLazyBody(FieldNode fieldNode) {
+    private static Statement nonLazyBody(FieldNode fieldNode) {
         return returnS(varX(fieldNode));
     }
 
-    private Statement lazyBody(ClassNode classNode, FieldNode fieldNode) {
+    private static Statement lazyBody(ClassNode classNode, FieldNode fieldNode) {
         final Expression instanceExpression = varX(fieldNode);
         return ifElseS(
                 notNullX(instanceExpression),
@@ -101,7 +101,7 @@ public class SingletonASTTransformation extends AbstractASTTransformation {
         );
     }
 
-    private String getGetterName(String propertyName) {
+    private static String getGetterName(String propertyName) {
         return "get" + Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
     }
 

--- a/src/main/org/codehaus/groovy/transform/SortableASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/SortableASTTransformation.java
@@ -106,7 +106,7 @@ public class SortableASTTransformation extends AbstractASTTransformation {
         new VariableScopeVisitor(sourceUnit, true).visitClass(classNode);
     }
 
-    private void implementComparable(ClassNode classNode) {
+    private static void implementComparable(ClassNode classNode) {
         if (!classNode.implementsInterface(COMPARABLE_TYPE)) {
             classNode.addInterface(makeClassSafeWithGenerics(Comparable.class, classNode));
         }

--- a/src/main/org/codehaus/groovy/transform/SourceURIASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/SourceURIASTTransformation.java
@@ -108,7 +108,7 @@ public class SourceURIASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    private Expression getExpression(URI uri) {
+    private static Expression getExpression(URI uri) {
         return callX(URI_TYPE, "create", args(constX(uri.toString())));
     }
 

--- a/src/main/org/codehaus/groovy/transform/SynchronizedASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/SynchronizedASTTransformation.java
@@ -107,7 +107,7 @@ public class SynchronizedASTTransformation extends AbstractASTTransformation {
         return "$lock";
     }
 
-    private Expression zeroLengthObjectArray() {
+    private static Expression zeroLengthObjectArray() {
         return new ArrayExpression(ClassHelper.OBJECT_TYPE, null, Collections.singletonList((Expression) constX(0)));
     }
 

--- a/src/main/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
@@ -105,7 +105,7 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
         }
     }
 
-    private void generateMethodsWithDefaultArgs(final ClassNode cNode) {
+    private static void generateMethodsWithDefaultArgs(final ClassNode cNode) {
         DefaultArgsMethodsAdder adder = new DefaultArgsMethodsAdder();
         adder.addDefaultParameterMethods(cNode);
     }
@@ -233,7 +233,7 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
         }
     }
 
-    private MethodNode createInitMethod(final boolean isStatic, final ClassNode cNode, final ClassNode helper) {
+    private static MethodNode createInitMethod(final boolean isStatic, final ClassNode cNode, final ClassNode helper) {
         MethodNode initializer = new MethodNode(
                 isStatic?Traits.STATIC_INIT_METHOD:Traits.INIT_METHOD,
                 ACC_STATIC | ACC_PUBLIC | ACC_SYNTHETIC,
@@ -274,7 +274,7 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
      * @param cNode the trait class node
      * @param helper the helper class node
      */
-    private void copyClassAnnotations(final ClassNode cNode, final ClassNode helper) {
+    private static void copyClassAnnotations(final ClassNode cNode, final ClassNode helper) {
         List<AnnotationNode> annotations = cNode.getAnnotations();
         for (AnnotationNode annotation : annotations) {
             if (!annotation.getClassNode().equals(Traits.TRAIT_CLASSNODE)) {
@@ -293,7 +293,7 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
         }
     }
 
-    private void generatePropertyMethods(final ClassNode cNode) {
+    private static void generatePropertyMethods(final ClassNode cNode) {
         for (PropertyNode node : cNode.getProperties()) {
             processProperty(cNode, node);
         }
@@ -494,13 +494,13 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
         return result;
     }
 
-    private Parameter createSelfParameter(final ClassNode traitClass, boolean isStatic) {
+    private static Parameter createSelfParameter(final ClassNode traitClass, boolean isStatic) {
         final ClassNode rawType = traitClass.getPlainNodeReference();
         ClassNode type = createReceiverType(isStatic, rawType);
         return new Parameter(type, isStatic?Traits.STATIC_THIS_OBJECT:Traits.THIS_OBJECT);
     }
 
-    private ClassNode createReceiverType(final boolean isStatic, final ClassNode rawType) {
+    private static ClassNode createReceiverType(final boolean isStatic, final ClassNode rawType) {
         ClassNode type;
         if (isStatic) {
             // Class<TraitClass>


### PR DESCRIPTION
Just a minor thing: Most AST transformations are stateless and only pass data via arguments, which allows to treat a lot of their helper methods as static functions.