### PR TITLE
Update asciidoctor gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
 
     dependencies {
         // using the old "classpath" style of plugins because the new one doesn't play well with multi-modules
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.2'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.0.3"
         classpath 'me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1'
         //classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.1.1'


### PR DESCRIPTION
Upgrading from 1.5.2. to 1.5.3 allows the asciidoctor tasks to
run successfully on jdk9, which failed with:

java.lang.RuntimeException: unsupported Java version: 9
    at org.jruby.RubyInstanceConfig.initGlobalJavaVersion(RubyInstanceConfig.java:1858)