### PR TITLE
Update external libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ ext {
     jarjarVersion = '1.3'
     jlineVersion = '2.12'
     jmockVersion = '1.2.0'
-    logbackVersion = '1.1.3'
+    logbackVersion = '1.1.5'
     log4jVersion = '1.2.17'
     log4j2Version = '2.3'
     luceneVersion = '4.7.2'

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ ext {
     openbeansVersion = '1.0'
     openejbVersion = '1.0'
     qdoxVersion = '1.12.1'
-    slf4jVersion = '1.7.12'
+    slf4jVersion = '1.7.16'
     xmlunitVersion = '1.6'
     xstreamVersion = '1.4.8'
     spockVersion = '1.0-groovy-2.4'

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ configurations {
 
 ext {
     antVersion = '1.9.6'
-    asmVersion = '5.0.3'
+    asmVersion = '5.0.4'
     antlrVersion = '2.7.7'
     coberturaVersion = '1.9.4.1'
     commonsCliVersion = '1.3.1'

--- a/subprojects/groovy-sql/build.gradle
+++ b/subprojects/groovy-sql/build.gradle
@@ -18,9 +18,9 @@
  */
 dependencies {
     compile rootProject
-    testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.3.2'
+    testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.3.3'
 // uncomment to test with other databases (requires changes elsewhere too)
-//    testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.3.2', classifier: 'jdk5'
+//    testCompile group: 'org.hsqldb', name: 'hsqldb', version: '2.3.3', classifier: 'jdk5'
 //    testCompile 'com.h2database:h2:1.3.164'
 //    testCompile 'hsqldb:hsqldb:1.8.0.10'
     testCompile project(':groovy-test')

--- a/subprojects/groovy-sql/src/spec/test/SqlTest.groovy
+++ b/subprojects/groovy-sql/src/spec/test/SqlTest.groovy
@@ -70,7 +70,7 @@ class SqlTest extends GroovyTestCase {
         /*
         commented out as already on classpath
 // tag::sql_connecting_grab[]
-        @Grab('org.hsqldb:hsqldb:2.3.2')
+        @Grab('org.hsqldb:hsqldb:2.3.3')
         @GrabConfig(systemClassLoader=true)
         // create, use, and then close sql instance ...
 // end::sql_connecting_grab[]
@@ -333,7 +333,7 @@ class SqlTest extends GroovyTestCase {
               // tag::sql_basic_table_metadata[]
               def md = sql.connection.metaData
               assert md.driverName == 'HSQL Database Engine Driver'
-              assert md.databaseProductVersion == '2.3.2'
+              assert md.databaseProductVersion == '2.3.3'
               assert ['JDBCMajorVersion', 'JDBCMinorVersion'].collect{ md[it] } == [4, 0]
               assert md.stringFunctions.tokenize(',').contains('CONCAT')
               def rs = md.getTables(null, null, 'AUTH%', null)

--- a/subprojects/groovy-testng/build.gradle
+++ b/subprojects/groovy-testng/build.gradle
@@ -18,7 +18,7 @@
  */
 dependencies {
     compile rootProject
-    runtime('org.testng:testng:6.9.4') {
+    runtime('org.testng:testng:6.9.10') {
         // exclude 'optional' beanshell even though testng's pom doesn't say optional
         exclude(group: 'org.beanshell', module: 'bsh')
     }

--- a/subprojects/performance/build.gradle
+++ b/subprojects/performance/build.gradle
@@ -26,7 +26,7 @@ configurations {
 
 dependencies {
     testCompile 'org.codehaus.groovy:groovy:2.4.4'
-    stats 'org.apache.commons:commons-math3:3.5'
+    stats 'org.apache.commons:commons-math3:3.6'
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
I did some minor updates for external libraries used by Groovy. None of this should be breaking in any way.

What I didn't update for now:
* log4j 2.3 -> 2.5 broke some tests in a way I could not resolve immediately
* servlet-api 2.4 -> 2.5 was not immediately clear to me whether this was fully compatible, left alone updating to servlet-api 3.x