### PR TITLE
Fix minor typo

### DIFF
--- a/src/main/org/codehaus/groovy/tools/LoaderConfiguration.java
+++ b/src/main/org/codehaus/groovy/tools/LoaderConfiguration.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 
 /**
  * Class used to configure a RootLoader from a stream or by using
- * it's methods.
+ * its methods.
  * <p>
  * The stream can be for example a FileInputStream from a file with
  * the following format:


### PR DESCRIPTION
"It's" is used for the contraction "it is."  "Its" is possessive.

I know it's minor, but it was bugging me.  So— for what it's worth... here's a one-character Pull.