### PR TITLE
Normalize groovysh command descriptions

### DIFF
--- a/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/ClearCommand.properties
+++ b/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/ClearCommand.properties
@@ -16,7 +16,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-command.description=Clear the buffer and reset the prompt counter.
+command.description=Clear the buffer and reset the prompt counter
 command.usage=
 command.help=Clears the current buffer, resetting the prompt counter to 000. Can be used to recover from compilation errors.
 

--- a/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/DocCommand.properties
+++ b/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/DocCommand.properties
@@ -16,6 +16,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-command.description=Opens a browser window displaying the doc for the argument
+command.description=Open a browser window displaying the doc for the argument
 command.usage=[<class>]
 command.help=Opens a browser window displaying the doc for the argument.

--- a/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/RegisterCommand.properties
+++ b/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/RegisterCommand.properties
@@ -16,6 +16,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-command.description=Registers a new command with the shell
+command.description=Register a new command with the shell
 command.usage=<classname> [<name>] [alias]
 command.help=Registers the given @|BOLD classname|@ as a new command.

--- a/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
+++ b/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
@@ -202,8 +202,8 @@ Available commands:
   :history   (:H ) Display, manage and recall edit-line history
   :alias     (:a ) Create an alias
   :set       (:= ) Set (or list) preferences
-  :register  (:rc) Registers a new command with the shell
-  :doc       (:D ) Opens a browser window displaying the doc for the argument
+  :register  (:rc) Register a new command with the shell
+  :doc       (:D ) Open a browser window displaying the doc for the argument
 
 For help on a specific command type:
     :help <command>

--- a/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
+++ b/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
@@ -190,7 +190,7 @@ Available commands:
   :quit      (:q ) Alias to: :exit
   import     (:i ) Import a class into the namespace
   :display   (:d ) Display the current buffer
-  :clear     (:c ) Clear the buffer and reset the prompt counter.
+  :clear     (:c ) Clear the buffer and reset the prompt counter
   :show      (:S ) Show variables, classes or imports
   :inspect   (:n ) Inspect a variable or the last result with the GUI object browser
   :purge     (:p ) Purge variables, classes, imports or preferences


### PR DESCRIPTION
A `:help` command issued from the Groovy Shell offers command descriptions.  The majority of commands match the same style, beginning with imperative verbs and not ending with punctuation.

I think that the description field is not only an extremely helpful feature, but makes the shell look like a very professional and polished product.

This commit attempts to change the style of all descriptions to match the style in the majority.

Hope this finds you all well, and hope it helps!
