### PR TITLE
GROOVY-7751 - CallableStatement leak in Sql.call() method

### DIFF
--- a/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
@@ -4223,8 +4223,12 @@ public class Sql {
         closeResources(connection);
     }
 
-    private void closeResources(BatchingStatementWrapper statement) {
+    private void closeResources(BatchingPreparedStatementWrapper statement) {
         if (cacheStatements) return;
+        closeResources((BatchingStatementWrapper) statement);
+    }
+
+    private void closeResources(BatchingStatementWrapper statement) {
         if (statement != null) {
             try {
                 statement.close();


### PR DESCRIPTION
Found a similar issue with `BatchingStatementWrapper` not having it's delegate statement closed when statement caching was enabled.  Added fix for that as a separate commit.