### PR TITLE
Delegate to getter

### DIFF
--- a/src/main/groovy/lang/Delegate.java
+++ b/src/main/groovy/lang/Delegate.java
@@ -26,11 +26,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-// TODO update javadoc for use on a getter method
 /**
- * Field annotation to automatically delegate part of the functionality of an owner class to the annotated field.
+ * Annotation to automatically delegate part of the functionality of an owner class to the
+ * annotated delegation target, i. e. a field or getter method's return value.
  * <p>
- * All public instance methods present in the type of the annotated field and not present in the owner class
+ * The delegate type is either the type of the annotated field or the return type of
+ * the annotated getter method.
+ * All public instance methods present in the delegate type and not present in the owner class
  * will be added to owner class at compile time. The implementation of such automatically added
  * methods is code which calls through to the delegate as per the normal delegate pattern.
  * <p>
@@ -63,7 +65,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * By default, the owner class will also be modified to implement any interfaces
- * implemented by the field. So, in the example above, because {@code Date}
+ * implemented by the delegate type. So, in the example above, because {@code Date}
  * implements {@code Cloneable} the following will be true:
  *
  * <pre>
@@ -82,9 +84,9 @@ import java.lang.annotation.Target;
  * assert !(gr8conf instanceof Cloneable)
  * </pre>
  *
- * If multiple delegate fields are used and the same method signature occurs
- * in more than one of the respective field types, then the delegate will be
- * made to the first defined field having that signature. If this does occur,
+ * If multiple delegation targets are used and the same method signature occurs
+ * in more than one of the respective delegate types, then the delegate will be
+ * made to the first defined target having that signature. If this does occur,
  * it might be regarded as a smell (or at least poor style) and it might be
  * clearer to do the delegation by long hand.
  * <p>
@@ -112,13 +114,13 @@ import java.lang.annotation.Target;
  * <li>Static methods, synthetic methods or methods from the <code>GroovyObject</code> interface
  * are not candidates for delegation</li>
  * <li>Non-abstract non-static methods defined in the owner class or its superclasses take
- * precedence over methods with identical signatures from a {@code @Delegate} field</li>
+ * precedence over methods with identical signatures from a {@code @Delegate} target</li>
  * <li>All methods defined in the owner class (including static, abstract or private etc.)
- * take precedence over methods with identical signatures from a {@code @Delegate} field</li>
+ * take precedence over methods with identical signatures from a {@code @Delegate} target</li>
  * <li>Recursive delegation to your own class is not allowed</li>
  * <li>Mixing of {@code @Delegate} with default method arguments is known not to work in some cases.
  * We recommend not using these features together.</li>
- * <li>When the type of the delegate field is an interface, the {@code deprecated} attribute will be
+ * <li>When the delegate type is an interface, the {@code deprecated} attribute will be
  * ignored if the owner class implements that interface (i.e. you must set {@code interfaces=false}
  * if you want the {@code deprecated} attribute to be used). Otherwise, the resulting class would
  * not compile anyway without manually adding in any deprecated methods in the interface.</li>
@@ -133,13 +135,13 @@ import java.lang.annotation.Target;
 @GroovyASTTransformationClass("org.codehaus.groovy.transform.DelegateASTTransformation")
 public @interface Delegate {
     /**
-     * @return true if owner class should implement interfaces implemented by field
+     * @return true if owner class should implement interfaces implemented by delegate type
      */
     boolean interfaces() default true;
 
     /**
      * Whether to apply the delegate pattern to deprecated methods; to avoid compilation
-     * errors, this is ignored if the type of the delegate field is an interface and
+     * errors, this is ignored if the type of the delegate target is an interface and
      * {@code interfaces=true}.
      *
      * @return true if owner class should delegate to methods annotated with @Deprecated

--- a/src/main/groovy/lang/Delegate.java
+++ b/src/main/groovy/lang/Delegate.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+// TODO update javadoc for use on a getter method
 /**
  * Field annotation to automatically delegate part of the functionality of an owner class to the annotated field.
  * <p>
@@ -128,7 +129,7 @@ import java.lang.annotation.Target;
  */
 @java.lang.annotation.Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.METHOD})
 @GroovyASTTransformationClass("org.codehaus.groovy.transform.DelegateASTTransformation")
 public @interface Delegate {
     /**

--- a/src/main/org/codehaus/groovy/transform/DelegateASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/DelegateASTTransformation.java
@@ -109,6 +109,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
             delegate.type = fieldNode.getType();
             delegate.owner = fieldNode.getOwner();
             delegate.getOp = varX(fieldNode);
+            delegate.origin = "field";
         } else if (parent instanceof MethodNode) {
             MethodNode methodNode = (MethodNode) parent;
 
@@ -119,6 +120,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
             delegate.type = methodNode.getReturnType();
             delegate.owner = methodNode.getDeclaringClass();
             delegate.getOp = callThisX(delegate.name);
+            delegate.origin = "method";
 
             if (methodNode.getParameters().length > 0) {
                 addError("You can only delegate to methods that take no parameters, but " +
@@ -129,14 +131,13 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         }
 
         if (delegate != null) {
-            // TODO may also be a method
             if (delegate.type.equals(ClassHelper.OBJECT_TYPE) || delegate.type.equals(GROOVYOBJECT_TYPE)) {
-                addError(MY_TYPE_NAME + " field '" + delegate.name + "' has an inappropriate type: " + delegate.type.getName() +
+                addError(MY_TYPE_NAME + " " + delegate.origin + " '" + delegate.name + "' has an inappropriate type: " + delegate.type.getName() +
                         ". Please add an explicit type but not java.lang.Object or groovy.lang.GroovyObject.", parent);
                 return;
             }
             if (delegate.type.equals(delegate.owner)) {
-                addError(MY_TYPE_NAME + " field '" + delegate.name + "' has an inappropriate type: " + delegate.type.getName() +
+                addError(MY_TYPE_NAME + " " + delegate.origin + " '" + delegate.name + "' has an inappropriate type: " + delegate.type.getName() +
                         ". Delegation to own type not supported. Please use a different type.", parent);
                 return;
             }
@@ -340,6 +341,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         ClassNode type;
         ClassNode owner;
         Expression getOp;
+        String origin;
         List<String> includes;
         List<String> excludes;
         List<ClassNode> includeTypes;

--- a/src/main/org/codehaus/groovy/transform/DelegateASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/DelegateASTTransformation.java
@@ -33,6 +33,7 @@ import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.tools.GenericsUtils;
 import org.codehaus.groovy.classgen.Verifier;
@@ -98,90 +99,98 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
 
         if (parent instanceof FieldNode) {
             FieldNode fieldNode = (FieldNode) parent;
-            final ClassNode type = fieldNode.getType();
-            final ClassNode owner = fieldNode.getOwner();
-            if (type.equals(ClassHelper.OBJECT_TYPE) || type.equals(GROOVYOBJECT_TYPE)) {
-                addError(MY_TYPE_NAME + " field '" + fieldNode.getName() + "' has an inappropriate type: " + type.getName() +
+
+            DelegateDescription delegate = new DelegateDescription();
+            delegate.delegate = fieldNode;
+            delegate.annotation = node;
+            delegate.delegateName = fieldNode.getName();
+            delegate.type = fieldNode.getType();
+            delegate.owner = fieldNode.getOwner();
+            delegate.getOp = varX(fieldNode);
+
+            if (delegate.type.equals(ClassHelper.OBJECT_TYPE) || delegate.type.equals(GROOVYOBJECT_TYPE)) {
+                addError(MY_TYPE_NAME + " field '" + delegate.delegateName + "' has an inappropriate type: " + delegate.type.getName() +
                         ". Please add an explicit type but not java.lang.Object or groovy.lang.GroovyObject.", parent);
                 return;
             }
-            if (type.equals(owner)) {
-                addError(MY_TYPE_NAME + " field '" + fieldNode.getName() + "' has an inappropriate type: " + type.getName() +
+            if (delegate.type.equals(delegate.owner)) {
+                addError(MY_TYPE_NAME + " field '" + delegate.delegateName + "' has an inappropriate type: " + delegate.type.getName() +
                         ". Delegation to own type not supported. Please use a different type.", parent);
                 return;
             }
-            final List<MethodNode> fieldMethods = getAllMethods(type);
-            for (ClassNode next : type.getAllInterfaces()) {
-                fieldMethods.addAll(getAllMethods(next));
+            final List<MethodNode> delegateMethods = getAllMethods(delegate.type);
+            for (ClassNode next : delegate.type.getAllInterfaces()) {
+                delegateMethods.addAll(getAllMethods(next));
             }
 
             final boolean skipInterfaces = memberHasValue(node, MEMBER_INTERFACES, false);
-            final boolean includeDeprecated = memberHasValue(node, MEMBER_DEPRECATED, true) || (type.isInterface() && !skipInterfaces);
+            final boolean includeDeprecated = memberHasValue(node, MEMBER_DEPRECATED, true) || (delegate.type.isInterface() && !skipInterfaces);
             final boolean allNames = memberHasValue(node, MEMBER_ALL_NAMES, true);
-            List<String> excludes = getMemberStringList(node, MEMBER_EXCLUDES);
-            List<String> includes = getMemberStringList(node, MEMBER_INCLUDES);
-            List<ClassNode> excludeTypes = getMemberClassList(node, MEMBER_EXCLUDE_TYPES);
-            List<ClassNode> includeTypes = getMemberClassList(node, MEMBER_INCLUDE_TYPES);
-            checkIncludeExcludeUndefinedAware(node, excludes, includes, excludeTypes, includeTypes, MY_TYPE_NAME);
+            delegate.excludes = getMemberStringList(node, MEMBER_EXCLUDES);
+            delegate.includes = getMemberStringList(node, MEMBER_INCLUDES);
+            delegate.excludeTypes = getMemberClassList(node, MEMBER_EXCLUDE_TYPES);
+            delegate.includeTypes = getMemberClassList(node, MEMBER_INCLUDE_TYPES);
+            checkIncludeExcludeUndefinedAware(node, delegate.excludes, delegate.includes,
+                                              delegate.excludeTypes, delegate.includeTypes, MY_TYPE_NAME);
 
-            final List<MethodNode> ownerMethods = getAllMethods(owner);
-            for (MethodNode mn : fieldMethods) {
-                addDelegateMethod(node, fieldNode, owner, ownerMethods, mn, includeDeprecated, includes, excludes, includeTypes, excludeTypes, allNames);
+            final List<MethodNode> ownerMethods = getAllMethods(delegate.owner);
+            for (MethodNode mn : delegateMethods) {
+                addDelegateMethod(delegate, ownerMethods, mn, includeDeprecated, allNames);
             }
 
-            for (PropertyNode prop : getAllProperties(type)) {
+            for (PropertyNode prop : getAllProperties(delegate.type)) {
                 if (prop.isStatic() || !prop.isPublic())
                     continue;
                 String name = prop.getName();
-                addGetterIfNeeded(fieldNode, owner, prop, name, includes, excludes, allNames);
-                addSetterIfNeeded(fieldNode, owner, prop, name, includes, excludes, allNames);
+                addGetterIfNeeded(delegate, prop, name, allNames);
+                addSetterIfNeeded(delegate, prop, name, allNames);
             }
 
             if (skipInterfaces) return;
 
-            final Set<ClassNode> allInterfaces = getInterfacesAndSuperInterfaces(type);
-            final Set<ClassNode> ownerIfaces = owner.getAllInterfaces();
-            Map<String,ClassNode> genericsSpec = createGenericsSpec(fieldNode.getDeclaringClass());
-            genericsSpec = createGenericsSpec(fieldNode.getType(), genericsSpec);
+            final Set<ClassNode> allInterfaces = getInterfacesAndSuperInterfaces(delegate.type);
+            final Set<ClassNode> ownerIfaces = delegate.owner.getAllInterfaces();
+            Map<String,ClassNode> genericsSpec = createGenericsSpec(delegate.owner);
+            genericsSpec = createGenericsSpec(delegate.type, genericsSpec);
             for (ClassNode iface : allInterfaces) {
                 if (Modifier.isPublic(iface.getModifiers()) && !ownerIfaces.contains(iface)) {
-                    final ClassNode[] ifaces = owner.getInterfaces();
+                    final ClassNode[] ifaces = delegate.owner.getInterfaces();
                     final ClassNode[] newIfaces = new ClassNode[ifaces.length + 1];
                     for (int i = 0; i < ifaces.length; i++) {
                         newIfaces[i] = correctToGenericsSpecRecurse(genericsSpec, ifaces[i]);
                     }
                     newIfaces[ifaces.length] = correctToGenericsSpecRecurse(genericsSpec, iface);
-                    owner.setInterfaces(newIfaces);
+                    delegate.owner.setInterfaces(newIfaces);
                 }
             }
         }
     }
 
-    private static void addSetterIfNeeded(FieldNode fieldNode, ClassNode owner, PropertyNode prop, String name, List<String> includes, List<String> excludes, boolean allNames) {
+    private static void addSetterIfNeeded(DelegateDescription delegate, PropertyNode prop, String name, boolean allNames) {
         String setterName = "set" + Verifier.capitalize(name);
         if ((prop.getModifiers() & ACC_FINAL) == 0
-                && owner.getSetterMethod(setterName) == null
-                && !shouldSkipPropertyMethod(name, setterName, excludes, includes, allNames)) {
-            owner.addMethod(setterName,
+                && delegate.owner.getSetterMethod(setterName) == null
+                && !shouldSkipPropertyMethod(name, setterName, delegate.excludes, delegate.includes, allNames)) {
+            delegate.owner.addMethod(setterName,
                     ACC_PUBLIC,
                     ClassHelper.VOID_TYPE,
                     params(new Parameter(GenericsUtils.nonGeneric(prop.getType()), "value")),
                     null,
-                    assignS(propX(varX(fieldNode), name), varX("value"))
+                    assignS(propX(delegate.getOp, name), varX("value"))
             );
         }
     }
 
-    private static void addGetterIfNeeded(FieldNode fieldNode, ClassNode owner, PropertyNode prop, String name, List<String> includes, List<String> excludes, boolean allNames) {
+    private static void addGetterIfNeeded(DelegateDescription delegate, PropertyNode prop, String name, boolean allNames) {
         String getterName = "get" + Verifier.capitalize(name);
-        if (owner.getGetterMethod(getterName) == null
-                && !shouldSkipPropertyMethod(name, getterName, excludes, includes, allNames)) {
-            owner.addMethod(getterName,
+        if (delegate.owner.getGetterMethod(getterName) == null
+                && !shouldSkipPropertyMethod(name, getterName, delegate.excludes, delegate.includes, allNames)) {
+            delegate.owner.addMethod(getterName,
                     ACC_PUBLIC,
                     GenericsUtils.nonGeneric(prop.getType()),
                     Parameter.EMPTY_ARRAY,
                     null,
-                    returnS(propX(varX(fieldNode), name)));
+                    returnS(propX(delegate.getOp, name)));
         }
     }
     
@@ -191,23 +200,23 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
                     || (includes != null && !includes.isEmpty() && !includes.contains(propertyName) && !includes.contains(methodName)));
     }
 
-    private void addDelegateMethod(AnnotationNode node, FieldNode fieldNode, ClassNode owner, List<MethodNode> ownMethods, MethodNode candidate, boolean includeDeprecated, List<String> includes, List<String> excludes, List<ClassNode> includeTypes, List<ClassNode> excludeTypes, boolean allNames) {
+    private void addDelegateMethod(DelegateDescription delegate, List<MethodNode> ownMethods, MethodNode candidate, boolean includeDeprecated, boolean allNames) {
         if (!candidate.isPublic() || candidate.isStatic() || 0 != (candidate.getModifiers () & ACC_SYNTHETIC))
             return;
 
         if (!candidate.getAnnotations(DEPRECATED_TYPE).isEmpty() && !includeDeprecated)
             return;
 
-        if (shouldSkip(candidate.getName(), excludes, includes, allNames)) return;
+        if (shouldSkip(candidate.getName(), delegate.excludes, delegate.includes, allNames)) return;
 
-        Map<String,ClassNode> genericsSpec = createGenericsSpec(fieldNode.getDeclaringClass());
+        Map<String,ClassNode> genericsSpec = createGenericsSpec(delegate.owner);
         genericsSpec = addMethodGenerics(candidate, genericsSpec);
-        extractSuperClassGenerics(fieldNode.getType(), candidate.getDeclaringClass(), genericsSpec);
+        extractSuperClassGenerics(delegate.type, candidate.getDeclaringClass(), genericsSpec);
 
-        if ((excludeTypes != null && !excludeTypes.isEmpty()) || includeTypes != null) {
+        if ((delegate.excludeTypes != null && !delegate.excludeTypes.isEmpty()) || delegate.includeTypes != null) {
             MethodNode correctedMethodNode = correctToGenericsSpec(genericsSpec, candidate);
-            boolean checkReturn = fieldNode.getType().getMethods().contains(candidate);
-            if (shouldSkipOnDescriptorUndefinedAware(checkReturn, genericsSpec, correctedMethodNode, excludeTypes, includeTypes))
+            boolean checkReturn = delegate.type.getMethods().contains(candidate);
+            if (shouldSkipOnDescriptorUndefinedAware(checkReturn, genericsSpec, correctedMethodNode, delegate.excludeTypes, delegate.includeTypes))
                 return;
         }
 
@@ -219,7 +228,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         }
 
         // ignore methods already in owner
-        for (MethodNode mn : owner.getMethods()) {
+        for (MethodNode mn : delegate.owner.getMethods()) {
             if (mn.getTypeDescriptor().equals(candidate.getTypeDescriptor())) {
                 return;
             }
@@ -242,26 +251,26 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
             List<String> currentMethodGenPlaceholders = genericPlaceholderNames(candidate);
             for (int i = 0; i < newParams.length; i++) {
                 ClassNode newParamType = correctToGenericsSpecRecurse(genericsSpec, params[i].getType(), currentMethodGenPlaceholders);
-                Parameter newParam = new Parameter(newParamType, getParamName(params, i, fieldNode.getName()));
+                Parameter newParam = new Parameter(newParamType, getParamName(params, i, delegate.delegateName));
                 newParam.setInitialExpression(params[i].getInitialExpression());
 
-                if (memberHasValue(node, MEMBER_PARAMETER_ANNOTATIONS, true)) {
+                if (memberHasValue(delegate.annotation, MEMBER_PARAMETER_ANNOTATIONS, true)) {
                     newParam.addAnnotations(copyAnnotatedNodeAnnotations(params[i], MY_TYPE_NAME));
                 }
 
                 newParams[i] = newParam;
                 args.addExpression(varX(newParam));
             }
-            boolean alsoLazy = !fieldNode.getAnnotations(LAZY_TYPE).isEmpty();
+            boolean alsoLazy = !delegate.delegate.getAnnotations(LAZY_TYPE).isEmpty();
             // addMethod will ignore attempts to override abstract or static methods with same signature on self
             MethodCallExpression mce = callX(
-                    alsoLazy ? propX(varX("this"), fieldNode.getName().substring(1)) :
-                    varX(fieldNode.getName(), correctToGenericsSpecRecurse(genericsSpec, fieldNode.getType())),
+                    alsoLazy ? propX(varX("this"), delegate.delegateName.substring(1)) :
+                    varX(delegate.delegateName, correctToGenericsSpecRecurse(genericsSpec, delegate.type)),
                     candidate.getName(),
                     args);
-            mce.setSourcePosition(fieldNode);
+            mce.setSourcePosition(delegate.delegate);
             ClassNode returnType = correctToGenericsSpecRecurse(genericsSpec, candidate.getReturnType(), currentMethodGenPlaceholders);
-            MethodNode newMethod = owner.addMethod(candidate.getName(),
+            MethodNode newMethod = delegate.owner.addMethod(candidate.getName(),
                     candidate.getModifiers() & (~ACC_ABSTRACT) & (~ACC_NATIVE),
                     returnType,
                     newParams,
@@ -269,7 +278,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
                     stmt(mce));
             newMethod.setGenericsTypes(candidate.getGenericsTypes());
 
-            if (memberHasValue(node, MEMBER_METHOD_ANNOTATIONS, true)) {
+            if (memberHasValue(delegate.annotation, MEMBER_METHOD_ANNOTATIONS, true)) {
                 newMethod.addAnnotations(copyAnnotatedNodeAnnotations(candidate, MY_TYPE_NAME));
             }
         }
@@ -302,4 +311,16 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
         return false;
     }
 
+    static class DelegateDescription {
+        AnnotationNode annotation;
+        AnnotatedNode delegate;
+        String delegateName;
+        ClassNode type;
+        ClassNode owner;
+        Expression getOp;
+        List<String> includes;
+        List<String> excludes;
+        List<ClassNode> includeTypes;
+        List<ClassNode> excludeTypes;
+    }
 }

--- a/src/test/org/codehaus/groovy/transform/DelegateTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/DelegateTransformTest.groovy
@@ -745,6 +745,15 @@ assert foo.dm.x == '123'
             assert delegates.respondsTo('set$')
         '''
     }
+
+    void testDelegateToGetterMethod() {
+        // given:
+        def delegate = { new DelegateFooImpl() }
+        // when:
+        def foo = new FooToMethod(delegate)
+        // then:
+        assert foo.foo() == delegate().foo()
+    }
 }
 
 interface DelegateFoo {
@@ -782,6 +791,17 @@ class DelegateBarForcingDeprecated {
 
 class Foo4244 {
     @Delegate Bar4244 bar = new Bar4244()
+}
+
+class FooToMethod {
+    private final Closure<DelegateFoo> strategy
+
+    FooToMethod(Closure<DelegateFoo> strategy) {
+        this.strategy = strategy
+    }
+
+    @Delegate
+    DelegateFoo getStrategy() { strategy() }
 }
 
 class Bar4244 {


### PR DESCRIPTION
Hi there,

what I basically want to do is this:
```diff
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.METHOD})
 public @interface Delegate {
```
so that I can
```groovy
@Delegate
Foo getSomeFoo() {
    // calcuate foo here
}
```

I rewrote the AST transform and put a lot of the FieldNode-specific context into a simple struct-like object (this rework is what makes the diff look so big, although it's just prepending `delegate.`). I then fill this object either with the field's data or the method's data. The actual code generation is not changed at all, except for the actual "getter", i.e. a field access or a method invocation.

However, I'm having trouble generating the correct AST. Currently the decompiled class looks like this:
```groovy
  @Delegate
  public DelegateFoo getStrategy() {
    // some stuff that works okay
  }

  public Object foo()
  {
    return ((DelegateFoo)getProperty("getStrategy")).foo(); return null;
  }
```
But there is no _property_ named `getStrategy`, the property is named `strategy` with a _method_ `getStrategy`. Yet I struggle to generate the correct expression to actually call the method as a method. Could someone please give me a hint?

Best regards