### PR TITLE
cache Gradle artifacts for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,10 @@ jdk:
 install: true
 
 script: travis_wait ./gradlew test
+
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
Caching Gradle's user home (except the lock-file which gets touched every time) will increase the CI build's performance.