### PR TITLE
GROOVY-7761: Groovydoc incorrectly rejects dollar signs and mucks up …

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
@@ -916,7 +916,7 @@ public class SimpleGroovyClassDoc extends SimpleGroovyAbstractableElementDoc imp
             while (matcher.find()) {
                 String tagName = matcher.group(1);
                 String tagBody = matcher.group(2);
-                String encodedBody = encodeAngleBrackets(tagBody);
+                String encodedBody = Matcher.quoteReplacement(encodeAngleBrackets(tagBody));
                 String replacement = "{@" + tagName + " " + encodedBody + "}";
                 matcher.appendReplacement(sb, replacement);
             }

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDocTests.groovy
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDocTests.groovy
@@ -47,10 +47,22 @@ class SimpleGroovyClassDocTests extends GroovyTestCase {
     void testEncodeAngleBracketsInTagBody() {
         def text = 'text with <tag1> outside and {@code <tag2> inside} a @code tag'
         def regex = SimpleGroovyClassDoc.CODE_REGEX
-
         def encodedText = SimpleGroovyClassDoc.encodeAngleBracketsInTagBody(text, regex)
-
         assert encodedText == 'text with <tag1> outside and {@code &lt;tag2&gt; inside} a @code tag'
+    }
+
+    void testEncodeAngleBracketsInTagBodyWithDollar() {
+        def text = 'text with dollar {@code $foo.bar} and dollar with less than {@code $foo < $bar}'
+        def regex = SimpleGroovyClassDoc.CODE_REGEX
+        def encodedText = SimpleGroovyClassDoc.encodeAngleBracketsInTagBody(text, regex)
+        assert encodedText == 'text with dollar {@code $foo.bar} and dollar with less than {@code $foo &lt; $bar}'
+    }
+
+    void testEncodeAngleBracketsInTagBodyLeavesSpecialChars() {
+        def text = 'text with illegal group ref {@code $3 \\$}'
+        def regex = SimpleGroovyClassDoc.CODE_REGEX
+        def encodedText = SimpleGroovyClassDoc.encodeAngleBracketsInTagBody(text, regex)
+        assert encodedText == text
     }
 
     void testEncodeAngleBrackets() {


### PR DESCRIPTION
…some backslashes during @code tag replacement. (closes #268)