### PR TITLE
Some bulk refactorings

### DIFF
--- a/src/main/groovy/beans/BindableASTTransformation.java
+++ b/src/main/groovy/beans/BindableASTTransformation.java
@@ -182,7 +182,7 @@ public class BindableASTTransformation implements ASTTransformation, Opcodes {
     /*
      * Wrap an existing setter.
      */
-    private void wrapSetterMethod(ClassNode classNode, String propertyName) {
+    private static void wrapSetterMethod(ClassNode classNode, String propertyName) {
         String getterName = "get" + MetaClassHelper.capitalize(propertyName);
         MethodNode setter = classNode.getSetterMethod("set" + MetaClassHelper.capitalize(propertyName));
 

--- a/src/main/groovy/beans/VetoableASTTransformation.java
+++ b/src/main/groovy/beans/VetoableASTTransformation.java
@@ -166,7 +166,7 @@ public class VetoableASTTransformation extends BindableASTTransformation {
     /**
      * Wrap an existing setter.
      */
-    private void wrapSetterMethod(ClassNode classNode, boolean bindable, String propertyName) {
+    private static void wrapSetterMethod(ClassNode classNode, boolean bindable, String propertyName) {
         String getterName = "get" + MetaClassHelper.capitalize(propertyName);
         MethodNode setter = classNode.getSetterMethod("set" + MetaClassHelper.capitalize(propertyName));
 

--- a/src/main/groovy/grape/GrabAnnotationTransformation.java
+++ b/src/main/groovy/grape/GrabAnnotationTransformation.java
@@ -443,7 +443,7 @@ public class GrabAnnotationTransformation extends ClassCodeVisitorSupport implem
         classNode.addStaticInitializerStatements(grabInitializers, true);
     }
 
-    private void addGrabResolverAsStaticInitIfNeeded(ClassNode grapeClassNode, AnnotationNode node,
+    private static void addGrabResolverAsStaticInitIfNeeded(ClassNode grapeClassNode, AnnotationNode node,
                                                       List<Statement> grabResolverInitializers, Map<String, Object> grabResolverMap) {
         if ((node.getMember("initClass") == null)
             || (node.getMember("initClass") == ConstantExpression.TRUE))
@@ -514,7 +514,7 @@ public class GrabAnnotationTransformation extends ClassCodeVisitorSupport implem
         }
     }
 
-    private void checkForConvenienceForm(AnnotationNode node, boolean exclude) {
+    private static void checkForConvenienceForm(AnnotationNode node, boolean exclude) {
         Object val = node.getMember("value");
         if (val == null || !(val instanceof ConstantExpression)) return;
         Object allParts = ((ConstantExpression)val).getValue();

--- a/src/main/groovy/grape/GrapeIvy.groovy
+++ b/src/main/groovy/grape/GrapeIvy.groovy
@@ -76,11 +76,11 @@ class GrapeIvy implements GrapeEngine {
     Set<String> resolvedDependencies
     Set<String> downloadedArtifacts
     // weak hash map so we don't leak loaders directly
-    Map<ClassLoader, Set<IvyGrabRecord>> loadedDeps = new WeakHashMap<ClassLoader, Set<IvyGrabRecord>>()
+    final Map<ClassLoader, Set<IvyGrabRecord>> loadedDeps = new WeakHashMap<ClassLoader, Set<IvyGrabRecord>>()
     // set that stores the IvyGrabRecord(s) for all the dependencies in each grab() call
-    Set<IvyGrabRecord> grabRecordsForCurrDependencies = new LinkedHashSet<IvyGrabRecord>()
+    final Set<IvyGrabRecord> grabRecordsForCurrDependencies = new LinkedHashSet<IvyGrabRecord>()
     // we keep the settings so that addResolver can add to the resolver chain
-    IvySettings settings
+    final IvySettings settings
 
     public GrapeIvy() {
         // if we are already initialized, quit

--- a/src/main/groovy/io/EncodingAwareBufferedWriter.java
+++ b/src/main/groovy/io/EncodingAwareBufferedWriter.java
@@ -29,7 +29,7 @@ import java.nio.charset.Charset;
  */
 
 public class EncodingAwareBufferedWriter extends BufferedWriter {
-    private OutputStreamWriter out;
+    private final OutputStreamWriter out;
     public EncodingAwareBufferedWriter(OutputStreamWriter out) {
         super(out);
         this.out = out;

--- a/src/main/groovy/io/PlatformLineWriter.java
+++ b/src/main/groovy/io/PlatformLineWriter.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * @author Paul King
  */
 public class PlatformLineWriter extends Writer {
-    private BufferedWriter writer;
+    private final BufferedWriter writer;
 
     public PlatformLineWriter(Writer out) {
         writer = new BufferedWriter(out);

--- a/src/main/groovy/lang/ExpandoMetaClass.java
+++ b/src/main/groovy/lang/ExpandoMetaClass.java
@@ -283,18 +283,18 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     private final boolean allowChangesAfterInit;
     public boolean inRegistry;
     
-    final Set<MetaMethod> inheritedMetaMethods = new HashSet<MetaMethod>();
+    private final Set<MetaMethod> inheritedMetaMethods = new HashSet<MetaMethod>();
     private final Map<String, MetaProperty> beanPropertyCache = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
     private final Map<String, MetaProperty> staticBeanPropertyCache = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
-    final Map<MethodKey, MetaMethod> expandoMethods = new ConcurrentHashMap<MethodKey, MetaMethod>(16, 0.75f, 1);
+    private final Map<MethodKey, MetaMethod> expandoMethods = new ConcurrentHashMap<MethodKey, MetaMethod>(16, 0.75f, 1);
 
     public Collection getExpandoSubclassMethods() {
         return expandoSubclassMethods.values();
     }
 
     private final ConcurrentHashMap expandoSubclassMethods = new ConcurrentHashMap(16, 0.75f, 1);
-    final Map<String, MetaProperty> expandoProperties = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
-    ClosureStaticMetaMethod invokeStaticMethodMethod;
+    private final Map<String, MetaProperty> expandoProperties = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
+    private ClosureStaticMetaMethod invokeStaticMethodMethod;
     private final Set<MixinInMetaClass> mixinClasses = new LinkedHashSet<MixinInMetaClass>();
 
     public ExpandoMetaClass(Class theClass, boolean register, boolean allowChangesAfterInit, MetaMethod[] add) {
@@ -932,7 +932,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     }
 
 
-    void performRegistryCallbacks() {
+    private void performRegistryCallbacks() {
         MetaClassRegistry registry = GroovySystem.getMetaClassRegistry();
         incVersion();
         if (!modified) {
@@ -953,7 +953,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
         }
     }
 
-    void registerBeanPropertyForMethod(MetaMethod metaMethod, String propertyName, boolean getter, boolean isStatic) {
+    private void registerBeanPropertyForMethod(MetaMethod metaMethod, String propertyName, boolean getter, boolean isStatic) {
         Map<String, MetaProperty> propertyCache = isStatic ? staticBeanPropertyCache : beanPropertyCache;
         MetaBeanProperty beanProperty = (MetaBeanProperty) propertyCache.get(propertyName);
         if (beanProperty==null) {
@@ -1233,7 +1233,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
      * @param args The arguments
      * @return True if it is a javabean property method
      */
-    boolean isGetter(String name, CachedClass[] args) {
+    private boolean isGetter(String name, CachedClass[] args) {
         if (name == null || name.length() == 0 || args == null) return false;
         if (args.length != 0) return false;
 
@@ -1253,7 +1253,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
      * @param getterName The getter name
      * @return The property name equivalent
      */
-    String getPropertyForGetter(String getterName) {
+    private String getPropertyForGetter(String getterName) {
         if (getterName == null || getterName.length() == 0) return null;
 
         if (getterName.startsWith("get")) {
@@ -1362,7 +1362,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
         }
     }
 
-    class DefiningClosure extends GroovyObjectSupport {
+    private class DefiningClosure extends GroovyObjectSupport {
         boolean definition = true;
 
         public void mixin(Class category) {

--- a/src/main/groovy/lang/ExpandoMetaClass.java
+++ b/src/main/groovy/lang/ExpandoMetaClass.java
@@ -283,18 +283,18 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     private final boolean allowChangesAfterInit;
     public boolean inRegistry;
     
-    private final Set<MetaMethod> inheritedMetaMethods = new HashSet<MetaMethod>();
+    final Set<MetaMethod> inheritedMetaMethods = new HashSet<MetaMethod>();
     private final Map<String, MetaProperty> beanPropertyCache = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
     private final Map<String, MetaProperty> staticBeanPropertyCache = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
-    private final Map<MethodKey, MetaMethod> expandoMethods = new ConcurrentHashMap<MethodKey, MetaMethod>(16, 0.75f, 1);
+    final Map<MethodKey, MetaMethod> expandoMethods = new ConcurrentHashMap<MethodKey, MetaMethod>(16, 0.75f, 1);
 
     public Collection getExpandoSubclassMethods() {
         return expandoSubclassMethods.values();
     }
 
     private final ConcurrentHashMap expandoSubclassMethods = new ConcurrentHashMap(16, 0.75f, 1);
-    private final Map<String, MetaProperty> expandoProperties = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
-    private ClosureStaticMetaMethod invokeStaticMethodMethod;
+    final Map<String, MetaProperty> expandoProperties = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
+    ClosureStaticMetaMethod invokeStaticMethodMethod;
     private final Set<MixinInMetaClass> mixinClasses = new LinkedHashSet<MixinInMetaClass>();
 
     public ExpandoMetaClass(Class theClass, boolean register, boolean allowChangesAfterInit, MetaMethod[] add) {
@@ -932,7 +932,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     }
 
 
-    private void performRegistryCallbacks() {
+    void performRegistryCallbacks() {
         MetaClassRegistry registry = GroovySystem.getMetaClassRegistry();
         incVersion();
         if (!modified) {
@@ -953,7 +953,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
         }
     }
 
-    private void registerBeanPropertyForMethod(MetaMethod metaMethod, String propertyName, boolean getter, boolean isStatic) {
+    void registerBeanPropertyForMethod(MetaMethod metaMethod, String propertyName, boolean getter, boolean isStatic) {
         Map<String, MetaProperty> propertyCache = isStatic ? staticBeanPropertyCache : beanPropertyCache;
         MetaBeanProperty beanProperty = (MetaBeanProperty) propertyCache.get(propertyName);
         if (beanProperty==null) {
@@ -1233,7 +1233,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
      * @param args The arguments
      * @return True if it is a javabean property method
      */
-    private boolean isGetter(String name, CachedClass[] args) {
+    boolean isGetter(String name, CachedClass[] args) {
         if (name == null || name.length() == 0 || args == null) return false;
         if (args.length != 0) return false;
 
@@ -1253,7 +1253,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
      * @param getterName The getter name
      * @return The property name equivalent
      */
-    private String getPropertyForGetter(String getterName) {
+    String getPropertyForGetter(String getterName) {
         if (getterName == null || getterName.length() == 0) return null;
 
         if (getterName.startsWith("get")) {
@@ -1362,7 +1362,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
         }
     }
 
-    private class DefiningClosure extends GroovyObjectSupport {
+    class DefiningClosure extends GroovyObjectSupport {
         boolean definition = true;
 
         public void mixin(Class category) {
@@ -1447,7 +1447,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     }
 
     private static class MixedInAccessor {
-        private final Object object;
+        final Object object;
         private final Set<MixinInMetaClass> mixinClasses;
 
         public MixedInAccessor(Object object, Set<MixinInMetaClass> mixinClasses) {

--- a/src/main/groovy/lang/GString.java
+++ b/src/main/groovy/lang/GString.java
@@ -56,7 +56,7 @@ public abstract class GString extends GroovyObjectSupport implements Comparable,
         }
     };
 
-    private Object[] values;
+    private final Object[] values;
 
     public GString(Object values) {
         this.values = (Object[]) values;

--- a/src/main/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/lang/GroovyClassLoader.java
@@ -73,7 +73,7 @@ public class GroovyClassLoader extends URLClassLoader {
      * to bypass compilation.
      */
     protected final Map<String, Class> sourceCache = new HashMap<String, Class>();
-    private final CompilerConfiguration config;
+    final CompilerConfiguration config;
     private Boolean recompile;
     // use 1000000 as offset to avoid conflicts with names form the GroovyShell
     private static int scriptNameCounter = 1000000;
@@ -473,7 +473,7 @@ public class GroovyClassLoader extends URLClassLoader {
     }
 
     public static class ClassCollector extends CompilationUnit.ClassgenCallback {
-        private Class generatedClass;
+        Class generatedClass;
         private final GroovyClassLoader cl;
         private final SourceUnit su;
         private final CompilationUnit unit;
@@ -858,7 +858,7 @@ public class GroovyClassLoader extends URLClassLoader {
         return null;
     }
 
-    private URL getSourceFile(String name, String extension) {
+    URL getSourceFile(String name, String extension) {
         String filename = name.replace('.', '/') + "." + extension;
         URL ret = getResource(filename);
         if (isFile(ret) && getFileForUrl(ret, filename) == null) return null;
@@ -977,7 +977,7 @@ public class GroovyClassLoader extends URLClassLoader {
     }
 
     private static class TimestampAdder extends CompilationUnit.PrimaryClassNodeOperation implements Opcodes {
-        private final static TimestampAdder INSTANCE = new TimestampAdder();
+        final static TimestampAdder INSTANCE = new TimestampAdder();
 
         private TimestampAdder() {}
 

--- a/src/main/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/lang/GroovyClassLoader.java
@@ -73,7 +73,7 @@ public class GroovyClassLoader extends URLClassLoader {
      * to bypass compilation.
      */
     protected final Map<String, Class> sourceCache = new HashMap<String, Class>();
-    final CompilerConfiguration config;
+    private final CompilerConfiguration config;
     private Boolean recompile;
     // use 1000000 as offset to avoid conflicts with names form the GroovyShell
     private static int scriptNameCounter = 1000000;
@@ -473,7 +473,7 @@ public class GroovyClassLoader extends URLClassLoader {
     }
 
     public static class ClassCollector extends CompilationUnit.ClassgenCallback {
-        Class generatedClass;
+        private Class generatedClass;
         private final GroovyClassLoader cl;
         private final SourceUnit su;
         private final CompilationUnit unit;
@@ -858,7 +858,7 @@ public class GroovyClassLoader extends URLClassLoader {
         return null;
     }
 
-    URL getSourceFile(String name, String extension) {
+    private URL getSourceFile(String name, String extension) {
         String filename = name.replace('.', '/') + "." + extension;
         URL ret = getResource(filename);
         if (isFile(ret) && getFileForUrl(ret, filename) == null) return null;

--- a/src/main/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/lang/GroovyClassLoader.java
@@ -43,7 +43,6 @@ import java.io.*;
 import java.net.*;
 import java.security.*;
 import java.util.*;
-import java.util.regex.Pattern;
 
 /**
  * A ClassLoader which can load Groovy classes. The loaded classes are cached,

--- a/src/main/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/lang/GroovyClassLoader.java
@@ -310,7 +310,7 @@ public class GroovyClassLoader extends URLClassLoader {
         return answer;
     }
 
-    private void validate(GroovyCodeSource codeSource) {
+    private static void validate(GroovyCodeSource codeSource) {
         if (codeSource.getFile() == null) {
             if (codeSource.getScriptText() == null) {
                 throw new IllegalArgumentException("Script text to compile cannot be null!");
@@ -810,7 +810,7 @@ public class GroovyClassLoader extends URLClassLoader {
      * where two scripts were sitting in a directory with spaces in its name.  The code would fail
      * when the class loader tried to resolve the file name and would choke on the URLEncoded space values.
      */
-    private String decodeFileName(String fileName) {
+    private static String decodeFileName(String fileName) {
         String decodedFile = fileName;
         try {
             decodedFile = URLDecoder.decode(fileName, "UTF-8");
@@ -822,11 +822,11 @@ public class GroovyClassLoader extends URLClassLoader {
         return decodedFile;
     }
 
-    private boolean isFile(URL ret) {
+    private static boolean isFile(URL ret) {
         return ret != null && ret.getProtocol().equals("file");
     }
 
-    private File getFileForUrl(URL ret, String filename) {
+    private static File getFileForUrl(URL ret, String filename) {
         String fileWithoutPackage = filename;
         if (fileWithoutPackage.indexOf('/') != -1) {
             int index = fileWithoutPackage.lastIndexOf('/');
@@ -835,7 +835,7 @@ public class GroovyClassLoader extends URLClassLoader {
         return fileReallyExists(ret, fileWithoutPackage);
     }
 
-    private File fileReallyExists(URL ret, String fileWithoutPackage) {
+    private static File fileReallyExists(URL ret, String fileWithoutPackage) {
         File path;
         try {
             /* fix for GROOVY-5809 */ 

--- a/src/main/groovy/lang/GroovyCodeSource.java
+++ b/src/main/groovy/lang/GroovyCodeSource.java
@@ -164,7 +164,7 @@ public class GroovyCodeSource {
         this(uri.toURL());
     }
 
-    public GroovyCodeSource(URL url) throws IOException {
+    public GroovyCodeSource(URL url) {
         if (url == null) {
             throw new RuntimeException("Could not construct a GroovyCodeSource from a null URL");
         }

--- a/src/main/groovy/lang/GroovyCodeSource.java
+++ b/src/main/groovy/lang/GroovyCodeSource.java
@@ -58,7 +58,7 @@ public class GroovyCodeSource {
     /**
      * The groovy source to be compiled and turned into a class
      */
-    String scriptText;
+    private String scriptText;
 
     /**
      * The certificates used to sign the items from the codesource

--- a/src/main/groovy/lang/GroovyCodeSource.java
+++ b/src/main/groovy/lang/GroovyCodeSource.java
@@ -58,7 +58,7 @@ public class GroovyCodeSource {
     /**
      * The groovy source to be compiled and turned into a class
      */
-    private String scriptText;
+    String scriptText;
 
     /**
      * The certificates used to sign the items from the codesource

--- a/src/main/groovy/lang/GroovyShell.java
+++ b/src/main/groovy/lang/GroovyShell.java
@@ -52,7 +52,7 @@ public class GroovyShell extends GroovyObjectSupport {
     private Binding context;
     private int counter;
     private CompilerConfiguration config;
-    private GroovyClassLoader loader;
+    GroovyClassLoader loader;
 
     public static void main(String[] args) {
         GroovyMain.main(args);

--- a/src/main/groovy/lang/GroovyShell.java
+++ b/src/main/groovy/lang/GroovyShell.java
@@ -324,7 +324,7 @@ public class GroovyShell extends GroovyObjectSupport {
         }
     }
 
-    private Object runRunnable(Class scriptClass, String[] args) {
+    private static Object runRunnable(Class scriptClass, String[] args) {
         Constructor constructor = null;
         Runnable runnable = null;
         Throwable reason = null;
@@ -369,7 +369,7 @@ public class GroovyShell extends GroovyObjectSupport {
      *
      * @param scriptClass the class to be run as a unit test
      */
-    private Object runJUnit3Test(Class scriptClass) {
+    private static Object runJUnit3Test(Class scriptClass) {
         try {
             Object testSuite = InvokerHelper.invokeConstructorOf("junit.framework.TestSuite", new Object[]{scriptClass});
             return InvokerHelper.invokeStaticMethod("junit.textui.TestRunner", "run", new Object[]{testSuite});
@@ -386,7 +386,7 @@ public class GroovyShell extends GroovyObjectSupport {
      *
      * @param scriptClass the class to be run as a unit test
      */
-    private Object runJUnit3TestSuite(Class scriptClass) {
+    private static Object runJUnit3TestSuite(Class scriptClass) {
         try {
             Object testSuite = InvokerHelper.invokeStaticMethod(scriptClass, "suite", new Object[]{});
             return InvokerHelper.invokeStaticMethod("junit.textui.TestRunner", "run", new Object[]{testSuite});

--- a/src/main/groovy/lang/GroovyShell.java
+++ b/src/main/groovy/lang/GroovyShell.java
@@ -49,10 +49,11 @@ public class GroovyShell extends GroovyObjectSupport {
 
     public static final String DEFAULT_CODE_BASE = "/groovy/shell";
 
-    private Binding context;
+    private final Binding context;
     private int counter;
-    private CompilerConfiguration config;
-    GroovyClassLoader loader;
+    private final CompilerConfiguration config;
+    // loader must not be final, it is set by AbstractBytecodeTestCase
+    protected GroovyClassLoader loader;
 
     public static void main(String[] args) {
         GroovyMain.main(args);

--- a/src/main/groovy/lang/GroovySystem.java
+++ b/src/main/groovy/lang/GroovySystem.java
@@ -37,10 +37,6 @@ public final class GroovySystem {
     }
     
     /**
-     * The MetaClass for java.lang.Object
-     */
-    private static MetaClass objectMetaClass;
-    /**
      * If true then the MetaClass will only use reflection for method dispatch, property access, etc.
      */
     private static final boolean USE_REFLECTION;

--- a/src/main/groovy/lang/IntRange.java
+++ b/src/main/groovy/lang/IntRange.java
@@ -54,7 +54,7 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer> {
     /**
      * Iterates through each number in an <code>IntRange</code>.
      */
-    class IntRangeIterator implements Iterator<Integer> {
+    private class IntRangeIterator implements Iterator<Integer> {
         /**
          * Counts from 0 up to size - 1.
          */

--- a/src/main/groovy/lang/IntRange.java
+++ b/src/main/groovy/lang/IntRange.java
@@ -54,7 +54,7 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer> {
     /**
      * Iterates through each number in an <code>IntRange</code>.
      */
-    private class IntRangeIterator implements Iterator<Integer> {
+    class IntRangeIterator implements Iterator<Integer> {
         /**
          * Counts from 0 up to size - 1.
          */

--- a/src/main/groovy/lang/ListWithDefault.java
+++ b/src/main/groovy/lang/ListWithDefault.java
@@ -198,7 +198,7 @@ public final class ListWithDefault<T> implements List<T> {
         return (T) initClosure.call(new Object[]{idx});
     }
 
-    private int normaliseIndex(int index, int size) {
+    private static int normaliseIndex(int index, int size) {
         if (index < 0) {
             index += size;
         }

--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -149,7 +149,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     protected MetaMethod invokeMethodMethod;
     protected MetaMethod setPropertyMethod;
     protected MetaClassRegistry registry;
-    private ClassNode classNode;
+    ClassNode classNode;
     private FastArray constructors;
     private boolean initialized;
     private MetaMethod genericGetMethod;
@@ -1649,7 +1649,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     public static final class MetaConstructor extends MetaMethod {
         private final CachedConstructor cc;
         private final boolean beanConstructor;
-        private MetaConstructor(CachedConstructor cc, boolean bean) {
+        MetaConstructor(CachedConstructor cc, boolean bean) {
             super(cc.getNativeParameterTypes());
             this.setParametersTypes(cc.getParameterTypes());
             this.cc = cc;
@@ -3068,7 +3068,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         list.add(method);
     }
 
-    private int findMatchingMethod(CachedMethod[] data, int from, int to, MetaMethod method) {
+    static int findMatchingMethod(CachedMethod[] data, int from, int to, MetaMethod method) {
         for (int j = from; j <= to; ++j) {
             CachedMethod aMethod = data[j];
             CachedClass[] params1 = aMethod.getParameterTypes();
@@ -3687,7 +3687,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return null;
     }
 
-    private abstract class MethodIndexAction {
+    abstract class MethodIndexAction {
         public void iterate() {
             final ComplexKeyHashMap.Entry[] table = metaMethodIndex.methodHeaders.getTable();
             int len = table.length;
@@ -3805,7 +3805,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         metaMethodIndex.clearCaches ();
     }
 
-    private static final SingleKeyHashMap.Copier NAME_INDEX_COPIER = new SingleKeyHashMap.Copier() {
+    static final SingleKeyHashMap.Copier NAME_INDEX_COPIER = new SingleKeyHashMap.Copier() {
         public Object copy(Object value) {
             if (value instanceof FastArray)
               return ((FastArray) value).copy();
@@ -3814,7 +3814,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
     };
 
-    private static final SingleKeyHashMap.Copier METHOD_INDEX_COPIER = new SingleKeyHashMap.Copier() {
+    static final SingleKeyHashMap.Copier METHOD_INDEX_COPIER = new SingleKeyHashMap.Copier() {
         public Object copy(Object value) {
             return SingleKeyHashMap.copy(new SingleKeyHashMap(false), (SingleKeyHashMap) value, NAME_INDEX_COPIER);
         }
@@ -3875,7 +3875,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
     }
 
-    private static class DummyMetaMethod extends MetaMethod {
+    static class DummyMetaMethod extends MetaMethod {
 
         public int getModifiers() {
             return 0;

--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -1269,7 +1269,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return metaClass;
     }
 
-    private Object invokeMethodOnGroovyObject(String methodName, Object[] originalArguments, Object owner) {
+    private static Object invokeMethodOnGroovyObject(String methodName, Object[] originalArguments, Object owner) {
         GroovyObject go = (GroovyObject) owner;
         return go.invokeMethod(methodName, originalArguments);
     }
@@ -1483,7 +1483,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return invokeStaticMissingMethod(sender, methodName, arguments);
     }
 
-    private Object invokeStaticClosureProperty(Object[] originalArguments, Object prop) {
+    private static Object invokeStaticClosureProperty(Object[] originalArguments, Object prop) {
         Closure closure = (Closure) prop;
         MetaClass delegateMetaClass = closure.getMetaClass();
         return delegateMetaClass.invokeMethod(closure.getClass(), closure, CLOSURE_DO_CALL_METHOD, originalArguments, false, false);
@@ -2028,7 +2028,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 
 
 
-    private MetaMethod getCategoryMethodGetter(Class sender, String name, boolean useLongVersion) {
+    private static MetaMethod getCategoryMethodGetter(Class sender, String name, boolean useLongVersion) {
         List possibleGenericMethods = GroovyCategorySupport.getCategoryMethods(name);
         if (possibleGenericMethods != null) {
             for (Iterator iter = possibleGenericMethods.iterator(); iter.hasNext();) {
@@ -2049,7 +2049,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return null;
     }
 
-    private MetaMethod getCategoryMethodSetter(Class sender, String name, boolean useLongVersion) {
+    private static MetaMethod getCategoryMethodSetter(Class sender, String name, boolean useLongVersion) {
         List possibleGenericMethods = GroovyCategorySupport.getCategoryMethods(name);
         if (possibleGenericMethods != null) {
             for (Iterator iter = possibleGenericMethods.iterator(); iter.hasNext();) {
@@ -2117,7 +2117,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
      * return null if nothing valid has been found, a MetaMethod (for getter always the case if not null) or
      * a LinkedList&lt;MetaMethod&gt; if there are multiple setter
      */
-    private Object filterPropertyMethod(Object methodOrList, boolean isGetter, boolean booleanGetter) {
+    private static Object filterPropertyMethod(Object methodOrList, boolean isGetter, boolean booleanGetter) {
         // Method has been optimized to reach a target of 325 bytecode size, making it JIT'able
         Object ret = null;
 
@@ -2183,7 +2183,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return method;
     }
 
-    private Object addElementToList(Object ret, MetaMethod element) {
+    private static Object addElementToList(Object ret, MetaMethod element) {
         if (ret == null)
             ret = element;
         else if (ret instanceof List)
@@ -2293,7 +2293,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 
     }
 
-    private MetaProperty establishStaticMetaProperty(MetaProperty mp) {
+    private static MetaProperty establishStaticMetaProperty(MetaProperty mp) {
         MetaBeanProperty mbp = (MetaBeanProperty) mp;
         MetaProperty result = null;
         final MetaMethod getterMethod = mbp.getGetter();
@@ -2372,14 +2372,14 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
     }
 
-    private void addFields(final CachedClass klass, SingleKeyHashMap propertyIndex) {
+    private static void addFields(final CachedClass klass, SingleKeyHashMap propertyIndex) {
         CachedField[] fields = klass.getFields();
         for (CachedField field : fields) {
             propertyIndex.put(field.getName(), field);
         }
     }
 
-    private void copyNonPrivateFields(SingleKeyHashMap from, SingleKeyHashMap to) {
+    private static void copyNonPrivateFields(SingleKeyHashMap from, SingleKeyHashMap to) {
         for (ComplexKeyHashMap.EntryIterator iter = from.getEntrySetIterator(); iter.hasNext();) {
             SingleKeyHashMap.Entry entry = (SingleKeyHashMap.Entry) iter.next();
             CachedField mfp = (CachedField) entry.getValue();
@@ -2422,7 +2422,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 
     private static final ConcurrentMap<String, String> PROP_NAMES = new ConcurrentHashMap<String, String>(1024);
 
-    private String getPropName(String methodName) {
+    private static String getPropName(String methodName) {
         String name = PROP_NAMES.get(methodName);
         if (name == null) {
             // assume "is" or "[gs]et"
@@ -2434,7 +2434,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return name;
     }
 
-    private MetaProperty makeReplacementMetaProperty(MetaProperty mp, String propName, boolean isGetter, MetaMethod propertyMethod) {
+    private static MetaProperty makeReplacementMetaProperty(MetaProperty mp, String propName, boolean isGetter, MetaMethod propertyMethod) {
         if (mp == null) {
             if (isGetter) {
                 return new MetaBeanProperty(propName,
@@ -2482,7 +2482,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 
     }
 
-    private void createMetaBeanProperty(SingleKeyHashMap propertyIndex, String propName, boolean isGetter, MetaMethod propertyMethod) {
+    private static void createMetaBeanProperty(SingleKeyHashMap propertyIndex, String propName, boolean isGetter, MetaMethod propertyMethod) {
         // is this property already accounted for?
         MetaProperty mp = (MetaProperty) propertyIndex.get(propName);
         MetaProperty newMp = makeReplacementMetaProperty(mp, propName, isGetter, propertyMethod);
@@ -2721,7 +2721,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         invokeMissingProperty(object, name, newValue, false);
     }
 
-    private boolean isPrivateOrPkgPrivate(int mod) {
+    private static boolean isPrivateOrPkgPrivate(int mod) {
         return !Modifier.isProtected(mod) && !Modifier.isPublic(mod);
     }
 
@@ -2970,15 +2970,15 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
     }
 
-    private boolean isSetPropertyMethod(MetaMethod metaMethod) {
+    private static boolean isSetPropertyMethod(MetaMethod metaMethod) {
         return SET_PROPERTY_METHOD.equals(metaMethod.getName())  && metaMethod.getParameterTypes().length == 2;
     }
 
-    private boolean isGetPropertyMethod(MetaMethod metaMethod) {
+    private static boolean isGetPropertyMethod(MetaMethod metaMethod) {
         return GET_PROPERTY_METHOD.equals(metaMethod.getName());
     }
 
-    private boolean isInvokeMethod(MetaMethod metaMethod) {
+    private static boolean isInvokeMethod(MetaMethod metaMethod) {
         return INVOKE_METHOD_METHOD.equals(metaMethod.getName()) && metaMethod.getParameterTypes().length == 2;
     }
 
@@ -3025,7 +3025,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
      *        null:  ignore method
      *        true:  replace
      */
-    private Boolean getMatchKindForCategory(MetaMethod aMethod, MetaMethod categoryMethod) {
+    private static Boolean getMatchKindForCategory(MetaMethod aMethod, MetaMethod categoryMethod) {
         CachedClass[] params1 = aMethod.getParameterTypes();
         CachedClass[] params2 = categoryMethod.getParameterTypes();
         if (params1.length != params2.length) return Boolean.FALSE;
@@ -3043,7 +3043,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return null;
     }
 
-    private void filterMatchingMethodForCategory(FastArray list, MetaMethod method) {
+    private static void filterMatchingMethodForCategory(FastArray list, MetaMethod method) {
         int len = list.size();
         if (len==0) {
             list.add(method);
@@ -3235,7 +3235,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         throw new GroovyRuntimeException(msg.toString());
     }
 
-    private boolean isGenericGetMethod(MetaMethod method) {
+    private static boolean isGenericGetMethod(MetaMethod method) {
         if (method.getName().equals("get")) {
             CachedClass[] parameterTypes = method.getParameterTypes();
             return parameterTypes.length == 1 && parameterTypes[0].getTheClass() == String.class;
@@ -3315,7 +3315,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
     }
 
-    private boolean isBeanDerivative(Class theClass) {
+    private static boolean isBeanDerivative(Class theClass) {
         Class next = theClass;
         while (next != null) {
             if (Arrays.asList(next.getInterfaces()).contains(BeanInfo.class)) return true;
@@ -3525,7 +3525,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return property;
     }
 
-    private MetaBeanProperty getMetaPropertyFromMutableMetaClass(String propertyName, MetaClass metaClass) {
+    private static MetaBeanProperty getMetaPropertyFromMutableMetaClass(String propertyName, MetaClass metaClass) {
         final boolean isModified = ((MutableMetaClass) metaClass).isModified();
         if (isModified) {
             final MetaProperty metaProperty = metaClass.getMetaProperty(propertyName);

--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -2893,7 +2893,6 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
                         }
                     };
 
-                    final ClassLoader parent = theClass.getClassLoader();
                     CompilationUnit unit = new CompilationUnit();
                     unit.setClassgenCallback(search);
                     unit.addSource(url);
@@ -3271,7 +3270,6 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 
     private void addProperties() {
         BeanInfo info;
-        final Class stopClass;
         //     introspect
         try {
             if (isBeanDerivative(theClass)) {

--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -149,7 +149,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     protected MetaMethod invokeMethodMethod;
     protected MetaMethod setPropertyMethod;
     protected MetaClassRegistry registry;
-    ClassNode classNode;
+    private ClassNode classNode;
     private FastArray constructors;
     private boolean initialized;
     private MetaMethod genericGetMethod;
@@ -1649,7 +1649,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     public static final class MetaConstructor extends MetaMethod {
         private final CachedConstructor cc;
         private final boolean beanConstructor;
-        MetaConstructor(CachedConstructor cc, boolean bean) {
+        private MetaConstructor(CachedConstructor cc, boolean bean) {
             super(cc.getNativeParameterTypes());
             this.setParametersTypes(cc.getParameterTypes());
             this.cc = cc;
@@ -3068,7 +3068,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         list.add(method);
     }
 
-    static int findMatchingMethod(CachedMethod[] data, int from, int to, MetaMethod method) {
+    private int findMatchingMethod(CachedMethod[] data, int from, int to, MetaMethod method) {
         for (int j = from; j <= to; ++j) {
             CachedMethod aMethod = data[j];
             CachedClass[] params1 = aMethod.getParameterTypes();
@@ -3687,7 +3687,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         return null;
     }
 
-    abstract class MethodIndexAction {
+    private abstract class MethodIndexAction {
         public void iterate() {
             final ComplexKeyHashMap.Entry[] table = metaMethodIndex.methodHeaders.getTable();
             int len = table.length;
@@ -3805,7 +3805,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         metaMethodIndex.clearCaches ();
     }
 
-    static final SingleKeyHashMap.Copier NAME_INDEX_COPIER = new SingleKeyHashMap.Copier() {
+    private static final SingleKeyHashMap.Copier NAME_INDEX_COPIER = new SingleKeyHashMap.Copier() {
         public Object copy(Object value) {
             if (value instanceof FastArray)
               return ((FastArray) value).copy();
@@ -3814,7 +3814,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
     };
 
-    static final SingleKeyHashMap.Copier METHOD_INDEX_COPIER = new SingleKeyHashMap.Copier() {
+    private static final SingleKeyHashMap.Copier METHOD_INDEX_COPIER = new SingleKeyHashMap.Copier() {
         public Object copy(Object value) {
             return SingleKeyHashMap.copy(new SingleKeyHashMap(false), (SingleKeyHashMap) value, NAME_INDEX_COPIER);
         }
@@ -3875,7 +3875,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
     }
 
-    static class DummyMetaMethod extends MetaMethod {
+    private static class DummyMetaMethod extends MetaMethod {
 
         public int getModifiers() {
             return 0;

--- a/src/main/groovy/lang/ObjectRange.java
+++ b/src/main/groovy/lang/ObjectRange.java
@@ -42,12 +42,12 @@ public class ObjectRange extends AbstractList implements Range {
     /**
      * The first value in the range.
      */
-    final Comparable from;
+    private final Comparable from;
 
     /**
      * The last value in the range.
      */
-    final Comparable to;
+    private final Comparable to;
 
     /**
      * The cached size, or -1 if not yet computed
@@ -57,7 +57,7 @@ public class ObjectRange extends AbstractList implements Range {
     /**
      * <code>true</code> if the range counts backwards from <code>to</code> to <code>from</code>.
      */
-    final boolean reverse;
+    private final boolean reverse;
 
     /**
      * Creates a new {@link ObjectRange}. Creates a reversed range if

--- a/src/main/groovy/lang/ObjectRange.java
+++ b/src/main/groovy/lang/ObjectRange.java
@@ -42,12 +42,12 @@ public class ObjectRange extends AbstractList implements Range {
     /**
      * The first value in the range.
      */
-    private final Comparable from;
+    final Comparable from;
 
     /**
      * The last value in the range.
      */
-    private final Comparable to;
+    final Comparable to;
 
     /**
      * The cached size, or -1 if not yet computed
@@ -57,7 +57,7 @@ public class ObjectRange extends AbstractList implements Range {
     /**
      * <code>true</code> if the range counts backwards from <code>to</code> to <code>from</code>.
      */
-    private final boolean reverse;
+    final boolean reverse;
 
     /**
      * Creates a new {@link ObjectRange}. Creates a reversed range if

--- a/src/main/groovy/lang/ObjectRange.java
+++ b/src/main/groovy/lang/ObjectRange.java
@@ -270,7 +270,8 @@ public class ObjectRange extends AbstractList implements Range {
     /**
      * protection against calls from Groovy
      */
-    private void setSize(int size) {
+    @Deprecated
+    void setSize(int size) {
         throw new UnsupportedOperationException("size must not be changed");
     }
 

--- a/src/main/groovy/lang/ParameterArray.java
+++ b/src/main/groovy/lang/ParameterArray.java
@@ -25,7 +25,7 @@ package groovy.lang;
  */
 public class ParameterArray {
 
-    private Object parameters;
+    private final Object parameters;
 
     public ParameterArray(Object data) {
         parameters = packArray(data);

--- a/src/main/groovy/lang/ParameterArray.java
+++ b/src/main/groovy/lang/ParameterArray.java
@@ -31,7 +31,7 @@ public class ParameterArray {
         parameters = packArray(data);
     }
 
-    private Object packArray(Object object) {
+    private static Object packArray(Object object) {
         if (object instanceof Object[])
             return (Object[]) object;
         else

--- a/src/main/groovy/lang/PropertyValue.java
+++ b/src/main/groovy/lang/PropertyValue.java
@@ -20,10 +20,10 @@ package groovy.lang;
 
 public class PropertyValue {
     // the owner of the property
-    private Object bean;
+    private final Object bean;
 
     // the description of the property
-    private MetaProperty mp;
+    private final MetaProperty mp;
 
     public PropertyValue(Object bean, MetaProperty mp) {
         this.bean = bean;

--- a/src/main/groovy/lang/ProxyMetaClass.java
+++ b/src/main/groovy/lang/ProxyMetaClass.java
@@ -18,8 +18,6 @@
  */
 package groovy.lang;
 
-import java.beans.IntrospectionException;
-
 /**
  * As subclass of MetaClass, ProxyMetaClass manages calls from Groovy Objects to POJOs.
  * It enriches MetaClass with the feature of making method invokations interceptable by
@@ -44,7 +42,7 @@ public class ProxyMetaClass extends MetaClassImpl implements AdaptingMetaClass {
     /**
      * convenience factory method for the most usual case.
      */
-    public static ProxyMetaClass getInstance(Class theClass) throws IntrospectionException {
+    public static ProxyMetaClass getInstance(Class theClass) {
         MetaClassRegistry metaRegistry = GroovySystem.getMetaClassRegistry();
         MetaClass meta = metaRegistry.getMetaClass(theClass);
         return new ProxyMetaClass(metaRegistry, theClass, meta);
@@ -53,7 +51,7 @@ public class ProxyMetaClass extends MetaClassImpl implements AdaptingMetaClass {
     /**
      * @param adaptee the MetaClass to decorate with interceptability
      */
-    public ProxyMetaClass(MetaClassRegistry registry, Class theClass, MetaClass adaptee) throws IntrospectionException {
+    public ProxyMetaClass(MetaClassRegistry registry, Class theClass, MetaClass adaptee) {
         super(registry, theClass);
         this.adaptee = adaptee;
         if (null == adaptee) throw new IllegalArgumentException("adaptee must not be null");

--- a/src/main/groovy/lang/Sequence.java
+++ b/src/main/groovy/lang/Sequence.java
@@ -36,7 +36,7 @@ import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 public class Sequence extends ArrayList implements GroovyObject {
 
     private MetaClass metaClass = InvokerHelper.getMetaClass(getClass());
-    private Class type;
+    private final Class type;
     private int hashCode;
 
     public Sequence() {

--- a/src/main/groovy/transform/builder/DefaultStrategy.java
+++ b/src/main/groovy/transform/builder/DefaultStrategy.java
@@ -55,7 +55,6 @@ import static org.codehaus.groovy.ast.tools.GenericsUtils.createGenericsSpec;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.extractSuperClassGenerics;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.newClass;
 import static org.codehaus.groovy.transform.AbstractASTTransformation.getMemberStringValue;
-import static org.codehaus.groovy.transform.AbstractASTTransformation.shouldSkip;
 import static org.codehaus.groovy.transform.AbstractASTTransformation.shouldSkipUndefinedAware;
 import static org.codehaus.groovy.transform.BuilderASTTransformation.NO_EXCEPTIONS;
 import static org.codehaus.groovy.transform.BuilderASTTransformation.NO_PARAMS;

--- a/src/main/groovy/transform/builder/DefaultStrategy.java
+++ b/src/main/groovy/transform/builder/DefaultStrategy.java
@@ -212,31 +212,31 @@ public class DefaultStrategy extends BuilderASTTransformation.AbstractBuilderStr
         builder.addMethod(createBuildMethod(anno, buildee, filteredFields));
     }
 
-    private ClassNode getCorrectedType(ClassNode buildee, FieldNode fieldNode) {
+    private static ClassNode getCorrectedType(ClassNode buildee, FieldNode fieldNode) {
         Map<String,ClassNode> genericsSpec = createGenericsSpec(fieldNode.getDeclaringClass());
         extractSuperClassGenerics(fieldNode.getType(), buildee, genericsSpec);
         return correctToGenericsSpecRecurse(genericsSpec, fieldNode.getType());
     }
 
-    private void createBuilderFactoryMethod(AnnotationNode anno, ClassNode buildee, ClassNode builder) {
+    private static void createBuilderFactoryMethod(AnnotationNode anno, ClassNode buildee, ClassNode builder) {
         buildee.getModule().addClass(builder);
         buildee.addMethod(createBuilderMethod(anno, builder));
     }
 
-    private ClassNode createBuilder(AnnotationNode anno, ClassNode buildee) {
+    private static ClassNode createBuilder(AnnotationNode anno, ClassNode buildee) {
         return new InnerClassNode(buildee, getFullName(anno, buildee), PUBLIC_STATIC, OBJECT_TYPE);
     }
 
-    private String getFullName(AnnotationNode anno, ClassNode buildee) {
+    private static String getFullName(AnnotationNode anno, ClassNode buildee) {
         String builderClassName = getMemberStringValue(anno, "builderClassName", buildee.getNameWithoutPackage() + "Builder");
         return buildee.getName() + "$" + builderClassName;
     }
 
-    private String getPrefix(AnnotationNode anno) {
+    private static String getPrefix(AnnotationNode anno) {
         return getMemberStringValue(anno, "prefix", "");
     }
 
-    private MethodNode createBuildMethodForMethod(AnnotationNode anno, ClassNode buildee, MethodNode mNode, Parameter[] params) {
+    private static MethodNode createBuildMethodForMethod(AnnotationNode anno, ClassNode buildee, MethodNode mNode, Parameter[] params) {
         String buildMethodName = getMemberStringValue(anno, "buildMethodName", "build");
         final BlockStatement body = new BlockStatement();
         ClassNode returnType;

--- a/src/main/groovy/transform/builder/InitializerStrategy.java
+++ b/src/main/groovy/transform/builder/InitializerStrategy.java
@@ -191,11 +191,11 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
         }
     }
 
-    private String getBuilderClassName(ClassNode buildee, AnnotationNode anno) {
+    private static String getBuilderClassName(ClassNode buildee, AnnotationNode anno) {
         return getMemberStringValue(anno, "builderClassName", buildee.getNameWithoutPackage() + "Initializer");
     }
 
-    private void addFields(ClassNode buildee, List<FieldNode> filteredFields, ClassNode builder) {
+    private static void addFields(ClassNode buildee, List<FieldNode> filteredFields, ClassNode builder) {
         for (FieldNode filteredField : filteredFields) {
             builder.addField(createFieldCopy(buildee, filteredField));
         }
@@ -214,7 +214,7 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
         builder.addMethod(createBuildMethod(builder, buildMethodName, fieldNodes));
     }
 
-    private List<FieldNode> convertParamsToFields(ClassNode builder, Parameter[] parameters) {
+    private static List<FieldNode> convertParamsToFields(ClassNode builder, Parameter[] parameters) {
         List<FieldNode> fieldNodes = new ArrayList<FieldNode>();
         for(Parameter parameter: parameters) {
             Map<String,ClassNode> genericsSpec = createGenericsSpec(builder);
@@ -226,7 +226,7 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
         return fieldNodes;
     }
 
-    private ClassNode createInnerHelperClass(ClassNode buildee, String builderClassName, int fieldsSize) {
+    private static ClassNode createInnerHelperClass(ClassNode buildee, String builderClassName, int fieldsSize) {
         final String fullName = buildee.getName() + "$" + builderClassName;
         ClassNode builder = new InnerClassNode(buildee, fullName, PUBLIC_STATIC, OBJECT_TYPE);
         GenericsType[] gtypes = new GenericsType[fieldsSize];
@@ -346,7 +346,7 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
         ));
     }
 
-    private GenericsType makePlaceholder(int i) {
+    private static GenericsType makePlaceholder(int i) {
         ClassNode type = ClassHelper.makeWithoutCaching("T" + i);
         type.setRedirect(OBJECT_TYPE);
         type.setGenericsPlaceHolder(true);

--- a/src/main/groovy/transform/stc/FromAbstractTypeMethods.java
+++ b/src/main/groovy/transform/stc/FromAbstractTypeMethods.java
@@ -45,7 +45,7 @@ public class FromAbstractTypeMethods extends ClosureSignatureHint {
         return extractSignaturesFromMethods(cn);
     }
 
-    private List<ClassNode[]> extractSignaturesFromMethods(final ClassNode cn) {
+    private static List<ClassNode[]> extractSignaturesFromMethods(final ClassNode cn) {
         List<MethodNode> methods = cn.getAllDeclaredMethods();
         List<ClassNode[]> signatures = new LinkedList<ClassNode[]>();
         for (MethodNode method : methods) {
@@ -56,7 +56,7 @@ public class FromAbstractTypeMethods extends ClosureSignatureHint {
         return signatures;
     }
 
-    private void extractParametersFromMethod(final List<ClassNode[]> signatures, final MethodNode method) {
+    private static void extractParametersFromMethod(final List<ClassNode[]> signatures, final MethodNode method) {
         if (Traits.hasDefaultImplementation(method)) return;
         Parameter[] parameters = method.getParameters();
         ClassNode[] typeParams = new ClassNode[parameters.length];

--- a/src/main/groovy/ui/GroovySocketServer.java
+++ b/src/main/groovy/ui/GroovySocketServer.java
@@ -65,9 +65,9 @@ import java.util.regex.Pattern;
  */
 public class GroovySocketServer implements Runnable {
     private URL url;
-    private GroovyShell groovy;
-    private GroovyCodeSource source;
-    private boolean autoOutput;
+    private final GroovyShell groovy;
+    private final GroovyCodeSource source;
+    private final boolean autoOutput;
     private static int counter;
 
     /**

--- a/src/main/groovy/util/CharsetToolkit.java
+++ b/src/main/groovy/util/CharsetToolkit.java
@@ -52,7 +52,7 @@ import java.util.Collection;
  * @author Guillaume Laforge
  */
 public class CharsetToolkit {
-    private byte[] buffer;
+    private final byte[] buffer;
     private Charset defaultCharset;
     private Charset charset;
     private boolean enforce8Bit = true;

--- a/src/main/groovy/util/ClosureComparator.java
+++ b/src/main/groovy/util/ClosureComparator.java
@@ -29,7 +29,7 @@ import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
  */
 public class ClosureComparator<T> implements Comparator<T> {
 
-	final Closure closure;
+    final Closure closure;
 
     public ClosureComparator(Closure closure) {
         this.closure = closure;

--- a/src/main/groovy/util/ClosureComparator.java
+++ b/src/main/groovy/util/ClosureComparator.java
@@ -29,7 +29,7 @@ import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
  */
 public class ClosureComparator<T> implements Comparator<T> {
 
-    Closure closure;
+	final Closure closure;
 
     public ClosureComparator(Closure closure) {
         this.closure = closure;

--- a/src/main/groovy/util/ConfigObject.java
+++ b/src/main/groovy/util/ConfigObject.java
@@ -255,7 +255,7 @@ public class ConfigObject extends GroovyObjectSupport implements Writable, Map, 
         }
     }
 
-    private void writeValue(String key, String space, String prefix, Object value, BufferedWriter out) throws IOException {
+    private static void writeValue(String key, String space, String prefix, Object value, BufferedWriter out) throws IOException {
 //        key = key.indexOf('.') > -1 ? InvokerHelper.inspect(key) : key;
         boolean isKeyword = KEYWORDS.contains(key);
         key = isKeyword ? InvokerHelper.inspect(key) : key;
@@ -274,7 +274,7 @@ public class ConfigObject extends GroovyObjectSupport implements Writable, Map, 
         out.newLine();
     }
 
-    private Properties convertValuesToString(Map props) {
+    private static Properties convertValuesToString(Map props) {
         Properties newProps = new Properties();
 
         for (Object o : props.entrySet()) {

--- a/src/main/groovy/util/FactoryBuilderSupport.java
+++ b/src/main/groovy/util/FactoryBuilderSupport.java
@@ -131,12 +131,12 @@ public abstract class FactoryBuilderSupport extends Binding {
         }
     }
 
-    private ThreadLocal<LinkedList<Map<String, Object>>> contexts = new ThreadLocal<LinkedList<Map<String, Object>>>();
+    private final ThreadLocal<LinkedList<Map<String, Object>>> contexts = new ThreadLocal<LinkedList<Map<String, Object>>>();
     protected LinkedList<Closure> attributeDelegates = new LinkedList<Closure>(); //
-    private List<Closure> disposalClosures = new ArrayList<Closure>(); // because of reverse iteration use ArrayList
-    private Map<String, Factory> factories = new HashMap<String, Factory>();
+    private final List<Closure> disposalClosures = new ArrayList<Closure>(); // because of reverse iteration use ArrayList
+    private final Map<String, Factory> factories = new HashMap<String, Factory>();
     private Closure nameMappingClosure;
-    private ThreadLocal<FactoryBuilderSupport> localProxyBuilder = new ThreadLocal<FactoryBuilderSupport>();
+    private final ThreadLocal<FactoryBuilderSupport> localProxyBuilder = new ThreadLocal<FactoryBuilderSupport>();
     private FactoryBuilderSupport globalProxyBuilder;
     protected LinkedList<Closure> preInstantiateDelegates = new LinkedList<Closure>();
     protected LinkedList<Closure> postInstantiateDelegates = new LinkedList<Closure>();

--- a/src/main/groovy/util/GroovyScriptEngine.java
+++ b/src/main/groovy/util/GroovyScriptEngine.java
@@ -77,8 +77,8 @@ public class GroovyScriptEngine implements ResourceConnector {
 
     static class LocalData {
         CompilationUnit cu;
-        StringSetMap dependencyCache = new StringSetMap();
-        Map<String, String> precompiledEntries = new HashMap<String, String>();
+        final StringSetMap dependencyCache = new StringSetMap();
+        final Map<String, String> precompiledEntries = new HashMap<String, String>();
     }
 
     private static WeakReference<ThreadLocal<LocalData>> localData = new WeakReference<ThreadLocal<LocalData>>(null);
@@ -91,8 +91,8 @@ public class GroovyScriptEngine implements ResourceConnector {
         return local;
     }
 
-    private URL[] roots;
-    ResourceConnector rc;
+    private final URL[] roots;
+    final ResourceConnector rc;
     final ClassLoader parentLoader;
     private final GroovyClassLoader groovyLoader;
     final Map<String, ScriptCacheEntry> scriptCache = new ConcurrentHashMap<String, ScriptCacheEntry>();

--- a/src/main/groovy/util/GroovyScriptEngine.java
+++ b/src/main/groovy/util/GroovyScriptEngine.java
@@ -109,7 +109,7 @@ public class GroovyScriptEngine implements ResourceConnector {
     private static class ScriptCacheEntry {
         final Class scriptClass;
         final long lastModified;
-		final long lastCheck;
+        final long lastCheck;
         final Set<String> dependencies;
         final boolean sourceNewer;
 

--- a/src/main/groovy/util/GroovyScriptEngine.java
+++ b/src/main/groovy/util/GroovyScriptEngine.java
@@ -75,7 +75,7 @@ public class GroovyScriptEngine implements ResourceConnector {
     };
     private static final URL[] EMPTY_URL_ARRAY = new URL[0];
 
-    private static class LocalData {
+    static class LocalData {
         CompilationUnit cu;
         StringSetMap dependencyCache = new StringSetMap();
         Map<String, String> precompiledEntries = new HashMap<String, String>();
@@ -83,7 +83,7 @@ public class GroovyScriptEngine implements ResourceConnector {
 
     private static WeakReference<ThreadLocal<LocalData>> localData = new WeakReference<ThreadLocal<LocalData>>(null);
 
-    private static synchronized ThreadLocal<LocalData> getLocalData() {
+    static synchronized ThreadLocal<LocalData> getLocalData() {
         ThreadLocal<LocalData> local = localData.get();
         if (local != null) return local;
         local = new ThreadLocal<LocalData>();
@@ -92,11 +92,11 @@ public class GroovyScriptEngine implements ResourceConnector {
     }
 
     private URL[] roots;
-    private ResourceConnector rc;
-    private final ClassLoader parentLoader;
+    ResourceConnector rc;
+    final ClassLoader parentLoader;
     private final GroovyClassLoader groovyLoader;
-    private final Map<String, ScriptCacheEntry> scriptCache = new ConcurrentHashMap<String, ScriptCacheEntry>();
-    private CompilerConfiguration config;
+    final Map<String, ScriptCacheEntry> scriptCache = new ConcurrentHashMap<String, ScriptCacheEntry>();
+    CompilerConfiguration config;
 
     {
         config = new CompilerConfiguration(CompilerConfiguration.DEFAULT);
@@ -107,10 +107,11 @@ public class GroovyScriptEngine implements ResourceConnector {
     //TODO: more finals?
 
     private static class ScriptCacheEntry {
-        private final Class scriptClass;
-        private final long lastModified, lastCheck;
-        private final Set<String> dependencies;
-        private final boolean sourceNewer;
+        final Class scriptClass;
+        final long lastModified;
+		final long lastCheck;
+        final Set<String> dependencies;
+        final boolean sourceNewer;
 
         public ScriptCacheEntry(Class clazz, long modified, long lastCheck, Set<String> depend, boolean sourceNewer) {
             this.scriptClass = clazz;
@@ -440,7 +441,7 @@ public class GroovyScriptEngine implements ResourceConnector {
      *
      * @param urlConnection the {@link URLConnection} to be "closed" to close the underlying file descriptors.
      */
-    private static void forceClose(URLConnection urlConnection) {
+    static void forceClose(URLConnection urlConnection) {
         if (urlConnection != null) {
             // We need to get the input stream and close it to force the open
             // file descriptor to be released. Otherwise, we will reach the limit
@@ -616,7 +617,7 @@ public class GroovyScriptEngine implements ResourceConnector {
         return InvokerHelper.createScript(loadScriptByName(scriptName), binding);
     }
 
-    private long getLastModified(String scriptName) throws ResourceException {
+    long getLastModified(String scriptName) throws ResourceException {
         URLConnection conn = rc.getResourceConnection(scriptName);
         long lastMod = 0;
         try {

--- a/src/main/groovy/util/GroovyScriptEngine.java
+++ b/src/main/groovy/util/GroovyScriptEngine.java
@@ -75,7 +75,7 @@ public class GroovyScriptEngine implements ResourceConnector {
     };
     private static final URL[] EMPTY_URL_ARRAY = new URL[0];
 
-    static class LocalData {
+    private static class LocalData {
         CompilationUnit cu;
         final StringSetMap dependencyCache = new StringSetMap();
         final Map<String, String> precompiledEntries = new HashMap<String, String>();
@@ -83,7 +83,7 @@ public class GroovyScriptEngine implements ResourceConnector {
 
     private static WeakReference<ThreadLocal<LocalData>> localData = new WeakReference<ThreadLocal<LocalData>>(null);
 
-    static synchronized ThreadLocal<LocalData> getLocalData() {
+    private static synchronized ThreadLocal<LocalData> getLocalData() {
         ThreadLocal<LocalData> local = localData.get();
         if (local != null) return local;
         local = new ThreadLocal<LocalData>();
@@ -92,11 +92,11 @@ public class GroovyScriptEngine implements ResourceConnector {
     }
 
     private final URL[] roots;
-    final ResourceConnector rc;
-    final ClassLoader parentLoader;
+    private final ResourceConnector rc;
+    private final ClassLoader parentLoader;
     private final GroovyClassLoader groovyLoader;
-    final Map<String, ScriptCacheEntry> scriptCache = new ConcurrentHashMap<String, ScriptCacheEntry>();
-    CompilerConfiguration config;
+    private final Map<String, ScriptCacheEntry> scriptCache = new ConcurrentHashMap<String, ScriptCacheEntry>();
+    private CompilerConfiguration config;
 
     {
         config = new CompilerConfiguration(CompilerConfiguration.DEFAULT);
@@ -441,7 +441,7 @@ public class GroovyScriptEngine implements ResourceConnector {
      *
      * @param urlConnection the {@link URLConnection} to be "closed" to close the underlying file descriptors.
      */
-    static void forceClose(URLConnection urlConnection) {
+    private static void forceClose(URLConnection urlConnection) {
         if (urlConnection != null) {
             // We need to get the input stream and close it to force the open
             // file descriptor to be released. Otherwise, we will reach the limit
@@ -617,7 +617,7 @@ public class GroovyScriptEngine implements ResourceConnector {
         return InvokerHelper.createScript(loadScriptByName(scriptName), binding);
     }
 
-    long getLastModified(String scriptName) throws ResourceException {
+    private long getLastModified(String scriptName) throws ResourceException {
         URLConnection conn = rc.getResourceConnection(scriptName);
         long lastMod = 0;
         try {

--- a/src/main/groovy/util/IndentPrinter.java
+++ b/src/main/groovy/util/IndentPrinter.java
@@ -63,8 +63,8 @@ import java.io.Writer;
 public class IndentPrinter {
 
     private int indentLevel;
-    private String indent;
-    private Writer out;
+    private final String indent;
+    private final Writer out;
     private final boolean addNewlines;
     private boolean autoIndent;
 

--- a/src/main/groovy/util/Node.java
+++ b/src/main/groovy/util/Node.java
@@ -140,7 +140,7 @@ public class Node implements Serializable, Cloneable {
         }
     }
 
-    private List getParentList(Node parent) {
+    private static List getParentList(Node parent) {
         Object parentValue = parent.value();
         List parentList;
         if (parentValue instanceof List) {
@@ -281,7 +281,7 @@ public class Node implements Serializable, Cloneable {
         parent().children().addAll(tail);
     }
 
-    private List<Node> buildChildrenFromClosure(Closure c) {
+    private static List<Node> buildChildrenFromClosure(Closure c) {
         NodeBuilder b = new NodeBuilder();
         Node newNode = (Node) b.invokeMethod("dummyNode", c);
         return newNode.children();

--- a/src/main/groovy/util/Node.java
+++ b/src/main/groovy/util/Node.java
@@ -61,9 +61,9 @@ public class Node implements Serializable, Cloneable {
 
     private Node parent;
 
-    private Object name;
+    private final Object name;
 
-    private Map attributes;
+    private final Map attributes;
 
     private Object value;
 

--- a/src/main/groovy/util/ObjectGraphBuilder.java
+++ b/src/main/groovy/util/ObjectGraphBuilder.java
@@ -59,15 +59,15 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
     ClassNameResolver classNameResolver;
     IdentifierResolver identifierResolver;
     NewInstanceResolver newInstanceResolver;
-    private ObjectFactory objectFactory = new ObjectFactory();
-    private ObjectBeanFactory objectBeanFactory = new ObjectBeanFactory();
-    private ObjectRefFactory objectRefFactory = new ObjectRefFactory();
+    private final ObjectFactory objectFactory = new ObjectFactory();
+    private final ObjectBeanFactory objectBeanFactory = new ObjectBeanFactory();
+    private final ObjectRefFactory objectRefFactory = new ObjectRefFactory();
     ReferenceResolver referenceResolver;
     RelationNameResolver relationNameResolver;
-    Map<String, Class> resolvedClasses = new HashMap<String, Class>();
+    final Map<String, Class> resolvedClasses = new HashMap<String, Class>();
     ClassLoader classLoader;
     private boolean lazyReferencesAllowed = true;
-    List<NodeReference> lazyReferences = new ArrayList<NodeReference>();
+    final List<NodeReference> lazyReferences = new ArrayList<NodeReference>();
     private String beanFactoryName = "bean";
 
     public ObjectGraphBuilder() {

--- a/src/main/groovy/util/ObjectGraphBuilder.java
+++ b/src/main/groovy/util/ObjectGraphBuilder.java
@@ -633,7 +633,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
         }
 
         protected Class resolveClass(FactoryBuilderSupport builder, String classname, Object name, Object value,
-                                  Map properties) throws InstantiationException, IllegalAccessException {
+                                  Map properties) {
             ObjectGraphBuilder ogbuilder = (ObjectGraphBuilder) builder;
             Class klass = ogbuilder.resolvedClasses.get(classname);
             if (klass == null) {

--- a/src/main/groovy/util/ObjectGraphBuilder.java
+++ b/src/main/groovy/util/ObjectGraphBuilder.java
@@ -53,21 +53,21 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
     public static final String CLASSNAME_RESOLVER_REFLECTION_ROOT = "root";
 
     // Regular expression pattern used to identify words ending in 'y' preceded by a consonant
-    private static final Pattern PLURAL_IES_PATTERN = Pattern.compile(".*[^aeiouy]y", Pattern.CASE_INSENSITIVE);
+    static final Pattern PLURAL_IES_PATTERN = Pattern.compile(".*[^aeiouy]y", Pattern.CASE_INSENSITIVE);
 
-    private ChildPropertySetter childPropertySetter;
-    private ClassNameResolver classNameResolver;
-    private IdentifierResolver identifierResolver;
-    private NewInstanceResolver newInstanceResolver;
+    ChildPropertySetter childPropertySetter;
+    ClassNameResolver classNameResolver;
+    IdentifierResolver identifierResolver;
+    NewInstanceResolver newInstanceResolver;
     private ObjectFactory objectFactory = new ObjectFactory();
     private ObjectBeanFactory objectBeanFactory = new ObjectBeanFactory();
     private ObjectRefFactory objectRefFactory = new ObjectRefFactory();
-    private ReferenceResolver referenceResolver;
-    private RelationNameResolver relationNameResolver;
-    private Map<String, Class> resolvedClasses = new HashMap<String, Class>();
-    private ClassLoader classLoader;
+    ReferenceResolver referenceResolver;
+    RelationNameResolver relationNameResolver;
+    Map<String, Class> resolvedClasses = new HashMap<String, Class>();
+    ClassLoader classLoader;
     private boolean lazyReferencesAllowed = true;
-    private List<NodeReference> lazyReferences = new ArrayList<NodeReference>();
+    List<NodeReference> lazyReferences = new ArrayList<NodeReference>();
     private String beanFactoryName = "bean";
 
     public ObjectGraphBuilder() {
@@ -584,7 +584,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
                                          Object child);
     }
 
-    private void resolveLazyReferences() {
+    void resolveLazyReferences() {
         if (!lazyReferencesAllowed) return;
         for (NodeReference ref : lazyReferences) {
             if (ref.parent == null) continue;
@@ -616,11 +616,11 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
         }
     }
 
-    private static String makeClassName(String root, String name) {
+    static String makeClassName(String root, String name) {
         return root + "." + name.substring(0, 1).toUpperCase() + name.substring(1);
     }
 
-    private static class ObjectFactory extends AbstractFactory {
+    static class ObjectFactory extends AbstractFactory {
         public Object newInstance(FactoryBuilderSupport builder, Object name, Object value,
                                   Map properties) throws InstantiationException, IllegalAccessException {
             ObjectGraphBuilder ogbuilder = (ObjectGraphBuilder) builder;
@@ -726,7 +726,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
         }
     }
 
-    private static class ObjectBeanFactory extends ObjectFactory {
+    static class ObjectBeanFactory extends ObjectFactory {
         public Object newInstance(FactoryBuilderSupport builder, Object name, Object value,
                                   Map properties) throws InstantiationException, IllegalAccessException {
             if(value == null) return super.newInstance(builder, name, value, properties);
@@ -761,7 +761,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
         }
     }
 
-    private static class ObjectRefFactory extends ObjectFactory {
+    static class ObjectRefFactory extends ObjectFactory {
         public boolean isLeaf() {
             return true;
         }
@@ -836,12 +836,12 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
     }
 
     private static final class NodeReference {
-        private final Object parent;
-        private final String parentName;
-        private final String childName;
-        private final String refId;
+        final Object parent;
+        final String parentName;
+        final String childName;
+        final String refId;
 
-        private NodeReference(Object parent, String parentName, String childName, String refId) {
+        NodeReference(Object parent, String parentName, String childName, String refId) {
             this.parent = parent;
             this.parentName = parentName;
             this.childName = childName;

--- a/src/main/groovy/util/ObjectGraphBuilder.java
+++ b/src/main/groovy/util/ObjectGraphBuilder.java
@@ -53,21 +53,21 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
     public static final String CLASSNAME_RESOLVER_REFLECTION_ROOT = "root";
 
     // Regular expression pattern used to identify words ending in 'y' preceded by a consonant
-    static final Pattern PLURAL_IES_PATTERN = Pattern.compile(".*[^aeiouy]y", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PLURAL_IES_PATTERN = Pattern.compile(".*[^aeiouy]y", Pattern.CASE_INSENSITIVE);
 
-    ChildPropertySetter childPropertySetter;
-    ClassNameResolver classNameResolver;
-    IdentifierResolver identifierResolver;
-    NewInstanceResolver newInstanceResolver;
+    private ChildPropertySetter childPropertySetter;
+    private ClassNameResolver classNameResolver;
+    private IdentifierResolver identifierResolver;
+    private NewInstanceResolver newInstanceResolver;
     private final ObjectFactory objectFactory = new ObjectFactory();
     private final ObjectBeanFactory objectBeanFactory = new ObjectBeanFactory();
     private final ObjectRefFactory objectRefFactory = new ObjectRefFactory();
-    ReferenceResolver referenceResolver;
-    RelationNameResolver relationNameResolver;
-    final Map<String, Class> resolvedClasses = new HashMap<String, Class>();
-    ClassLoader classLoader;
+    private ReferenceResolver referenceResolver;
+    private RelationNameResolver relationNameResolver;
+    private final Map<String, Class> resolvedClasses = new HashMap<String, Class>();
+    private ClassLoader classLoader;
     private boolean lazyReferencesAllowed = true;
-    final List<NodeReference> lazyReferences = new ArrayList<NodeReference>();
+    private final List<NodeReference> lazyReferences = new ArrayList<NodeReference>();
     private String beanFactoryName = "bean";
 
     public ObjectGraphBuilder() {
@@ -584,7 +584,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
                                          Object child);
     }
 
-    void resolveLazyReferences() {
+    private void resolveLazyReferences() {
         if (!lazyReferencesAllowed) return;
         for (NodeReference ref : lazyReferences) {
             if (ref.parent == null) continue;
@@ -616,11 +616,11 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
         }
     }
 
-    static String makeClassName(String root, String name) {
+    private static String makeClassName(String root, String name) {
         return root + "." + name.substring(0, 1).toUpperCase() + name.substring(1);
     }
 
-    static class ObjectFactory extends AbstractFactory {
+    private static class ObjectFactory extends AbstractFactory {
         public Object newInstance(FactoryBuilderSupport builder, Object name, Object value,
                                   Map properties) throws InstantiationException, IllegalAccessException {
             ObjectGraphBuilder ogbuilder = (ObjectGraphBuilder) builder;
@@ -726,7 +726,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
         }
     }
 
-    static class ObjectBeanFactory extends ObjectFactory {
+    private static class ObjectBeanFactory extends ObjectFactory {
         public Object newInstance(FactoryBuilderSupport builder, Object name, Object value,
                                   Map properties) throws InstantiationException, IllegalAccessException {
             if(value == null) return super.newInstance(builder, name, value, properties);
@@ -761,7 +761,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
         }
     }
 
-    static class ObjectRefFactory extends ObjectFactory {
+    private static class ObjectRefFactory extends ObjectFactory {
         public boolean isLeaf() {
             return true;
         }

--- a/src/main/groovy/util/ObservableList.java
+++ b/src/main/groovy/util/ObservableList.java
@@ -65,9 +65,9 @@ import java.util.ListIterator;
  * @author <a href="mailto:aalmiray@users.sourceforge.net">Andres Almiray</a>
  */
 public class ObservableList implements List {
-    private List delegate;
-    private PropertyChangeSupport pcs;
-    private Closure test;
+    private final List delegate;
+    private final PropertyChangeSupport pcs;
+    private final Closure test;
 
     public static final String SIZE_PROPERTY = "size";
     public static final String CONTENT_PROPERTY = "content";
@@ -375,7 +375,7 @@ public class ObservableList implements List {
     }
 
     protected class ObservableIterator implements Iterator {
-        private Iterator iterDelegate;
+        private final Iterator iterDelegate;
         protected int cursor = -1 ;
 
         public ObservableIterator(Iterator iterDelegate) {
@@ -545,7 +545,7 @@ public class ObservableList implements List {
     }
 
     public static class ElementClearedEvent extends ElementEvent {
-        private List values = new ArrayList();
+        private final List values = new ArrayList();
 
         public ElementClearedEvent(Object source, List values) {
             super(source, ChangeType.oldValue, ChangeType.newValue, 0, ChangeType.CLEARED);
@@ -560,7 +560,7 @@ public class ObservableList implements List {
     }
 
     public static class MultiElementAddedEvent extends ElementEvent {
-        private List values = new ArrayList();
+        private final List values = new ArrayList();
 
         public MultiElementAddedEvent(Object source, int index, List values) {
             super(source, ChangeType.oldValue, ChangeType.newValue, index, ChangeType.MULTI_ADD);
@@ -575,7 +575,7 @@ public class ObservableList implements List {
     }
 
     public static class MultiElementRemovedEvent extends ElementEvent {
-        private List values = new ArrayList();
+        private final List values = new ArrayList();
 
         public MultiElementRemovedEvent(Object source, List values) {
             super(source, ChangeType.oldValue, ChangeType.newValue, 0, ChangeType.MULTI_REMOVE);

--- a/src/main/groovy/util/ObservableMap.java
+++ b/src/main/groovy/util/ObservableMap.java
@@ -390,7 +390,7 @@ public class ObservableMap implements Map {
                 this.events = new PropertyEvent[events.length];
                 System.arraycopy(events, 0, this.events, 0, events.length);
             } else {
-            	this.events = EMPTY_PROPERTY_EVENTS;
+                this.events = EMPTY_PROPERTY_EVENTS;
             }
         }
 

--- a/src/main/groovy/util/ObservableMap.java
+++ b/src/main/groovy/util/ObservableMap.java
@@ -57,9 +57,9 @@ import java.util.*;
  * @author <a href="mailto:aalmiray@users.sourceforge.net">Andres Almiray</a>
  */
 public class ObservableMap implements Map {
-    private Map delegate;
-    private PropertyChangeSupport pcs;
-    private Closure test;
+    private final Map delegate;
+    private final PropertyChangeSupport pcs;
+    private final Closure test;
 
     public static final String SIZE_PROPERTY = "size";
     public static final String CONTENT_PROPERTY = "content";
@@ -325,7 +325,7 @@ public class ObservableMap implements Map {
     }
 
     public abstract static class PropertyEvent extends PropertyChangeEvent {
-        private ChangeType type;
+        private final ChangeType type;
 
         public PropertyEvent(Object source, String propertyName, Object oldValue, Object newValue, ChangeType type) {
             super(source, propertyName, oldValue, newValue);
@@ -364,7 +364,7 @@ public class ObservableMap implements Map {
     }
 
     public static class PropertyClearedEvent extends PropertyEvent {
-        private Map values = new HashMap();
+        private final Map values = new HashMap();
 
         public PropertyClearedEvent(Object source, Map values) {
             super(source, ObservableMap.CLEARED_PROPERTY, values, null, ChangeType.CLEARED);
@@ -382,13 +382,15 @@ public class ObservableMap implements Map {
         public static final String MULTI_PROPERTY = "groovy_util_ObservableMap_MultiPropertyEvent_MULTI";
         private static final PropertyEvent[] EMPTY_PROPERTY_EVENTS = new PropertyEvent[0];
 
-        private PropertyEvent[] events = EMPTY_PROPERTY_EVENTS;
+        private final PropertyEvent[] events;
 
         public MultiPropertyEvent(Object source, PropertyEvent[] events) {
             super(source, MULTI_PROPERTY, ChangeType.oldValue, ChangeType.newValue, ChangeType.MULTI);
             if (events != null && events.length > 0) {
                 this.events = new PropertyEvent[events.length];
                 System.arraycopy(events, 0, this.events, 0, events.length);
+            } else {
+            	this.events = EMPTY_PROPERTY_EVENTS;
             }
         }
 

--- a/src/main/groovy/util/ObservableSet.java
+++ b/src/main/groovy/util/ObservableSet.java
@@ -61,9 +61,9 @@ import java.util.*;
  * @author <a href="mailto:aalmiray@users.sourceforge.net">Andres Almiray</a>
  */
 public class ObservableSet<E> implements Set<E> {
-    private Set<E> delegate;
-    private PropertyChangeSupport pcs;
-    private Closure test;
+    private final Set<E> delegate;
+    private final PropertyChangeSupport pcs;
+    private final Closure test;
 
     public static final String SIZE_PROPERTY = "size";
     public static final String CONTENT_PROPERTY = "content";
@@ -301,7 +301,7 @@ public class ObservableSet<E> implements Set<E> {
     }
 
     protected class ObservableIterator<E> implements Iterator<E> {
-        private Iterator<E> iterDelegate;
+        private final Iterator<E> iterDelegate;
         private final Stack<E> stack = new Stack<E>();
 
         public ObservableIterator(Iterator<E> iterDelegate) {
@@ -370,7 +370,7 @@ public class ObservableSet<E> implements Set<E> {
     }
 
     public static class ElementClearedEvent extends ElementEvent {
-        private List values = new ArrayList();
+        private final List values = new ArrayList();
 
         public ElementClearedEvent(Object source, List values) {
             super(source, ChangeType.oldValue, ChangeType.newValue, ChangeType.CLEARED);
@@ -385,7 +385,7 @@ public class ObservableSet<E> implements Set<E> {
     }
 
     public static class MultiElementAddedEvent extends ElementEvent {
-        private List values = new ArrayList();
+        private final List values = new ArrayList();
 
         public MultiElementAddedEvent(Object source, List values) {
             super(source, ChangeType.oldValue, ChangeType.newValue, ChangeType.MULTI_ADD);
@@ -400,7 +400,7 @@ public class ObservableSet<E> implements Set<E> {
     }
 
     public static class MultiElementRemovedEvent extends ElementEvent {
-        private List values = new ArrayList();
+        private final List values = new ArrayList();
 
         public MultiElementRemovedEvent(Object source, List values) {
             super(source, ChangeType.oldValue, ChangeType.newValue, ChangeType.MULTI_REMOVE);

--- a/src/main/groovy/util/PermutationGenerator.java
+++ b/src/main/groovy/util/PermutationGenerator.java
@@ -33,10 +33,10 @@ import java.util.List;
  * Kenneth H. Rosen, Discrete Mathematics and Its Applications, 2nd edition (NY: McGraw-Hill, 1991), pp. 282-284
  */
 public class PermutationGenerator<E> implements Iterator<List<E>> {
-    private int[] a;
+    private final int[] a;
     private BigInteger numLeft;
-    private BigInteger total;
-    private List<E> items;
+    private final BigInteger total;
+    private final List<E> items;
 
     /**
      * WARNING: Don't make n too large.

--- a/src/main/groovy/util/ProxyGenerator.java
+++ b/src/main/groovy/util/ProxyGenerator.java
@@ -255,7 +255,7 @@ public class ProxyGenerator {
         private final ClassReference baseClass;
         private final ClassReference[] interfaces;
 
-        private CacheKey(final Class baseClass, final Class delegateClass, final Set<String> methods, final Class[] interfaces, final boolean emptyMethods, final boolean useDelegate) {
+        CacheKey(final Class baseClass, final Class delegateClass, final Set<String> methods, final Class[] interfaces, final boolean emptyMethods, final boolean useDelegate) {
             this.useDelegate = useDelegate;
             this.baseClass = new ClassReference(baseClass);
             this.delegateClass = new ClassReference(delegateClass);

--- a/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
+++ b/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
@@ -2370,7 +2370,6 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
             } else if (leftExpression instanceof ConstantExpression) {
                 throw new ASTRuntimeException(node, "\n[" + ((ConstantExpression) leftExpression).getValue() + "] is a constant expression, but it should be a variable expression");
             } else if (leftExpression instanceof BinaryExpression) {
-                Expression leftexp = ((BinaryExpression) leftExpression).getLeftExpression();
                 int lefttype = ((BinaryExpression) leftExpression).getOperation().getType();
                 if (!Types.ofType(lefttype, Types.ASSIGNMENT_OPERATOR) && lefttype != Types.LEFT_SQUARE_BRACKET) {
                     throw new ASTRuntimeException(node, "\n" + ((BinaryExpression) leftExpression).getText() + " is a binary expression, but it should be a variable expression");
@@ -2469,15 +2468,6 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         ConstructorCallExpression expression = new ConstructorCallExpression(special, arguments);
         configureAST(expression, methodCallNode);
         return expression;
-    }
-
-    private int getTypeInParenthesis(AST node) {
-        if (!isType(EXPR, node)) node = node.getFirstChild();
-        while (node != null && isType(EXPR, node) && node.getNextSibling() == null) {
-            node = node.getFirstChild();
-        }
-        if (node == null) return -1;
-        return node.getType();
     }
 
     protected Expression methodCallExpression(AST methodCallNode) {
@@ -2917,13 +2907,6 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         } else {
             return qualifiedNameNode.getText();
         }
-    }
-
-    private static AST getTypeArgumentsNode(AST root) {
-        while (root != null && !isType(TYPE_ARGUMENTS, root)) {
-            root = root.getNextSibling();
-        }
-        return root;
     }
 
     private int getBoundType(AST node) {

--- a/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
+++ b/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
@@ -101,7 +101,7 @@ import java.util.Set;
  */
 public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, GroovyTokenTypes {
 
-    private static class AnonymousInnerClassCarrier extends Expression {
+    static class AnonymousInnerClassCarrier extends Expression {
         ClassNode innerClass;
 
         public Expression transformExpression(ExpressionTransformer transformer) {
@@ -211,7 +211,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         return null; //new Reduction(Tpken.EOF);
     }
 
-    private void outputASTInVariousFormsIfNeeded(SourceUnit sourceUnit, SourceBuffer sourceBuffer) {
+    void outputASTInVariousFormsIfNeeded(SourceUnit sourceUnit, SourceBuffer sourceBuffer) {
         // straight xstream output of AST
         String formatProp = System.getProperty("ANTLR.AST".toLowerCase()); // uppercase to hide from jarjar
 

--- a/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
+++ b/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
@@ -101,7 +101,7 @@ import java.util.Set;
  */
 public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, GroovyTokenTypes {
 
-    static class AnonymousInnerClassCarrier extends Expression {
+    private static class AnonymousInnerClassCarrier extends Expression {
         ClassNode innerClass;
 
         public Expression transformExpression(ExpressionTransformer transformer) {
@@ -211,7 +211,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         return null; //new Reduction(Tpken.EOF);
     }
 
-    void outputASTInVariousFormsIfNeeded(SourceUnit sourceUnit, SourceBuffer sourceBuffer) {
+    private void outputASTInVariousFormsIfNeeded(SourceUnit sourceUnit, SourceBuffer sourceBuffer) {
         // straight xstream output of AST
         String formatProp = System.getProperty("ANTLR.AST".toLowerCase()); // uppercase to hide from jarjar
 

--- a/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
+++ b/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
@@ -272,7 +272,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         }
     }
 
-    private void saveAsXML(String name, AST ast) {
+    private static void saveAsXML(String name, AST ast) {
         XStreamUtils.serialize(name+".antlr", ast);
     }
 
@@ -915,7 +915,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         methodNode = oldNode;
     }
 
-    private void checkNoInvalidModifier(AST node, String nodeType, int modifiers, int modifier, String modifierText) {
+    private static void checkNoInvalidModifier(AST node, String nodeType, int modifiers, int modifier, String modifierText) {
         if ((modifiers & modifier) != 0) {
             throw new ASTRuntimeException(node, nodeType + " has an incorrect modifier '" + modifierText + "'.");
         }
@@ -2559,7 +2559,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         return ret;
     }
 
-    private void setTypeArgumentsOnMethodCallExpression(MethodCallExpression expression,
+    private static void setTypeArgumentsOnMethodCallExpression(MethodCallExpression expression,
                                                         List<GenericsType> typeArgumentList) {
         if (typeArgumentList != null && !typeArgumentList.isEmpty()) {
             expression.setGenericsTypes(typeArgumentList.toArray(new GenericsType[typeArgumentList.size()]));
@@ -2606,7 +2606,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         return ret;
     }
 
-    private ClassNode getAnonymousInnerClassNode(Expression arguments) {
+    private static ClassNode getAnonymousInnerClassNode(Expression arguments) {
         if (arguments instanceof TupleExpression) {
             TupleExpression te = (TupleExpression) arguments;
             List<Expression> expressions = te.getExpressions();
@@ -2706,7 +2706,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         }
     }
 
-    private void checkDuplicateNamedParams(AST elist, List expressionList) {
+    private static void checkDuplicateNamedParams(AST elist, List expressionList) {
         if (expressionList.isEmpty()) return;
 
         Set<String> namedArgumentNames = new HashSet<String>();

--- a/src/main/org/codehaus/groovy/antlr/LexerFrame.java
+++ b/src/main/org/codehaus/groovy/antlr/LexerFrame.java
@@ -44,7 +44,7 @@ public class LexerFrame extends JFrame implements ActionListener{
     Border border1;
     Border border2;
 
-    Class lexerClass;
+    final Class lexerClass;
 
     public LexerFrame(Class lexerClass, Class tokenTypesClass){
         super("Token Steam Viewer");
@@ -70,7 +70,7 @@ public class LexerFrame extends JFrame implements ActionListener{
         }
     }
 
-    Hashtable tokens = new Hashtable();
+    final Hashtable tokens = new Hashtable();
 
     private void listTokens(Class tokenTypes) throws Exception{
         Field field[] = tokenTypes.getDeclaredFields();

--- a/src/main/org/codehaus/groovy/antlr/LexerFrame.java
+++ b/src/main/org/codehaus/groovy/antlr/LexerFrame.java
@@ -107,7 +107,7 @@ public class LexerFrame extends JFrame implements ActionListener{
         }
     };
 
-    void scanScript(File file) throws Exception{
+    private void scanScript(File file) throws Exception{
         scriptPane.read(new FileReader(file), null);
 
         // create lexer

--- a/src/main/org/codehaus/groovy/antlr/LexerFrame.java
+++ b/src/main/org/codehaus/groovy/antlr/LexerFrame.java
@@ -107,7 +107,7 @@ public class LexerFrame extends JFrame implements ActionListener{
         }
     };
 
-    private void scanScript(File file) throws Exception{
+    void scanScript(File file) throws Exception{
         scriptPane.read(new FileReader(file), null);
 
         // create lexer

--- a/src/main/org/codehaus/groovy/antlr/UnicodeEscapingReader.java
+++ b/src/main/org/codehaus/groovy/antlr/UnicodeEscapingReader.java
@@ -42,7 +42,7 @@ public class UnicodeEscapingReader extends Reader {
     private int numUnicodeEscapesFound = 0;
     private int numUnicodeEscapesFoundOnCurrentLine = 0;
 
-    static class DummyLexer extends CharScanner {
+    private static class DummyLexer extends CharScanner {
         private final Token t = new Token();
         public Token nextToken() throws TokenStreamException {
             return t;

--- a/src/main/org/codehaus/groovy/antlr/UnicodeEscapingReader.java
+++ b/src/main/org/codehaus/groovy/antlr/UnicodeEscapingReader.java
@@ -42,7 +42,7 @@ public class UnicodeEscapingReader extends Reader {
     private int numUnicodeEscapesFound = 0;
     private int numUnicodeEscapesFoundOnCurrentLine = 0;
 
-    private static class DummyLexer extends CharScanner {
+    static class DummyLexer extends CharScanner {
         private final Token t = new Token();
         public Token nextToken() throws TokenStreamException {
             return t;

--- a/src/main/org/codehaus/groovy/antlr/java/Groovifier.java
+++ b/src/main/org/codehaus/groovy/antlr/java/Groovifier.java
@@ -24,7 +24,7 @@ import org.codehaus.groovy.antlr.treewalker.VisitorAdapter;
 
 public class Groovifier extends VisitorAdapter implements GroovyTokenTypes {
     private String currentClassName = "";
-    private boolean cleanRedundantPublic;
+    private final boolean cleanRedundantPublic;
 
     public Groovifier(String[] tokenNames) {
         this(tokenNames, true);

--- a/src/main/org/codehaus/groovy/antlr/java/Groovifier.java
+++ b/src/main/org/codehaus/groovy/antlr/java/Groovifier.java
@@ -23,7 +23,6 @@ import org.codehaus.groovy.antlr.parser.GroovyTokenTypes;
 import org.codehaus.groovy.antlr.treewalker.VisitorAdapter;
 
 public class Groovifier extends VisitorAdapter implements GroovyTokenTypes {
-    private String[] tokenNames;
     private String currentClassName = "";
     private boolean cleanRedundantPublic;
 
@@ -32,7 +31,6 @@ public class Groovifier extends VisitorAdapter implements GroovyTokenTypes {
     }
 
     public Groovifier(String[] tokenNames, boolean cleanRedundantPublic) {
-        this.tokenNames = tokenNames;
         this.cleanRedundantPublic = cleanRedundantPublic;
     }
 

--- a/src/main/org/codehaus/groovy/antlr/java/Java2GroovyConverter.java
+++ b/src/main/org/codehaus/groovy/antlr/java/Java2GroovyConverter.java
@@ -23,11 +23,9 @@ import org.codehaus.groovy.antlr.parser.GroovyTokenTypes;
 import org.codehaus.groovy.antlr.treewalker.VisitorAdapter;
 
 public class Java2GroovyConverter extends VisitorAdapter{
-    private String[] tokenNames;
     private int[] typeMapping;
 
     public Java2GroovyConverter(String[] tokenNames) {
-        this.tokenNames = tokenNames;
         typeMapping = new int[400]; // magic number, much greater than current number of java tokens
         typeMapping[JavaTokenTypes.ABSTRACT] = GroovyTokenTypes.ABSTRACT;
 

--- a/src/main/org/codehaus/groovy/antlr/java/Java2GroovyConverter.java
+++ b/src/main/org/codehaus/groovy/antlr/java/Java2GroovyConverter.java
@@ -23,7 +23,7 @@ import org.codehaus.groovy.antlr.parser.GroovyTokenTypes;
 import org.codehaus.groovy.antlr.treewalker.VisitorAdapter;
 
 public class Java2GroovyConverter extends VisitorAdapter{
-    private int[] typeMapping;
+    private final int[] typeMapping;
 
     public Java2GroovyConverter(String[] tokenNames) {
         typeMapping = new int[400]; // magic number, much greater than current number of java tokens

--- a/src/main/org/codehaus/groovy/antlr/java/Java2GroovyConverter.java
+++ b/src/main/org/codehaus/groovy/antlr/java/Java2GroovyConverter.java
@@ -221,12 +221,12 @@ public class Java2GroovyConverter extends VisitorAdapter{
         }
     }
 
-    private boolean isSingleQuoted(String text) {
+    private static boolean isSingleQuoted(String text) {
         return text != null && text.length() > 2
                 && text.charAt(0) == '\''
                 && text.charAt(text.length() - 1) == '\'';
     }
-    private boolean isDoubleQuoted(String text) {
+    private static boolean isDoubleQuoted(String text) {
         return text != null && text.length() > 2
                 && text.charAt(0) == '"'
                 && text.charAt(text.length() - 1) == '"';

--- a/src/main/org/codehaus/groovy/antlr/java/PreJava2GroovyConverter.java
+++ b/src/main/org/codehaus/groovy/antlr/java/PreJava2GroovyConverter.java
@@ -25,7 +25,7 @@ import org.codehaus.groovy.antlr.treewalker.VisitorAdapter;
 
 /** This class mutates the Java AST, whilst it is still a Java AST, in readiness for conversion to Groovy, yippee-ky-a ! */
 public class PreJava2GroovyConverter extends VisitorAdapter{
-    private Stack stack;
+    private final Stack stack;
 
     public PreJava2GroovyConverter(String[] tokenNames) {
         this.stack = new Stack();

--- a/src/main/org/codehaus/groovy/antlr/java/PreJava2GroovyConverter.java
+++ b/src/main/org/codehaus/groovy/antlr/java/PreJava2GroovyConverter.java
@@ -25,11 +25,9 @@ import org.codehaus.groovy.antlr.treewalker.VisitorAdapter;
 
 /** This class mutates the Java AST, whilst it is still a Java AST, in readiness for conversion to Groovy, yippee-ky-a ! */
 public class PreJava2GroovyConverter extends VisitorAdapter{
-    private String[] tokenNames;
     private Stack stack;
 
     public PreJava2GroovyConverter(String[] tokenNames) {
-        this.tokenNames = tokenNames;
         this.stack = new Stack();
     }
 
@@ -136,13 +134,6 @@ public class PreJava2GroovyConverter extends VisitorAdapter{
             return (GroovySourceAST) stack.pop();
         }
         return null;
-    }
-
-    private GroovySourceAST getParentNode() {
-        Object currentNode = stack.pop();
-        Object parentNode = stack.peek();
-        stack.push(currentNode);
-        return (GroovySourceAST) parentNode;
     }
 
     private GroovySourceAST getGrandParentNode() {

--- a/src/main/org/codehaus/groovy/antlr/treewalker/CompositeVisitor.java
+++ b/src/main/org/codehaus/groovy/antlr/treewalker/CompositeVisitor.java
@@ -38,7 +38,6 @@ import org.codehaus.groovy.antlr.GroovySourceAST;
 public class CompositeVisitor implements Visitor{
     final List visitors;
     final List backToFrontVisitors;
-    private final Stack stack;
 
     /**
      * A composite of the supplied list of antlr AST visitors.
@@ -46,7 +45,6 @@ public class CompositeVisitor implements Visitor{
      */
     public CompositeVisitor(List visitors) {
         this.visitors = visitors;
-        this.stack = new Stack();
         backToFrontVisitors = new ArrayList();
         backToFrontVisitors.addAll(visitors);
         Collections.reverse(backToFrontVisitors);

--- a/src/main/org/codehaus/groovy/antlr/treewalker/MindMapPrinter.java
+++ b/src/main/org/codehaus/groovy/antlr/treewalker/MindMapPrinter.java
@@ -90,7 +90,7 @@ public class MindMapPrinter extends VisitorAdapter {
         return "";
     }
 
-    private String getColour(GroovySourceAST t) {
+    private static String getColour(GroovySourceAST t) {
         String colour = "";
         String black = " COLOR=\"#000000\"";
         String cyan = " COLOR=\"#006699\"";
@@ -362,7 +362,7 @@ public class MindMapPrinter extends VisitorAdapter {
         return name;
     }
 
-    private String escape(String name) {
+    private static String escape(String name) {
         if (name == null) return null;
         // remove middle of large bits of text
         if (name.length() > 200) {

--- a/src/main/org/codehaus/groovy/antlr/treewalker/NodeAsHTMLPrinter.java
+++ b/src/main/org/codehaus/groovy/antlr/treewalker/NodeAsHTMLPrinter.java
@@ -58,7 +58,7 @@ public class NodeAsHTMLPrinter extends VisitorAdapter {
         }
     }
 
-    private String quote(String tokenName) {
+    private static String quote(String tokenName) {
         if (tokenName.length() > 0 && tokenName.charAt(0) != '\'')
             return "'" + tokenName + "'";
         else
@@ -69,7 +69,7 @@ public class NodeAsHTMLPrinter extends VisitorAdapter {
         out.println("</pre></body></html>");
     }
 
-    private String colour(GroovySourceAST t) {
+    private static String colour(GroovySourceAST t) {
         String black = "000000";
         String blue = "17178B";
         String green = "008000";

--- a/src/main/org/codehaus/groovy/antlr/treewalker/NodeCollector.java
+++ b/src/main/org/codehaus/groovy/antlr/treewalker/NodeCollector.java
@@ -30,7 +30,7 @@ import org.codehaus.groovy.antlr.GroovySourceAST;
  */
 
 public class NodeCollector extends VisitorAdapter {
-    private List nodes;
+    private final List nodes;
     public NodeCollector() {
         nodes = new ArrayList();
     }

--- a/src/main/org/codehaus/groovy/antlr/treewalker/NodePrinter.java
+++ b/src/main/org/codehaus/groovy/antlr/treewalker/NodePrinter.java
@@ -29,8 +29,8 @@ import org.codehaus.groovy.antlr.GroovySourceAST;
  */
 
 public class NodePrinter extends VisitorAdapter {
-    private String[] tokenNames;
-    private PrintStream out;
+    private final String[] tokenNames;
+    private final PrintStream out;
 
     /**
      * A visitor that prints a pseudo xml output to the supplied PrintStream

--- a/src/main/org/codehaus/groovy/antlr/treewalker/SourcePrinter.java
+++ b/src/main/org/codehaus/groovy/antlr/treewalker/SourcePrinter.java
@@ -900,7 +900,7 @@ public class SourcePrinter extends VisitorAdapter {
         }
     }
 
-    private String escape(String literal) {
+    private static String escape(String literal) {
         literal = literal.replaceAll("\n","\\\\<<REMOVE>>n"); // can't seem to do \n in one go with Java regex
         literal = literal.replaceAll("<<REMOVE>>","");
         return literal;

--- a/src/main/org/codehaus/groovy/ast/AnnotationNode.java
+++ b/src/main/org/codehaus/groovy/ast/AnnotationNode.java
@@ -44,7 +44,7 @@ public class AnnotationNode extends ASTNode {
         | FIELD_TARGET | PARAMETER_TARGET | LOCAL_VARIABLE_TARGET | ANNOTATION_TARGET | PACKAGE_TARGET;
     
     private final ClassNode classNode;
-    private Map<String, Expression> members = new HashMap<String, Expression>();
+    private final Map<String, Expression> members = new HashMap<String, Expression>();
     private boolean runtimeRetention= false, sourceRetention= false, classRetention = false;
     private int allowedTargets = ALL_TARGETS;
 

--- a/src/main/org/codehaus/groovy/ast/ClassHelper.java
+++ b/src/main/org/codehaus/groovy/ast/ClassHelper.java
@@ -18,7 +18,6 @@
  */
 package org.codehaus.groovy.ast;
 
-import static org.codehaus.groovy.ast.ClassHelper.OBJECT_TYPE;
 import groovy.lang.*;
 
 import org.codehaus.groovy.runtime.GeneratedClosure;

--- a/src/main/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/org/codehaus/groovy/ast/ClassNode.java
@@ -91,7 +91,7 @@ import java.util.*;
  * @author Jochen Theodorou
  */
 public class ClassNode extends AnnotatedNode implements Opcodes {
-    static class MapOfLists {
+    private static class MapOfLists {
         private final Map<Object, List<MethodNode>> map = new HashMap<Object, List<MethodNode>>();
         public List<MethodNode> get(Object key) {
             return map.get(key);

--- a/src/main/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/org/codehaus/groovy/ast/ClassNode.java
@@ -91,7 +91,7 @@ import java.util.*;
  * @author Jochen Theodorou
  */
 public class ClassNode extends AnnotatedNode implements Opcodes {
-    private static class MapOfLists {
+    static class MapOfLists {
         private Map<Object, List<MethodNode>> map = new HashMap<Object, List<MethodNode>>();
         public List<MethodNode> get(Object key) {
             return map.get(key);

--- a/src/main/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/org/codehaus/groovy/ast/ClassNode.java
@@ -92,7 +92,7 @@ import java.util.*;
  */
 public class ClassNode extends AnnotatedNode implements Opcodes {
     static class MapOfLists {
-        private Map<Object, List<MethodNode>> map = new HashMap<Object, List<MethodNode>>();
+        private final Map<Object, List<MethodNode>> map = new HashMap<Object, List<MethodNode>>();
         public List<MethodNode> get(Object key) {
             return map.get(key);
         }

--- a/src/main/org/codehaus/groovy/ast/CompileUnit.java
+++ b/src/main/org/codehaus/groovy/ast/CompileUnit.java
@@ -46,13 +46,13 @@ import org.codehaus.groovy.syntax.SyntaxException;
 public class CompileUnit {
 
     private final List<ModuleNode> modules = new ArrayList<ModuleNode>();
-    private Map<String, ClassNode> classes = new HashMap<String, ClassNode>();
-    private CompilerConfiguration config;
-    private GroovyClassLoader classLoader;
-    private CodeSource codeSource;
-    private Map<String, ClassNode> classesToCompile = new HashMap<String, ClassNode>();
-    private Map<String, SourceUnit> classNameToSource = new HashMap<String, SourceUnit>();
-    private Map<String, InnerClassNode> generatedInnerClasses = new HashMap();
+    private final Map<String, ClassNode> classes = new HashMap<String, ClassNode>();
+    private final CompilerConfiguration config;
+    private final GroovyClassLoader classLoader;
+    private final CodeSource codeSource;
+    private final Map<String, ClassNode> classesToCompile = new HashMap<String, ClassNode>();
+    private final Map<String, SourceUnit> classNameToSource = new HashMap<String, SourceUnit>();
+    private final Map<String, InnerClassNode> generatedInnerClasses = new HashMap();
 
     public CompileUnit(GroovyClassLoader classLoader, CompilerConfiguration config) {
         this(classLoader, null, config);

--- a/src/main/org/codehaus/groovy/ast/DynamicVariable.java
+++ b/src/main/org/codehaus/groovy/ast/DynamicVariable.java
@@ -24,7 +24,7 @@ import org.codehaus.groovy.ast.expr.Expression;
 // declaration, or the "it" argument to a closure.
 public class DynamicVariable implements Variable {
 
-    private String name;
+    private final String name;
     private boolean closureShare = false;
     private boolean staticContext = false;
 

--- a/src/main/org/codehaus/groovy/ast/GenericsType.java
+++ b/src/main/org/codehaus/groovy/ast/GenericsType.java
@@ -37,13 +37,13 @@ import java.util.Set;
 public class GenericsType extends ASTNode {
     public static final GenericsType[] EMPTY_ARRAY = new GenericsType[0];
     
-    final ClassNode[] upperBounds;
-    final ClassNode lowerBound;
-    ClassNode type;
-    String name;
-    boolean placeholder;
+    private final ClassNode[] upperBounds;
+    private final ClassNode lowerBound;
+    private ClassNode type;
+    private String name;
+    private boolean placeholder;
     private boolean resolved;
-    boolean wildcard;
+    private boolean wildcard;
 
     public GenericsType(ClassNode type, ClassNode[] upperBounds, ClassNode lowerBound) {
         this.type = type;
@@ -201,7 +201,7 @@ public class GenericsType extends ASTNode {
     /**
      * Implements generics type comparison.
      */
-    class GenericsTypeMatcher {
+    private class GenericsTypeMatcher {
 
         public boolean implementsInterfaceOrIsSubclassOf(ClassNode type, ClassNode superOrInterface) {
             boolean result = type.equals(superOrInterface)
@@ -477,7 +477,7 @@ public class GenericsType extends ASTNode {
      * @param classNode the class for which we want to return the parameterized superclass
      * @return the parameterized superclass
      */
-    static ClassNode getParameterizedSuperClass(ClassNode classNode) {
+    private static ClassNode getParameterizedSuperClass(ClassNode classNode) {
         if (ClassHelper.OBJECT_TYPE.equals(classNode)) return null;
         ClassNode superClass = classNode.getUnresolvedSuperClass();
         if (superClass==null) {

--- a/src/main/org/codehaus/groovy/ast/GenericsType.java
+++ b/src/main/org/codehaus/groovy/ast/GenericsType.java
@@ -37,13 +37,13 @@ import java.util.Set;
 public class GenericsType extends ASTNode {
     public static final GenericsType[] EMPTY_ARRAY = new GenericsType[0];
     
-    private final ClassNode[] upperBounds;
-    private final ClassNode lowerBound;
-    private ClassNode type;
-    private String name;
-    private boolean placeholder;
+    final ClassNode[] upperBounds;
+    final ClassNode lowerBound;
+    ClassNode type;
+    String name;
+    boolean placeholder;
     private boolean resolved;
-    private boolean wildcard;
+    boolean wildcard;
 
     public GenericsType(ClassNode type, ClassNode[] upperBounds, ClassNode lowerBound) {
         this.type = type;
@@ -201,7 +201,7 @@ public class GenericsType extends ASTNode {
     /**
      * Implements generics type comparison.
      */
-    private class GenericsTypeMatcher {
+    class GenericsTypeMatcher {
 
         public boolean implementsInterfaceOrIsSubclassOf(ClassNode type, ClassNode superOrInterface) {
             boolean result = type.equals(superOrInterface)
@@ -477,7 +477,7 @@ public class GenericsType extends ASTNode {
      * @param classNode the class for which we want to return the parameterized superclass
      * @return the parameterized superclass
      */
-    private static ClassNode getParameterizedSuperClass(ClassNode classNode) {
+    static ClassNode getParameterizedSuperClass(ClassNode classNode) {
         if (ClassHelper.OBJECT_TYPE.equals(classNode)) return null;
         ClassNode superClass = classNode.getUnresolvedSuperClass();
         if (superClass==null) {

--- a/src/main/org/codehaus/groovy/ast/InnerClassNode.java
+++ b/src/main/org/codehaus/groovy/ast/InnerClassNode.java
@@ -29,7 +29,7 @@ import java.util.LinkedList;
  */
 public class InnerClassNode extends ClassNode {
 
-    private ClassNode outerClass;
+    private final ClassNode outerClass;
     private VariableScope scope;
     private boolean anonymous;
 

--- a/src/main/org/codehaus/groovy/ast/ModuleNode.java
+++ b/src/main/org/codehaus/groovy/ast/ModuleNode.java
@@ -55,13 +55,13 @@ import java.util.Map;
  */
 public class ModuleNode extends ASTNode implements Opcodes {
 
-    private BlockStatement statementBlock = new BlockStatement();
+    private final BlockStatement statementBlock = new BlockStatement();
     List<ClassNode> classes = new LinkedList<ClassNode>();
-    private List<MethodNode> methods = new ArrayList<MethodNode>();
-    private Map<String, ImportNode> imports = new HashMap<String, ImportNode>();
-    private List<ImportNode> starImports = new ArrayList<ImportNode>();
-    private Map<String, ImportNode> staticImports = new LinkedHashMap<String, ImportNode>();
-    private Map<String, ImportNode> staticStarImports = new LinkedHashMap<String, ImportNode>();
+    private final List<MethodNode> methods = new ArrayList<MethodNode>();
+    private final Map<String, ImportNode> imports = new HashMap<String, ImportNode>();
+    private final List<ImportNode> starImports = new ArrayList<ImportNode>();
+    private final Map<String, ImportNode> staticImports = new LinkedHashMap<String, ImportNode>();
+    private final Map<String, ImportNode> staticStarImports = new LinkedHashMap<String, ImportNode>();
     private CompileUnit unit;
     private PackageNode packageNode;
     private String description;

--- a/src/main/org/codehaus/groovy/ast/PackageNode.java
+++ b/src/main/org/codehaus/groovy/ast/PackageNode.java
@@ -24,7 +24,7 @@ package org.codehaus.groovy.ast;
  * @author Paul King
  */
 public class PackageNode extends AnnotatedNode {
-    private String name;
+    private final String name;
 
     public PackageNode(String name) {
         this.name = name;

--- a/src/main/org/codehaus/groovy/ast/PropertyNode.java
+++ b/src/main/org/codehaus/groovy/ast/PropertyNode.java
@@ -34,7 +34,6 @@ public class PropertyNode extends AnnotatedNode implements Opcodes, Variable {
     private Statement getterBlock;
     private Statement setterBlock;
     private final int modifiers;
-    private boolean closureShare = false;
 
     public PropertyNode(
             String name, int modifiers, ClassNode type, ClassNode owner,
@@ -127,7 +126,7 @@ public class PropertyNode extends AnnotatedNode implements Opcodes, Variable {
       */
     @Deprecated
     public void setClosureSharedVariable(boolean inClosure) {
-        closureShare = inClosure;
+        // unused
     }
 
     public ClassNode getOriginType() {

--- a/src/main/org/codehaus/groovy/ast/builder/AstBuilderTransformation.java
+++ b/src/main/org/codehaus/groovy/ast/builder/AstBuilderTransformation.java
@@ -114,7 +114,7 @@ public class AstBuilderTransformation extends MethodCallTransformation {
             return false;
         }
 
-        private List<Expression> getNonClosureArguments(MethodCallExpression call) {
+        private static List<Expression> getNonClosureArguments(MethodCallExpression call) {
             List<Expression> result = new ArrayList<Expression>();
             if (call.getArguments() instanceof TupleExpression) {
                 for (ASTNode node : ((TupleExpression) call.getArguments()).getExpressions()) {
@@ -126,7 +126,7 @@ public class AstBuilderTransformation extends MethodCallTransformation {
             return result;
         }
 
-        private ClosureExpression getClosureArgument(MethodCallExpression call) {
+        private static ClosureExpression getClosureArgument(MethodCallExpression call) {
 
             if (call.getArguments() instanceof TupleExpression) {
                 for (ASTNode node : ((TupleExpression) call.getArguments()).getExpressions()) {

--- a/src/main/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
@@ -41,7 +41,7 @@ public abstract class AsmDecompiler {
          * It's synchronized "just in case". Occasional misses are expected if several threads attempt to load the same class,
          * but this shouldn't result in serious memory issues.
          */
-        static Map<URL, SoftReference<ClassStub>> map = Collections.synchronizedMap(new HashMap<URL, SoftReference<ClassStub>>());
+        static final Map<URL, SoftReference<ClassStub>> map = Collections.synchronizedMap(new HashMap<URL, SoftReference<ClassStub>>());
     }
 
     /**

--- a/src/main/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
@@ -71,7 +71,7 @@ public abstract class AsmDecompiler {
 
     private static class DecompilingVisitor extends ClassVisitor {
         private static final String[] EMPTY_STRING_ARRAY = new String[0];
-        private ClassStub result;
+        ClassStub result;
 
         public DecompilingVisitor() {
             super(Opcodes.ASM5);
@@ -144,7 +144,7 @@ public abstract class AsmDecompiler {
         }
     }
 
-    private static AnnotationReader readAnnotationMembers(final AnnotationStub stub) {
+    static AnnotationReader readAnnotationMembers(final AnnotationStub stub) {
         return new AnnotationReader() {
             @Override
             void visitAttribute(String name, Object value) {

--- a/src/main/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
@@ -144,7 +144,7 @@ public abstract class AsmDecompiler {
         }
     }
 
-    static AnnotationReader readAnnotationMembers(final AnnotationStub stub) {
+    private static AnnotationReader readAnnotationMembers(final AnnotationStub stub) {
         return new AnnotationReader() {
             @Override
             void visitAttribute(String name, Object value) {

--- a/src/main/org/codehaus/groovy/ast/decompiled/FormalParameterParser.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/FormalParameterParser.java
@@ -33,7 +33,7 @@ import java.util.List;
 abstract class FormalParameterParser extends SignatureVisitor {
     private final AsmReferenceResolver resolver;
     private String currentTypeParameter;
-    final List<ClassNode> parameterBounds = new ArrayList<ClassNode>();
+    private final List<ClassNode> parameterBounds = new ArrayList<ClassNode>();
     private final List<GenericsType> typeParameters = new ArrayList<GenericsType>();
 
     public FormalParameterParser(AsmReferenceResolver resolver) {

--- a/src/main/org/codehaus/groovy/ast/decompiled/FormalParameterParser.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/FormalParameterParser.java
@@ -33,7 +33,7 @@ import java.util.List;
 abstract class FormalParameterParser extends SignatureVisitor {
     private final AsmReferenceResolver resolver;
     private String currentTypeParameter;
-    List<ClassNode> parameterBounds = new ArrayList<ClassNode>();
+    final List<ClassNode> parameterBounds = new ArrayList<ClassNode>();
     private final List<GenericsType> typeParameters = new ArrayList<GenericsType>();
 
     public FormalParameterParser(AsmReferenceResolver resolver) {

--- a/src/main/org/codehaus/groovy/ast/decompiled/FormalParameterParser.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/FormalParameterParser.java
@@ -33,7 +33,7 @@ import java.util.List;
 abstract class FormalParameterParser extends SignatureVisitor {
     private final AsmReferenceResolver resolver;
     private String currentTypeParameter;
-    private List<ClassNode> parameterBounds = new ArrayList<ClassNode>();
+    List<ClassNode> parameterBounds = new ArrayList<ClassNode>();
     private final List<GenericsType> typeParameters = new ArrayList<GenericsType>();
 
     public FormalParameterParser(AsmReferenceResolver resolver) {

--- a/src/main/org/codehaus/groovy/ast/decompiled/MemberSignatureParser.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/MemberSignatureParser.java
@@ -126,7 +126,7 @@ class MemberSignatureParser {
         return result;
     }
 
-    static ClassNode applyErasure(ClassNode genericType, ClassNode erasure) {
+    private static ClassNode applyErasure(ClassNode genericType, ClassNode erasure) {
         if (genericType.isGenericsPlaceHolder()) {
             genericType.setRedirect(erasure);
         }

--- a/src/main/org/codehaus/groovy/ast/decompiled/MemberSignatureParser.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/MemberSignatureParser.java
@@ -126,7 +126,7 @@ class MemberSignatureParser {
         return result;
     }
 
-    private static ClassNode applyErasure(ClassNode genericType, ClassNode erasure) {
+    static ClassNode applyErasure(ClassNode genericType, ClassNode erasure) {
         if (genericType.isGenericsPlaceHolder()) {
             genericType.setRedirect(erasure);
         }

--- a/src/main/org/codehaus/groovy/ast/decompiled/TypeSignatureParser.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/TypeSignatureParser.java
@@ -93,7 +93,7 @@ abstract class TypeSignatureParser extends SignatureVisitor {
         };
     }
 
-    private static GenericsType createWildcard(ClassNode[] upper, ClassNode lower) {
+    static GenericsType createWildcard(ClassNode[] upper, ClassNode lower) {
         ClassNode base = ClassHelper.makeWithoutCaching("?");
         base.setRedirect(ClassHelper.OBJECT_TYPE);
         GenericsType t = new GenericsType(base, upper, lower);

--- a/src/main/org/codehaus/groovy/ast/decompiled/TypeSignatureParser.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/TypeSignatureParser.java
@@ -43,7 +43,7 @@ abstract class TypeSignatureParser extends SignatureVisitor {
     abstract void finished(ClassNode result);
 
     private String baseName;
-    private List<GenericsType> arguments = new ArrayList<GenericsType>();
+    private final List<GenericsType> arguments = new ArrayList<GenericsType>();
 
     @Override
     public void visitTypeVariable(String name) {

--- a/src/main/org/codehaus/groovy/ast/decompiled/TypeSignatureParser.java
+++ b/src/main/org/codehaus/groovy/ast/decompiled/TypeSignatureParser.java
@@ -93,7 +93,7 @@ abstract class TypeSignatureParser extends SignatureVisitor {
         };
     }
 
-    static GenericsType createWildcard(ClassNode[] upper, ClassNode lower) {
+    private static GenericsType createWildcard(ClassNode[] upper, ClassNode lower) {
         ClassNode base = ClassHelper.makeWithoutCaching("?");
         base.setRedirect(ClassHelper.OBJECT_TYPE);
         GenericsType t = new GenericsType(base, upper, lower);

--- a/src/main/org/codehaus/groovy/ast/expr/ArrayExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/ArrayExpression.java
@@ -31,10 +31,10 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
  */
 public class ArrayExpression extends Expression {
-    private List<Expression> expressions;
-    private List<Expression> sizeExpression;
+    private final List<Expression> expressions;
+    private final List<Expression> sizeExpression;
 
-    private ClassNode elementType;
+    private final ClassNode elementType;
 
     private static ClassNode makeArray(ClassNode base, List<Expression> sizeExpression) {
         ClassNode ret = base.makeArray();

--- a/src/main/org/codehaus/groovy/ast/expr/BitwiseNegationExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/BitwiseNegationExpression.java
@@ -26,7 +26,7 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  */
 public class BitwiseNegationExpression extends Expression {
 
-    private Expression expression;
+    private final Expression expression;
 
     public BitwiseNegationExpression(Expression expression) {
         this.expression = expression;

--- a/src/main/org/codehaus/groovy/ast/expr/ClosureExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/ClosureExpression.java
@@ -31,7 +31,7 @@ import org.codehaus.groovy.runtime.InvokerHelper;
  */
 public class ClosureExpression extends Expression {
     
-    private Parameter[] parameters;
+    private final Parameter[] parameters;
     private Statement code;
     private VariableScope variableScope;
     

--- a/src/main/org/codehaus/groovy/ast/expr/ConstantExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/ConstantExpression.java
@@ -42,7 +42,7 @@ public class ConstantExpression extends Expression {
     public static final ConstantExpression VOID = new ConstantExpression(Void.class);
     public static final ConstantExpression EMPTY_EXPRESSION = new ConstantExpression(null);
     
-    private Object value;
+    private final Object value;
     private String constantName;
 
     public ConstantExpression(Object value) {

--- a/src/main/org/codehaus/groovy/ast/expr/DeclarationExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/DeclarationExpression.java
@@ -74,7 +74,7 @@ public class DeclarationExpression extends BinaryExpression {
         check(left);
     }
     
-    private void check(Expression left) {
+    private static void check(Expression left) {
         if (left instanceof VariableExpression) {
             //nothing
         } else if (left instanceof TupleExpression) {

--- a/src/main/org/codehaus/groovy/ast/expr/GStringExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/GStringExpression.java
@@ -32,13 +32,15 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  */
 public class GStringExpression extends Expression {
 
-    private String verbatimText;
-    private List<ConstantExpression> strings = new ArrayList<ConstantExpression>();
-    private List<Expression> values = new ArrayList<Expression>();
+    private final String verbatimText;
+    private final List<ConstantExpression> strings;
+    private final List<Expression> values;
     
     public GStringExpression(String verbatimText) {
         this.verbatimText = verbatimText;
         super.setType(ClassHelper.GSTRING_TYPE);
+        this.strings = new ArrayList<ConstantExpression>();
+        this.values = new ArrayList<Expression>();
     }
 
     public GStringExpression(String verbatimText, List<ConstantExpression> strings, List<Expression> values) {

--- a/src/main/org/codehaus/groovy/ast/expr/ListExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/ListExpression.java
@@ -30,7 +30,7 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
  */
 public class ListExpression extends Expression {
-    private List<Expression> expressions;
+    private final List<Expression> expressions;
     private boolean wrapped = false;
 
     public ListExpression() {

--- a/src/main/org/codehaus/groovy/ast/expr/MethodPointerExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/MethodPointerExpression.java
@@ -34,8 +34,8 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  */
 public class MethodPointerExpression extends Expression {
 
-    private Expression expression;
-    private Expression methodName;
+    private final Expression expression;
+    private final Expression methodName;
 
     public MethodPointerExpression(Expression expression, Expression methodName) {
         this.expression = expression;

--- a/src/main/org/codehaus/groovy/ast/expr/PostfixExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/PostfixExpression.java
@@ -29,7 +29,7 @@ import org.codehaus.groovy.syntax.Token;
  */
 public class PostfixExpression extends Expression {
 
-    private Token operation;
+    private final Token operation;
     private Expression expression;
 
     public PostfixExpression(Expression expression, Token operation) {

--- a/src/main/org/codehaus/groovy/ast/expr/PrefixExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/PrefixExpression.java
@@ -29,7 +29,7 @@ import org.codehaus.groovy.syntax.Token;
  */
 public class PrefixExpression extends Expression {
 
-    private Token operation;
+    private final Token operation;
     private Expression expression;
 
     public PrefixExpression(Token operation, Expression expression) {

--- a/src/main/org/codehaus/groovy/ast/expr/PropertyExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/PropertyExpression.java
@@ -28,7 +28,7 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
 public class PropertyExpression extends Expression {
 
     private Expression objectExpression;
-    private Expression property;
+    private final Expression property;
     private boolean spreadSafe = false;
     private boolean safe = false;
     private boolean isStatic = false;

--- a/src/main/org/codehaus/groovy/ast/expr/RangeExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/RangeExpression.java
@@ -29,9 +29,9 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  */
 public class RangeExpression extends Expression {
 
-    private Expression from;
-    private Expression to;
-    private boolean inclusive;
+    private final Expression from;
+    private final Expression to;
+    private final boolean inclusive;
 
     public RangeExpression(Expression from, Expression to, boolean inclusive) {
         this.from = from;

--- a/src/main/org/codehaus/groovy/ast/expr/SpreadMapExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/SpreadMapExpression.java
@@ -29,7 +29,7 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  */
 public class SpreadMapExpression extends Expression {
 
-    private Expression expression;
+    private final Expression expression;
 
     public SpreadMapExpression(Expression expression) {
         this.expression = expression;

--- a/src/main/org/codehaus/groovy/ast/expr/StaticMethodCallExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/StaticMethodCallExpression.java
@@ -32,8 +32,8 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
 public class StaticMethodCallExpression extends Expression implements MethodCall {
 
     private ClassNode ownerType;
-    private String method;
-    private Expression arguments;
+    private final String method;
+    private final Expression arguments;
     private MetaMethod metaMethod = null;
 
     public StaticMethodCallExpression(ClassNode type, String method, Expression arguments) {

--- a/src/main/org/codehaus/groovy/ast/expr/TernaryExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/TernaryExpression.java
@@ -29,9 +29,9 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  */
 public class TernaryExpression extends Expression {
 
-    private BooleanExpression booleanExpression;
-    private Expression trueExpression;
-    private Expression falseExpression;
+    private final BooleanExpression booleanExpression;
+    private final Expression trueExpression;
+    private final Expression falseExpression;
 
     public TernaryExpression(
         BooleanExpression booleanExpression,

--- a/src/main/org/codehaus/groovy/ast/expr/TupleExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/TupleExpression.java
@@ -28,7 +28,7 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
  */
 public class TupleExpression extends Expression implements Iterable<Expression> {
-    private List<Expression> expressions;
+    private final List<Expression> expressions;
 
     public TupleExpression() {
         this(0);

--- a/src/main/org/codehaus/groovy/ast/expr/VariableExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/VariableExpression.java
@@ -35,7 +35,7 @@ public class VariableExpression extends Expression implements Variable {
     public static final VariableExpression THIS_EXPRESSION = new VariableExpression("this", ClassHelper.DYNAMIC_TYPE);
     public static final VariableExpression SUPER_EXPRESSION = new VariableExpression("super", ClassHelper.DYNAMIC_TYPE);
 
-    private String variable;
+    private final String variable;
     private int modifiers;
     private boolean inStaticContext;
     private boolean isDynamicTyped=false;

--- a/src/main/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -48,9 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.codehaus.groovy.ast.tools.GenericsUtils.correctToGenericsSpec;
-import static org.codehaus.groovy.ast.tools.GenericsUtils.extractSuperClassGenerics;
-
 /**
  * Utility methods to deal with generic types.
  *

--- a/src/main/org/codehaus/groovy/ast/tools/WideningCategories.java
+++ b/src/main/org/codehaus/groovy/ast/tools/WideningCategories.java
@@ -573,7 +573,7 @@ public class WideningCategories {
             }
         };
         private final ClassNode compileTimeClassNode;
-        final String name;
+        private final String name;
         private final String text;
 
         private final ClassNode upper;

--- a/src/main/org/codehaus/groovy/ast/tools/WideningCategories.java
+++ b/src/main/org/codehaus/groovy/ast/tools/WideningCategories.java
@@ -590,14 +590,14 @@ public class WideningCategories {
             usesGenerics = upper.isUsingGenerics();
             List<GenericsType[]> genericsTypesList = new LinkedList<GenericsType[]>();
             genericsTypesList.add(upper.getGenericsTypes());
-			for (ClassNode anInterface : interfaces) {
+            for (ClassNode anInterface : interfaces) {
                 usesGenerics |= anInterface.isUsingGenerics();
                 genericsTypesList.add(anInterface.getGenericsTypes());
-				for (MethodNode methodNode : anInterface.getMethods()) {
+                for (MethodNode methodNode : anInterface.getMethods()) {
                     MethodNode method = addMethod(methodNode.getName(), methodNode.getModifiers(), methodNode.getReturnType(), methodNode.getParameters(), methodNode.getExceptions(), methodNode.getCode());
                     method.setDeclaringClass(anInterface); // important for static compilation!
                 }
-			}
+            }
             setUsingGenerics(usesGenerics);
             if (usesGenerics) {
                 List<GenericsType> asArrayList = new ArrayList<GenericsType>();

--- a/src/main/org/codehaus/groovy/ast/tools/WideningCategories.java
+++ b/src/main/org/codehaus/groovy/ast/tools/WideningCategories.java
@@ -573,7 +573,7 @@ public class WideningCategories {
             }
         };
         private final ClassNode compileTimeClassNode;
-        private final String name;
+        final String name;
         private final String text;
 
         private final ClassNode upper;

--- a/src/main/org/codehaus/groovy/classgen/AnnotationVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/AnnotationVisitor.java
@@ -177,7 +177,7 @@ public class AnnotationVisitor {
         return method.getReturnType();
     }
 
-    private boolean isValidAnnotationClass(ClassNode node) {
+    private static boolean isValidAnnotationClass(ClassNode node) {
         return node.implementsInterface(ClassHelper.Annotation_TYPE);
     }
 
@@ -283,7 +283,7 @@ public class AnnotationVisitor {
         }
     }
 
-    private boolean hasCompatibleType(ClassNode attrType, ClassNode wrapperType) {
+    private static boolean hasCompatibleType(ClassNode attrType, ClassNode wrapperType) {
         return wrapperType.isDerivedFrom(ClassHelper.getWrapper(attrType));
     }
 

--- a/src/main/org/codehaus/groovy/classgen/AnnotationVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/AnnotationVisitor.java
@@ -40,8 +40,8 @@ import org.codehaus.groovy.vmplugin.VMPluginFactory;
  * @author <a href='mailto:the[dot]mindstorm[at]gmail[dot]com'>Alex Popescu</a>
  */
 public class AnnotationVisitor {
-    private SourceUnit source;
-    private ErrorCollector errorCollector;
+    private final SourceUnit source;
+    private final ErrorCollector errorCollector;
     private AnnotationNode annotation;
     private ClassNode reportClass;
 

--- a/src/main/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -350,7 +350,7 @@ public class AsmClassGenerator extends ClassGenerator {
         genericParameterNames.put(type.getName(), genericsType);
     }
 
-    private String[] buildExceptions(ClassNode[] exceptions) {
+    private static String[] buildExceptions(ClassNode[] exceptions) {
         if (exceptions == null) return null;
         String[] ret = new String[exceptions.length];
         for (int i = 0; i < exceptions.length; i++) {
@@ -1797,7 +1797,7 @@ public class AsmClassGenerator extends ClassGenerator {
         operandStack.push(ClassHelper.LIST_TYPE);
     }
 
-    private boolean containsOnlyConstants(ListExpression list) {
+    private static boolean containsOnlyConstants(ListExpression list) {
         for (Expression exp : list.getExpressions()) {
             if (exp instanceof ConstantExpression) continue;
             return false;
@@ -1951,7 +1951,7 @@ public class AsmClassGenerator extends ClassGenerator {
         }
     }
 
-    private int determineCommonArrayType(List values) {
+    private static int determineCommonArrayType(List values) {
         Expression expr = (Expression) values.get(0);
         int arrayElementType = -1;
         if (expr instanceof AnnotationConstantExpression) {

--- a/src/main/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -96,8 +96,8 @@ import java.util.Map;
 public class AsmClassGenerator extends ClassGenerator {
 
     private final ClassVisitor cv;
-    private GeneratorContext context;
-    private String sourceFile;
+    private final GeneratorContext context;
+    private final String sourceFile;
 
     // fields and properties
     static final MethodCallerMultiAdapter setField = MethodCallerMultiAdapter.newStatic(ScriptBytecodeAdapter.class, "setField", false, false);
@@ -130,7 +130,7 @@ public class AsmClassGenerator extends ClassGenerator {
     static final MethodCaller createGroovyObjectWrapperMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "createGroovyObjectWrapper");
 
     // exception blocks list
-    private Map<String,ClassNode> referencedClasses = new HashMap<String,ClassNode>();
+    private final Map<String,ClassNode> referencedClasses = new HashMap<String,ClassNode>();
     private boolean passingParams;
 
     public static final boolean CREATE_DEBUG_INFO = true;
@@ -138,8 +138,8 @@ public class AsmClassGenerator extends ClassGenerator {
     public static final boolean ASM_DEBUG = false; // add marker in the bytecode to show source-bytecode relationship
 
     private ASTNode currentASTNode = null;
-    private Map genericParameterNames = null;
-    private SourceUnit source;
+    private final Map genericParameterNames;
+    private final SourceUnit source;
     private WriterController controller;
     
     public AsmClassGenerator(

--- a/src/main/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -361,7 +361,7 @@ public class AsmClassGenerator extends ClassGenerator {
 
     protected void visitConstructorOrMethod(MethodNode node, boolean isConstructor) {
         controller.resetLineNumber();
-    	Parameter[] parameters = node.getParameters();
+        Parameter[] parameters = node.getParameters();
         String methodType = BytecodeHelper.getMethodDescriptor(node.getReturnType(), parameters);
         String signature = BytecodeHelper.getGenericsMethodSignature(node);
         int modifiers = node.getModifiers();
@@ -875,7 +875,7 @@ public class AsmClassGenerator extends ClassGenerator {
                         privateSuperField = true;
                     }
                 } else {
-                	if (controller.isNotExplicitThisInClosure(expression.isImplicitThis())) {
+                    if (controller.isNotExplicitThisInClosure(expression.isImplicitThis())) {
                         field = classNode.getDeclaredField(name);
                         if (field==null && classNode instanceof InnerClassNode) {
                             ClassNode outer = classNode.getOuterClass();
@@ -911,7 +911,7 @@ public class AsmClassGenerator extends ClassGenerator {
                                 return;
                             }
                         }
-                	}
+                    }
                 }
                 if (field != null && !privateSuperField) {//GROOVY-4497: don't visit super field if it is private
                     visitFieldExpression(new FieldExpression(field));

--- a/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -49,7 +49,7 @@ import static org.objectweb.asm.Opcodes.*;
 public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
 
     private ClassNode currentClass;
-    private SourceUnit source;
+    private final SourceUnit source;
     private boolean inConstructor = false;
     private boolean inStaticConstructor = false;
 

--- a/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -207,15 +207,15 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
         addError("The " + getDescription(node) + " has an incorrect modifier " + modifierName + ".", node);
     }
 
-    private String getDescription(ClassNode node) {
+    private static String getDescription(ClassNode node) {
         return (node.isInterface() ? (Traits.isTrait(node)?"trait":"interface") : "class") + " '" + node.getName() + "'";
     }
 
-    private String getDescription(MethodNode node) {
+    private static String getDescription(MethodNode node) {
         return "method '" + node.getTypeDescriptor() + "'";
     }
 
-    private String getDescription(FieldNode node) {
+    private static String getDescription(FieldNode node) {
         return "field '" + node.getName() + "'";
     }
 
@@ -271,7 +271,7 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
         }
     }
 
-    private boolean isConstructor(MethodNode method) {
+    private static boolean isConstructor(MethodNode method) {
         return method.getName().equals("<clinit>");
     }
 
@@ -330,7 +330,7 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
         addError(msg.toString(), method);
     }
 
-    private boolean hasEqualParameterTypes(Parameter[] first, Parameter[] second) {
+    private static boolean hasEqualParameterTypes(Parameter[] first, Parameter[] second) {
         if (first.length != second.length) return false;
         for (int i = 0; i < first.length; i++) {
             String ft = first[i].getType().getName();
@@ -636,7 +636,7 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
         }
     }
 
-    private String getRefDescriptor(ASTNode ref) {
+    private static String getRefDescriptor(ASTNode ref) {
         if (ref instanceof FieldNode) {
             FieldNode f = (FieldNode) ref;
             return "the field "+f.getName()+" ";

--- a/src/main/org/codehaus/groovy/classgen/DummyClassGenerator.java
+++ b/src/main/org/codehaus/groovy/classgen/DummyClassGenerator.java
@@ -37,9 +37,9 @@ import java.util.Iterator;
  */
 public class DummyClassGenerator extends ClassGenerator {
 
-    private ClassVisitor cv;
+    private final ClassVisitor cv;
     private MethodVisitor mv;
-    private GeneratorContext context;
+    private final GeneratorContext context;
 
     // current class details
     private ClassNode classNode;

--- a/src/main/org/codehaus/groovy/classgen/EnumCompletionVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/EnumCompletionVisitor.java
@@ -70,7 +70,7 @@ public class EnumCompletionVisitor extends ClassCodeVisitorSupport {
     /**
      * Add map and no-arg constructor or mirror those of the superclass (i.e. base enum).
      */
-    private void addImplicitConstructors(ClassNode enumClass, boolean aic) {
+    private static void addImplicitConstructors(ClassNode enumClass, boolean aic) {
         if (aic) {
             ClassNode sn = enumClass.getSuperClass();
             List<ConstructorNode> sctors = new ArrayList<ConstructorNode>(sn.getDeclaredConstructors());
@@ -154,7 +154,7 @@ public class EnumCompletionVisitor extends ClassCodeVisitorSupport {
         return name;
     }
 
-    private boolean isAnonymousInnerClass(ClassNode enumClass) {
+    private static boolean isAnonymousInnerClass(ClassNode enumClass) {
         if (!(enumClass instanceof EnumConstantClassNode)) return false;
         InnerClassNode ic = (InnerClassNode) enumClass;
         return ic.getVariableScope() == null;

--- a/src/main/org/codehaus/groovy/classgen/EnumVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/EnumVisitor.java
@@ -90,7 +90,7 @@ public class EnumVisitor extends ClassCodeVisitorSupport {
         addInit(enumClass, minValue, maxValue, values, isAic);
     }
 
-    private void checkForAbstractMethods(ClassNode enumClass) {
+    private static void checkForAbstractMethods(ClassNode enumClass) {
         List<MethodNode> methods = enumClass.getMethods();
         for (MethodNode m : methods) {
             if (m.isAbstract()) {
@@ -101,7 +101,7 @@ public class EnumVisitor extends ClassCodeVisitorSupport {
         }
     }
 
-    private void addMethods(ClassNode enumClass, FieldNode values) {
+    private static void addMethods(ClassNode enumClass, FieldNode values) {
         List<MethodNode> methods = enumClass.getMethods();
 
         boolean hasNext = false;
@@ -419,7 +419,7 @@ public class EnumVisitor extends ClassCodeVisitorSupport {
         );
     }
 
-    private boolean isAnonymousInnerClass(ClassNode enumClass) {
+    private static boolean isAnonymousInnerClass(ClassNode enumClass) {
         if (!(enumClass instanceof EnumConstantClassNode)) return false;
         InnerClassNode ic = (InnerClassNode) enumClass;
         return ic.getVariableScope() == null;

--- a/src/main/org/codehaus/groovy/classgen/ExtendedVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ExtendedVerifier.java
@@ -52,7 +52,7 @@ import static org.codehaus.groovy.ast.tools.GenericsUtils.createGenericsSpec;
 public class ExtendedVerifier extends ClassCodeVisitorSupport {
     public static final String JVM_ERROR_MESSAGE = "Please make sure you are running on a JVM >= 1.5";
 
-    private SourceUnit source;
+    private final SourceUnit source;
     private ClassNode currentClass;
 
     public ExtendedVerifier(SourceUnit sourceUnit) {

--- a/src/main/org/codehaus/groovy/classgen/ExtendedVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ExtendedVerifier.java
@@ -153,7 +153,7 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport implements GroovyC
         }
     }
 
-    private void visitDeprecation(AnnotatedNode node, AnnotationNode visited) {
+    private static void visitDeprecation(AnnotatedNode node, AnnotationNode visited) {
         if (visited.getClassNode().isResolved() && visited.getClassNode().getName().equals("java.lang.Deprecated")) {
             if (node instanceof MethodNode) {
                 MethodNode mn = (MethodNode) node;
@@ -196,7 +196,7 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport implements GroovyC
         }
     }
 
-    private boolean isOverrideMethod(MethodNode method) {
+    private static boolean isOverrideMethod(MethodNode method) {
         ClassNode cNode = method.getDeclaringClass();
         ClassNode next = cNode;
         outer:
@@ -231,7 +231,7 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport implements GroovyC
         return next != null;
     }
 
-    private MethodNode getDeclaredMethodCorrected(Map genericsSpec, MethodNode mn, ClassNode correctedNext) {
+    private static MethodNode getDeclaredMethodCorrected(Map genericsSpec, MethodNode mn, ClassNode correctedNext) {
         for (MethodNode orig :  correctedNext.getDeclaredMethods(mn.getName())) {
             MethodNode method = correctToGenericsSpec(genericsSpec, orig);
             if (parametersEqual(method.getParameters(), mn.getParameters())) {

--- a/src/main/org/codehaus/groovy/classgen/ExtendedVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ExtendedVerifier.java
@@ -49,7 +49,7 @@ import static org.codehaus.groovy.ast.tools.GenericsUtils.createGenericsSpec;
  *
  * @author <a href='mailto:the[dot]mindstorm[at]gmail[dot]com'>Alex Popescu</a>
  */
-public class ExtendedVerifier extends ClassCodeVisitorSupport implements GroovyClassVisitor {
+public class ExtendedVerifier extends ClassCodeVisitorSupport {
     public static final String JVM_ERROR_MESSAGE = "Please make sure you are running on a JVM >= 1.5";
 
     private SourceUnit source;

--- a/src/main/org/codehaus/groovy/classgen/FinalVariableAnalyzer.java
+++ b/src/main/org/codehaus/groovy/classgen/FinalVariableAnalyzer.java
@@ -98,7 +98,7 @@ public class FinalVariableAnalyzer extends ClassCodeVisitorSupport {
         return state;
     }
 
-    static Variable getTarget(Variable v) {
+    private static Variable getTarget(Variable v) {
         if (v instanceof VariableExpression) {
             Variable t = ((VariableExpression) v).getAccessedVariable();
             if (t==v) return t;
@@ -342,7 +342,7 @@ public class FinalVariableAnalyzer extends ClassCodeVisitorSupport {
         void variableNotAlwaysInitialized(VariableExpression var);
     }
 
-    static class StateMap extends HashMap<Variable, VariableState> {
+    private static class StateMap extends HashMap<Variable, VariableState> {
         @Override
         public VariableState get(final Object key) {
             return super.get(getTarget((Variable)key));

--- a/src/main/org/codehaus/groovy/classgen/FinalVariableAnalyzer.java
+++ b/src/main/org/codehaus/groovy/classgen/FinalVariableAnalyzer.java
@@ -59,7 +59,7 @@ public class FinalVariableAnalyzer extends ClassCodeVisitorSupport {
         is_final(true),
         is_var(false);
 
-        private final boolean isFinal;
+        final boolean isFinal;
 
         VariableState(final boolean isFinal) {
             this.isFinal = isFinal;
@@ -98,7 +98,7 @@ public class FinalVariableAnalyzer extends ClassCodeVisitorSupport {
         return state;
     }
 
-    private static Variable getTarget(Variable v) {
+    static Variable getTarget(Variable v) {
         if (v instanceof VariableExpression) {
             Variable t = ((VariableExpression) v).getAccessedVariable();
             if (t==v) return t;
@@ -342,7 +342,7 @@ public class FinalVariableAnalyzer extends ClassCodeVisitorSupport {
         void variableNotAlwaysInitialized(VariableExpression var);
     }
 
-    private static class StateMap extends HashMap<Variable, VariableState> {
+    static class StateMap extends HashMap<Variable, VariableState> {
         @Override
         public VariableState get(final Object key) {
             return super.get(getTarget((Variable)key));

--- a/src/main/org/codehaus/groovy/classgen/GeneratorContext.java
+++ b/src/main/org/codehaus/groovy/classgen/GeneratorContext.java
@@ -34,7 +34,7 @@ public class GeneratorContext {
 
     private int innerClassIdx = 1;
     private int closureClassIdx = 1;
-    private CompileUnit compileUnit;
+    private final CompileUnit compileUnit;
     
     public GeneratorContext(CompileUnit compileUnit) {
         this.compileUnit = compileUnit;

--- a/src/main/org/codehaus/groovy/classgen/InnerClassCompletionVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/InnerClassCompletionVisitor.java
@@ -157,7 +157,7 @@ public class InnerClassCompletionVisitor extends InnerClassVisitorHelper impleme
         method.setCode(block);
     }
 
-    void getThis(MethodVisitor mv, String classInternalName, String outerClassDescriptor, String innerClassInternalName) {
+    private void getThis(MethodVisitor mv, String classInternalName, String outerClassDescriptor, String innerClassInternalName) {
         mv.visitVarInsn(ALOAD, 0);
         if (CLOSURE_TYPE.equals(thisField.getType())) {
             mv.visitFieldInsn(GETFIELD, classInternalName, "this$0", CLOSURE_DESCRIPTOR);

--- a/src/main/org/codehaus/groovy/classgen/InnerClassCompletionVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/InnerClassCompletionVisitor.java
@@ -157,7 +157,7 @@ public class InnerClassCompletionVisitor extends InnerClassVisitorHelper impleme
         method.setCode(block);
     }
 
-    private void getThis(MethodVisitor mv, String classInternalName, String outerClassDescriptor, String innerClassInternalName) {
+    void getThis(MethodVisitor mv, String classInternalName, String outerClassDescriptor, String innerClassInternalName) {
         mv.visitVarInsn(ALOAD, 0);
         if (CLOSURE_TYPE.equals(thisField.getType())) {
             mv.visitFieldInsn(GETFIELD, classInternalName, "this$0", CLOSURE_DESCRIPTOR);

--- a/src/main/org/codehaus/groovy/classgen/InnerClassCompletionVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/InnerClassCompletionVisitor.java
@@ -89,15 +89,15 @@ public class InnerClassCompletionVisitor extends InnerClassVisitorHelper impleme
         super.visitConstructor(node);
     }
 
-    private String getTypeDescriptor(ClassNode node, boolean isStatic) {
+    private static String getTypeDescriptor(ClassNode node, boolean isStatic) {
         return BytecodeHelper.getTypeDescription(getClassNode(node, isStatic));
     }
 
-    private String getInternalName(ClassNode node, boolean isStatic) {
+    private static String getInternalName(ClassNode node, boolean isStatic) {
         return BytecodeHelper.getClassInternalName(getClassNode(node, isStatic));
     }
 
-    private void addDispatcherMethods(ClassNode classNode) {
+    private static void addDispatcherMethods(ClassNode classNode) {
         final int objectDistance = getObjectDistance(classNode);
 
         // since we added an anonymous inner class we should also
@@ -302,7 +302,7 @@ public class InnerClassCompletionVisitor extends InnerClassVisitorHelper impleme
         }
     }
 
-    private boolean shouldHandleImplicitThisForInnerClass(ClassNode cn) {
+    private static boolean shouldHandleImplicitThisForInnerClass(ClassNode cn) {
         if (cn.isEnum() || cn.isInterface()) return false;
         if ((cn.getModifiers() & Opcodes.ACC_STATIC) != 0) return false;
         if (!(cn instanceof InnerClassNode)) return false;
@@ -393,7 +393,7 @@ public class InnerClassCompletionVisitor extends InnerClassVisitorHelper impleme
         return namePrefix;
     }
 
-    private ConstructorCallExpression getFirstIfSpecialConstructorCall(BlockStatement code) {
+    private static ConstructorCallExpression getFirstIfSpecialConstructorCall(BlockStatement code) {
         if (code == null) return null;
 
         final List<Statement> statementList = code.getStatements();

--- a/src/main/org/codehaus/groovy/classgen/InnerClassVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/InnerClassVisitor.java
@@ -100,7 +100,7 @@ public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcode
         processingObjInitStatements = false;
     }
 
-    private boolean shouldHandleImplicitThisForInnerClass(ClassNode cn) {
+    private static boolean shouldHandleImplicitThisForInnerClass(ClassNode cn) {
         if (cn.isEnum() || cn.isInterface()) return false;
         if ((cn.getModifiers() & Opcodes.ACC_STATIC) != 0) return false;
 

--- a/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
@@ -54,7 +54,7 @@ public class VariableScopeVisitor extends ClassCodeVisitorSupport {
     private final LinkedList stateStack = new LinkedList();
 
     private class StateStackElement {
-    	final VariableScope scope;
+        final VariableScope scope;
         final ClassNode clazz;
         final boolean inConstructor;
 

--- a/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
@@ -43,12 +43,12 @@ import static java.lang.reflect.Modifier.isFinal;
  */
 public class VariableScopeVisitor extends ClassCodeVisitorSupport {
 
-    VariableScope currentScope = null;
+    private VariableScope currentScope = null;
     private final VariableScope headScope = new VariableScope();
-    ClassNode currentClass = null;
+    private ClassNode currentClass = null;
     private final SourceUnit source;
     private boolean isSpecialConstructorCall = false;
-    boolean inConstructor = false;
+    private boolean inConstructor = false;
     private final boolean recurseInnerClasses;
 
     private final LinkedList stateStack = new LinkedList();

--- a/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
@@ -43,12 +43,12 @@ import static java.lang.reflect.Modifier.isFinal;
  */
 public class VariableScopeVisitor extends ClassCodeVisitorSupport {
 
-    private VariableScope currentScope = null;
+    VariableScope currentScope = null;
     private VariableScope headScope = new VariableScope();
-    private ClassNode currentClass = null;
+    ClassNode currentClass = null;
     private SourceUnit source;
     private boolean isSpecialConstructorCall = false;
-    private boolean inConstructor = false;
+    boolean inConstructor = false;
     private final boolean recurseInnerClasses;
 
     private LinkedList stateStack = new LinkedList();

--- a/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
@@ -44,19 +44,19 @@ import static java.lang.reflect.Modifier.isFinal;
 public class VariableScopeVisitor extends ClassCodeVisitorSupport {
 
     VariableScope currentScope = null;
-    private VariableScope headScope = new VariableScope();
+    private final VariableScope headScope = new VariableScope();
     ClassNode currentClass = null;
-    private SourceUnit source;
+    private final SourceUnit source;
     private boolean isSpecialConstructorCall = false;
     boolean inConstructor = false;
     private final boolean recurseInnerClasses;
 
-    private LinkedList stateStack = new LinkedList();
+    private final LinkedList stateStack = new LinkedList();
 
     private class StateStackElement {
-        VariableScope scope;
-        ClassNode clazz;
-        boolean inConstructor;
+    	final VariableScope scope;
+        final ClassNode clazz;
+        final boolean inConstructor;
 
         StateStackElement() {
             scope = VariableScopeVisitor.this.currentScope;

--- a/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/VariableScopeVisitor.java
@@ -179,7 +179,7 @@ public class VariableScopeVisitor extends ClassCodeVisitorSupport {
         return findClassMember(cn.getOuterClass(), name);
     }
 
-    private String getPropertyName(MethodNode m) {
+    private static String getPropertyName(MethodNode m) {
         String name = m.getName();
         if (!(name.startsWith("set") || name.startsWith("get"))) return null;
         String pname = name.substring(3);

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -116,7 +116,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return methodNode;
     }
 
-    private FieldNode setMetaClassFieldIfNotExists(ClassNode node, FieldNode metaClassField) {
+    private static FieldNode setMetaClassFieldIfNotExists(ClassNode node, FieldNode metaClassField) {
         if (metaClassField != null) return metaClassField;
         final String classInternalName = BytecodeHelper.getClassInternalName(node);
         metaClassField =
@@ -130,7 +130,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return metaClassField;
     }
 
-    private FieldNode getMetaClassField(ClassNode node) {
+    private static FieldNode getMetaClassField(ClassNode node) {
         FieldNode ret = node.getDeclaredField("metaClass");
         if (ret != null) {
             ClassNode mcFieldType = ret.getType();
@@ -238,7 +238,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         };
     }
 
-    private void checkForDuplicateMethods(ClassNode cn) {
+    private static void checkForDuplicateMethods(ClassNode cn) {
         HashSet<String> descriptors = new HashSet<String>();
         for (MethodNode mn : cn.getMethods()) {
             if (mn.isSynthetic()) continue;
@@ -256,14 +256,14 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         }
     }
 
-    private String scriptBodySignatureWithoutReturnType(ClassNode cn) {
+    private static String scriptBodySignatureWithoutReturnType(ClassNode cn) {
         for (MethodNode mn : cn.getMethods()) {
             if (mn.isScriptBody()) return makeDescriptorWithoutReturnType(mn);
         }
         return null;
     }
 
-    private FieldNode checkFieldDoesNotExist(ClassNode node, String fieldName) {
+    private static FieldNode checkFieldDoesNotExist(ClassNode node, String fieldName) {
         FieldNode ret = node.getDeclaredField(fieldName);
         if (ret != null) {
             if (    Modifier.isPublic(ret.getModifiers()) &&
@@ -277,7 +277,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return null;
     }
 
-    private void addFastPathHelperFieldsAndHelperMethod(ClassNode node, final String classInternalName, boolean knownSpecialCase) {
+    private static void addFastPathHelperFieldsAndHelperMethod(ClassNode node, final String classInternalName, boolean knownSpecialCase) {
         if (node.getNodeMetaData(ClassNodeSkip.class)!=null) return;
         FieldNode stMCB = checkFieldDoesNotExist(node,STATIC_METACLASS_BOOL);
         if (stMCB==null) {
@@ -530,7 +530,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
     protected void addTimeStamp(ClassNode node) {
     }
 
-    private void checkReturnInObjectInitializer(List init) {
+    private static void checkReturnInObjectInitializer(List init) {
         CodeVisitorSupport cvs = new CodeVisitorSupport() {
             @Override
             public void visitClosureExpression(ClosureExpression expression) {
@@ -601,7 +601,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         if (statement != null) statement.visit(new VerifierCodeVisitor(this));
     }
 
-    private void adjustTypesIfStaticMainMethod(MethodNode node) {
+    private static void adjustTypesIfStaticMainMethod(MethodNode node) {
         if (node.getName().equals("main") && node.isStatic()) {
             Parameter[] params = node.getParameters();
             if (params.length == 1) {
@@ -1036,7 +1036,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return null;
     }
 
-    private boolean extractImplicitThis$0StmtIfInnerClassFromExpression(final List<Statement> stmts, final Statement bstmt) {
+    private static boolean extractImplicitThis$0StmtIfInnerClassFromExpression(final List<Statement> stmts, final Statement bstmt) {
         Expression expr = ((ExpressionStatement) bstmt).getExpression();
         if (expr instanceof BinaryExpression) {
             Expression lExpr = ((BinaryExpression) expr).getLeftExpression();
@@ -1050,7 +1050,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return false;
     }
 
-    private ConstructorCallExpression getFirstIfSpecialConstructorCall(Statement code) {
+    private static ConstructorCallExpression getFirstIfSpecialConstructorCall(Statement code) {
         if (code == null || !(code instanceof ExpressionStatement)) return null;
 
         Expression expression = ((ExpressionStatement) code).getExpression();
@@ -1226,7 +1226,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         }
     }
 
-    private void collectSuperInterfaceMethods(ClassNode cn, Map<String, MethodNode> allInterfaceMethods) {
+    private static void collectSuperInterfaceMethods(ClassNode cn, Map<String, MethodNode> allInterfaceMethods) {
         List cnInterfaces = Arrays.asList(cn.getInterfaces());
         ClassNode sn = cn.getSuperClass();
         while (sn != null && !sn.equals(ClassHelper.OBJECT_TYPE)) {
@@ -1404,7 +1404,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return node.equals(testNode);
     }
 
-    private Parameter[] cleanParameters(Parameter[] parameters) {
+    private static Parameter[] cleanParameters(Parameter[] parameters) {
         Parameter[] params = new Parameter[parameters.length];
         for (int i = 0; i < params.length; i++) {
             params[i] = new Parameter(cleanType(parameters[i].getType()), parameters[i].getName());
@@ -1428,7 +1428,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         }
     }
 
-    private boolean equalParametersNormal(MethodNode m1, MethodNode m2) {
+    private static boolean equalParametersNormal(MethodNode m1, MethodNode m2) {
         Parameter[] p1 = m1.getParameters();
         Parameter[] p2 = m2.getParameters();
         if (p1.length != p2.length) return false;
@@ -1440,7 +1440,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return true;
     }
 
-    private boolean equalParametersWithGenerics(MethodNode m1, MethodNode m2, Map genericsSpec) {
+    private static boolean equalParametersWithGenerics(MethodNode m1, MethodNode m2, Map genericsSpec) {
         Parameter[] p1 = m1.getParameters();
         Parameter[] p2 = m2.getParameters();
         if (p1.length != p2.length) return false;
@@ -1453,7 +1453,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return true;
     }
 
-    private boolean moveOptimizedConstantsInitialization(final ClassNode node) {
+    private static boolean moveOptimizedConstantsInitialization(final ClassNode node) {
         if (node.isInterface() && !Traits.isTrait(node)) return false;
 
         final int mods = Opcodes.ACC_STATIC|Opcodes.ACC_SYNTHETIC| Opcodes.ACC_PUBLIC;

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -101,7 +101,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
             new Parameter(ClassHelper.METACLASS_TYPE, "mc")
     };
 
-    ClassNode classNode;
+    private ClassNode classNode;
     private MethodNode methodNode;
 
     public ClassNode getClassNode() {

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -300,12 +300,6 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         node.addConstructor(constructor);
     }
 
-    private static boolean isInnerClassOf(ClassNode a, ClassNode b) {
-        if (a.redirect()==b) return true;
-        if (b.redirect() instanceof InnerClassNode) return isInnerClassOf(a, b.redirect().getOuterClass());
-        return false;
-    }
-    
     private void addStaticMetaClassField(final ClassNode node, final String classInternalName) {
         String _staticClassInfoFieldName = "$staticClassInfo";
         while (node.getDeclaredField(_staticClassInfoFieldName) != null)

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -101,7 +101,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
             new Parameter(ClassHelper.METACLASS_TYPE, "mc")
     };
 
-    private ClassNode classNode;
+    ClassNode classNode;
     private MethodNode methodNode;
 
     public ClassNode getClassNode() {
@@ -1514,7 +1514,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
 
     private static class SwapInitStatement extends BytecodeSequence {
 
-        private WriterController controller;
+        WriterController controller;
 
         public SwapInitStatement() {
             super(new SwapInitInstruction());
@@ -1530,7 +1530,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
             super.visit(visitor);
         }
 
-        private static class SwapInitInstruction extends BytecodeInstruction {
+        static class SwapInitInstruction extends BytecodeInstruction {
             SwapInitStatement statement;
 
             @Override

--- a/src/main/org/codehaus/groovy/classgen/VerifierCodeVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/VerifierCodeVisitor.java
@@ -40,7 +40,7 @@ import org.objectweb.asm.Opcodes;
  */
 public class VerifierCodeVisitor extends CodeVisitorSupport implements Opcodes {
 
-    private Verifier verifier;
+    private final Verifier verifier;
 
     VerifierCodeVisitor(Verifier verifier) {
         this.verifier = verifier;

--- a/src/main/org/codehaus/groovy/classgen/asm/AssertionWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/AssertionWriter.java
@@ -42,7 +42,7 @@ public class AssertionWriter {
     // assert
     private static final MethodCaller assertFailedMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "assertFailed");
     
-    private static class AssertionTracker {
+    static class AssertionTracker {
         int recorderIndex;
         SourceText sourceText;
     }

--- a/src/main/org/codehaus/groovy/classgen/asm/AssertionWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/AssertionWriter.java
@@ -42,7 +42,7 @@ public class AssertionWriter {
     // assert
     private static final MethodCaller assertFailedMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "assertFailed");
     
-    static class AssertionTracker {
+    private static class AssertionTracker {
         int recorderIndex;
         SourceText sourceText;
     }

--- a/src/main/org/codehaus/groovy/classgen/asm/AssertionWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/AssertionWriter.java
@@ -47,7 +47,7 @@ public class AssertionWriter {
         SourceText sourceText;
     }
 
-    private WriterController controller;
+    private final WriterController controller;
     private AssertionTracker assertionTracker;
     private AssertionTracker disabledTracker;
     

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionHelper.java
@@ -68,7 +68,7 @@ public class BinaryExpressionHelper {
     // isCase
     private static final MethodCaller isCaseMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "isCase");
 
-    private WriterController controller;
+    private final WriterController controller;
     
     public BinaryExpressionHelper(WriterController wc) {
         this.controller = wc;

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionHelper.java
@@ -819,10 +819,6 @@ public class BinaryExpressionHelper {
         
     }
 
-    private static boolean isNullConstant(Expression expression) {
-        return expression instanceof ConstantExpression && ((ConstantExpression) expression).getValue()==null;
-    }
-
     private void evaluateNormalTernary(TernaryExpression expression) {
         MethodVisitor mv = controller.getMethodVisitor();
         OperandStack operandStack = controller.getOperandStack();

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionMultiTypeDispatcher.java
@@ -104,7 +104,7 @@ public class BinaryExpressionMultiTypeDispatcher extends BinaryExpressionHelper 
         super(wc);
     }
 
-    private int getOperandConversionType(ClassNode leftType, ClassNode rightType) {
+    private static int getOperandConversionType(ClassNode leftType, ClassNode rightType) {
         if (isIntCategory(leftType) && isIntCategory(rightType)) return 1;
         if (isLongCategory(leftType) && isLongCategory(rightType)) return 2;
         if (isBigDecCategory(leftType) && isBigDecCategory(rightType)) return 0;
@@ -231,13 +231,13 @@ public class BinaryExpressionMultiTypeDispatcher extends BinaryExpressionHelper 
         return isNumberCategory(type);
     }
 
-    private boolean isShiftOperation(int operation) {
+    private static boolean isShiftOperation(int operation) {
         return  operation==LEFT_SHIFT   || 
                 operation==RIGHT_SHIFT  ||
                 operation==RIGHT_SHIFT_UNSIGNED;
     }
 
-    private boolean isAssignmentToArray(BinaryExpression binExp) {
+    private static boolean isAssignmentToArray(BinaryExpression binExp) {
         Expression leftExpression = binExp.getLeftExpression();
         if (!(leftExpression instanceof BinaryExpression)) return false;
         BinaryExpression leftBinExpr = (BinaryExpression) leftExpression;
@@ -245,7 +245,7 @@ public class BinaryExpressionMultiTypeDispatcher extends BinaryExpressionHelper 
         return true;
     }
     
-    private int removeAssignment(int op) {
+    private static int removeAssignment(int op) {
         switch (op) {
             case PLUS_EQUAL: return PLUS;
             case MINUS_EQUAL: return MINUS;

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionMultiTypeDispatcher.java
@@ -148,7 +148,6 @@ public class BinaryExpressionMultiTypeDispatcher extends BinaryExpressionHelper 
     protected void evaluateCompareExpression(final MethodCaller compareMethod, BinaryExpression binExp) {
         ClassNode current =  getController().getClassNode();
         TypeChooser typeChooser = getController().getTypeChooser();
-        int operation = binExp.getOperation().getType();
         
         Expression leftExp = binExp.getLeftExpression();
         ClassNode leftType = typeChooser.resolveType(leftExp, current);

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionWriter.java
@@ -32,7 +32,7 @@ import org.objectweb.asm.MethodVisitor;
  */
 public abstract class BinaryExpressionWriter {
     
-    private WriterController controller;
+    private final WriterController controller;
     private MethodCaller arraySet, arrayGet;
 
     public BinaryExpressionWriter(WriterController controller, MethodCaller arraySet, MethodCaller arrayGet) {

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryObjectExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryObjectExpressionHelper.java
@@ -82,6 +82,6 @@ public class BinaryObjectExpressionHelper extends BinaryExpressionWriter {
     
     @Override
     protected ClassNode getArrayGetResultType() {
-    	return ClassHelper.OBJECT_TYPE;
+        return ClassHelper.OBJECT_TYPE;
     }
 }

--- a/src/main/org/codehaus/groovy/classgen/asm/BytecodeHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BytecodeHelper.java
@@ -267,6 +267,10 @@ public class BytecodeHelper implements Opcodes {
      * @param name
      */
     public static String formatNameForClassLoading(String name) {
+        if (name == null) {
+            return "java.lang.Object;";
+        }
+
         if (name.equals("int")
                 || name.equals("long")
                 || name.equals("short")
@@ -278,10 +282,6 @@ public class BytecodeHelper implements Opcodes {
                 || name.equals("void")
                 ) {
             return name;
-        }
-
-        if (name == null) {
-            return "java.lang.Object;";
         }
 
         if (name.startsWith("[")) {

--- a/src/main/org/codehaus/groovy/classgen/asm/BytecodeVariable.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BytecodeVariable.java
@@ -33,7 +33,7 @@ public class BytecodeVariable {
     public static final BytecodeVariable THIS_VARIABLE = new BytecodeVariable();
     public static final BytecodeVariable SUPER_VARIABLE = new BytecodeVariable();
 
-    private int index;
+    private final int index;
     private ClassNode type;
     private String name;
     private final int prevCurrent;

--- a/src/main/org/codehaus/groovy/classgen/asm/CallSiteWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/CallSiteWriter.java
@@ -85,7 +85,7 @@ public class CallSiteWriter {
     
     private final List callSites = new ArrayList(32);
     private int callSiteArrayVarIndex = -1;
-    private WriterController controller;
+    private final WriterController controller;
 
     public CallSiteWriter(WriterController wc) {
         this.controller = wc;

--- a/src/main/org/codehaus/groovy/classgen/asm/ClosureWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/ClosureWriter.java
@@ -59,7 +59,7 @@ public class ClosureWriter {
     protected interface UseExistingReference {}
 
     private final Map<Expression,ClassNode> closureClassMap;
-    final WriterController controller;
+    private final WriterController controller;
     private final WriterControllerFactory factory;
 
     public ClosureWriter(WriterController wc) {

--- a/src/main/org/codehaus/groovy/classgen/asm/ClosureWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/ClosureWriter.java
@@ -297,7 +297,7 @@ public class ClosureWriter {
         return answer;
     }
 
-    private void correctAccessedVariable(final InnerClassNode closureClass, ClosureExpression ce) {
+    private static void correctAccessedVariable(final InnerClassNode closureClass, ClosureExpression ce) {
         CodeVisitorSupport visitor = new CodeVisitorSupport() {
             @Override
             public void visitVariableExpression(VariableExpression expression) {
@@ -321,7 +321,7 @@ public class ClosureWriter {
      * same method, in this case the constructor. A closure should not
      * have more than one constructor!
      */
-    private void removeInitialValues(Parameter[] params) {
+    private static void removeInitialValues(Parameter[] params) {
         for (int i = 0; i < params.length; i++) {
             if (params[i].hasInitialExpression()) {
                 Parameter p = new Parameter(params[i].getType(), params[i].getName());

--- a/src/main/org/codehaus/groovy/classgen/asm/ClosureWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/ClosureWriter.java
@@ -59,7 +59,7 @@ public class ClosureWriter {
     protected interface UseExistingReference {}
 
     private final Map<Expression,ClassNode> closureClassMap;
-    private final WriterController controller;
+    final WriterController controller;
     private final WriterControllerFactory factory;
 
     public ClosureWriter(WriterController wc) {

--- a/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
@@ -72,13 +72,13 @@ public class CompileStack implements Opcodes {
     // state flag
     private boolean clear=true;
     // current scope
-    private VariableScope scope;
+    VariableScope scope;
     // current label for continue
-    private Label continueLabel;
+    Label continueLabel;
     // current label for break
-    private Label breakLabel;
+    Label breakLabel;
     // available variables on stack
-    private Map stackVariables = new HashMap();
+    Map stackVariables = new HashMap();
     // index of the last variable on stack
     private int currentVariableIndex = 1;
     // index for the next variable on stack
@@ -90,11 +90,11 @@ public class CompileStack implements Opcodes {
     // map containing named labels of parenting blocks
     private Map superBlockNamedLabels = new HashMap();
     // map containing named labels of current block
-    private Map currentBlockNamedLabels = new HashMap();
+    Map currentBlockNamedLabels = new HashMap();
     // list containing finally blocks
     // such a block is created by synchronized or finally and
     // must be called for break/continue/return
-    private LinkedList<BlockRecorder> finallyBlocks = new LinkedList<BlockRecorder>();
+    LinkedList<BlockRecorder> finallyBlocks = new LinkedList<BlockRecorder>();
     private LinkedList<BlockRecorder> visitedBlocks = new LinkedList<BlockRecorder>();
 
     private Label thisStartLabel, thisEndLabel;
@@ -130,7 +130,7 @@ public class CompileStack implements Opcodes {
     // stores if implicit or explicit this is used.
     private boolean implicitThis;
     private WriterController controller;
-    private boolean inSpecialConstructallCall;
+    boolean inSpecialConstructallCall;
 
     protected static class LabelRange {
         public Label start;
@@ -138,7 +138,7 @@ public class CompileStack implements Opcodes {
     }
 
     public static class BlockRecorder {
-        private boolean isEmpty = true;
+        boolean isEmpty = true;
         public Runnable excludedStatement;
         public LinkedList<LabelRange> ranges;
         public BlockRecorder() {
@@ -159,7 +159,7 @@ public class CompileStack implements Opcodes {
         }
     }
 
-    private class ExceptionTableEntry {
+    class ExceptionTableEntry {
         Label start,end,goal;
         String sig;
     }

--- a/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
@@ -632,7 +632,7 @@ public class CompileStack implements Opcodes {
         mv.visitVarInsn(ASTORE, reference.getIndex());
     }
 
-    private void pushInitValue(ClassNode type, MethodVisitor mv) {
+    private static void pushInitValue(ClassNode type, MethodVisitor mv) {
         if (ClassHelper.isPrimitiveType(type)) {
             if (type==ClassHelper.long_TYPE) {
                 mv.visitInsn(LCONST_0);

--- a/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
@@ -72,13 +72,13 @@ public class CompileStack implements Opcodes {
     // state flag
     private boolean clear=true;
     // current scope
-    VariableScope scope;
+    private VariableScope scope;
     // current label for continue
-    Label continueLabel;
+    private Label continueLabel;
     // current label for break
-    Label breakLabel;
+    private Label breakLabel;
     // available variables on stack
-    Map stackVariables = new HashMap();
+    private Map stackVariables = new HashMap();
     // index of the last variable on stack
     private int currentVariableIndex = 1;
     // index for the next variable on stack
@@ -90,11 +90,11 @@ public class CompileStack implements Opcodes {
     // map containing named labels of parenting blocks
     private Map superBlockNamedLabels = new HashMap();
     // map containing named labels of current block
-    Map currentBlockNamedLabels = new HashMap();
+    private Map currentBlockNamedLabels = new HashMap();
     // list containing finally blocks
     // such a block is created by synchronized or finally and
     // must be called for break/continue/return
-    LinkedList<BlockRecorder> finallyBlocks = new LinkedList<BlockRecorder>();
+    private LinkedList<BlockRecorder> finallyBlocks = new LinkedList<BlockRecorder>();
     private final LinkedList<BlockRecorder> visitedBlocks = new LinkedList<BlockRecorder>();
 
     private Label thisStartLabel, thisEndLabel;
@@ -130,7 +130,7 @@ public class CompileStack implements Opcodes {
     // stores if implicit or explicit this is used.
     private boolean implicitThis;
     private final WriterController controller;
-    boolean inSpecialConstructallCall;
+    private boolean inSpecialConstructallCall;
 
     protected static class LabelRange {
         public Label start;
@@ -138,7 +138,7 @@ public class CompileStack implements Opcodes {
     }
 
     public static class BlockRecorder {
-        boolean isEmpty = true;
+        private boolean isEmpty = true;
         public Runnable excludedStatement;
         public final LinkedList<LabelRange> ranges;
         public BlockRecorder() {
@@ -159,7 +159,7 @@ public class CompileStack implements Opcodes {
         }
     }
 
-    class ExceptionTableEntry {
+    private class ExceptionTableEntry {
         Label start,end,goal;
         String sig;
     }

--- a/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
@@ -95,7 +95,7 @@ public class CompileStack implements Opcodes {
     // such a block is created by synchronized or finally and
     // must be called for break/continue/return
     LinkedList<BlockRecorder> finallyBlocks = new LinkedList<BlockRecorder>();
-    private LinkedList<BlockRecorder> visitedBlocks = new LinkedList<BlockRecorder>();
+    private final LinkedList<BlockRecorder> visitedBlocks = new LinkedList<BlockRecorder>();
 
     private Label thisStartLabel, thisEndLabel;
 
@@ -105,9 +105,9 @@ public class CompileStack implements Opcodes {
     private final LinkedList stateStack = new LinkedList();
 
     // handle different states for the implicit "this"
-    private LinkedList<Boolean> implicitThisStack = new LinkedList();
+    private final LinkedList<Boolean> implicitThisStack = new LinkedList();
     // handle different states for being on the left hand side
-    private LinkedList<Boolean> lhsStack = new LinkedList();
+    private final LinkedList<Boolean> lhsStack = new LinkedList();
     {
         implicitThisStack.add(false);
         lhsStack.add(false);
@@ -123,13 +123,13 @@ public class CompileStack implements Opcodes {
     // in a loop where foo is a label.
     private final Map namedLoopContinueLabel = new HashMap();
     private String className;
-    private LinkedList<ExceptionTableEntry> typedExceptions = new LinkedList<ExceptionTableEntry>();
-    private LinkedList<ExceptionTableEntry> untypedExceptions = new LinkedList<ExceptionTableEntry>();
+    private final LinkedList<ExceptionTableEntry> typedExceptions = new LinkedList<ExceptionTableEntry>();
+    private final LinkedList<ExceptionTableEntry> untypedExceptions = new LinkedList<ExceptionTableEntry>();
     // stores if on left-hand-side during compilation
     private boolean lhs;
     // stores if implicit or explicit this is used.
     private boolean implicitThis;
-    private WriterController controller;
+    private final WriterController controller;
     boolean inSpecialConstructallCall;
 
     protected static class LabelRange {
@@ -140,7 +140,7 @@ public class CompileStack implements Opcodes {
     public static class BlockRecorder {
         boolean isEmpty = true;
         public Runnable excludedStatement;
-        public LinkedList<LabelRange> ranges;
+        public final LinkedList<LabelRange> ranges;
         public BlockRecorder() {
             ranges = new LinkedList<LabelRange>();
         }

--- a/src/main/org/codehaus/groovy/classgen/asm/DelegatingController.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/DelegatingController.java
@@ -33,7 +33,7 @@ import org.objectweb.asm.MethodVisitor;
  * @author <a href="mailto:blackdrag@gmx.org">Jochen "blackdrag" Theodorou</a>
  */
 public class DelegatingController extends WriterController {
-    private WriterController delegationController;
+    private final WriterController delegationController;
     
     public DelegatingController(WriterController normalController) {
         this.delegationController = normalController;

--- a/src/main/org/codehaus/groovy/classgen/asm/ExpressionAsVariableSlot.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/ExpressionAsVariableSlot.java
@@ -33,9 +33,9 @@ import org.objectweb.asm.MethodVisitor;
  */
 public class ExpressionAsVariableSlot extends BytecodeExpression {
     private int index = -1;
-    private Expression exp;
-    private WriterController controller;
-    private String name;
+    private final Expression exp;
+    private final WriterController controller;
+    private final String name;
 
     public ExpressionAsVariableSlot(WriterController controller, Expression expression, String name) {
         this.exp = expression;

--- a/src/main/org/codehaus/groovy/classgen/asm/InvocationWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/InvocationWriter.java
@@ -63,7 +63,7 @@ public class InvocationWriter {
     // constructor calls with this() and super()
     static final MethodCaller selectConstructorAndTransformArguments = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "selectConstructorAndTransformArguments");
 
-    private WriterController controller;
+    private final WriterController controller;
     
     public InvocationWriter(WriterController wc) {
         this.controller = wc;

--- a/src/main/org/codehaus/groovy/classgen/asm/InvocationWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/InvocationWriter.java
@@ -632,7 +632,7 @@ public class InvocationWriter {
         }
     }
 
-    private List<ConstructorNode> sortConstructors(ConstructorCallExpression call, ClassNode callNode) {
+    private static List<ConstructorNode> sortConstructors(ConstructorCallExpression call, ClassNode callNode) {
         // sort in a new list to prevent side effects
         List<ConstructorNode> constructors = new ArrayList<ConstructorNode>(callNode.getDeclaredConstructors());
         Comparator comp = new Comparator() {

--- a/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
@@ -201,7 +201,7 @@ public class MopWriter {
         }
     }
 
-    static boolean equalParameterTypes(Parameter[] p1, Parameter[] p2) {
+    private static boolean equalParameterTypes(Parameter[] p1, Parameter[] p2) {
         if (p1.length!=p2.length) return false;
         for (int i=0; i<p1.length; i++) {
             if (!p1[i].getType().equals(p2[i].getType())) return false;

--- a/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
@@ -83,7 +83,7 @@ public class MopWriter {
         visitMopMethodList(classNode.getSuperClass().getAllDeclaredMethods(), false, currentClassSignatures);
     }
 
-    private Set<MopKey> buildCurrentClassSignatureSet(List<MethodNode> methods) {
+    private static Set<MopKey> buildCurrentClassSignatureSet(List<MethodNode> methods) {
         if (methods.isEmpty()) return Collections.EMPTY_SET;
         HashSet<MopKey> result = new HashSet<MopKey>(methods.size());
         for (MethodNode mn : methods) {

--- a/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
@@ -201,7 +201,7 @@ public class MopWriter {
         }
     }
 
-    private static boolean equalParameterTypes(Parameter[] p1, Parameter[] p2) {
+    static boolean equalParameterTypes(Parameter[] p1, Parameter[] p2) {
         if (p1.length!=p2.length) return false;
         for (int i=0; i<p1.length; i++) {
             if (!p1[i].getType().equals(p2[i].getType())) return false;

--- a/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
@@ -47,9 +47,9 @@ public class MopWriter {
     };
 
     private static class MopKey {
-        int hash = 0;
-        String name;
-        Parameter[] params;
+        final int hash;
+        final String name;
+        final Parameter[] params;
 
         MopKey(String name, Parameter[] params) {
             this.name = name;
@@ -67,7 +67,7 @@ public class MopWriter {
         }
     }
     
-    private WriterController controller;
+    private final WriterController controller;
     
     public MopWriter(WriterController wc) {
         controller = wc;

--- a/src/main/org/codehaus/groovy/classgen/asm/OperandStack.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/OperandStack.java
@@ -36,8 +36,8 @@ import static org.objectweb.asm.Opcodes.*;
 
 public class OperandStack {
 
-    private WriterController controller;
-    private ArrayList<ClassNode> stack = new ArrayList<ClassNode>();
+    private final WriterController controller;
+    private final ArrayList<ClassNode> stack = new ArrayList<ClassNode>();
 
     public OperandStack(WriterController wc) {
         this.controller = wc;        

--- a/src/main/org/codehaus/groovy/classgen/asm/OperandStack.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/OperandStack.java
@@ -76,7 +76,7 @@ public class OperandStack {
     /**
      * returns true for long and double
      */
-    private boolean isTwoSlotType(ClassNode type) {
+    private static boolean isTwoSlotType(ClassNode type) {
         return type==ClassHelper.long_TYPE || type==ClassHelper.double_TYPE;
     }
 
@@ -122,7 +122,7 @@ public class OperandStack {
      * convert primitive (not boolean) to boolean or byte.
      * type needs to be a primitive type (not checked) 
      */
-    private void primitive2b(MethodVisitor mv, ClassNode type) {
+    private static void primitive2b(MethodVisitor mv, ClassNode type) {
         Label trueLabel = new Label();
         Label falseLabel = new Label();
         // for the various types we make first a 
@@ -505,7 +505,7 @@ public class OperandStack {
         if (boxing) box(); 
     }
 
-    private void pushPrimitiveConstant(final MethodVisitor mv, final Object value, final ClassNode type) {
+    private static void pushPrimitiveConstant(final MethodVisitor mv, final Object value, final ClassNode type) {
         boolean isInt = ClassHelper.int_TYPE.equals(type);
         boolean isShort = ClassHelper.short_TYPE.equals(type);
         boolean isByte = ClassHelper.byte_TYPE.equals(type);

--- a/src/main/org/codehaus/groovy/classgen/asm/OptimizingStatementWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/OptimizingStatementWriter.java
@@ -72,7 +72,7 @@ public class OptimizingStatementWriter extends StatementWriter {
         }
     }
 
-    private static MethodCaller[] guards = {
+    private static final MethodCaller[] guards = {
         null,
         MethodCaller.newStatic(BytecodeInterface8.class, "isOrigInt"),
         MethodCaller.newStatic(BytecodeInterface8.class, "isOrigL"),
@@ -86,7 +86,7 @@ public class OptimizingStatementWriter extends StatementWriter {
     
     private static final MethodCaller disabledStandardMetaClass = MethodCaller.newStatic(BytecodeInterface8.class, "disabledStandardMetaClass");
     private boolean fastPathBlocked = false;
-    private WriterController controller;
+    private final WriterController controller;
 
     public OptimizingStatementWriter(WriterController controller) {
         super(controller);
@@ -424,7 +424,7 @@ public class OptimizingStatementWriter extends StatementWriter {
             boolean[] involvedTypes = new boolean[typeMapKeyNames.length];
         }
         OptimizeFlagsEntry current = new OptimizeFlagsEntry();
-        private LinkedList<OptimizeFlagsEntry> olderEntries = new LinkedList<OptimizeFlagsEntry>();
+        private final LinkedList<OptimizeFlagsEntry> olderEntries = new LinkedList<OptimizeFlagsEntry>();
         public void push() {
             olderEntries.addLast(current);
             current = new OptimizeFlagsEntry();

--- a/src/main/org/codehaus/groovy/classgen/asm/OptimizingStatementWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/OptimizingStatementWriter.java
@@ -44,7 +44,7 @@ import static org.codehaus.groovy.ast.tools.WideningCategories.*;
  */
 public class OptimizingStatementWriter extends StatementWriter {
     
-    static class FastPathData {
+    private static class FastPathData {
         Label pathStart = new Label();
         Label afterPath = new Label();
     }
@@ -52,7 +52,7 @@ public class OptimizingStatementWriter extends StatementWriter {
     public static class ClassNodeSkip{}
     
     public static class StatementMeta {
-        boolean optimize=false;
+        private boolean optimize=false;
         protected MethodNode target;
         protected ClassNode type;
         protected boolean[] involvedTypes = new boolean[typeMapKeyNames.length];
@@ -402,7 +402,7 @@ public class OptimizingStatementWriter extends StatementWriter {
         new OptVisitor(chooser).visitClass(classNode);
     }
     
-    static StatementMeta addMeta(ASTNode node) {
+    private static StatementMeta addMeta(ASTNode node) {
         StatementMeta metaOld = (StatementMeta) node.getNodeMetaData(StatementMeta.class);
         StatementMeta meta = metaOld;
         if (meta==null) meta = new StatementMeta();
@@ -411,13 +411,13 @@ public class OptimizingStatementWriter extends StatementWriter {
         return meta;
     }
     
-    static StatementMeta addMeta(ASTNode node, OptimizeFlagsCollector opt) {
+    private static StatementMeta addMeta(ASTNode node, OptimizeFlagsCollector opt) {
         StatementMeta meta = addMeta(node);
         meta.chainInvolvedTypes(opt);
         return meta;
     }
     
-    static class OptimizeFlagsCollector {
+    private static class OptimizeFlagsCollector {
         static class OptimizeFlagsEntry {
             boolean canOptimize = false;
             boolean shouldOptimize = false;
@@ -456,13 +456,13 @@ public class OptimizingStatementWriter extends StatementWriter {
         /**
          * @return true iff we should Optimize - this is almost seen as must
          */
-        boolean shouldOptimize() {
+        private boolean shouldOptimize() {
             return current.shouldOptimize;
         }
         /**
          * @return true iff we can optimize, but not have to
          */
-        boolean canOptimize() {
+        private boolean canOptimize() {
             return current.canOptimize || current.shouldOptimize;
         }
         /**

--- a/src/main/org/codehaus/groovy/classgen/asm/OptimizingStatementWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/OptimizingStatementWriter.java
@@ -44,15 +44,15 @@ import static org.codehaus.groovy.ast.tools.WideningCategories.*;
  */
 public class OptimizingStatementWriter extends StatementWriter {
     
-    private static class FastPathData {
-        private Label pathStart = new Label();
-        private Label afterPath = new Label();
+    static class FastPathData {
+        Label pathStart = new Label();
+        Label afterPath = new Label();
     }
     
     public static class ClassNodeSkip{}
     
     public static class StatementMeta {
-        private boolean optimize=false;
+        boolean optimize=false;
         protected MethodNode target;
         protected ClassNode type;
         protected boolean[] involvedTypes = new boolean[typeMapKeyNames.length];
@@ -402,7 +402,7 @@ public class OptimizingStatementWriter extends StatementWriter {
         new OptVisitor(chooser).visitClass(classNode);
     }
     
-    private static StatementMeta addMeta(ASTNode node) {
+    static StatementMeta addMeta(ASTNode node) {
         StatementMeta metaOld = (StatementMeta) node.getNodeMetaData(StatementMeta.class);
         StatementMeta meta = metaOld;
         if (meta==null) meta = new StatementMeta();
@@ -411,19 +411,19 @@ public class OptimizingStatementWriter extends StatementWriter {
         return meta;
     }
     
-    private static StatementMeta addMeta(ASTNode node, OptimizeFlagsCollector opt) {
+    static StatementMeta addMeta(ASTNode node, OptimizeFlagsCollector opt) {
         StatementMeta meta = addMeta(node);
         meta.chainInvolvedTypes(opt);
         return meta;
     }
     
-    private static class OptimizeFlagsCollector {
-        private static class OptimizeFlagsEntry {
-            private boolean canOptimize = false;
-            private boolean shouldOptimize = false;
-            private boolean[] involvedTypes = new boolean[typeMapKeyNames.length];
+    static class OptimizeFlagsCollector {
+        static class OptimizeFlagsEntry {
+            boolean canOptimize = false;
+            boolean shouldOptimize = false;
+            boolean[] involvedTypes = new boolean[typeMapKeyNames.length];
         }
-        private OptimizeFlagsEntry current = new OptimizeFlagsEntry();
+        OptimizeFlagsEntry current = new OptimizeFlagsEntry();
         private LinkedList<OptimizeFlagsEntry> olderEntries = new LinkedList<OptimizeFlagsEntry>();
         public void push() {
             olderEntries.addLast(current);
@@ -456,13 +456,13 @@ public class OptimizingStatementWriter extends StatementWriter {
         /**
          * @return true iff we should Optimize - this is almost seen as must
          */
-        private boolean shouldOptimize() {
+        boolean shouldOptimize() {
             return current.shouldOptimize;
         }
         /**
          * @return true iff we can optimize, but not have to
          */
-        private boolean canOptimize() {
+        boolean canOptimize() {
             return current.canOptimize || current.shouldOptimize;
         }
         /**

--- a/src/main/org/codehaus/groovy/classgen/asm/StatementWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/StatementWriter.java
@@ -59,7 +59,7 @@ public class StatementWriter {
     private static final MethodCaller iteratorNextMethod = MethodCaller.newInterface(Iterator.class, "next");
     private static final MethodCaller iteratorHasNextMethod = MethodCaller.newInterface(Iterator.class, "hasNext");
     
-    final WriterController controller;
+    private final WriterController controller;
     public StatementWriter(WriterController controller) {
         this.controller = controller;
     }

--- a/src/main/org/codehaus/groovy/classgen/asm/StatementWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/StatementWriter.java
@@ -59,7 +59,7 @@ public class StatementWriter {
     private static final MethodCaller iteratorNextMethod = MethodCaller.newInterface(Iterator.class, "next");
     private static final MethodCaller iteratorHasNextMethod = MethodCaller.newInterface(Iterator.class, "hasNext");
     
-    WriterController controller;
+    final WriterController controller;
     public StatementWriter(WriterController controller) {
         this.controller = controller;
     }

--- a/src/main/org/codehaus/groovy/classgen/asm/StatementWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/StatementWriter.java
@@ -59,7 +59,7 @@ public class StatementWriter {
     private static final MethodCaller iteratorNextMethod = MethodCaller.newInterface(Iterator.class, "next");
     private static final MethodCaller iteratorHasNextMethod = MethodCaller.newInterface(Iterator.class, "hasNext");
     
-    private WriterController controller;
+    WriterController controller;
     public StatementWriter(WriterController controller) {
         this.controller = controller;
     }

--- a/src/main/org/codehaus/groovy/classgen/asm/VariableSlotLoader.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/VariableSlotLoader.java
@@ -24,8 +24,8 @@ import org.objectweb.asm.MethodVisitor;
 
 public class VariableSlotLoader extends BytecodeExpression {
 
-    private int idx;
-    private OperandStack operandStack;
+    private final int idx;
+    private final OperandStack operandStack;
     
     public VariableSlotLoader(ClassNode type, int index, OperandStack os) {
         super(type);

--- a/src/main/org/codehaus/groovy/classgen/asm/WriterController.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/WriterController.java
@@ -396,12 +396,12 @@ public class WriterController {
     }
     
     public void setLineNumber(int n) {
-    	lineNumber = n;
+        lineNumber = n;
     }
 
-	public void resetLineNumber() {
-		setLineNumber(-1);
-	}
+    public void resetLineNumber() {
+        setLineNumber(-1);
+    }
 
     public int getNextHelperMethodIndex() {
         return helperMethodIndex++;

--- a/src/main/org/codehaus/groovy/classgen/asm/indy/IndyCallSiteWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/indy/IndyCallSiteWriter.java
@@ -29,7 +29,7 @@ import org.codehaus.groovy.classgen.asm.*;
  * @author <a href="mailto:blackdrag@gmx.org">Jochen "blackdrag" Theodorou</a>
  */
 public class IndyCallSiteWriter extends CallSiteWriter {
-    private WriterController controller;
+    private final WriterController controller;
     public IndyCallSiteWriter(WriterController controller) {
         super(controller);
         this.controller = controller;

--- a/src/main/org/codehaus/groovy/classgen/asm/indy/InvokeDynamicWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/indy/InvokeDynamicWriter.java
@@ -157,7 +157,7 @@ public class InvokeDynamicWriter extends InvocationWriter {
         finishIndyCall(BSM, callSiteName, sig, numberOfArguments, methodName, flags);
     }
     
-    private int getMethodCallFlags(MethodCallerMultiAdapter adapter, boolean safe, boolean spread) {
+    private static int getMethodCallFlags(MethodCallerMultiAdapter adapter, boolean safe, boolean spread) {
         int ret = 0;
         if (safe)                           ret |= SAFE_NAVIGATION;
         if (adapter==invokeMethodOnCurrent) ret |= THIS_CALL;
@@ -170,7 +170,7 @@ public class InvokeDynamicWriter extends InvocationWriter {
         makeIndyCall(invokeMethod, receiver, false, false, message, arguments);
     }
 
-    private int getPropertyFlags(boolean safe, boolean implicitThis, boolean groovyObject) {
+    private static int getPropertyFlags(boolean safe, boolean implicitThis, boolean groovyObject) {
         int flags = 0;
         if (implicitThis)   flags |= IMPLICIT_THIS;
         if (groovyObject)   flags |= GROOVY_OBJECT;

--- a/src/main/org/codehaus/groovy/classgen/asm/indy/InvokeDynamicWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/indy/InvokeDynamicWriter.java
@@ -77,7 +77,7 @@ public class InvokeDynamicWriter extends InvocationWriter {
                 "bootstrap",
                 BSM_METHOD_TYPE_DESCRIPTOR);
 
-    private WriterController controller;
+    private final WriterController controller;
 
     public InvokeDynamicWriter(WriterController wc) {
         super(wc);

--- a/src/main/org/codehaus/groovy/classgen/asm/indy/sc/IndyStaticTypesMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/indy/sc/IndyStaticTypesMultiTypeDispatcher.java
@@ -46,7 +46,7 @@ public class IndyStaticTypesMultiTypeDispatcher extends StaticTypesBinaryExpress
             MethodType.methodType(
                     CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class
             ).toMethodDescriptorString();
-    static final Handle BSM =
+    private static final Handle BSM =
             new Handle(
                     H_INVOKESTATIC,
                     INDY_INTERFACE_NAME,

--- a/src/main/org/codehaus/groovy/classgen/asm/indy/sc/IndyStaticTypesMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/indy/sc/IndyStaticTypesMultiTypeDispatcher.java
@@ -46,7 +46,7 @@ public class IndyStaticTypesMultiTypeDispatcher extends StaticTypesBinaryExpress
             MethodType.methodType(
                     CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class
             ).toMethodDescriptorString();
-    private static final Handle BSM =
+    static final Handle BSM =
             new Handle(
                     H_INVOKESTATIC,
                     INDY_INTERFACE_NAME,

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
@@ -78,7 +78,7 @@ public class StaticInvocationWriter extends InvocationWriter {
 
     private final AtomicInteger labelCounter = new AtomicInteger();
 
-    final WriterController controller;
+    private final WriterController controller;
 
     private MethodCallExpression currentCall;
 

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
@@ -34,7 +34,6 @@ import org.codehaus.groovy.classgen.Verifier;
 import org.codehaus.groovy.classgen.asm.*;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.syntax.SyntaxException;
-import org.codehaus.groovy.syntax.Token;
 import org.codehaus.groovy.transform.sc.StaticCompilationMetadataKeys;
 import org.codehaus.groovy.transform.sc.StaticCompilationVisitor;
 import org.codehaus.groovy.transform.sc.TemporaryVariableExpression;
@@ -79,7 +78,7 @@ public class StaticInvocationWriter extends InvocationWriter {
 
     private final AtomicInteger labelCounter = new AtomicInteger();
 
-    private final WriterController controller;
+    final WriterController controller;
 
     private MethodCallExpression currentCall;
 
@@ -344,7 +343,6 @@ public class StaticInvocationWriter extends InvocationWriter {
                 ) {
             int stackLen = operandStack.getStackLength() + argumentList.size();
             MethodVisitor mv = controller.getMethodVisitor();
-            MethodVisitor orig = mv;
             //mv = new org.objectweb.asm.util.TraceMethodVisitor(mv);
             controller.setMethodVisitor(mv);
             // varg call
@@ -596,23 +594,6 @@ public class StaticInvocationWriter extends InvocationWriter {
             return true;
         }
         return false;
-    }
-
-    private static void pushZero(final MethodVisitor mv, final ClassNode type) {
-        boolean isInt = ClassHelper.int_TYPE.equals(type);
-        boolean isShort = ClassHelper.short_TYPE.equals(type);
-        boolean isByte = ClassHelper.byte_TYPE.equals(type);
-        if (isInt || isShort || isByte) {
-            mv.visitInsn(ICONST_0);
-        } else if (ClassHelper.long_TYPE.equals(type)) {
-            mv.visitInsn(LCONST_0);
-        } else if (ClassHelper.float_TYPE.equals(type)) {
-            mv.visitInsn(FCONST_0);
-        } else if (ClassHelper.double_TYPE.equals(type)) {
-            mv.visitInsn(DCONST_0);
-        } else {
-            mv.visitLdcInsn(0);
-        }
     }
 
     private class CheckcastReceiverExpression extends Expression {

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
@@ -415,7 +415,7 @@ public class StaticInvocationWriter extends InvocationWriter {
         }
     }
 
-    private boolean isNullConstant(final Expression expression) {
+    private static boolean isNullConstant(final Expression expression) {
         return (expression instanceof ConstantExpression && ((ConstantExpression) expression).getValue() == null);
     }
 

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticPropertyAccessHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticPropertyAccessHelper.java
@@ -101,7 +101,7 @@ public abstract class StaticPropertyAccessHelper {
     private static class PoppingMethodCallExpression extends MethodCallExpression {
         private final Expression receiver;
         private final MethodNode setter;
-        private final TemporaryVariableExpression tmp;
+        final TemporaryVariableExpression tmp;
 
         public PoppingMethodCallExpression(final Expression receiver, final MethodNode setterMethod, final TemporaryVariableExpression tmp) {
             super(receiver, setterMethod.getName(), tmp);

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesBinaryExpressionMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesBinaryExpressionMultiTypeDispatcher.java
@@ -24,11 +24,9 @@ import org.codehaus.groovy.ast.stmt.EmptyStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.ForStatement;
 import org.codehaus.groovy.ast.tools.WideningCategories;
-import org.codehaus.groovy.classgen.AsmClassGenerator;
 import org.codehaus.groovy.classgen.asm.*;
 import org.codehaus.groovy.runtime.MetaClassHelper;
 import org.codehaus.groovy.syntax.Token;
-import org.codehaus.groovy.syntax.Types;
 import org.codehaus.groovy.transform.sc.StaticCompilationMetadataKeys;
 import org.codehaus.groovy.transform.sc.StaticCompilationVisitor;
 import org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport;
@@ -60,16 +58,6 @@ public class StaticTypesBinaryExpressionMultiTypeDispatcher extends BinaryExpres
 
     public StaticTypesBinaryExpressionMultiTypeDispatcher(WriterController wc) {
         super(wc);
-    }
-
-    private int incValue(Token token) {
-        switch (token.getType()) {
-            case Types.PLUS_PLUS:
-                return 1;
-            case Types.MINUS_MINUS:
-                return -1;
-        }
-        return 0;
     }
 
     @Override
@@ -365,7 +353,6 @@ public class StaticTypesBinaryExpressionMultiTypeDispatcher extends BinaryExpres
         ClassNode arrayComponentType = arrayType.getComponentType();
         int operationType = getOperandType(arrayComponentType);
         BinaryExpressionWriter bew = binExpWriter[operationType];
-        AsmClassGenerator acg = getController().getAcg();
 
         if (bew.arraySet(true) && arrayType.isArray()) {
             super.assignToArray(parent, receiver, index, rhsValueLoader);
@@ -384,7 +371,6 @@ public class StaticTypesBinaryExpressionMultiTypeDispatcher extends BinaryExpres
             ArgumentListExpression ae = new ArgumentListExpression(index, rhsValueLoader);
             if (rhsValueLoader instanceof VariableSlotLoader && parent instanceof BinaryExpression) {
                 // GROOVY-6061
-                Expression right = ((BinaryExpression) parent).getRightExpression();
                 rhsValueLoader.putNodeMetaData(StaticTypesMarker.INFERRED_TYPE,
                         controller.getTypeChooser().resolveType(parent, controller.getClassNode()));
             }

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
@@ -59,7 +59,7 @@ public class StaticTypesCallSiteWriter extends CallSiteWriter implements Opcodes
     private static final MethodNode MAP_GET_METHOD = MAP_TYPE.getMethod("get", new Parameter[] { new Parameter(OBJECT_TYPE, "key")});
 
 
-    private StaticTypesWriterController controller;
+    private final StaticTypesWriterController controller;
 
     public StaticTypesCallSiteWriter(final StaticTypesWriterController controller) {
         super(controller);

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
@@ -532,7 +532,6 @@ public class StaticTypesCallSiteWriter extends CallSiteWriter implements Opcodes
             CompileStack compileStack = controller.getCompileStack();
             MethodVisitor mv = controller.getMethodVisitor();
             ClassNode replacementType = field.getOriginType();
-            ClassNode boxedReplacementType = ClassHelper.getWrapper(replacementType);
             OperandStack operandStack = controller.getOperandStack();
             if (field.isStatic()) {
                 mv.visitFieldInsn(GETSTATIC, BytecodeHelper.getClassInternalName(field.getOwner()), fieldName, BytecodeHelper.getTypeDescription(replacementType));

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesClosureWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesClosureWriter.java
@@ -114,7 +114,7 @@ public class StaticTypesClosureWriter extends ClosureWriter {
 
         private final MethodNode doCallMethod;
 
-        private MethodTargetCompletionVisitor(final MethodNode doCallMethod) {
+        MethodTargetCompletionVisitor(final MethodNode doCallMethod) {
             this.doCallMethod = doCallMethod;
         }
 

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesClosureWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesClosureWriter.java
@@ -73,7 +73,7 @@ public class StaticTypesClosureWriter extends ClosureWriter {
         return closureClass;
     }
 
-    private void createDirectCallMethod(final ClassNode closureClass, final MethodNode doCallMethod) {
+    private static void createDirectCallMethod(final ClassNode closureClass, final MethodNode doCallMethod) {
         // in case there is no "call" method on the closure, we can create a "fast invocation" paths
         // to avoid going through ClosureMetaClass by call(Object...) method
 

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesStatementWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesStatementWriter.java
@@ -52,7 +52,7 @@ public class StaticTypesStatementWriter extends StatementWriter {
     private static final MethodCaller ENUMERATION_NEXT_METHOD = MethodCaller.newInterface(Enumeration.class, "nextElement");
     private static final MethodCaller ENUMERATION_HASMORE_METHOD = MethodCaller.newInterface(Enumeration.class, "hasMoreElements");
 
-    private StaticTypesWriterController controller;
+    private final StaticTypesWriterController controller;
 
     public StaticTypesStatementWriter(StaticTypesWriterController controller) {
         super(controller);

--- a/src/main/org/codehaus/groovy/control/AnnotationConstantsVisitor.java
+++ b/src/main/org/codehaus/groovy/control/AnnotationConstantsVisitor.java
@@ -54,7 +54,7 @@ public class AnnotationConstantsVisitor extends ClassCodeVisitorSupport {
         visitStatement(node.getFirstStatement(), node.getReturnType());
     }
 
-    private void visitStatement(Statement statement, ClassNode returnType) {
+    private static void visitStatement(Statement statement, ClassNode returnType) {
         if (statement instanceof ReturnStatement) {
             // normal path
             ReturnStatement rs = (ReturnStatement) statement;
@@ -66,7 +66,7 @@ public class AnnotationConstantsVisitor extends ClassCodeVisitorSupport {
         }
     }
 
-    private Expression transformConstantExpression(Expression val, ClassNode returnType) {
+    private static Expression transformConstantExpression(Expression val, ClassNode returnType) {
         ClassNode returnWrapperType = ClassHelper.getWrapper(returnType);
         if (val instanceof ConstantExpression) {
             Expression result = revertType(val, returnWrapperType);
@@ -92,7 +92,7 @@ public class AnnotationConstantsVisitor extends ClassCodeVisitorSupport {
         return val;
     }
 
-    private Expression revertType(Expression val, ClassNode returnWrapperType) {
+    private static Expression revertType(Expression val, ClassNode returnWrapperType) {
         ConstantExpression ce = (ConstantExpression) val;
         if (ClassHelper.Character_TYPE.equals(returnWrapperType) && ClassHelper.STRING_TYPE.equals(val.getType())) {
             return configure(val, Verifier.transformToPrimitiveConstantIfPossible((ConstantExpression) val));
@@ -122,7 +122,7 @@ public class AnnotationConstantsVisitor extends ClassCodeVisitorSupport {
         return null;
     }
 
-    private Expression configure(Expression orig, Expression result) {
+    private static Expression configure(Expression orig, Expression result) {
         result.setSourcePosition(orig);
         return result;
     }

--- a/src/main/org/codehaus/groovy/control/ClassNodeResolver.java
+++ b/src/main/org/codehaus/groovy/control/ClassNodeResolver.java
@@ -63,8 +63,8 @@ public class ClassNodeResolver {
      * @author <a href="mailto:blackdrag@gmx.org">Jochen "blackdrag" Theodorou</a>
      */
     public static class LookupResult {
-        private SourceUnit su;
-        private ClassNode cn;
+        private final SourceUnit su;
+        private final ClassNode cn;
         /**
          * creates a new LookupResult. You are not supposed to supply
          * a SourceUnit and a ClassNode at the same time
@@ -94,7 +94,7 @@ public class ClassNodeResolver {
     }
 
     // Map to store cached classes
-    private Map<String,ClassNode> cachedClasses = new HashMap();
+    private final Map<String,ClassNode> cachedClasses = new HashMap();
     /**
      * Internal helper used to indicate a cache hit for a class that does not exist. 
      * This way further lookups through a slow {@link #findClassNode(String, CompilationUnit)} 

--- a/src/main/org/codehaus/groovy/control/ClassNodeResolver.java
+++ b/src/main/org/codehaus/groovy/control/ClassNodeResolver.java
@@ -204,7 +204,7 @@ public class ClassNodeResolver {
     /**
      * Search for classes using class loading
      */
-    private LookupResult findByClassLoading(String name, CompilationUnit compilationUnit, GroovyClassLoader loader) {
+    private static LookupResult findByClassLoading(String name, CompilationUnit compilationUnit, GroovyClassLoader loader) {
         Class cls;
         try {
             // NOTE: it's important to do no lookup against script files
@@ -279,7 +279,7 @@ public class ClassNodeResolver {
     /**
      * try to find a script using the compilation unit class loader.
      */
-    private LookupResult tryAsScript(String name, CompilationUnit compilationUnit, ClassNode oldClass) {
+    private static LookupResult tryAsScript(String name, CompilationUnit compilationUnit, ClassNode oldClass) {
         LookupResult lr = null;
         if (oldClass!=null) {
             lr = new LookupResult(null, oldClass);
@@ -308,7 +308,7 @@ public class ClassNodeResolver {
      * get the time stamp of a class
      * NOTE: copied from GroovyClassLoader
      */
-    private long getTimeStamp(ClassNode cls) {
+    private static long getTimeStamp(ClassNode cls) {
         if (!(cls instanceof DecompiledClassNode)) {
             return Verifier.getTimestamp(cls.getTypeClass());
         }
@@ -320,7 +320,7 @@ public class ClassNodeResolver {
      * returns true if the source in URL is newer than the class
      * NOTE: copied from GroovyClassLoader
      */
-    private boolean isSourceNewer(URL source, ClassNode cls) {
+    private static boolean isSourceNewer(URL source, ClassNode cls) {
         try {
             long lastMod;
 

--- a/src/main/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/org/codehaus/groovy/control/CompilationUnit.java
@@ -654,7 +654,7 @@ public class CompilationUnit extends ProcessingUnit {
         }
     };
 
-    private PrimaryClassNodeOperation staticImport = new PrimaryClassNodeOperation() {
+    private final PrimaryClassNodeOperation staticImport = new PrimaryClassNodeOperation() {
         public void call(SourceUnit source, GeneratorContext context, ClassNode classNode) throws CompilationFailedException {
             staticImportVisitor.visitClass(classNode, source);
         }
@@ -663,7 +663,7 @@ public class CompilationUnit extends ProcessingUnit {
     /**
      * Runs convert() on a single SourceUnit.
      */
-    private SourceUnitOperation convert = new SourceUnitOperation() {
+    private final SourceUnitOperation convert = new SourceUnitOperation() {
         public void call(SourceUnit source) throws CompilationFailedException {
             source.convert();
             CompilationUnit.this.ast.addModule(source.getAST());
@@ -675,7 +675,7 @@ public class CompilationUnit extends ProcessingUnit {
         }
     };
 
-    private GroovyClassOperation output = new GroovyClassOperation() {
+    private final GroovyClassOperation output = new GroovyClassOperation() {
         public void call(GroovyClass gclass) throws CompilationFailedException {
             String name = gclass.getName().replace('.', File.separatorChar) + ".class";
             File path = new File(configuration.getTargetDirectory(), name);
@@ -712,7 +712,7 @@ public class CompilationUnit extends ProcessingUnit {
     };
 
     /* checks if all needed classes are compiled before generating the bytecode */
-    private SourceUnitOperation compileCompleteCheck = new SourceUnitOperation() {
+    private final SourceUnitOperation compileCompleteCheck = new SourceUnitOperation() {
         public void call(SourceUnit source) throws CompilationFailedException {
             List<ClassNode> classes = source.ast.getClasses();
             for (ClassNode node : classes) {
@@ -755,7 +755,7 @@ public class CompilationUnit extends ProcessingUnit {
     /**
      * Runs classgen() on a single ClassNode.
      */
-    PrimaryClassNodeOperation classgen = new PrimaryClassNodeOperation() {
+    final PrimaryClassNodeOperation classgen = new PrimaryClassNodeOperation() {
         public boolean needSortedInput() {
             return true;
         }
@@ -894,7 +894,7 @@ public class CompilationUnit extends ProcessingUnit {
      * Marks a single SourceUnit with the current phase,
      * if it isn't already there yet.
      */
-    private SourceUnitOperation mark = new SourceUnitOperation() {
+    private final SourceUnitOperation mark = new SourceUnitOperation() {
         public void call(SourceUnit source) throws CompilationFailedException {
             if (source.phase < phase) {
                 source.gotoPhase(phase);

--- a/src/main/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/org/codehaus/groovy/control/CompilationUnit.java
@@ -755,7 +755,7 @@ public class CompilationUnit extends ProcessingUnit {
     /**
      * Runs classgen() on a single ClassNode.
      */
-    private PrimaryClassNodeOperation classgen = new PrimaryClassNodeOperation() {
+    PrimaryClassNodeOperation classgen = new PrimaryClassNodeOperation() {
         public boolean needSortedInput() {
             return true;
         }

--- a/src/main/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/org/codehaus/groovy/control/CompilationUnit.java
@@ -965,7 +965,7 @@ public class CompilationUnit extends ProcessingUnit {
         public abstract void call(GroovyClass gclass) throws CompilationFailedException;
     }
 
-    private int getSuperClassCount(ClassNode element) {
+    private static int getSuperClassCount(ClassNode element) {
         int count = 0;
         while (element != null) {
             count++;
@@ -1014,7 +1014,7 @@ public class CompilationUnit extends ProcessingUnit {
         return sorted;
     }
 
-    private List<ClassNode> getSorted(int[] index, List<ClassNode> unsorted) {
+    private static List<ClassNode> getSorted(int[] index, List<ClassNode> unsorted) {
         List<ClassNode> sorted = new ArrayList<ClassNode>(unsorted.size());
         for (int i = 0; i < unsorted.size(); i++) {
             int min = -1;

--- a/src/main/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/org/codehaus/groovy/control/CompilationUnit.java
@@ -755,7 +755,7 @@ public class CompilationUnit extends ProcessingUnit {
     /**
      * Runs classgen() on a single ClassNode.
      */
-    final PrimaryClassNodeOperation classgen = new PrimaryClassNodeOperation() {
+    private final PrimaryClassNodeOperation classgen = new PrimaryClassNodeOperation() {
         public boolean needSortedInput() {
             return true;
         }

--- a/src/main/org/codehaus/groovy/control/CompilePhase.java
+++ b/src/main/org/codehaus/groovy/control/CompilePhase.java
@@ -88,7 +88,7 @@ public enum CompilePhase {
         FINALIZATION,
     };
 
-    int phaseNumber;
+    final int phaseNumber;
     CompilePhase(int phaseNumber) {
         this.phaseNumber = phaseNumber;
     }

--- a/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -163,7 +163,7 @@ public class CompilerConfiguration {
      */
     private Map<String, Boolean> optimizationOptions;
 
-    private List<CompilationCustomizer> compilationCustomizers = new LinkedList<CompilationCustomizer>();
+    private final List<CompilationCustomizer> compilationCustomizers = new LinkedList<CompilationCustomizer>();
 
     /**
      * Sets a list of global AST transformations which should not be loaded even if they are

--- a/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -237,7 +237,7 @@ public class CompilerConfiguration {
      * @param key the name of the system property.
      * @return value of the system property or null
      */
-    private String safeGetSystemProperty(String key){
+    private static String safeGetSystemProperty(String key){
         return safeGetSystemProperty(key, null);
     }
 
@@ -253,7 +253,7 @@ public class CompilerConfiguration {
      * @param def a default value.
      * @return  value of the system property or null
      */
-    private String safeGetSystemProperty(String key, String def){
+    private static String safeGetSystemProperty(String key, String def){
         try {
             return System.getProperty(key, def);
         } catch (SecurityException t){

--- a/src/main/org/codehaus/groovy/control/GenericsVisitor.java
+++ b/src/main/org/codehaus/groovy/control/GenericsVisitor.java
@@ -115,7 +115,7 @@ public class GenericsVisitor extends ClassCodeVisitorSupport {
         }
     }
     
-    private String getPrintName(GenericsType gt) {
+    private static String getPrintName(GenericsType gt) {
         String ret = gt.getName();
         ClassNode[] upperBounds = gt.getUpperBounds();
         ClassNode lowerBound = gt.getLowerBound();
@@ -132,7 +132,7 @@ public class GenericsVisitor extends ClassCodeVisitorSupport {
 
     }
     
-    private String getPrintName(ClassNode cn) {
+    private static String getPrintName(ClassNode cn) {
         String ret = cn.getName();
         GenericsType[] gts = cn.getGenericsTypes();
         if (gts!=null) {

--- a/src/main/org/codehaus/groovy/control/GenericsVisitor.java
+++ b/src/main/org/codehaus/groovy/control/GenericsVisitor.java
@@ -31,7 +31,7 @@ import org.codehaus.groovy.ast.Parameter;
  * @author Jochen Theodorou
  */
 public class GenericsVisitor extends ClassCodeVisitorSupport {
-    private SourceUnit source;
+    private final SourceUnit source;
     
     public GenericsVisitor(SourceUnit source) {
         this.source = source;

--- a/src/main/org/codehaus/groovy/control/GenericsVisitor.java
+++ b/src/main/org/codehaus/groovy/control/GenericsVisitor.java
@@ -145,13 +145,4 @@ public class GenericsVisitor extends ClassCodeVisitorSupport {
         }
         return ret;
     }
-    
-    private void checkBounds(ClassNode[] given, ClassNode[] restrictions) {
-        if (restrictions==null) return;
-        for (int i=0; i<given.length; i++) {
-            for (int j=0; j<restrictions.length; j++) {
-                if (! given[i].isDerivedFrom(restrictions[j])){}
-            }
-        }
-    }
 }

--- a/src/main/org/codehaus/groovy/control/LabelVerifier.java
+++ b/src/main/org/codehaus/groovy/control/LabelVerifier.java
@@ -38,7 +38,7 @@ import java.util.List;
  */
 public class LabelVerifier extends ClassCodeVisitorSupport {
 
-    private SourceUnit source;
+    private final SourceUnit source;
     private LinkedList<String> visitedLabels;
     private LinkedList<ContinueStatement> continueLabels;
     private LinkedList<BreakStatement> breakLabels;

--- a/src/main/org/codehaus/groovy/control/MultipleCompilationErrorsException.java
+++ b/src/main/org/codehaus/groovy/control/MultipleCompilationErrorsException.java
@@ -27,7 +27,7 @@ import java.io.StringWriter;
 public class MultipleCompilationErrorsException extends
         CompilationFailedException {
     
-    protected ErrorCollector collector;
+    protected final ErrorCollector collector;
     
     public MultipleCompilationErrorsException(ErrorCollector ec) {
         super(0, null);

--- a/src/main/org/codehaus/groovy/control/OptimizerVisitor.java
+++ b/src/main/org/codehaus/groovy/control/OptimizerVisitor.java
@@ -38,8 +38,8 @@ public class OptimizerVisitor extends ClassCodeExpressionTransformer {
     private ClassNode currentClass;
     private SourceUnit source;
 
-    private Map const2Var = new HashMap();
-    private List<FieldNode> missingFields = new LinkedList<FieldNode>();
+    private final Map const2Var = new HashMap();
+    private final List<FieldNode> missingFields = new LinkedList<FieldNode>();
 
     public OptimizerVisitor(CompilationUnit cu) {
     }

--- a/src/main/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/org/codehaus/groovy/control/ResolveVisitor.java
@@ -52,7 +52,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
     private ClassNode currentClass;
     // note: BigInteger and BigDecimal are also imported by default
     public static final String[] DEFAULT_IMPORTS = {"java.lang.", "java.io.", "java.net.", "java.util.", "groovy.lang.", "groovy.util."};
-    private CompilationUnit compilationUnit;
+    private final CompilationUnit compilationUnit;
     private SourceUnit source;
     private VariableScope currentScope;
 
@@ -61,7 +61,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
     private boolean inClosure = false;
 
     private Map<String, GenericsType> genericParameterNames = new HashMap<String, GenericsType>();
-    private Set<FieldNode> fieldTypesChecked = new HashSet<FieldNode>();
+    private final Set<FieldNode> fieldTypesChecked = new HashSet<FieldNode>();
     private boolean checkingVariableTypeInDeclaration = false;
     private ImportNode currImportNode = null;
     private MethodNode currentMethod;
@@ -74,7 +74,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
      * the outer class we know is already resolved.
      */
     private static class ConstructedNestedClass extends ClassNode {
-        ClassNode knownEnclosingType;
+        final ClassNode knownEnclosingType;
         public ConstructedNestedClass(ClassNode outer, String inner) {
             super(outer.getName()+"$"+(inner=replacePoints(inner)), Opcodes.ACC_PUBLIC,ClassHelper.OBJECT_TYPE);
             this.knownEnclosingType = outer;
@@ -107,7 +107,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
      * can't be done in these cases...
      */
     private static class ConstructedClassWithPackage extends ClassNode {
-        String prefix;
+        final String prefix;
         String className;
         public ConstructedClassWithPackage(String pkg, String name) {
             super(pkg+name, Opcodes.ACC_PUBLIC,ClassHelper.OBJECT_TYPE);
@@ -143,7 +143,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
      * for an alias for this name which is much faster.
      */
     private static class LowerCaseClass extends ClassNode {
-        String className;
+        final String className;
         public LowerCaseClass(String name) {
             super(name, Opcodes.ACC_PUBLIC,ClassHelper.OBJECT_TYPE);
             isPrimaryNode = false;

--- a/src/main/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/org/codehaus/groovy/control/ResolveVisitor.java
@@ -94,7 +94,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
     }
 
 
-    static String replacePoints(String name) {
+    private static String replacePoints(String name) {
         return name.replace('.','$');
     }
 

--- a/src/main/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/org/codehaus/groovy/control/ResolveVisitor.java
@@ -94,7 +94,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
     }
 
 
-    private static String replacePoints(String name) {
+    static String replacePoints(String name) {
         return name.replace('.','$');
     }
 

--- a/src/main/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/org/codehaus/groovy/control/ResolveVisitor.java
@@ -391,7 +391,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         return false;
     }
 
-    private String replaceLastPoint(String name) {
+    private static String replaceLastPoint(String name) {
         int lastPoint = name.lastIndexOf('.');
         name = new StringBuffer()
                 .append(name.substring(0, lastPoint))
@@ -716,7 +716,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         return ret;
     }
 
-    private String lookupClassName(PropertyExpression pe) {
+    private static String lookupClassName(PropertyExpression pe) {
         boolean doInitialClassTest=true;
         String name = "";
         // this loop builds a name from right to left each name part
@@ -778,7 +778,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
     // this check will ignore a .class property, for Example Integer.class will be
     // a PropertyExpression with the ClassExpression of Integer as objectExpression
     // and class as property
-    private Expression correctClassClassChain(PropertyExpression pe) {
+    private static Expression correctClassClassChain(PropertyExpression pe) {
         LinkedList<Expression> stack = new LinkedList<Expression>();
         ClassExpression found = null;
         for (Expression it = pe; it != null; it = ((PropertyExpression) it).getObjectExpression()) {
@@ -947,12 +947,12 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         return ve;
     }
 
-    private boolean testVanillaNameForClass(String name) {
+    private static boolean testVanillaNameForClass(String name) {
         if (name==null || name.length()==0) return false;
         return !Character.isLowerCase(name.charAt(0));
     }
 
-    private boolean isLeftSquareBracket(int op) {
+    private static boolean isLeftSquareBracket(int op) {
         return op == Types.ARRAY_EXPRESSION
                 || op == Types.LEFT_SQUARE_BRACKET
                 || op == Types.SYNTH_LIST
@@ -1062,7 +1062,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         return ret;
     }
 
-    private String getDescription(ClassNode node) {
+    private static String getDescription(ClassNode node) {
         return (node.isInterface() ? "interface" : "class") + " '" + node.getName() + "'";
     }
     

--- a/src/main/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/org/codehaus/groovy/control/ResolveVisitor.java
@@ -75,11 +75,9 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
      */
     private static class ConstructedNestedClass extends ClassNode {
         ClassNode knownEnclosingType;
-        String nestClassName;
         public ConstructedNestedClass(ClassNode outer, String inner) {
             super(outer.getName()+"$"+(inner=replacePoints(inner)), Opcodes.ACC_PUBLIC,ClassHelper.OBJECT_TYPE);
             this.knownEnclosingType = outer;
-            this.nestClassName = inner;
             this.isPrimaryNode = false;
         }
         public boolean hasPackageName() {

--- a/src/main/org/codehaus/groovy/control/SourceUnit.java
+++ b/src/main/org/codehaus/groovy/control/SourceUnit.java
@@ -288,7 +288,7 @@ public class SourceUnit extends ProcessingUnit {
         }
     }
 
-    private void saveAsXML(String name, ModuleNode ast) {
+    private static void saveAsXML(String name, ModuleNode ast) {
         XStreamUtils.serialize(name, ast);
     }
 

--- a/src/main/org/codehaus/groovy/control/StaticImportVisitor.java
+++ b/src/main/org/codehaus/groovy/control/StaticImportVisitor.java
@@ -186,7 +186,7 @@ public class StaticImportVisitor extends ClassCodeExpressionTransformer {
      * @param toSet resulting node
      * @param origNode original node
      */
-    private void setSourcePosition(Expression toSet, Expression origNode) {
+    private static void setSourcePosition(Expression toSet, Expression origNode) {
         toSet.setSourcePosition(origNode);
         if (toSet instanceof PropertyExpression) {
             ((PropertyExpression) toSet).getProperty().setSourcePosition(origNode);
@@ -217,7 +217,7 @@ public class StaticImportVisitor extends ClassCodeExpressionTransformer {
         return exp;
     }
 
-    private Expression findConstant(FieldNode fn) {
+    private static Expression findConstant(FieldNode fn) {
         if (fn != null && !fn.isEnum() && fn.isStatic() && fn.isFinal()) {
             if (fn.getInitialValueExpression() instanceof ConstantExpression) {
                 return fn.getInitialValueExpression();
@@ -469,18 +469,18 @@ public class StaticImportVisitor extends ClassCodeExpressionTransformer {
         return null;
     }
 
-    private String prefix(String name) {
+    private static String prefix(String name) {
         return name.startsWith("is") ? "is" : name.substring(0, 3);
     }
 
-    private String getPropNameForAccessor(String fieldName) {
+    private static String getPropNameForAccessor(String fieldName) {
         int prefixLength = fieldName.startsWith("is") ? 2 : 3;
         if (fieldName.length() < prefixLength + 1) return fieldName;
         if (!validPropName(fieldName)) return fieldName;
         return String.valueOf(fieldName.charAt(prefixLength)).toLowerCase() + fieldName.substring(prefixLength + 1);
     }
 
-    private boolean validPropName(String propName) {
+    private static boolean validPropName(String propName) {
         return propName.startsWith("get") || propName.startsWith("is") || propName.startsWith("set");
     }
 
@@ -509,7 +509,7 @@ public class StaticImportVisitor extends ClassCodeExpressionTransformer {
         return accessor;
     }
 
-    private boolean hasStaticProperty(ClassNode staticImportType, String propName) {
+    private static boolean hasStaticProperty(ClassNode staticImportType, String propName) {
         ClassNode classNode = staticImportType;
         while (classNode != null) {
             for (PropertyNode pn : classNode.getProperties()) {
@@ -527,7 +527,7 @@ public class StaticImportVisitor extends ClassCodeExpressionTransformer {
         return findStaticMethod(staticImportType, accessorMethodName, (inLeftExpression ? dummyArgs : ArgumentListExpression.EMPTY_ARGUMENTS));
     }
 
-    private Expression findStaticField(ClassNode staticImportType, String fieldName) {
+    private static Expression findStaticField(ClassNode staticImportType, String fieldName) {
         if (staticImportType.isPrimaryClassNode() || staticImportType.isResolved()) {
             FieldNode field = staticImportType.getField(fieldName);
             if (field != null && field.isStatic())
@@ -536,7 +536,7 @@ public class StaticImportVisitor extends ClassCodeExpressionTransformer {
         return null;
     }
 
-    private Expression findStaticMethod(ClassNode staticImportType, String methodName, Expression args) {
+    private static Expression findStaticMethod(ClassNode staticImportType, String methodName, Expression args) {
         if (staticImportType.isPrimaryClassNode() || staticImportType.isResolved()) {
             if (staticImportType.hasPossibleStaticMethod(methodName, args)) {
                 return new StaticMethodCallExpression(staticImportType, methodName, args);

--- a/src/main/org/codehaus/groovy/control/StaticVerifier.java
+++ b/src/main/org/codehaus/groovy/control/StaticVerifier.java
@@ -154,7 +154,7 @@ public class StaticVerifier extends ClassCodeVisitorSupport {
         addVariableError(ve);
     }
 
-    private void addVariableError(VariableExpression ve) {
+    void addVariableError(VariableExpression ve) {
         addError("Apparent variable '" + ve.getName() + "' was found in a static scope but doesn't refer" +
                 " to a local variable, static field or class. Possible causes:\n" +
                 "You attempted to reference a variable in the binding or an instance variable from a static context.\n" +

--- a/src/main/org/codehaus/groovy/control/StaticVerifier.java
+++ b/src/main/org/codehaus/groovy/control/StaticVerifier.java
@@ -154,7 +154,7 @@ public class StaticVerifier extends ClassCodeVisitorSupport {
         addVariableError(ve);
     }
 
-    void addVariableError(VariableExpression ve) {
+    private void addVariableError(VariableExpression ve) {
         addError("Apparent variable '" + ve.getName() + "' was found in a static scope but doesn't refer" +
                 " to a local variable, static field or class. Possible causes:\n" +
                 "You attempted to reference a variable in the binding or an instance variable from a static context.\n" +

--- a/src/main/org/codehaus/groovy/control/StaticVerifier.java
+++ b/src/main/org/codehaus/groovy/control/StaticVerifier.java
@@ -163,7 +163,7 @@ public class StaticVerifier extends ClassCodeVisitorSupport {
                 "' but left out brackets in a place not allowed by the grammar.", ve);
     }
 
-    private FieldNode getDeclaredOrInheritedField(ClassNode cn, String fieldName) {
+    private static FieldNode getDeclaredOrInheritedField(ClassNode cn, String fieldName) {
         ClassNode node = cn;
         while (node != null) {
             FieldNode fn = node.getDeclaredField(fieldName);

--- a/src/main/org/codehaus/groovy/control/customizers/ImportCustomizer.java
+++ b/src/main/org/codehaus/groovy/control/customizers/ImportCustomizer.java
@@ -134,7 +134,7 @@ public class ImportCustomizer extends CompilationCustomizer {
         final String field;
         final String star; // only used for star imports
 
-        private Import(final ImportType type, final String alias, final ClassNode classNode, final String field) {
+        Import(final ImportType type, final String alias, final ClassNode classNode, final String field) {
             this.alias = alias;
             this.classNode = classNode;
             this.field = field;
@@ -142,7 +142,7 @@ public class ImportCustomizer extends CompilationCustomizer {
             this.star = null;
         }
 
-        private Import(final ImportType type, final String alias, final ClassNode classNode) {
+        Import(final ImportType type, final String alias, final ClassNode classNode) {
             this.alias = alias;
             this.classNode = classNode;
             this.type = type;
@@ -150,7 +150,7 @@ public class ImportCustomizer extends CompilationCustomizer {
             this.star = null;
         }
 
-        private Import(final ImportType type, final String star) {
+        Import(final ImportType type, final String star) {
             this.type = type;
             this.star = star;
             this.alias = null;

--- a/src/main/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
+++ b/src/main/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
@@ -577,7 +577,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
         if (!methods.isEmpty()) throw new SecurityException("Method definitions are not allowed");
     }
     
-    private List<MethodNode> filterMethods(ClassNode owner) {
+    private static List<MethodNode> filterMethods(ClassNode owner) {
         List<MethodNode> result = new LinkedList<MethodNode>();
         List<MethodNode> methods = owner.getMethods();
         for (MethodNode method : methods) {

--- a/src/main/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
+++ b/src/main/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
@@ -122,7 +122,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
 
     private boolean isPackageAllowed = true;
     private boolean isMethodDefinitionAllowed = true;
-    private boolean isClosuresAllowed = true;
+    boolean isClosuresAllowed = true;
 
     // imports
     private List<String> importsWhitelist;
@@ -144,29 +144,29 @@ public class SecureASTCustomizer extends CompilationCustomizer {
     // indirect import checks
     // if set to true, then security rules on imports will also be applied on classnodes.
     // Direct instantiation of classes without imports will therefore also fail if this option is enabled
-    private boolean isIndirectImportCheckEnabled;
+    boolean isIndirectImportCheckEnabled;
 
     // statements
-    private List<Class<? extends Statement>> statementsWhitelist;
-    private List<Class<? extends Statement>> statementsBlacklist;
-    private final List<StatementChecker> statementCheckers = new LinkedList<StatementChecker>();
+    List<Class<? extends Statement>> statementsWhitelist;
+    List<Class<? extends Statement>> statementsBlacklist;
+    final List<StatementChecker> statementCheckers = new LinkedList<StatementChecker>();
 
     // expressions
-    private List<Class<? extends Expression>> expressionsWhitelist;
-    private List<Class<? extends Expression>> expressionsBlacklist;
-    private final List<ExpressionChecker> expressionCheckers = new LinkedList<ExpressionChecker>();
+    List<Class<? extends Expression>> expressionsWhitelist;
+    List<Class<? extends Expression>> expressionsBlacklist;
+    final List<ExpressionChecker> expressionCheckers = new LinkedList<ExpressionChecker>();
 
     // tokens from Types
-    private List<Integer> tokensWhitelist;
-    private List<Integer> tokensBlacklist;
+    List<Integer> tokensWhitelist;
+    List<Integer> tokensBlacklist;
 
     // constant types
-    private List<String> constantTypesWhiteList;
-    private List<String> constantTypesBlackList;
+    List<String> constantTypesWhiteList;
+    List<String> constantTypesBlackList;
 
     // receivers
-    private List<String> receiversWhiteList;
-    private List<String> receiversBlackList;
+    List<String> receiversWhiteList;
+    List<String> receiversBlackList;
 
     public SecureASTCustomizer() {
         super(CompilePhase.CANONICALIZATION);
@@ -598,7 +598,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
         }
     }
 
-    private void assertImportIsAllowed(final String className) {
+    void assertImportIsAllowed(final String className) {
         if (importsWhitelist != null && !importsWhitelist.contains(className)) {
             if (starImportsWhitelist != null) {
                 // we should now check if the import is in the star imports
@@ -624,7 +624,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
         }
     }
 
-    private void assertStaticImportIsAllowed(final String member, final String className) {
+    void assertStaticImportIsAllowed(final String member, final String className) {
         final String fqn = member.equals(className) ? member : className + "." + member;
         if (staticImportsWhitelist != null && !staticImportsWhitelist.contains(fqn)) {
             if (staticStarImportsWhitelist != null) {
@@ -652,7 +652,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
      * CodeVisitorSupport} class to make sure that future features of the language gets managed by this visitor. Thus,
      * adding a new feature would result in a compilation error if this visitor is not updated.
      */
-    private class SecuringCodeVisitor implements GroovyCodeVisitor {
+    class SecuringCodeVisitor implements GroovyCodeVisitor {
 
         /**
          * Checks that a given statement is either in the whitelist or not in the blacklist.

--- a/src/main/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
+++ b/src/main/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
@@ -122,7 +122,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
 
     private boolean isPackageAllowed = true;
     private boolean isMethodDefinitionAllowed = true;
-    boolean isClosuresAllowed = true;
+    private boolean isClosuresAllowed = true;
 
     // imports
     private List<String> importsWhitelist;
@@ -144,29 +144,29 @@ public class SecureASTCustomizer extends CompilationCustomizer {
     // indirect import checks
     // if set to true, then security rules on imports will also be applied on classnodes.
     // Direct instantiation of classes without imports will therefore also fail if this option is enabled
-    boolean isIndirectImportCheckEnabled;
+    private boolean isIndirectImportCheckEnabled;
 
     // statements
-    List<Class<? extends Statement>> statementsWhitelist;
-    List<Class<? extends Statement>> statementsBlacklist;
-    final List<StatementChecker> statementCheckers = new LinkedList<StatementChecker>();
+    private List<Class<? extends Statement>> statementsWhitelist;
+    private List<Class<? extends Statement>> statementsBlacklist;
+    private final List<StatementChecker> statementCheckers = new LinkedList<StatementChecker>();
 
     // expressions
-    List<Class<? extends Expression>> expressionsWhitelist;
-    List<Class<? extends Expression>> expressionsBlacklist;
-    final List<ExpressionChecker> expressionCheckers = new LinkedList<ExpressionChecker>();
+    private List<Class<? extends Expression>> expressionsWhitelist;
+    private List<Class<? extends Expression>> expressionsBlacklist;
+    private final List<ExpressionChecker> expressionCheckers = new LinkedList<ExpressionChecker>();
 
     // tokens from Types
-    List<Integer> tokensWhitelist;
-    List<Integer> tokensBlacklist;
+    private List<Integer> tokensWhitelist;
+    private List<Integer> tokensBlacklist;
 
     // constant types
-    List<String> constantTypesWhiteList;
-    List<String> constantTypesBlackList;
+    private List<String> constantTypesWhiteList;
+    private List<String> constantTypesBlackList;
 
     // receivers
-    List<String> receiversWhiteList;
-    List<String> receiversBlackList;
+    private List<String> receiversWhiteList;
+    private List<String> receiversBlackList;
 
     public SecureASTCustomizer() {
         super(CompilePhase.CANONICALIZATION);
@@ -598,7 +598,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
         }
     }
 
-    void assertImportIsAllowed(final String className) {
+    private void assertImportIsAllowed(final String className) {
         if (importsWhitelist != null && !importsWhitelist.contains(className)) {
             if (starImportsWhitelist != null) {
                 // we should now check if the import is in the star imports
@@ -624,7 +624,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
         }
     }
 
-    void assertStaticImportIsAllowed(final String member, final String className) {
+    private void assertStaticImportIsAllowed(final String member, final String className) {
         final String fqn = member.equals(className) ? member : className + "." + member;
         if (staticImportsWhitelist != null && !staticImportsWhitelist.contains(fqn)) {
             if (staticStarImportsWhitelist != null) {
@@ -652,7 +652,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
      * CodeVisitorSupport} class to make sure that future features of the language gets managed by this visitor. Thus,
      * adding a new feature would result in a compilation error if this visitor is not updated.
      */
-    class SecuringCodeVisitor implements GroovyCodeVisitor {
+    private class SecuringCodeVisitor implements GroovyCodeVisitor {
 
         /**
          * Checks that a given statement is either in the whitelist or not in the blacklist.

--- a/src/main/org/codehaus/groovy/control/customizers/builder/ImportCustomizerFactory.java
+++ b/src/main/org/codehaus/groovy/control/customizers/builder/ImportCustomizerFactory.java
@@ -89,7 +89,7 @@ public class ImportCustomizerFactory extends AbstractFactory {
     private static class ImportHelper {
         private final ImportCustomizer customizer;
 
-        private ImportHelper(final ImportCustomizer customizer) {
+        ImportHelper(final ImportCustomizer customizer) {
             this.customizer = customizer;
         }
 

--- a/src/main/org/codehaus/groovy/control/customizers/builder/SourceAwareCustomizerFactory.java
+++ b/src/main/org/codehaus/groovy/control/customizers/builder/SourceAwareCustomizerFactory.java
@@ -109,7 +109,7 @@ public class SourceAwareCustomizerFactory extends AbstractFactory implements Pos
         return sourceAwareCustomizer;
     }
 
-    private void addExtensionValidator(final SourceAwareCustomizer sourceAwareCustomizer, final SourceOptions data) {
+    private static void addExtensionValidator(final SourceAwareCustomizer sourceAwareCustomizer, final SourceOptions data) {
         final List<String> extensions = data.extensions!=null?data.extensions : new LinkedList<String>();
         if (data.extension!=null) extensions.add(data.extension);
         Closure<Boolean> extensionValidator = data.extensionValidator;
@@ -125,7 +125,7 @@ public class SourceAwareCustomizerFactory extends AbstractFactory implements Pos
         sourceAwareCustomizer.setExtensionValidator(extensionValidator);
     }
 
-    private void addBasenameValidator(final SourceAwareCustomizer sourceAwareCustomizer, final SourceOptions data) {
+    private static void addBasenameValidator(final SourceAwareCustomizer sourceAwareCustomizer, final SourceOptions data) {
         final List<String> basenames = data.basenames!=null?data.basenames : new LinkedList<String>();
         if (data.basename!=null) basenames.add(data.basename);
         Closure<Boolean> basenameValidator = data.basenameValidator;

--- a/src/main/org/codehaus/groovy/control/io/FileReaderSource.java
+++ b/src/main/org/codehaus/groovy/control/io/FileReaderSource.java
@@ -30,7 +30,7 @@ import org.codehaus.groovy.control.CompilerConfiguration;
  *  @author <a href="mailto:cpoirier@dreaming.org">Chris Poirier</a>
  */
 public class FileReaderSource extends AbstractReaderSource {
-    private File file;  // The File from which we produce Readers.
+    private final File file;  // The File from which we produce Readers.
     private final Charset UTF8 = Charset.forName("UTF-8");
 
    /**

--- a/src/main/org/codehaus/groovy/control/io/URLReaderSource.java
+++ b/src/main/org/codehaus/groovy/control/io/URLReaderSource.java
@@ -34,7 +34,7 @@ import org.codehaus.groovy.control.CompilerConfiguration;
  *  @author <a href="mailto:cpoirier@dreaming.org">Chris Poirier</a>
  */
 public class URLReaderSource extends AbstractReaderSource {
-    private URL url;  // The URL from which we produce Readers.
+    private final URL url;  // The URL from which we produce Readers.
     
    /**
     *  Creates the ReaderSource from a File descriptor.

--- a/src/main/org/codehaus/groovy/control/messages/WarningMessage.java
+++ b/src/main/org/codehaus/groovy/control/messages/WarningMessage.java
@@ -69,7 +69,7 @@ public class WarningMessage extends LocatedMessage
   //---------------------------------------------------------------------------
   // CONSTRUCTION AND DATA ACCESS
 
-    private int importance;  // The warning level, for filtering
+    private final int importance;  // The warning level, for filtering
     
     
    /**

--- a/src/main/org/codehaus/groovy/reflection/CachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/CachedClass.java
@@ -39,8 +39,8 @@ import java.util.*;
  * @author Alex.Tkachman
  */
 public class CachedClass {
-    static final Method[] EMPTY_METHOD_ARRAY = new Method[0];
-    final Class cachedClass;
+    private static final Method[] EMPTY_METHOD_ARRAY = new Method[0];
+    private final Class cachedClass;
     public ClassInfo classInfo;
     
     private static ReferenceBundle softBundle = ReferenceBundle.getSoftBundle();

--- a/src/main/org/codehaus/groovy/reflection/CachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/CachedClass.java
@@ -69,7 +69,7 @@ public class CachedClass {
         }
     };
 
-    private LazyReference<CachedConstructor[]> constructors = new LazyReference<CachedConstructor[]>(softBundle) {
+    private final LazyReference<CachedConstructor[]> constructors = new LazyReference<CachedConstructor[]>(softBundle) {
         public CachedConstructor[] initValue() {
             final Constructor[] declaredConstructors = (Constructor[])
                AccessController.doPrivileged(new PrivilegedAction/*<Constructor[]>*/() {
@@ -84,7 +84,7 @@ public class CachedClass {
         }
     };
 
-    private LazyReference<CachedMethod[]> methods = new LazyReference<CachedMethod[]>(softBundle) {
+    private final LazyReference<CachedMethod[]> methods = new LazyReference<CachedMethod[]>(softBundle) {
         public CachedMethod[] initValue() {
             final Method[] declaredMethods = (Method[])
                AccessController.doPrivileged(new PrivilegedAction/*<Method[]>*/() {
@@ -138,7 +138,7 @@ public class CachedClass {
         }
     };
 
-    private LazyReference<CachedClass> cachedSuperClass = new LazyReference<CachedClass>(softBundle) {
+    private final LazyReference<CachedClass> cachedSuperClass = new LazyReference<CachedClass>(softBundle) {
         public CachedClass initValue() {
             if (!isArray)
               return ReflectionCache.getCachedClass(getTheClass().getSuperclass());

--- a/src/main/org/codehaus/groovy/reflection/CachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/CachedClass.java
@@ -39,8 +39,8 @@ import java.util.*;
  * @author Alex.Tkachman
  */
 public class CachedClass {
-    private static final Method[] EMPTY_METHOD_ARRAY = new Method[0];
-    private final Class cachedClass;
+    static final Method[] EMPTY_METHOD_ARRAY = new Method[0];
+    final Class cachedClass;
     public ClassInfo classInfo;
     
     private static ReferenceBundle softBundle = ReferenceBundle.getSoftBundle();

--- a/src/main/org/codehaus/groovy/reflection/CachedMethod.java
+++ b/src/main/org/codehaus/groovy/reflection/CachedMethod.java
@@ -218,14 +218,14 @@ public class CachedMethod extends MetaMethod implements Comparable {
         return cachedMethod.toString();
     }
     
-    private Constructor getConstrcutor(SoftReference<Constructor> ref) {
+    private static Constructor getConstructor(SoftReference<Constructor> ref) {
         if (ref==null) return null;
         return ref.get();
     }
 
     public CallSite createPogoMetaMethodSite(CallSite site, MetaClassImpl metaClass, Class[] params) {
         if (!skipCompiled) {
-            Constructor constr = getConstrcutor(pogoCallSiteConstructor);
+            Constructor constr = getConstructor(pogoCallSiteConstructor);
             if (constr==null) {
                 if (CallSiteGenerator.isCompilable(this)) {
                   constr = CallSiteGenerator.compilePogoMethod(this);
@@ -254,7 +254,7 @@ public class CachedMethod extends MetaMethod implements Comparable {
 
     public CallSite createPojoMetaMethodSite(CallSite site, MetaClassImpl metaClass, Class[] params) {
         if (!skipCompiled) {
-            Constructor constr = getConstrcutor(pojoCallSiteConstructor);
+            Constructor constr = getConstructor(pojoCallSiteConstructor);
             if (constr==null) {
                 if (CallSiteGenerator.isCompilable(this)) {
                   constr = CallSiteGenerator.compilePojoMethod(this);
@@ -282,7 +282,7 @@ public class CachedMethod extends MetaMethod implements Comparable {
 
     public CallSite createStaticMetaMethodSite(CallSite site, MetaClassImpl metaClass, Class[] params) {
         if (!skipCompiled) {
-            Constructor constr = getConstrcutor(staticCallSiteConstructor);
+            Constructor constr = getConstructor(staticCallSiteConstructor);
             if (constr==null) {
                 if (CallSiteGenerator.isCompilable(this)) {
                   constr = CallSiteGenerator.compileStaticMethod(this);

--- a/src/main/org/codehaus/groovy/reflection/CachedMethod.java
+++ b/src/main/org/codehaus/groovy/reflection/CachedMethod.java
@@ -42,7 +42,7 @@ public class CachedMethod extends MetaMethod implements Comparable {
     private final Method cachedMethod;
     private int hashCode;
 
-    private static MyComparator comparator = new MyComparator();
+    private static final MyComparator comparator = new MyComparator();
 
     private SoftReference<Constructor> pogoCallSiteConstructor, pojoCallSiteConstructor, staticCallSiteConstructor;
 

--- a/src/main/org/codehaus/groovy/reflection/CachedMethod.java
+++ b/src/main/org/codehaus/groovy/reflection/CachedMethod.java
@@ -309,7 +309,7 @@ public class CachedMethod extends MetaMethod implements Comparable {
         return new StaticMetaMethodSite.StaticMetaMethodSiteNoUnwrapNoCoerce(site, metaClass, this, params);
     }
 
-    private static class MyComparator implements Comparator {
+    static class MyComparator implements Comparator {
         public int compare(Object o1, Object o2) {
             if (o1 instanceof CachedMethod)
                 return ((CachedMethod)o1).compareTo(o2);

--- a/src/main/org/codehaus/groovy/reflection/CachedMethod.java
+++ b/src/main/org/codehaus/groovy/reflection/CachedMethod.java
@@ -309,7 +309,7 @@ public class CachedMethod extends MetaMethod implements Comparable {
         return new StaticMetaMethodSite.StaticMetaMethodSiteNoUnwrapNoCoerce(site, metaClass, this, params);
     }
 
-    static class MyComparator implements Comparator {
+    private static class MyComparator implements Comparator {
         public int compare(Object o1, Object o2) {
             if (o1 instanceof CachedMethod)
                 return ((CachedMethod)o1).compareTo(o2);

--- a/src/main/org/codehaus/groovy/reflection/ClassInfo.java
+++ b/src/main/org/codehaus/groovy/reflection/ClassInfo.java
@@ -37,11 +37,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ClassInfo {
 
-    private final LazyCachedClassRef cachedClassRef;
-    private final LazyClassLoaderRef artifactClassLoader;
+    final LazyCachedClassRef cachedClassRef;
+    final LazyClassLoaderRef artifactClassLoader;
     private final LockableObject lock = new LockableObject();
     public final int hash = -1;
-    private final Class klazz;
+    final Class klazz;
 
     private final AtomicInteger version = new AtomicInteger();
 
@@ -51,8 +51,8 @@ public class ClassInfo {
     MetaMethod[] newMetaMethods = CachedClass.EMPTY;
     private ManagedConcurrentMap<Object, MetaClass> perInstanceMetaClassMap;
     
-    private static final ReferenceBundle softBundle = ReferenceBundle.getSoftBundle();
-    private static final ReferenceBundle weakBundle = ReferenceBundle.getWeakBundle();
+    static final ReferenceBundle softBundle = ReferenceBundle.getSoftBundle();
+    static final ReferenceBundle weakBundle = ReferenceBundle.getWeakBundle();
     
     private static final ManagedLinkedList<ClassInfo> modifiedExpandos = new ManagedLinkedList<ClassInfo>(weakBundle);
 
@@ -65,7 +65,7 @@ public class ClassInfo {
 		}
 	});
     
-    private static final GlobalClassSet globalClassSet = new GlobalClassSet();
+    static final GlobalClassSet globalClassSet = new GlobalClassSet();
 
     ClassInfo(Class klazz) {
     	this.klazz = klazz;
@@ -275,7 +275,7 @@ public class ClassInfo {
         return globalClassSet.fullSize();
     }
 
-    private static CachedClass createCachedClass(Class klazz, ClassInfo classInfo) {
+    static CachedClass createCachedClass(Class klazz, ClassInfo classInfo) {
         if (klazz == Object.class)
             return new ObjectCachedClass(classInfo);
 
@@ -425,7 +425,7 @@ public class ClassInfo {
         }
     }
     
-    private static class GlobalClassSet {
+    static class GlobalClassSet {
     	
     	private final ManagedLinkedList<ClassInfo> items = new ManagedLinkedList<ClassInfo>(weakBundle);
     	

--- a/src/main/org/codehaus/groovy/reflection/ClassInfo.java
+++ b/src/main/org/codehaus/groovy/reflection/ClassInfo.java
@@ -233,7 +233,7 @@ public class ClassInfo {
         return answer;
     }
     
-    private boolean isValidWeakMetaClass(MetaClass metaClass) {
+    private static boolean isValidWeakMetaClass(MetaClass metaClass) {
         return isValidWeakMetaClass(metaClass, GroovySystem.getMetaClassRegistry().getMetaClassCreationHandler());
     }
 
@@ -241,7 +241,7 @@ public class ClassInfo {
      * if EMC.enableGlobally() is OFF, return whatever the cached answer is.
      * but if EMC.enableGlobally() is ON and the cached answer is not an EMC, come up with a fresh answer
      */
-    private boolean isValidWeakMetaClass(MetaClass metaClass, MetaClassRegistry.MetaClassCreationHandle mccHandle) {
+    private static boolean isValidWeakMetaClass(MetaClass metaClass, MetaClassRegistry.MetaClassCreationHandle mccHandle) {
         if(metaClass==null) return false;
         boolean enableGloballyOn = (mccHandle instanceof ExpandoMetaClassCreationHandle);
         boolean cachedAnswerIsEMC = (metaClass instanceof ExpandoMetaClass);

--- a/src/main/org/codehaus/groovy/reflection/ClassInfo.java
+++ b/src/main/org/codehaus/groovy/reflection/ClassInfo.java
@@ -37,11 +37,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ClassInfo {
 
-    final LazyCachedClassRef cachedClassRef;
-    final LazyClassLoaderRef artifactClassLoader;
+    private final LazyCachedClassRef cachedClassRef;
+    private final LazyClassLoaderRef artifactClassLoader;
     private final LockableObject lock = new LockableObject();
     public final int hash = -1;
-    final Class klazz;
+    private final Class klazz;
 
     private final AtomicInteger version = new AtomicInteger();
 
@@ -51,8 +51,8 @@ public class ClassInfo {
     MetaMethod[] newMetaMethods = CachedClass.EMPTY;
     private ManagedConcurrentMap<Object, MetaClass> perInstanceMetaClassMap;
     
-    static final ReferenceBundle softBundle = ReferenceBundle.getSoftBundle();
-    static final ReferenceBundle weakBundle = ReferenceBundle.getWeakBundle();
+    private static final ReferenceBundle softBundle = ReferenceBundle.getSoftBundle();
+    private static final ReferenceBundle weakBundle = ReferenceBundle.getWeakBundle();
     
     private static final ManagedLinkedList<ClassInfo> modifiedExpandos = new ManagedLinkedList<ClassInfo>(weakBundle);
 
@@ -65,7 +65,7 @@ public class ClassInfo {
 		}
 	});
     
-    static final GlobalClassSet globalClassSet = new GlobalClassSet();
+    private static final GlobalClassSet globalClassSet = new GlobalClassSet();
 
     ClassInfo(Class klazz) {
     	this.klazz = klazz;
@@ -275,7 +275,7 @@ public class ClassInfo {
         return globalClassSet.fullSize();
     }
 
-    static CachedClass createCachedClass(Class klazz, ClassInfo classInfo) {
+    private static CachedClass createCachedClass(Class klazz, ClassInfo classInfo) {
         if (klazz == Object.class)
             return new ObjectCachedClass(classInfo);
 
@@ -425,7 +425,7 @@ public class ClassInfo {
         }
     }
     
-    static class GlobalClassSet {
+    private static class GlobalClassSet {
     	
     	private final ManagedLinkedList<ClassInfo> items = new ManagedLinkedList<ClassInfo>(weakBundle);
     	

--- a/src/main/org/codehaus/groovy/reflection/GeneratedMetaMethod.java
+++ b/src/main/org/codehaus/groovy/reflection/GeneratedMetaMethod.java
@@ -162,7 +162,7 @@ public abstract class GeneratedMetaMethod extends MetaMethod {
             out.close();
         }
 
-        public static List<DgmMethodRecord> loadDgmInfo() throws IOException, ClassNotFoundException {
+        public static List<DgmMethodRecord> loadDgmInfo() throws IOException {
 
             ClassLoader loader = DgmMethodRecord.class.getClassLoader();
             DataInputStream in = new DataInputStream(new BufferedInputStream(loader.getResourceAsStream("META-INF/dgminfo")));

--- a/src/main/org/codehaus/groovy/reflection/GroovyClassValuePreJava7.java
+++ b/src/main/org/codehaus/groovy/reflection/GroovyClassValuePreJava7.java
@@ -28,7 +28,7 @@ import org.codehaus.groovy.util.ReferenceBundle;
  * @param <T>
  */
 class GroovyClassValuePreJava7<T> implements GroovyClassValue<T> {
-	private static final ReferenceBundle weakBundle = ReferenceBundle.getWeakBundle();
+	static final ReferenceBundle weakBundle = ReferenceBundle.getWeakBundle();
 
 	private class EntryWithValue extends ManagedConcurrentMap.EntryWithValue<Class<?>,T>{
 
@@ -70,7 +70,7 @@ class GroovyClassValuePreJava7<T> implements GroovyClassValue<T> {
 
 	}
 
-	private final ComputeValue<T> computeValue;
+	final ComputeValue<T> computeValue;
 
 	private final GroovyClassValuePreJava7Map map = new GroovyClassValuePreJava7Map();
 

--- a/src/main/org/codehaus/groovy/reflection/GroovyClassValuePreJava7.java
+++ b/src/main/org/codehaus/groovy/reflection/GroovyClassValuePreJava7.java
@@ -28,7 +28,7 @@ import org.codehaus.groovy.util.ReferenceBundle;
  * @param <T>
  */
 class GroovyClassValuePreJava7<T> implements GroovyClassValue<T> {
-	static final ReferenceBundle weakBundle = ReferenceBundle.getWeakBundle();
+	private static final ReferenceBundle weakBundle = ReferenceBundle.getWeakBundle();
 
 	private class EntryWithValue extends ManagedConcurrentMap.EntryWithValue<Class<?>,T>{
 
@@ -70,7 +70,7 @@ class GroovyClassValuePreJava7<T> implements GroovyClassValue<T> {
 
 	}
 
-	final ComputeValue<T> computeValue;
+	private final ComputeValue<T> computeValue;
 
 	private final GroovyClassValuePreJava7Map map = new GroovyClassValuePreJava7Map();
 

--- a/src/main/org/codehaus/groovy/reflection/MixinInMetaClass.java
+++ b/src/main/org/codehaus/groovy/reflection/MixinInMetaClass.java
@@ -43,7 +43,7 @@ public class MixinInMetaClass extends ManagedConcurrentMap {
     final CachedClass mixinClass;
     final CachedConstructor constructor;
 
-    private static ReferenceBundle softBundle = ReferenceBundle.getSoftBundle();
+    private static final ReferenceBundle softBundle = ReferenceBundle.getSoftBundle();
 
     public MixinInMetaClass(ExpandoMetaClass emc, CachedClass mixinClass) {
         super(softBundle);

--- a/src/main/org/codehaus/groovy/reflection/MixinInMetaClass.java
+++ b/src/main/org/codehaus/groovy/reflection/MixinInMetaClass.java
@@ -54,7 +54,7 @@ public class MixinInMetaClass extends ManagedConcurrentMap {
         emc.addMixinClass(this);
     }
 
-    private CachedConstructor findDefaultConstructor(CachedClass mixinClass) {
+    private static CachedConstructor findDefaultConstructor(CachedClass mixinClass) {
         for (CachedConstructor constr : mixinClass.getConstructors()) {
             if (!Modifier.isPublic(constr.getModifiers()))
                 continue;

--- a/src/main/org/codehaus/groovy/reflection/ParameterTypes.java
+++ b/src/main/org/codehaus/groovy/reflection/ParameterTypes.java
@@ -250,7 +250,7 @@ public class ParameterTypes
         return false;
     }
 
-    private boolean isValidExactMethod(Class[] arguments, CachedClass[] pt) {
+    private static boolean isValidExactMethod(Class[] arguments, CachedClass[] pt) {
         // lets check the parameter types match
         int size = pt.length;
         for (int i = 0; i < size; i++) {
@@ -297,7 +297,7 @@ public class ParameterTypes
         return MetaClassHelper.isAssignableFrom(toTestAgainst, component);
     }
 
-    private boolean isValidVarargsMethod(Class[] arguments, int size, CachedClass[] pt, int paramMinus1) {
+    private static boolean isValidVarargsMethod(Class[] arguments, int size, CachedClass[] pt, int paramMinus1) {
         // first check normal number of parameters
         for (int i = 0; i < paramMinus1; i++) {
             if (pt[i].isAssignableFrom(arguments[i])) continue;
@@ -369,7 +369,7 @@ public class ParameterTypes
         return false;
     }
 
-    private Class getArgClass(Object arg) {
+    private static Class getArgClass(Object arg) {
         Class cls;
         if (arg == null) {
             cls = null;

--- a/src/main/org/codehaus/groovy/reflection/ReflectionCache.java
+++ b/src/main/org/codehaus/groovy/reflection/ReflectionCache.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ReflectionCache {
-    private static Map primitiveTypesMap = new HashMap();
+    private static final Map primitiveTypesMap = new HashMap();
 
     static {
         primitiveTypesMap.put(byte.class, Byte.class);

--- a/src/main/org/codehaus/groovy/reflection/ReflectionUtils.java
+++ b/src/main/org/codehaus/groovy/reflection/ReflectionUtils.java
@@ -131,7 +131,7 @@ public class ReflectionUtils {
                           || extraIgnoredPackages.contains(c.getPackage().getName())))));
     }
 
-    private static class ClassContextHelper extends SecurityManager {
+    static class ClassContextHelper extends SecurityManager {
         @Override
         public Class[] getClassContext() {
             return super.getClassContext();

--- a/src/main/org/codehaus/groovy/reflection/ReflectionUtils.java
+++ b/src/main/org/codehaus/groovy/reflection/ReflectionUtils.java
@@ -131,7 +131,7 @@ public class ReflectionUtils {
                           || extraIgnoredPackages.contains(c.getPackage().getName())))));
     }
 
-    static class ClassContextHelper extends SecurityManager {
+    private static class ClassContextHelper extends SecurityManager {
         @Override
         public Class[] getClassContext() {
             return super.getClassContext();

--- a/src/main/org/codehaus/groovy/reflection/stdclasses/BooleanCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/BooleanCachedClass.java
@@ -25,7 +25,7 @@ import org.codehaus.groovy.reflection.ClassInfo;
  * @author Alex.Tkachman
  */
 public class BooleanCachedClass extends CachedClass {
-    private boolean allowNull;
+    private final boolean allowNull;
     public BooleanCachedClass(Class klazz, ClassInfo classInfo, boolean allowNull) {
         super(klazz, classInfo);
         this.allowNull = allowNull;

--- a/src/main/org/codehaus/groovy/reflection/stdclasses/ByteCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/ByteCachedClass.java
@@ -24,7 +24,7 @@ import org.codehaus.groovy.reflection.ClassInfo;
  * @author Alex.Tkachman
  */
 public class ByteCachedClass extends NumberCachedClass {
-    private boolean allowNull;
+    private final boolean allowNull;
     public ByteCachedClass(Class klazz, ClassInfo classInfo, boolean allowNull) {
         super(klazz, classInfo);
         this.allowNull = allowNull;

--- a/src/main/org/codehaus/groovy/reflection/stdclasses/CharacterCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/CharacterCachedClass.java
@@ -25,7 +25,7 @@ import org.codehaus.groovy.reflection.ClassInfo;
  * @author Alex.Tkachman
  */
 public class CharacterCachedClass extends CachedClass {
-    private boolean allowNull;
+    private final boolean allowNull;
 
     public CharacterCachedClass(Class klazz, ClassInfo classInfo, boolean allowNull) {
         super(klazz, classInfo);

--- a/src/main/org/codehaus/groovy/reflection/stdclasses/DoubleCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/DoubleCachedClass.java
@@ -27,7 +27,7 @@ import java.math.BigInteger;
  * @author Alex.Tkachman
  */
 public class DoubleCachedClass extends NumberCachedClass { // Double, double
-    private boolean allowNull;
+    private final boolean allowNull;
 
     public DoubleCachedClass(Class klazz, ClassInfo classInfo, boolean allowNull) {
         super(klazz, classInfo);

--- a/src/main/org/codehaus/groovy/reflection/stdclasses/FloatCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/FloatCachedClass.java
@@ -27,7 +27,7 @@ import java.math.BigInteger;
  * @author Alex.Tkachman
  */
 public class FloatCachedClass extends NumberCachedClass {
-    private boolean allowNull;
+    private final boolean allowNull;
 
     public FloatCachedClass(Class klazz, ClassInfo classInfo, boolean allowNull) {
         super(klazz, classInfo);

--- a/src/main/org/codehaus/groovy/reflection/stdclasses/IntegerCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/IntegerCachedClass.java
@@ -26,7 +26,7 @@ import java.math.BigInteger;
  * @author Alex.Tkachman
  */
 public class IntegerCachedClass extends NumberCachedClass {  // int, Integer
-    private boolean allowNull;
+    private final boolean allowNull;
 
     public IntegerCachedClass(Class klazz, ClassInfo classInfo, boolean allowNull) {
         super(klazz, classInfo);

--- a/src/main/org/codehaus/groovy/reflection/stdclasses/LongCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/LongCachedClass.java
@@ -24,7 +24,7 @@ import org.codehaus.groovy.reflection.ClassInfo;
  * @author Alex.Tkachman
  */
 public class LongCachedClass extends NumberCachedClass {
-    private boolean allowNull;
+    private final boolean allowNull;
 
     public LongCachedClass(Class klazz, ClassInfo classInfo, boolean allowNull) {
         super(klazz, classInfo);

--- a/src/main/org/codehaus/groovy/reflection/stdclasses/ShortCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/ShortCachedClass.java
@@ -24,7 +24,7 @@ import org.codehaus.groovy.reflection.ClassInfo;
  * @author Alex.Tkachman
  */
 public class ShortCachedClass extends NumberCachedClass {
-    private boolean allowNull;
+    private final boolean allowNull;
 
     public ShortCachedClass(Class klazz, ClassInfo classInfo, boolean allowNull) {
         super(klazz, classInfo);

--- a/src/main/org/codehaus/groovy/reflection/v7/GroovyClassValueJava7.java
+++ b/src/main/org/codehaus/groovy/reflection/v7/GroovyClassValueJava7.java
@@ -19,7 +19,6 @@
 package org.codehaus.groovy.reflection.v7;
 
 import org.codehaus.groovy.reflection.GroovyClassValue;
-import org.codehaus.groovy.reflection.GroovyClassValue.ComputeValue;
 
 /** GroovyClassValue implementaion that simply delegates to Java 7's java.lang.ClassValue
  * @see java.lang.ClassValue

--- a/src/main/org/codehaus/groovy/runtime/ComposedClosure.java
+++ b/src/main/org/codehaus/groovy/runtime/ComposedClosure.java
@@ -59,8 +59,8 @@ import java.util.List;
  */
 public final class ComposedClosure<V> extends Closure<V> {
 
-    private Closure first;
-    private Closure<V> second;
+    private final Closure first;
+    private final Closure<V> second;
 
     public ComposedClosure(Closure first, Closure<V> second) {
         super(first.clone());

--- a/src/main/org/codehaus/groovy/runtime/CurriedClosure.java
+++ b/src/main/org/codehaus/groovy/runtime/CurriedClosure.java
@@ -46,7 +46,6 @@ public final class CurriedClosure<V> extends Closure<V> {
 
     private Object[] curriedParams;
     private int index;
-    private int numTrailingArgs = 0;
     private Class varargType = null;
 
     public CurriedClosure(int index, Closure<V> uncurriedClosure, Object... arguments) {
@@ -61,11 +60,7 @@ public final class CurriedClosure<V> extends Closure<V> {
             varargType = lastType;
         }
 
-        if (isVararg()) {
-            if (index < 0) {
-                numTrailingArgs = (-index) - arguments.length;
-            }
-        } else {
+        if (!isVararg()) {
             // perform some early param checking for non-vararg case
             if (index < 0) {
                 // normalise

--- a/src/main/org/codehaus/groovy/runtime/CurriedClosure.java
+++ b/src/main/org/codehaus/groovy/runtime/CurriedClosure.java
@@ -44,7 +44,7 @@ import groovy.lang.Closure;
  */
 public final class CurriedClosure<V> extends Closure<V> {
 
-    private Object[] curriedParams;
+    private final Object[] curriedParams;
     private int index;
     private Class varargType = null;
 

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -8796,7 +8796,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     static class NumberAwareValueComparator<K, V> implements Comparator<Map.Entry<K, V>> {
-        private Comparator<V> delegate = new NumberAwareComparator<V>();
+        private final Comparator<V> delegate = new NumberAwareComparator<V>();
 
         @Override
         public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -1524,7 +1524,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
                 : new ClosureComparator<T>(condition));
     }
 
-    static final class UniqueIterator<E> implements Iterator<E> {
+    private static final class UniqueIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private final Set<E> seen;
         private boolean exhausted;
@@ -8107,7 +8107,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new ZipPreIterator<E>(self, offset);
     }
 
-    static final class ZipPostIterator<E> implements Iterator<Tuple2<E, Integer>> {
+    private static final class ZipPostIterator<E> implements Iterator<Tuple2<E, Integer>> {
         private final Iterator<E> delegate;
         private int index;
 
@@ -8130,7 +8130,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         }
     }
 
-    static final class ZipPreIterator<E> implements Iterator<Tuple2<Integer, E>> {
+    private static final class ZipPreIterator<E> implements Iterator<Tuple2<Integer, E>> {
         private final Iterator<E> delegate;
         private int index;
 
@@ -8795,7 +8795,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return toSorted(self, new NumberAwareValueComparator<K, V>());
     }
 
-    static class NumberAwareValueComparator<K, V> implements Comparator<Map.Entry<K, V>> {
+    private static class NumberAwareValueComparator<K, V> implements Comparator<Map.Entry<K, V>> {
         private final Comparator<V> delegate = new NumberAwareComparator<V>();
 
         @Override
@@ -9337,7 +9337,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new InitIterator<T>(self);
     }
 
-    static final class InitIterator<E> implements Iterator<E> {
+    private static final class InitIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private boolean exhausted;
         private E next;
@@ -9576,7 +9576,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new TakeIterator<T>(self, num);
     }
 
-    static final class TakeIterator<E> implements Iterator<E> {
+    private static final class TakeIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private Integer num;
 
@@ -10174,7 +10174,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new TakeWhileIterator<T>(self, condition);
     }
 
-    static final class TakeWhileIterator<E> implements Iterator<E> {
+    private static final class TakeWhileIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private final BooleanClosureWrapper condition;
         private boolean exhausted;
@@ -10382,7 +10382,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new DropWhileIterator<T>(self, condition);
     }
 
-    static final class DropWhileIterator<E> implements Iterator<E> {
+    private static final class DropWhileIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private final Closure condition;
         private boolean buffering = false;

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -1524,13 +1524,13 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
                 : new ClosureComparator<T>(condition));
     }
 
-    private static final class UniqueIterator<E> implements Iterator<E> {
+    static final class UniqueIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private final Set<E> seen;
         private boolean exhausted;
         private E next;
 
-        private UniqueIterator(Iterator<E> delegate, Comparator<E> comparator) {
+        UniqueIterator(Iterator<E> delegate, Comparator<E> comparator) {
             this.delegate = delegate;
             seen = new TreeSet<E>(comparator);
             advance();
@@ -8107,11 +8107,11 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new ZipPreIterator<E>(self, offset);
     }
 
-    private static final class ZipPostIterator<E> implements Iterator<Tuple2<E, Integer>> {
+    static final class ZipPostIterator<E> implements Iterator<Tuple2<E, Integer>> {
         private final Iterator<E> delegate;
         private int index;
 
-        private ZipPostIterator(Iterator<E> delegate, int offset) {
+        ZipPostIterator(Iterator<E> delegate, int offset) {
             this.delegate = delegate;
             this.index = offset;
         }
@@ -8130,11 +8130,11 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         }
     }
 
-    private static final class ZipPreIterator<E> implements Iterator<Tuple2<Integer, E>> {
+    static final class ZipPreIterator<E> implements Iterator<Tuple2<Integer, E>> {
         private final Iterator<E> delegate;
         private int index;
 
-        private ZipPreIterator(Iterator<E> delegate, int offset) {
+        ZipPreIterator(Iterator<E> delegate, int offset) {
             this.delegate = delegate;
             this.index = offset;
         }
@@ -8795,7 +8795,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return toSorted(self, new NumberAwareValueComparator<K, V>());
     }
 
-    private static class NumberAwareValueComparator<K, V> implements Comparator<Map.Entry<K, V>> {
+    static class NumberAwareValueComparator<K, V> implements Comparator<Map.Entry<K, V>> {
         private Comparator<V> delegate = new NumberAwareComparator<V>();
 
         @Override
@@ -9337,12 +9337,12 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new InitIterator<T>(self);
     }
 
-    private static final class InitIterator<E> implements Iterator<E> {
+    static final class InitIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private boolean exhausted;
         private E next;
 
-        private InitIterator(Iterator<E> delegate) {
+        InitIterator(Iterator<E> delegate) {
             this.delegate = delegate;
             advance();
         }
@@ -9576,11 +9576,11 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new TakeIterator<T>(self, num);
     }
 
-    private static final class TakeIterator<E> implements Iterator<E> {
+    static final class TakeIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private Integer num;
 
-        private TakeIterator(Iterator<E> delegate, Integer num) {
+        TakeIterator(Iterator<E> delegate, Integer num) {
             this.delegate = delegate;
             this.num = num;
         }
@@ -10174,13 +10174,13 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new TakeWhileIterator<T>(self, condition);
     }
 
-    private static final class TakeWhileIterator<E> implements Iterator<E> {
+    static final class TakeWhileIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private final BooleanClosureWrapper condition;
         private boolean exhausted;
         private E next;
 
-        private TakeWhileIterator(Iterator<E> delegate, Closure condition) {
+        TakeWhileIterator(Iterator<E> delegate, Closure condition) {
             this.delegate = delegate;
             this.condition = new BooleanClosureWrapper(condition);
             advance();
@@ -10382,13 +10382,13 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return new DropWhileIterator<T>(self, condition);
     }
 
-    private static final class DropWhileIterator<E> implements Iterator<E> {
+    static final class DropWhileIterator<E> implements Iterator<E> {
         private final Iterator<E> delegate;
         private final Closure condition;
         private boolean buffering = false;
         private E buffer = null;
 
-        private DropWhileIterator(Iterator<E> delegate, Closure condition) {
+        DropWhileIterator(Iterator<E> delegate, Closure condition) {
             this.delegate = delegate;
             this.condition = condition;
             prepare();

--- a/src/main/org/codehaus/groovy/runtime/EncodingGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/EncodingGroovyMethods.java
@@ -34,7 +34,7 @@ import java.io.Writer;
  */
 public class EncodingGroovyMethods {
 
-    static final char[] T_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".toCharArray();
+    private static final char[] T_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".toCharArray();
 
     private static final String CHUNK_SEPARATOR = "\r\n";
 

--- a/src/main/org/codehaus/groovy/runtime/EncodingGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/EncodingGroovyMethods.java
@@ -34,7 +34,7 @@ import java.io.Writer;
  */
 public class EncodingGroovyMethods {
 
-    private static final char[] T_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".toCharArray();
+    static final char[] T_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".toCharArray();
 
     private static final String CHUNK_SEPARATOR = "\r\n";
 

--- a/src/main/org/codehaus/groovy/runtime/GStringImpl.java
+++ b/src/main/org/codehaus/groovy/runtime/GStringImpl.java
@@ -30,7 +30,7 @@ import groovy.lang.GString;
  * @see groovy.lang.GString
  */
 public class GStringImpl extends GString {
-    private String[] strings;
+    private final String[] strings;
 
     /**
      * Create a new GString with values and strings.

--- a/src/main/org/codehaus/groovy/runtime/GroovyCategorySupport.java
+++ b/src/main/org/codehaus/groovy/runtime/GroovyCategorySupport.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class GroovyCategorySupport {
 
     static int categoriesInUse = 0;
-    static AtomicInteger atomicCategoryUsageCounter = new AtomicInteger();
+    static final AtomicInteger atomicCategoryUsageCounter = new AtomicInteger();
 
     public static class CategoryMethodList extends ArrayList<CategoryMethod> {
         public final int level;
@@ -294,7 +294,7 @@ public class GroovyCategorySupport {
 
     static class MyThreadLocal extends ThreadLocal<SoftReference> {
 
-        ConcurrentHashMap<String,AtomicInteger> usage = new ConcurrentHashMap<String,AtomicInteger> ();
+        final ConcurrentHashMap<String,AtomicInteger> usage = new ConcurrentHashMap<String,AtomicInteger> ();
 
         public ThreadCategoryInfo getInfo() {
             final SoftReference reference = get();

--- a/src/main/org/codehaus/groovy/runtime/GroovyCategorySupport.java
+++ b/src/main/org/codehaus/groovy/runtime/GroovyCategorySupport.java
@@ -39,8 +39,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class GroovyCategorySupport {
 
-    private static int categoriesInUse = 0;
-    private static AtomicInteger atomicCategoryUsageCounter = new AtomicInteger();
+    static int categoriesInUse = 0;
+    static AtomicInteger atomicCategoryUsageCounter = new AtomicInteger();
 
     public static class CategoryMethodList extends ArrayList<CategoryMethod> {
         public final int level;
@@ -103,7 +103,7 @@ public class GroovyCategorySupport {
             }
         }
 
-        private <T> T use(Class categoryClass, Closure<T> closure) {
+        <T> T use(Class categoryClass, Closure<T> closure) {
             newScope();
             try {
                 use(categoryClass);
@@ -160,7 +160,7 @@ public class GroovyCategorySupport {
         }
 
         // Precondition: accessorName.length() > prefixLength
-        private Map<String, String> putPropertyAccessor(int prefixLength, String accessorName, Map<String, String> map) {
+        private static Map<String, String> putPropertyAccessor(int prefixLength, String accessorName, Map<String, String> map) {
             if (map == null) {
               map = new HashMap<String, String>();
             }
@@ -196,7 +196,7 @@ public class GroovyCategorySupport {
         }
     }
 
-    private static final MyThreadLocal THREAD_INFO = new MyThreadLocal();
+    static final MyThreadLocal THREAD_INFO = new MyThreadLocal();
 
     public static class CategoryMethod extends NewInstanceMetaMethod implements Comparable {
         private final Class metaClass;
@@ -223,7 +223,7 @@ public class GroovyCategorySupport {
             return 0;
         }
 
-        private boolean isChildOfParent(Class candidateChild, Class candidateParent) {
+        private static boolean isChildOfParent(Class candidateChild, Class candidateParent) {
             Class loop = candidateChild;
             while(loop != null && loop != Object.class) {
                 loop = loop.getSuperclass();
@@ -292,7 +292,7 @@ public class GroovyCategorySupport {
          return categoryInfo == null ? null : categoryInfo.getPropertyCategorySetterName(propertyName);
    }
 
-    private static class MyThreadLocal extends ThreadLocal<SoftReference> {
+    static class MyThreadLocal extends ThreadLocal<SoftReference> {
 
         ConcurrentHashMap<String,AtomicInteger> usage = new ConcurrentHashMap<String,AtomicInteger> ();
 

--- a/src/main/org/codehaus/groovy/runtime/GroovyCategorySupport.java
+++ b/src/main/org/codehaus/groovy/runtime/GroovyCategorySupport.java
@@ -39,8 +39,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class GroovyCategorySupport {
 
-    static int categoriesInUse = 0;
-    static final AtomicInteger atomicCategoryUsageCounter = new AtomicInteger();
+    private static int categoriesInUse = 0;
+    private static final AtomicInteger atomicCategoryUsageCounter = new AtomicInteger();
 
     public static class CategoryMethodList extends ArrayList<CategoryMethod> {
         public final int level;
@@ -103,7 +103,7 @@ public class GroovyCategorySupport {
             }
         }
 
-        <T> T use(Class categoryClass, Closure<T> closure) {
+        private <T> T use(Class categoryClass, Closure<T> closure) {
             newScope();
             try {
                 use(categoryClass);
@@ -196,7 +196,7 @@ public class GroovyCategorySupport {
         }
     }
 
-    static final MyThreadLocal THREAD_INFO = new MyThreadLocal();
+    private static final MyThreadLocal THREAD_INFO = new MyThreadLocal();
 
     public static class CategoryMethod extends NewInstanceMetaMethod implements Comparable {
         private final Class metaClass;
@@ -292,7 +292,7 @@ public class GroovyCategorySupport {
          return categoryInfo == null ? null : categoryInfo.getPropertyCategorySetterName(propertyName);
    }
 
-    static class MyThreadLocal extends ThreadLocal<SoftReference> {
+    private static class MyThreadLocal extends ThreadLocal<SoftReference> {
 
         final ConcurrentHashMap<String,AtomicInteger> usage = new ConcurrentHashMap<String,AtomicInteger> ();
 

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -56,7 +56,7 @@ import java.util.regex.Pattern;
  * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
  */
 public class InvokerHelper {
-    static final Object[] EMPTY_MAIN_ARGS = new Object[]{new String[0]};
+    private static final Object[] EMPTY_MAIN_ARGS = new Object[]{new String[0]};
 
     public static final Object[] EMPTY_ARGS = {};
     protected static final Object[] EMPTY_ARGUMENTS = EMPTY_ARGS;

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -56,7 +56,7 @@ import java.util.regex.Pattern;
  * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
  */
 public class InvokerHelper {
-    private static final Object[] EMPTY_MAIN_ARGS = new Object[]{new String[0]};
+    static final Object[] EMPTY_MAIN_ARGS = new Object[]{new String[0]};
 
     public static final Object[] EMPTY_ARGS = {};
     protected static final Object[] EMPTY_ARGUMENTS = EMPTY_ARGS;

--- a/src/main/org/codehaus/groovy/runtime/MetaClassHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/MetaClassHelper.java
@@ -565,16 +565,6 @@ public class MetaClassHelper {
 
     // 
 
-    private static int calculateSimplifiedClassDistanceToObject(Class clazz) {
-        int objectDistance = 0;
-        while (clazz != null) {
-            clazz = clazz.getSuperclass();
-            objectDistance++;
-        }
-        return objectDistance;
-    }
-
-
     /**
      * @param list   a list of MetaMethods
      * @param method the MetaMethod of interest
@@ -646,9 +636,9 @@ public class MetaClassHelper {
             int tmpCount = 0;
             for (int i = offset; i < arguments.length; i++) {
                 if (arguments[i] != null) {
-                    Class argClass, tmpClass;
+                    Class tmpClass;
                     Set<Class> intfs = new HashSet<Class>();
-                    tmpClass = argClass = arguments[i].getClass();
+                    tmpClass = arguments[i].getClass();
                     for (; tmpClass != Object.class; tmpClass = tmpClass.getSuperclass()) {
                         intfs.addAll(Arrays.asList(tmpClass.getInterfaces()));
                     }

--- a/src/main/org/codehaus/groovy/runtime/MethodClosure.java
+++ b/src/main/org/codehaus/groovy/runtime/MethodClosure.java
@@ -35,7 +35,7 @@ public class MethodClosure extends Closure {
     public static boolean ALLOW_RESOLVE = false;
 
     private static final Class[] EMPTY_CLASS_ARRAY = new Class[0];
-    private String method;
+    private final String method;
 
     public MethodClosure(Object owner, String method) {
         super(owner);

--- a/src/main/org/codehaus/groovy/runtime/MethodKey.java
+++ b/src/main/org/codehaus/groovy/runtime/MethodKey.java
@@ -32,9 +32,9 @@ import java.util.List;
 public abstract class MethodKey {
 
     private int hash;
-    private String name;
-    private Class sender;
-    private boolean isCallToSuper;
+    private final String name;
+    private final Class sender;
+    private final boolean isCallToSuper;
     
     public MethodKey(Class sender, String name, boolean isCallToSuper) {
         this.sender = sender;

--- a/src/main/org/codehaus/groovy/runtime/MethodRankHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/MethodRankHelper.java
@@ -55,8 +55,8 @@ public class MethodRankHelper{
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
     private static final class Pair<U,V> {
-        U u;
-        V v;
+        final U u;
+        final V v;
         public Pair(U u, V v){
             this.u = u;
             this.v = v;

--- a/src/main/org/codehaus/groovy/runtime/MethodRankHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/MethodRankHelper.java
@@ -55,8 +55,8 @@ public class MethodRankHelper{
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
     private static final class Pair<U,V> {
-        private U u;
-        private V v;
+        U u;
+        V v;
         public Pair(U u, V v){
             this.u = u;
             this.v = v;

--- a/src/main/org/codehaus/groovy/runtime/ProcessGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/ProcessGroovyMethods.java
@@ -433,7 +433,7 @@ public class ProcessGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     protected static class ProcessRunner implements Runnable {
-        Process process;
+        final Process process;
         private boolean finished;
 
         public ProcessRunner(Process process) {
@@ -472,8 +472,8 @@ public class ProcessGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     private static class TextDumper implements Runnable {
-        InputStream in;
-        Appendable app;
+        final InputStream in;
+        final Appendable app;
 
         public TextDumper(InputStream in, Appendable app) {
             this.in = in;
@@ -498,8 +498,8 @@ public class ProcessGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     private static class ByteDumper implements Runnable {
-        InputStream in;
-        OutputStream out;
+        final InputStream in;
+        final OutputStream out;
 
         public ByteDumper(InputStream in, OutputStream out) {
             this.in = new BufferedInputStream(in);

--- a/src/main/org/codehaus/groovy/runtime/ProxyGeneratorAdapter.java
+++ b/src/main/org/codehaus/groovy/runtime/ProxyGeneratorAdapter.java
@@ -235,7 +235,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
         return result;
     }
 
-    private void collectTraits(final Class clazz, final Set<ClassNode> traits) {
+    private static void collectTraits(final Class clazz, final Set<ClassNode> traits) {
         Annotation annotation = clazz.getAnnotation(Trait.class);
         if (annotation!=null) {
             ClassNode trait = ClassHelper.make(clazz);
@@ -631,7 +631,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
         return null;
     }
 
-    private int registerLen(Type[] args) {
+    private static int registerLen(Type[] args) {
         int i = 0;
         for (Type arg : args) {
             i += registerLen(arg);
@@ -639,7 +639,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
         return i;
     }
 
-    private int registerLen(final Type arg) {
+    private static int registerLen(final Type arg) {
         return arg== Type.DOUBLE_TYPE||arg==Type.LONG_TYPE?2:1;
     }
 
@@ -695,7 +695,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
         mv.visitFieldInsn(PUTFIELD, proxyName, DELEGATE_OBJECT_FIELD, BytecodeHelper.getTypeDescription(delegateClass));
     }
 
-    private int getTypeArgsRegisterLength(Type[] args)  {
+    private static int getTypeArgsRegisterLength(Type[] args)  {
         int length = 0;
         for (Type type : args)  { length += registerLen(type); }
         return length;
@@ -800,7 +800,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
         return null;
     }
 
-    private void unwrapResult(final MethodVisitor mv, final String desc) {
+    private static void unwrapResult(final MethodVisitor mv, final String desc) {
         Type returnType = Type.getReturnType(desc);
         if (returnType==Type.VOID_TYPE) {
             mv.visitInsn(POP);
@@ -894,7 +894,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
         return ARETURN;
     }
 
-    private boolean isPrimitive(final Type arg) {
+    private static boolean isPrimitive(final Type arg) {
         return arg == Type.BOOLEAN_TYPE
                 || arg == Type.BYTE_TYPE
                 || arg == Type.CHAR_TYPE
@@ -905,7 +905,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
                 || arg == Type.SHORT_TYPE;
     }
 
-    private String getWrappedClassDescriptor(Type type) {
+    private static String getWrappedClassDescriptor(Type type) {
         if (type == Type.BOOLEAN_TYPE) return "java/lang/Boolean";
         if (type == Type.BYTE_TYPE) return "java/lang/Byte";
         if (type == Type.CHAR_TYPE) return "java/lang/Character";

--- a/src/main/org/codehaus/groovy/runtime/ReverseListIterator.java
+++ b/src/main/org/codehaus/groovy/runtime/ReverseListIterator.java
@@ -32,7 +32,7 @@ import java.util.ListIterator;
  * @author Mike Dillon
  */
 public class ReverseListIterator<T> implements Iterator<T> {
-    private ListIterator<T> delegate;
+    private final ListIterator<T> delegate;
 
     /**
      * Constructs a new <code>ReverseListIterator</code> for the provided list.

--- a/src/main/org/codehaus/groovy/runtime/ScriptReference.java
+++ b/src/main/org/codehaus/groovy/runtime/ScriptReference.java
@@ -28,8 +28,8 @@ import groovy.lang.Script;
  */
 public class ScriptReference extends Reference {
 
-    private Script script;
-    private String variable;
+    private final Script script;
+    private final String variable;
 
     public ScriptReference(Script script, String variable) {
         this.script = script;

--- a/src/main/org/codehaus/groovy/runtime/SocketGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/SocketGroovyMethods.java
@@ -189,7 +189,7 @@ public class SocketGroovyMethods extends DefaultGroovyMethodsSupport {
         return socket;
     }
 
-    static void invokeClosureWithSocket(Socket socket, Closure closure) {
+    private static void invokeClosureWithSocket(Socket socket, Closure closure) {
         try {
             closure.call(socket);
         } finally {

--- a/src/main/org/codehaus/groovy/runtime/SocketGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/SocketGroovyMethods.java
@@ -189,7 +189,7 @@ public class SocketGroovyMethods extends DefaultGroovyMethodsSupport {
         return socket;
     }
 
-    private static void invokeClosureWithSocket(Socket socket, Closure closure) {
+    static void invokeClosureWithSocket(Socket socket, Closure closure) {
         try {
             closure.call(socket);
         } finally {

--- a/src/main/org/codehaus/groovy/runtime/StackTraceUtils.java
+++ b/src/main/org/codehaus/groovy/runtime/StackTraceUtils.java
@@ -68,7 +68,7 @@ public class StackTraceUtils {
                             "gjdk.groovy.,"
             ).split("(\\s|,)+");
 
-    private static List<Closure> tests = new ArrayList<Closure>();
+    private static final List<Closure> tests = new ArrayList<Closure>();
 
     /**
      * Adds a groovy.lang.Closure to test whether the stack trace

--- a/src/main/org/codehaus/groovy/runtime/StringBufferWriter.java
+++ b/src/main/org/codehaus/groovy/runtime/StringBufferWriter.java
@@ -30,7 +30,7 @@ import java.io.Writer;
  */
 public class StringBufferWriter extends Writer {
 
-    private StringBuffer buffer;
+    private final StringBuffer buffer;
 
     /**
      * Create a new string writer which will append the text to the given StringBuffer

--- a/src/main/org/codehaus/groovy/runtime/StringGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/StringGroovyMethods.java
@@ -588,7 +588,7 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
 
     private static final class CharacterIterator implements Iterator<Character> {
         private final CharSequence delegate;
-        private int length;
+        private final int length;
         private int index;
 
         public CharacterIterator(CharSequence delegate) {
@@ -611,7 +611,7 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
 
     private static final class StringIterator implements Iterator<String> {
         private final CharSequence delegate;
-        private int length;
+        private final int length;
         private int index;
 
         public StringIterator(CharSequence delegate) {
@@ -2808,8 +2808,8 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
         int tempIndex = -1;
         int replaceIndex = -1;
         int start = -1;
-        boolean[] noMoreMatches;
-        private List<Map.Entry<CharSequence, CharSequence>> replacementsList;
+        final boolean[] noMoreMatches;
+        private final List<Map.Entry<CharSequence, CharSequence>> replacementsList;
 
         CharSequence key(int i) {
             return replacementsList.get(i).getKey();

--- a/src/main/org/codehaus/groovy/runtime/StringGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/StringGroovyMethods.java
@@ -430,16 +430,6 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
         return count((CharSequence) self, (CharSequence) text);
     }
 
-    private static StringBufferWriter createStringBufferWriter(StringBuffer self) {
-        return new StringBufferWriter(self);
-    }
-
-    private static StringWriter createStringWriter(String self) {
-        StringWriter answer = new StringWriter();
-        answer.write(self);
-        return answer;
-    }
-
     /**
      * Return a CharSequence with lines (separated by LF, CR/LF, or CR)
      * terminated by the platform specific line separator.
@@ -596,19 +586,6 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
         return dropWhile(self.toString(), condition);
     }
 
-    private static final class CharacterIterable implements Iterable<Character> {
-        private final CharSequence delegate;
-
-        public CharacterIterable(CharSequence delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public Iterator<Character> iterator() {
-            return new CharacterIterator(delegate);
-        }
-    }
-
     private static final class CharacterIterator implements Iterator<Character> {
         private final CharSequence delegate;
         private int length;
@@ -629,19 +606,6 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
 
         public void remove() {
             throw new UnsupportedOperationException("Remove not supported for CharSequence iterators");
-        }
-    }
-
-    private static final class StringIterable implements Iterable<String> {
-        private final CharSequence delegate;
-
-        public StringIterable(CharSequence delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public Iterator<String> iterator() {
-            return new StringIterator(delegate);
         }
     }
 

--- a/src/main/org/codehaus/groovy/runtime/callsite/ConstructorSite.java
+++ b/src/main/org/codehaus/groovy/runtime/callsite/ConstructorSite.java
@@ -133,8 +133,6 @@ public class ConstructorSite extends MetaClassSite {
     }
     
     public static class NoParamSiteInnerClass extends ConstructorSiteNoUnwrapNoCoerce {
-        private static final Object[] NO_ARGS = new Object[0];
-
         public NoParamSiteInnerClass(CallSite site, MetaClassImpl metaClass, CachedConstructor constructor, Class[] params) {
             super(site, metaClass, constructor, params);
         }

--- a/src/main/org/codehaus/groovy/runtime/dgmimpl/arrays/ObjectArrayPutAtMetaMethod.java
+++ b/src/main/org/codehaus/groovy/runtime/dgmimpl/arrays/ObjectArrayPutAtMetaMethod.java
@@ -47,7 +47,7 @@ public class ObjectArrayPutAtMetaMethod extends ArrayPutAtMetaMethod {
         return null;
     }
 
-    static Object adjustNewValue(Object[] objects, Object newValue) {
+    private static Object adjustNewValue(Object[] objects, Object newValue) {
         Class arrayComponentClass = objects.getClass().getComponentType();
         Object adjustedNewVal = newValue;
         if (newValue instanceof Number) {

--- a/src/main/org/codehaus/groovy/runtime/dgmimpl/arrays/ObjectArrayPutAtMetaMethod.java
+++ b/src/main/org/codehaus/groovy/runtime/dgmimpl/arrays/ObjectArrayPutAtMetaMethod.java
@@ -47,7 +47,7 @@ public class ObjectArrayPutAtMetaMethod extends ArrayPutAtMetaMethod {
         return null;
     }
 
-    private static Object adjustNewValue(Object[] objects, Object newValue) {
+    static Object adjustNewValue(Object[] objects, Object newValue) {
         Class arrayComponentClass = objects.getClass().getComponentType();
         Object adjustedNewVal = newValue;
         if (newValue instanceof Number) {

--- a/src/main/org/codehaus/groovy/runtime/m12n/SimpleExtensionModule.java
+++ b/src/main/org/codehaus/groovy/runtime/m12n/SimpleExtensionModule.java
@@ -115,7 +115,7 @@ public abstract class SimpleExtensionModule extends ExtensionModule {
         return metaMethods;
     }
 
-    private void createMetaMethods(final Class extensionClass, final List<MetaMethod> metaMethods, final boolean isStatic) {
+    private static void createMetaMethods(final Class extensionClass, final List<MetaMethod> metaMethods, final boolean isStatic) {
         CachedClass cachedClass = ReflectionCache.getCachedClass(extensionClass);
         CachedMethod[] methods = cachedClass.getMethods();
         for (CachedMethod method : methods) {

--- a/src/main/org/codehaus/groovy/runtime/memoize/Memoize.java
+++ b/src/main/org/codehaus/groovy/runtime/memoize/Memoize.java
@@ -38,7 +38,7 @@ public abstract class Memoize {
     /**
      * A place-holder for null values in cache
      */
-    static final MemoizeNullValue MEMOIZE_NULL = new MemoizeNullValue();
+    private static final MemoizeNullValue MEMOIZE_NULL = new MemoizeNullValue();
 
     /**
      * Creates a new closure delegating to the supplied one and memoizing all return values by the arguments.
@@ -93,7 +93,7 @@ public abstract class Memoize {
      *
      * @return The key - a list holding all arguments
      */
-    static Object generateKey(final Object[] args) {
+    private static Object generateKey(final Object[] args) {
         if (args == null) return Collections.emptyList();
         Object[] copyOfArgs = copyOf(args, args.length);
         return asList(copyOfArgs);
@@ -102,7 +102,7 @@ public abstract class Memoize {
     /**
      * A place-holder for cached null values
      */
-    static class MemoizeNullValue {
+    private static class MemoizeNullValue {
 
         @Override
         public boolean equals(final Object obj) {
@@ -115,7 +115,7 @@ public abstract class Memoize {
         }
     }
 
-    static class MemoizeFunction<V> extends Closure<V> {
+    private static class MemoizeFunction<V> extends Closure<V> {
         final MemoizeCache<Object, Object> cache;
         final Closure<V> closure;
         
@@ -137,7 +137,7 @@ public abstract class Memoize {
         }
     }
     
-    static class SoftReferenceMemoizeFunction<V> extends MemoizeFunction<V> {
+    private static class SoftReferenceMemoizeFunction<V> extends MemoizeFunction<V> {
         final ProtectionStorage lruProtectionStorage;
         final ReferenceQueue queue;
         

--- a/src/main/org/codehaus/groovy/runtime/memoize/Memoize.java
+++ b/src/main/org/codehaus/groovy/runtime/memoize/Memoize.java
@@ -38,7 +38,7 @@ public abstract class Memoize {
     /**
      * A place-holder for null values in cache
      */
-    private static final MemoizeNullValue MEMOIZE_NULL = new MemoizeNullValue();
+    static final MemoizeNullValue MEMOIZE_NULL = new MemoizeNullValue();
 
     /**
      * Creates a new closure delegating to the supplied one and memoizing all return values by the arguments.
@@ -93,7 +93,7 @@ public abstract class Memoize {
      *
      * @return The key - a list holding all arguments
      */
-    private static Object generateKey(final Object[] args) {
+    static Object generateKey(final Object[] args) {
         if (args == null) return Collections.emptyList();
         Object[] copyOfArgs = copyOf(args, args.length);
         return asList(copyOfArgs);
@@ -102,7 +102,7 @@ public abstract class Memoize {
     /**
      * A place-holder for cached null values
      */
-    private static class MemoizeNullValue {
+    static class MemoizeNullValue {
 
         @Override
         public boolean equals(final Object obj) {
@@ -115,7 +115,7 @@ public abstract class Memoize {
         }
     }
 
-    private static class MemoizeFunction<V> extends Closure<V> {
+    static class MemoizeFunction<V> extends Closure<V> {
         final MemoizeCache<Object, Object> cache;
         final Closure<V> closure;
         
@@ -137,7 +137,7 @@ public abstract class Memoize {
         }
     }
     
-    private static class SoftReferenceMemoizeFunction<V> extends MemoizeFunction<V> {
+    static class SoftReferenceMemoizeFunction<V> extends MemoizeFunction<V> {
         final ProtectionStorage lruProtectionStorage;
         final ReferenceQueue queue;
         

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ClosureMetaClass.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ClosureMetaClass.java
@@ -200,7 +200,7 @@ public final class ClosureMetaClass extends MetaClassImpl {
         return CLOSURE_METACLASS.getMetaProperty(name);
     }
 
-    private void unwrap(Object[] arguments) {
+    private static void unwrap(Object[] arguments) {
         for (int i = 0; i != arguments.length; i++) {
             if (arguments[i] instanceof Wrapper) {
                 arguments[i] = ((Wrapper) arguments[i]).unwrap();
@@ -402,12 +402,12 @@ public final class ClosureMetaClass extends MetaClassImpl {
         throw new MissingMethodException(methodName, theClass, arguments, false);
     }
 
-    private boolean isInternalMethod(String methodName) {
+    private static boolean isInternalMethod(String methodName) {
         return methodName.equals("curry") || methodName.equals("ncurry") || methodName.equals("rcurry") ||
                 methodName.equals("leftShift") || methodName.equals("rightShift");
     }
 
-    private Object[] makeArguments(Object[] arguments, String methodName) {
+    private static Object[] makeArguments(Object[] arguments, String methodName) {
         if (arguments == null) return EMPTY_ARGUMENTS;
         return arguments;
     }
@@ -419,7 +419,7 @@ public final class ClosureMetaClass extends MetaClassImpl {
         return th;
     }
 
-    private Object invokeOnDelegationObjects(
+    private static Object invokeOnDelegationObjects(
             boolean invoke1, Object o1,
             boolean invoke2, Object o2,
             String methodName, Object[] args) {

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ConcurrentReaderHashMap.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ConcurrentReaderHashMap.java
@@ -139,7 +139,7 @@ import java.io.IOException;
  */
 public class ConcurrentReaderHashMap 
   extends AbstractMap 
-  implements Map, Cloneable, Serializable {
+  implements Cloneable, Serializable {
 
 
   /*

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ConcurrentReaderHashMap.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ConcurrentReaderHashMap.java
@@ -849,7 +849,7 @@ public class ConcurrentReaderHashMap
     return (ks != null)? ks : (keySet = new KeySet());
   }
   
-  private class KeySet extends AbstractSet {
+  class KeySet extends AbstractSet {
     public Iterator iterator() {
       return new KeyIterator();
     }
@@ -895,7 +895,7 @@ public class ConcurrentReaderHashMap
     return (vs != null)? vs : (values = new Values());
   }
   
-  private class Values extends AbstractCollection {
+  class Values extends AbstractCollection {
     public Iterator iterator() {
       return new ValueIterator();
     }
@@ -939,7 +939,7 @@ public class ConcurrentReaderHashMap
     return (es != null) ? es : (entrySet = new EntrySet());
   }
 
-  private class EntrySet extends AbstractSet {
+  class EntrySet extends AbstractSet {
     public Iterator iterator() {
       return new HashIterator();
     }

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ConcurrentReaderHashMap.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ConcurrentReaderHashMap.java
@@ -849,7 +849,7 @@ public class ConcurrentReaderHashMap
     return (ks != null)? ks : (keySet = new KeySet());
   }
   
-  class KeySet extends AbstractSet {
+  private class KeySet extends AbstractSet {
     public Iterator iterator() {
       return new KeyIterator();
     }
@@ -895,7 +895,7 @@ public class ConcurrentReaderHashMap
     return (vs != null)? vs : (values = new Values());
   }
   
-  class Values extends AbstractCollection {
+  private class Values extends AbstractCollection {
     public Iterator iterator() {
       return new ValueIterator();
     }
@@ -939,7 +939,7 @@ public class ConcurrentReaderHashMap
     return (es != null) ? es : (entrySet = new EntrySet());
   }
 
-  class EntrySet extends AbstractSet {
+  private class EntrySet extends AbstractSet {
     public Iterator iterator() {
       return new HashIterator();
     }

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ConcurrentReaderHashMap.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ConcurrentReaderHashMap.java
@@ -260,7 +260,7 @@ public class ConcurrentReaderHashMap
    * Returns the appropriate capacity (power of two) for the specified 
    * initial capacity argument.
    */
-  private int p2capacity(int initialCapacity) {
+  private static int p2capacity(int initialCapacity) {
     int cap = initialCapacity;
     
     // Compute the appropriate capacity

--- a/src/main/org/codehaus/groovy/runtime/metaclass/DefaultMetaClassInfo.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/DefaultMetaClassInfo.java
@@ -325,7 +325,7 @@ public class DefaultMetaClassInfo {
     //         GlobalMetaClassVersioning
     //---------------------------------------------
     public static class ConstantMetaClassVersioning {
-        private boolean valid = true; 
+        boolean valid = true; 
         public boolean isValid(){return valid;}
     }
     private static ConstantMetaClassVersioning constantMetaClassVersioning = new ConstantMetaClassVersioning();

--- a/src/main/org/codehaus/groovy/runtime/metaclass/DefaultMetaClassInfo.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/DefaultMetaClassInfo.java
@@ -325,7 +325,7 @@ public class DefaultMetaClassInfo {
     //         GlobalMetaClassVersioning
     //---------------------------------------------
     public static class ConstantMetaClassVersioning {
-        boolean valid = true; 
+        private boolean valid = true; 
         public boolean isValid(){return valid;}
     }
     private static ConstantMetaClassVersioning constantMetaClassVersioning = new ConstantMetaClassVersioning();

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
@@ -57,13 +57,13 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
 
     private final boolean useAccessible;
 
-    final FastArray instanceMethods = new FastArray();
-    final FastArray staticMethods = new FastArray();
+    private final FastArray instanceMethods = new FastArray();
+    private final FastArray staticMethods = new FastArray();
 
     private final LinkedList<MetaClassRegistryChangeEventListener> changeListenerList = new LinkedList<MetaClassRegistryChangeEventListener>();
     private final LinkedList<MetaClassRegistryChangeEventListener> nonRemoveableChangeListenerList = new LinkedList<MetaClassRegistryChangeEventListener>();
-    final ManagedLinkedList metaClassInfo = new ManagedLinkedList<MetaClass>(ReferenceBundle.getWeakBundle());
-    final ExtensionModuleRegistry moduleRegistry = new ExtensionModuleRegistry();
+    private final ManagedLinkedList metaClassInfo = new ManagedLinkedList<MetaClass>(ReferenceBundle.getWeakBundle());
+    private final ExtensionModuleRegistry moduleRegistry = new ExtensionModuleRegistry();
 
     public static final int LOAD_DEFAULT = 0;
     public static final int DONT_LOAD_DEFAULT = 1;
@@ -267,7 +267,7 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
      * if oldMc is not null, then newMc will be used only if he stored mc is
      * the same as oldMc
      */
-    void setMetaClass(Class theClass, MetaClass oldMc, MetaClass newMc) {
+    private void setMetaClass(Class theClass, MetaClass oldMc, MetaClass newMc) {
         final ClassInfo info = ClassInfo.getClassInfo(theClass);
         
         MetaClass mc = null;

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
@@ -143,7 +143,7 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
         });
    }
 
-    private void refreshMopMethods(final Map<CachedClass, List<MetaMethod>> map) {
+    private static void refreshMopMethods(final Map<CachedClass, List<MetaMethod>> map) {
         for (Map.Entry<CachedClass, List<MetaMethod>> e : map.entrySet()) {
             CachedClass cls = e.getKey();
             cls.setNewMopMethods(e.getValue());

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
@@ -57,13 +57,13 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
 
     private final boolean useAccessible;
 
-    private final FastArray instanceMethods = new FastArray();
-    private final FastArray staticMethods = new FastArray();
+    final FastArray instanceMethods = new FastArray();
+    final FastArray staticMethods = new FastArray();
 
     private final LinkedList<MetaClassRegistryChangeEventListener> changeListenerList = new LinkedList<MetaClassRegistryChangeEventListener>();
     private final LinkedList<MetaClassRegistryChangeEventListener> nonRemoveableChangeListenerList = new LinkedList<MetaClassRegistryChangeEventListener>();
-    private final ManagedLinkedList metaClassInfo = new ManagedLinkedList<MetaClass>(ReferenceBundle.getWeakBundle());
-    private final ExtensionModuleRegistry moduleRegistry = new ExtensionModuleRegistry();
+    final ManagedLinkedList metaClassInfo = new ManagedLinkedList<MetaClass>(ReferenceBundle.getWeakBundle());
+    final ExtensionModuleRegistry moduleRegistry = new ExtensionModuleRegistry();
 
     public static final int LOAD_DEFAULT = 0;
     public static final int DONT_LOAD_DEFAULT = 1;
@@ -267,7 +267,7 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
      * if oldMc is not null, then newMc will be used only if he stored mc is
      * the same as oldMc
      */
-    private void setMetaClass(Class theClass, MetaClass oldMc, MetaClass newMc) {
+    void setMetaClass(Class theClass, MetaClass oldMc, MetaClass newMc) {
         final ClassInfo info = ClassInfo.getClassInfo(theClass);
         
         MetaClass mc = null;

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MetaMethodIndex.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MetaMethodIndex.java
@@ -31,7 +31,7 @@ public class MetaMethodIndex {
 
     public static class Header {
         public Entry head;
-        Class cls;
+        final Class cls;
         public int clsHashCode31;
         public Class subclass;
 

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MetaMethodIndex.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MetaMethodIndex.java
@@ -165,7 +165,6 @@ public class MetaMethodIndex {
         return new EntryIterator() {
             Entry next;    // next entry to return
             int index;        // current slot
-            Entry current;    // current entry
 
             {
                 Entry[] t = table;
@@ -199,7 +198,7 @@ public class MetaMethodIndex {
                     n = t[--i];
                 index = i;
                 next = n;
-                return current = e;
+                return e;
             }
         };
     }

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MetaMethodIndex.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MetaMethodIndex.java
@@ -438,7 +438,7 @@ public class MetaMethodIndex {
         return o;
     }
 
-    private boolean isNonRealMethod(MetaMethod method) {
+    private static boolean isNonRealMethod(MetaMethod method) {
         return method instanceof NewInstanceMetaMethod ||
                 method instanceof NewStaticMetaMethod ||
                 method instanceof ClosureMetaMethod ||
@@ -448,7 +448,7 @@ public class MetaMethodIndex {
                 method instanceof ClosureMetaMethod.AnonymousMetaMethod;
     }
 
-    private boolean isMatchingMethod(MetaMethod aMethod, MetaMethod method) {
+    private static boolean isMatchingMethod(MetaMethod aMethod, MetaMethod method) {
         if (aMethod==method) return true;
         CachedClass[] params1 = aMethod.getParameterTypes();
         CachedClass[] params2 = method.getParameterTypes();
@@ -466,7 +466,7 @@ public class MetaMethodIndex {
         return matches;
     }
 
-    private int findMatchingMethod(FastArray list, MetaMethod method) {
+    private static int findMatchingMethod(FastArray list, MetaMethod method) {
         int len = list.size();
         Object data[] = list.getArray();
         for (int j = 0; j != len; ++j) {

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MethodSelectionException.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MethodSelectionException.java
@@ -64,7 +64,7 @@ public class MethodSelectionException extends GroovyRuntimeException {
     }
     
     
-    private void appendClassNames(StringBuilder argBuf, Class[] classes) {
+    private static void appendClassNames(StringBuilder argBuf, Class[] classes) {
         argBuf.append("(");
         for (int i = 0; i < classes.length; i++) {
             if (i > 0) {

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MissingMethodExecutionFailed.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MissingMethodExecutionFailed.java
@@ -24,7 +24,7 @@ package org.codehaus.groovy.runtime.metaclass;
  * invokeMethod for GroovyObject implementing classes.
  */
 public class MissingMethodExecutionFailed extends MissingMethodExceptionNoStack {
-    private Throwable cause;
+    private final Throwable cause;
     public MissingMethodExecutionFailed(String method, Class type, Object[] arguments, boolean isStatic, Throwable cause) {
         super(method, type, arguments, isStatic);
         this.cause = cause;

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ThreadManagedMetaBeanProperty.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ThreadManagedMetaBeanProperty.java
@@ -43,9 +43,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ThreadManagedMetaBeanProperty extends MetaBeanProperty {
     private static final ConcurrentHashMap<String,ManagedConcurrentMap> PROPNAME_TO_MAP = new ConcurrentHashMap<String, ManagedConcurrentMap>();
 
-    final ManagedConcurrentMap instance2Prop;
+    private final ManagedConcurrentMap instance2Prop;
 
-    final Class declaringClass;
+    private final Class declaringClass;
     private final ThreadBoundGetter getter;
     private final ThreadBoundSetter setter;
     private Object initialValue;

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ThreadManagedMetaBeanProperty.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ThreadManagedMetaBeanProperty.java
@@ -43,9 +43,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ThreadManagedMetaBeanProperty extends MetaBeanProperty {
     private static final ConcurrentHashMap<String,ManagedConcurrentMap> PROPNAME_TO_MAP = new ConcurrentHashMap<String, ManagedConcurrentMap>();
 
-    private final ManagedConcurrentMap instance2Prop;
+    final ManagedConcurrentMap instance2Prop;
 
-    private Class declaringClass;
+    Class declaringClass;
     private ThreadBoundGetter getter;
     private ThreadBoundSetter setter;
     private Object initialValue;

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ThreadManagedMetaBeanProperty.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ThreadManagedMetaBeanProperty.java
@@ -45,9 +45,9 @@ public class ThreadManagedMetaBeanProperty extends MetaBeanProperty {
 
     final ManagedConcurrentMap instance2Prop;
 
-    Class declaringClass;
-    private ThreadBoundGetter getter;
-    private ThreadBoundSetter setter;
+    final Class declaringClass;
+    private final ThreadBoundGetter getter;
+    private final ThreadBoundSetter setter;
     private Object initialValue;
     private Closure initialValueCreator;
     

--- a/src/main/org/codehaus/groovy/runtime/metaclass/TransformMetaMethod.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/TransformMetaMethod.java
@@ -29,7 +29,7 @@ import org.codehaus.groovy.reflection.CachedClass;
 
 public class TransformMetaMethod extends MetaMethod {
     
-    private MetaMethod metaMethod;
+    private final MetaMethod metaMethod;
 
     public TransformMetaMethod(MetaMethod metaMethod) {
         this.metaMethod = metaMethod;

--- a/src/main/org/codehaus/groovy/runtime/powerassert/SourceText.java
+++ b/src/main/org/codehaus/groovy/runtime/powerassert/SourceText.java
@@ -109,7 +109,7 @@ public class SourceText {
         return textOffsets.get(deltaLine) + deltaColumn;
     }
 
-    private boolean hasPlausibleSourcePosition(ASTNode node) {
+    private static boolean hasPlausibleSourcePosition(ASTNode node) {
         return node.getLineNumber() > 0
                 && node.getColumnNumber() > 0
                 && node.getLastLineNumber() >= node.getLineNumber()
@@ -117,7 +117,7 @@ public class SourceText {
                 (node.getLineNumber() == node.getLastLineNumber() ? node.getColumnNumber() : 0);
     }
 
-    private int countLeadingWhitespace(String lineText) {
+    private static int countLeadingWhitespace(String lineText) {
         int result = 0;
         while (result < lineText.length() && Character.isWhitespace(lineText.charAt(result)))
             result++;

--- a/src/main/org/codehaus/groovy/tools/Compiler.java
+++ b/src/main/org/codehaus/groovy/tools/Compiler.java
@@ -36,7 +36,7 @@ public class Compiler {
     // TODO: delete this constant?
     public static final Compiler DEFAULT = new Compiler();
     
-    private CompilerConfiguration configuration = null;  // Optional configuration data
+    private final CompilerConfiguration configuration;  // Optional configuration data
     
    /**
     *  Initializes the Compiler with default configuration.

--- a/src/main/org/codehaus/groovy/tools/DgmConverter.java
+++ b/src/main/org/codehaus/groovy/tools/DgmConverter.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 public class DgmConverter implements Opcodes {
 
-    public static void main(String[] args) throws IOException, ClassNotFoundException {
+    public static void main(String[] args) throws IOException {
         String targetDirectory = "target/classes/";
         boolean info = (args.length == 1 && args[0].equals("--info"))
                 || (args.length==2 && args[0].equals("--info"));

--- a/src/main/org/codehaus/groovy/tools/GroovyClass.java
+++ b/src/main/org/codehaus/groovy/tools/GroovyClass.java
@@ -22,8 +22,8 @@ public class GroovyClass
 {
     public static final GroovyClass[] EMPTY_ARRAY = new GroovyClass[ 0 ];
 
-    private String name;
-    private byte[] bytes;
+    private final String name;
+    private final byte[] bytes;
 
     public GroovyClass(String name,
                        byte[] bytes)

--- a/src/main/org/codehaus/groovy/tools/LoaderConfiguration.java
+++ b/src/main/org/codehaus/groovy/tools/LoaderConfiguration.java
@@ -144,7 +144,7 @@ public class LoaderConfiguration {
     /*
     * Expands the properties inside the given string to it's values.
     */
-    private String assignProperties(String str) {
+    private static String assignProperties(String str) {
         int propertyIndexStart = 0, propertyIndexEnd = 0;
         boolean requireProperty;
         String result = "";
@@ -196,7 +196,7 @@ public class LoaderConfiguration {
     }
 
 
-    private String correctDoubleSlash(String propertyValue, int propertyIndexEnd, String str) {
+    private static String correctDoubleSlash(String propertyValue, int propertyIndexEnd, String str) {
         int index = propertyIndexEnd + 1;
         if (index < str.length() && str.charAt(index) == '/' &&
                 propertyValue.endsWith("/") &&
@@ -255,7 +255,7 @@ public class LoaderConfiguration {
 
     // change path representation to something more system independent.
     // This solution is based on an absolute path
-    private String getSlashyPath(final String path) {
+    private static String getSlashyPath(final String path) {
         String changedPath = path;
         if (File.separatorChar != '/')
             changedPath = changedPath.replace(File.separatorChar, '/');

--- a/src/main/org/codehaus/groovy/tools/LoaderConfiguration.java
+++ b/src/main/org/codehaus/groovy/tools/LoaderConfiguration.java
@@ -78,7 +78,7 @@ import java.util.regex.Pattern;
 public class LoaderConfiguration {
 
     private static final String MAIN_PREFIX = "main is", LOAD_PREFIX = "load", GRAB_PREFIX = "grab", PROP_PREFIX = "property";
-    private List<URL> classPath = new ArrayList<URL>();
+    private final List<URL> classPath = new ArrayList<URL>();
     private String main;
     private boolean requireMain;
     private static final char WILDCARD = '*';

--- a/src/main/org/codehaus/groovy/tools/RootLoader.java
+++ b/src/main/org/codehaus/groovy/tools/RootLoader.java
@@ -76,7 +76,7 @@ import java.util.Map;
 public class RootLoader extends URLClassLoader {
 
     private static final URL[] EMPTY_URL_ARRAY = new URL[0];
-    private Map<String, Class> customClasses = new HashMap<String, Class>();
+    private final Map<String, Class> customClasses = new HashMap<String, Class>();
 
     /**
      * constructs a new RootLoader without classpath

--- a/src/main/org/codehaus/groovy/tools/gse/DependencyTracker.java
+++ b/src/main/org/codehaus/groovy/tools/gse/DependencyTracker.java
@@ -39,9 +39,9 @@ import org.codehaus.groovy.control.SourceUnit;
 
 public class DependencyTracker extends ClassCodeVisitorSupport {
     private Set<String> current;
-    private Map<String, ?> precompiledDependencies;
-    private SourceUnit source;
-    private StringSetMap cache;
+    private final Map<String, ?> precompiledDependencies;
+    private final SourceUnit source;
+    private final StringSetMap cache;
 
     public DependencyTracker(SourceUnit source, StringSetMap cache) {
         this(source, cache, new HashMap());

--- a/src/main/org/codehaus/groovy/tools/gse/StringSetMap.java
+++ b/src/main/org/codehaus/groovy/tools/gse/StringSetMap.java
@@ -47,8 +47,6 @@ public class StringSetMap extends LinkedHashMap<String,Set<String>> {
 
     public void makeTransitiveHull() {
         Set<String> nameSet = new TreeSet<String>(keySet());
-        // TODO use it or lose it
-        StringSetMap ret = new StringSetMap(this);
         
         for (String k: nameSet) {
             StringSetMap delta = new StringSetMap();

--- a/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
@@ -59,7 +59,7 @@ public class JavaAwareCompilationUnit extends CompilationUnit {
         Map options = configuration.getJointCompilationOptions();
         generationGoal = (File) options.get("stubDir");
         boolean useJava5 = CompilerConfiguration.isPostJDK5(configuration.getTargetBytecode());
-		String encoding = configuration.getSourceEncoding();
+        String encoding = configuration.getSourceEncoding();
         stubGenerator = new JavaStubGenerator(generationGoal, false, useJava5, encoding);
         keepStubs = Boolean.TRUE.equals(options.get("keepStubs"));
 

--- a/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
@@ -38,11 +38,11 @@ import java.util.Map;
  * @author Alex.Tkachman
  */
 public class JavaAwareCompilationUnit extends CompilationUnit {
-    List<String> javaSources;
-    JavaStubGenerator stubGenerator;
+    final List<String> javaSources;
+    final JavaStubGenerator stubGenerator;
     private JavaCompilerFactory compilerFactory = new JavacCompilerFactory();
-    private File generationGoal;
-    private boolean keepStubs;
+    private final File generationGoal;
+    private final boolean keepStubs;
 
     public JavaAwareCompilationUnit(CompilerConfiguration configuration) {
         this(configuration, null, null);

--- a/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
@@ -38,8 +38,8 @@ import java.util.Map;
  * @author Alex.Tkachman
  */
 public class JavaAwareCompilationUnit extends CompilationUnit {
-    final List<String> javaSources;
-    final JavaStubGenerator stubGenerator;
+    private final List<String> javaSources;
+    private final JavaStubGenerator stubGenerator;
     private JavaCompilerFactory compilerFactory = new JavacCompilerFactory();
     private final File generationGoal;
     private final boolean keepStubs;

--- a/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
@@ -38,8 +38,8 @@ import java.util.Map;
  * @author Alex.Tkachman
  */
 public class JavaAwareCompilationUnit extends CompilationUnit {
-    private List<String> javaSources;
-    private JavaStubGenerator stubGenerator;
+    List<String> javaSources;
+    JavaStubGenerator stubGenerator;
     private JavaCompilerFactory compilerFactory = new JavacCompilerFactory();
     private File generationGoal;
     private boolean keepStubs;

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubCompilationUnit.java
@@ -40,11 +40,9 @@ import java.util.Map;
  * @author Guillaume Laforge
  */
 public class JavaStubCompilationUnit extends CompilationUnit {
-    private static final String DOT_GROOVY = ".groovy";
+    final JavaStubGenerator stubGenerator;
 
-    private final JavaStubGenerator stubGenerator;
-
-    private int stubCount;
+    int stubCount;
 
     public JavaStubCompilationUnit(final CompilerConfiguration config, final GroovyClassLoader gcl, File destDir) {
         super(config, null, gcl);

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubCompilationUnit.java
@@ -53,7 +53,7 @@ public class JavaStubCompilationUnit extends CompilationUnit {
             destDir = (File) options.get("stubDir");
         }
         boolean useJava5 = CompilerConfiguration.isPostJDK5(configuration.getTargetBytecode());
-		String encoding = configuration.getSourceEncoding();
+        String encoding = configuration.getSourceEncoding();
         stubGenerator = new JavaStubGenerator(destDir, false, useJava5, encoding);
 
         addPhaseOperation(new PrimaryClassNodeOperation() {

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubCompilationUnit.java
@@ -40,9 +40,9 @@ import java.util.Map;
  * @author Guillaume Laforge
  */
 public class JavaStubCompilationUnit extends CompilationUnit {
-    final JavaStubGenerator stubGenerator;
+    private final JavaStubGenerator stubGenerator;
 
-    int stubCount;
+    private int stubCount;
 
     public JavaStubCompilationUnit(final CompilerConfiguration config, final GroovyClassLoader gcl, File destDir) {
         super(config, null, gcl);

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -60,9 +60,9 @@ public class JavaStubGenerator {
     private boolean requireSuperResolved = false;
     private File outputPath;
     private List<String> toCompile = new ArrayList<String>();
-    private ArrayList<MethodNode> propertyMethods = new ArrayList<MethodNode>();
-    private Map<String, MethodNode> propertyMethodsWithSigs = new HashMap<String, MethodNode>();
-    private ArrayList<ConstructorNode> constructors = new ArrayList<ConstructorNode>();
+    ArrayList<MethodNode> propertyMethods = new ArrayList<MethodNode>();
+    Map<String, MethodNode> propertyMethodsWithSigs = new HashMap<String, MethodNode>();
+    ArrayList<ConstructorNode> constructors = new ArrayList<ConstructorNode>();
     private ModuleNode currentModule;
 
     public JavaStubGenerator(final File outputPath, final boolean requireSuperResolved, final boolean java5, String encoding) {

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -55,21 +55,21 @@ import java.util.List;
 import java.util.Map;
 
 public class JavaStubGenerator {
-    private boolean java5 = false;
-	private String encoding;
-    private boolean requireSuperResolved = false;
-    private File outputPath;
-    private List<String> toCompile = new ArrayList<String>();
-    ArrayList<MethodNode> propertyMethods = new ArrayList<MethodNode>();
-    Map<String, MethodNode> propertyMethodsWithSigs = new HashMap<String, MethodNode>();
-    ArrayList<ConstructorNode> constructors = new ArrayList<ConstructorNode>();
+    private final boolean java5;
+    private final String encoding;
+    private final boolean requireSuperResolved;
+    private final File outputPath;
+    private final List<String> toCompile = new ArrayList<String>();
+    final ArrayList<MethodNode> propertyMethods = new ArrayList<MethodNode>();
+    final Map<String, MethodNode> propertyMethodsWithSigs = new HashMap<String, MethodNode>();
+    final ArrayList<ConstructorNode> constructors = new ArrayList<ConstructorNode>();
     private ModuleNode currentModule;
 
     public JavaStubGenerator(final File outputPath, final boolean requireSuperResolved, final boolean java5, String encoding) {
         this.outputPath = outputPath;
         this.requireSuperResolved = requireSuperResolved;
         this.java5 = java5;
-		this.encoding = encoding;
+        this.encoding = encoding;
         outputPath.mkdirs();
     }
 

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -60,9 +60,9 @@ public class JavaStubGenerator {
     private final boolean requireSuperResolved;
     private final File outputPath;
     private final List<String> toCompile = new ArrayList<String>();
-    final ArrayList<MethodNode> propertyMethods = new ArrayList<MethodNode>();
-    final Map<String, MethodNode> propertyMethodsWithSigs = new HashMap<String, MethodNode>();
-    final ArrayList<ConstructorNode> constructors = new ArrayList<ConstructorNode>();
+    private final ArrayList<MethodNode> propertyMethods = new ArrayList<MethodNode>();
+    private final Map<String, MethodNode> propertyMethodsWithSigs = new HashMap<String, MethodNode>();
+    private final ArrayList<ConstructorNode> constructors = new ArrayList<ConstructorNode>();
     private ModuleNode currentModule;
 
     public JavaStubGenerator(final File outputPath, final boolean requireSuperResolved, final boolean java5, String encoding) {

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -506,8 +506,6 @@ public class JavaStubGenerator {
         return null;
     }
 
-    final private static ClassNode RUNTIME_EXCEPTION = ClassHelper.make(RuntimeException.class);
-
     private static boolean noExceptionToAvoid(ConstructorNode fromStub, ConstructorNode fromSuper) {
         ClassNode[] superExceptions = fromSuper.getExceptions();
         if (superExceptions==null || superExceptions.length==0) return true;
@@ -751,15 +749,6 @@ public class JavaStubGenerator {
             out.print(type.getGenericsTypes()[0].getName());
         } else {
             printGenericsBounds(out, type, false);
-        }
-    }
-
-    private void printTypeWithoutBounds(PrintWriter out, ClassNode type) {
-        if (type.isArray()) {
-            printTypeWithoutBounds(out, type.getComponentType());
-            out.print("[]");
-        } else {
-            printTypeName(out, type);
         }
     }
 

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -77,7 +77,7 @@ public class JavaStubGenerator {
         this(outputPath, false, false, Charset.defaultCharset().name());
     }
 
-    private void mkdirs(File parent, String relativeFile) {
+    private static void mkdirs(File parent, String relativeFile) {
         int index = relativeFile.lastIndexOf('/');
         if (index == -1) return;
         File dir = new File(parent, relativeFile.substring(0, index));
@@ -367,7 +367,7 @@ public class JavaStubGenerator {
         }
     }
 
-    private void printEnumFields(PrintWriter out, List<FieldNode> fields) {
+    private static void printEnumFields(PrintWriter out, List<FieldNode> fields) {
         if (!fields.isEmpty()) {
             boolean first = true;
             for (FieldNode field : fields) {
@@ -427,15 +427,15 @@ public class JavaStubGenerator {
         out.println(";");
     }
 
-    private String formatChar(String ch) {
+    private static String formatChar(String ch) {
         return "'" + escapeSpecialChars("" + ch.charAt(0)) + "'";
     }
 
-    private String formatString(String s) {
+    private static String formatString(String s) {
         return "\"" + escapeSpecialChars(s) + "\"";
     }
 
-    private ConstructorCallExpression getConstructorCallExpression(ConstructorNode constructorNode) {
+    private static ConstructorCallExpression getConstructorCallExpression(ConstructorNode constructorNode) {
         Statement code = constructorNode.getCode();
         if (!(code instanceof BlockStatement))
             return null;
@@ -478,7 +478,7 @@ public class JavaStubGenerator {
         }
     }
 
-    private Parameter[] selectAccessibleConstructorFromSuper(ConstructorNode node) {
+    private static Parameter[] selectAccessibleConstructorFromSuper(ConstructorNode node) {
         ClassNode type = node.getDeclaringClass();
         ClassNode superType = type.getUnresolvedSuperClass();
 
@@ -508,7 +508,7 @@ public class JavaStubGenerator {
 
     final private static ClassNode RUNTIME_EXCEPTION = ClassHelper.make(RuntimeException.class);
 
-    private boolean noExceptionToAvoid(ConstructorNode fromStub, ConstructorNode fromSuper) {
+    private static boolean noExceptionToAvoid(ConstructorNode fromStub, ConstructorNode fromSuper) {
         ClassNode[] superExceptions = fromSuper.getExceptions();
         if (superExceptions==null || superExceptions.length==0) return true;
 
@@ -586,7 +586,7 @@ public class JavaStubGenerator {
         out.println(");");
     }
 
-    private ClassNode getConstructorArgumentType(Expression arg, ConstructorNode node) {
+    private static ClassNode getConstructorArgumentType(Expression arg, ConstructorNode node) {
         if (!(arg instanceof VariableExpression)) return arg.getType();
         VariableExpression vexp = (VariableExpression) arg;
         String name = vexp.getName();
@@ -666,7 +666,7 @@ public class JavaStubGenerator {
         }
     }
 
-    private boolean isAbstract(final MethodNode methodNode) {
+    private static boolean isAbstract(final MethodNode methodNode) {
         if (isDefaultTraitImpl(methodNode)) {
             return false;
         }
@@ -676,11 +676,11 @@ public class JavaStubGenerator {
         return false;
     }
 
-    private boolean isDefaultTraitImpl(final MethodNode methodNode) {
+    private static boolean isDefaultTraitImpl(final MethodNode methodNode) {
         return Traits.isTrait(methodNode.getDeclaringClass()) && Traits.hasDefaultImplementation(methodNode);
     }
 
-    private void printValue(PrintWriter out, Expression re, boolean assumeClass) {
+    private static void printValue(PrintWriter out, Expression re, boolean assumeClass) {
         if (assumeClass) {
             if (re.getType().getName().equals("groovy.lang.Closure")) {
                 out.print("groovy.lang.Closure.class");
@@ -801,7 +801,7 @@ public class JavaStubGenerator {
         }
     }
 
-    private void printGenericsBounds(PrintWriter out, GenericsType[] genericsTypes) {
+    private static void printGenericsBounds(PrintWriter out, GenericsType[] genericsTypes) {
         if (genericsTypes == null || genericsTypes.length == 0) return;
         out.print('<');
         for (int i = 0; i < genericsTypes.length; i++) {
@@ -898,7 +898,7 @@ public class JavaStubGenerator {
         return val;
     }
 
-    private void printModifiers(PrintWriter out, int modifiers) {
+    private static void printModifiers(PrintWriter out, int modifiers) {
         if ((modifiers & Opcodes.ACC_PUBLIC) != 0)
             out.print("public ");
 
@@ -921,7 +921,7 @@ public class JavaStubGenerator {
             out.print("abstract ");
     }
 
-    private void printImports(PrintWriter out, ClassNode classNode) {
+    private static void printImports(PrintWriter out, ClassNode classNode) {
         List<String> imports = new ArrayList<String>();
 
         ModuleNode moduleNode = classNode.getModule();

--- a/src/main/org/codehaus/groovy/tools/javac/JavacJavaCompiler.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavacJavaCompiler.java
@@ -82,7 +82,7 @@ public class JavacJavaCompiler implements JavaCompiler {
         }
     }
 
-    private void addJavacError(String header, CompilationUnit cu, StringWriter msg) {
+    private static void addJavacError(String header, CompilationUnit cu, StringWriter msg) {
         if (msg != null) {
             header = header + "\n" + msg.getBuffer().toString();
         } else {

--- a/src/main/org/codehaus/groovy/tools/javac/JavacJavaCompiler.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavacJavaCompiler.java
@@ -37,7 +37,7 @@ import org.codehaus.groovy.control.messages.SimpleMessage;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
 public class JavacJavaCompiler implements JavaCompiler {
-    private CompilerConfiguration config;
+    private final CompilerConfiguration config;
 
     public JavacJavaCompiler(CompilerConfiguration config) {
         this.config = config;

--- a/src/main/org/codehaus/groovy/tools/shell/IO.java
+++ b/src/main/org/codehaus/groovy/tools/shell/IO.java
@@ -130,7 +130,7 @@ public class IO implements Closeable
     /**
      * Flush both output streams.
      */
-    public void flush() throws IOException {
+    public void flush() {
         out.flush();
         err.flush();
     }

--- a/src/main/org/codehaus/groovy/tools/shell/util/Logger.java
+++ b/src/main/org/codehaus/groovy/tools/shell/util/Logger.java
@@ -20,8 +20,6 @@ package org.codehaus.groovy.tools.shell.util;
 
 import org.codehaus.groovy.tools.shell.IO;
 
-import java.io.IOException;
-
 import static org.fusesource.jansi.Ansi.ansi;
 import static org.fusesource.jansi.Ansi.Color;
 import static org.fusesource.jansi.Ansi.Color.*;
@@ -72,11 +70,7 @@ public final class Logger {
             cause.printStackTrace(io.out);
         }
 
-        try {
-            io.flush();
-        } catch (IOException io) {
-            throw new RuntimeException(io);
-        }
+        io.flush();
     }
     
     //

--- a/src/main/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
@@ -62,9 +62,9 @@ import java.util.TreeMap;
  * @author Jochen Theodorou (blackdrag)
  */
 public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSupport {
-    private SourceUnit source;
+    private final SourceUnit source;
     private ClassNode classNode;
-    private GroovyClassLoader transformLoader;
+    private final GroovyClassLoader transformLoader;
 
     public ASTTransformationCollectorCodeVisitor(SourceUnit source, GroovyClassLoader transformLoader) {
         this.source = source;

--- a/src/main/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -58,7 +58,7 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
 
     private final ASTTransformationsContext context;
     private final CompilePhase phase;
-    private SourceUnit source;
+    SourceUnit source;
     private List<ASTNode[]> targetNodes;
     private Map<ASTNode, List<ASTTransformation>> transforms;
 

--- a/src/main/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -58,7 +58,7 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
 
     private final ASTTransformationsContext context;
     private final CompilePhase phase;
-    SourceUnit source;
+    private SourceUnit source;
     private List<ASTNode[]> targetNodes;
     private Map<ASTNode, List<ASTTransformation>> transforms;
 

--- a/src/main/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
+++ b/src/main/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
@@ -42,7 +42,7 @@ import static org.objectweb.asm.Opcodes.*;
  */
 public class AnnotationCollectorTransform {
 
-    static List<AnnotationNode> getMeta(ClassNode cn) {
+    private static List<AnnotationNode> getMeta(ClassNode cn) {
         List<AnnotationNode> meta = cn.getNodeMetaData(AnnotationCollector.class);
         if (meta == null) {
             if (cn.isPrimaryClassNode()) {

--- a/src/main/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
+++ b/src/main/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
@@ -42,7 +42,7 @@ import static org.objectweb.asm.Opcodes.*;
  */
 public class AnnotationCollectorTransform {
 
-    private static List<AnnotationNode> getMeta(ClassNode cn) {
+    static List<AnnotationNode> getMeta(ClassNode cn) {
         List<AnnotationNode> meta = cn.getNodeMetaData(AnnotationCollector.class);
         if (meta == null) {
             if (cn.isPrimaryClassNode()) {

--- a/src/main/org/codehaus/groovy/transform/CategoryASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/CategoryASTTransformation.java
@@ -68,7 +68,7 @@ import java.util.Set;
 public class CategoryASTTransformation implements ASTTransformation, Opcodes {
     // should not use a static variable because of possible changes to node metadata
     // which would be visible to other compilation units
-    final VariableExpression thisExpression = createThisExpression();
+    private final VariableExpression thisExpression = createThisExpression();
 
     private static VariableExpression createThisExpression() {
         VariableExpression expr = new VariableExpression("$this");

--- a/src/main/org/codehaus/groovy/transform/CategoryASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/CategoryASTTransformation.java
@@ -68,7 +68,7 @@ import java.util.Set;
 public class CategoryASTTransformation implements ASTTransformation, Opcodes {
     // should not use a static variable because of possible changes to node metadata
     // which would be visible to other compilation units
-    private final VariableExpression thisExpression = createThisExpression();
+    final VariableExpression thisExpression = createThisExpression();
 
     private static VariableExpression createThisExpression() {
         VariableExpression expr = new VariableExpression("$this");

--- a/src/main/org/codehaus/groovy/transform/MapConstructorASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/MapConstructorASTTransformation.java
@@ -72,7 +72,7 @@ public class MapConstructorASTTransformation extends AbstractASTTransformation {
     static final Class MY_CLASS = MapConstructor.class;
     static final ClassNode MY_TYPE = make(MY_CLASS);
     static final String MY_TYPE_NAME = "@" + MY_TYPE.getNameWithoutPackage();
-    static final ClassNode MAP_TYPE = makeWithoutCaching(Map.class, false);
+    private static final ClassNode MAP_TYPE = makeWithoutCaching(Map.class, false);
 //    private static final ClassNode CHECK_METHOD_TYPE = make(ImmutableASTTransformation.class);
 
     public void visit(ASTNode[] nodes, SourceUnit source) {

--- a/src/main/org/codehaus/groovy/transform/MapConstructorASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/MapConstructorASTTransformation.java
@@ -72,7 +72,7 @@ public class MapConstructorASTTransformation extends AbstractASTTransformation {
     static final Class MY_CLASS = MapConstructor.class;
     static final ClassNode MY_TYPE = make(MY_CLASS);
     static final String MY_TYPE_NAME = "@" + MY_TYPE.getNameWithoutPackage();
-    private static final ClassNode MAP_TYPE = makeWithoutCaching(Map.class, false);
+    static final ClassNode MAP_TYPE = makeWithoutCaching(Map.class, false);
 //    private static final ClassNode CHECK_METHOD_TYPE = make(ImmutableASTTransformation.class);
 
     public void visit(ASTNode[] nodes, SourceUnit source) {

--- a/src/main/org/codehaus/groovy/transform/TupleConstructorASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/TupleConstructorASTTransformation.java
@@ -77,7 +77,7 @@ public class TupleConstructorASTTransformation extends AbstractASTTransformation
     private static final ClassNode LHMAP_TYPE = makeWithoutCaching(LinkedHashMap.class, false);
     private static final ClassNode HMAP_TYPE = makeWithoutCaching(HashMap.class, false);
     private static final ClassNode CHECK_METHOD_TYPE = make(ImmutableASTTransformation.class);
-    private static Map<Class<?>, Expression> primitivesInitialValues;
+    private static final Map<Class<?>, Expression> primitivesInitialValues;
 
     static {
         final ConstantExpression zero = constX(0);

--- a/src/main/org/codehaus/groovy/transform/sc/StaticCompilationVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/sc/StaticCompilationVisitor.java
@@ -170,7 +170,7 @@ public class StaticCompilationVisitor extends StaticTypeCheckingVisitor {
      * Adds special accessors and mutators for private fields so that inner classes can get/set them
      */
     @SuppressWarnings("unchecked")
-    private void addPrivateFieldsAccessors(ClassNode node) {
+    private static void addPrivateFieldsAccessors(ClassNode node) {
         Set<ASTNode> accessedFields = (Set<ASTNode>) node.getNodeMetaData(StaticTypesMarker.PV_FIELDS_ACCESS);
         Set<ASTNode> mutatedFields = (Set<ASTNode>) node.getNodeMetaData(StaticTypesMarker.PV_FIELDS_MUTATION);
         if (accessedFields == null && mutatedFields == null) return;
@@ -225,7 +225,7 @@ public class StaticCompilationVisitor extends StaticTypeCheckingVisitor {
      * @param node an inner/outer class node for which to generate bridge methods
      */
     @SuppressWarnings("unchecked")
-    private void addPrivateBridgeMethods(final ClassNode node) {
+    private static void addPrivateBridgeMethods(final ClassNode node) {
         Set<ASTNode> accessedMethods = (Set<ASTNode>) node.getNodeMetaData(StaticTypesMarker.PV_METHODS_ACCESS);
         if (accessedMethods==null) return;
         List<MethodNode> methods = new ArrayList<MethodNode>(node.getAllDeclaredMethods());
@@ -300,7 +300,7 @@ public class StaticCompilationVisitor extends StaticTypeCheckingVisitor {
         return genericTypeTokens;
     }
 
-    private void memorizeInitialExpressions(final MethodNode node) {
+    private static void memorizeInitialExpressions(final MethodNode node) {
         // add node metadata for default parameters because they are erased by the Verifier
         if (node.getParameters()!=null) {
             for (Parameter parameter : node.getParameters()) {

--- a/src/main/org/codehaus/groovy/transform/sc/StaticCompilationVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/sc/StaticCompilationVisitor.java
@@ -32,7 +32,6 @@ import org.codehaus.groovy.classgen.asm.*;
 import org.codehaus.groovy.classgen.asm.sc.StaticCompilationMopWriter;
 import org.codehaus.groovy.classgen.asm.sc.StaticTypesTypeChooser;
 import org.codehaus.groovy.control.SourceUnit;
-import org.codehaus.groovy.syntax.Token;
 import org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport;
 import org.codehaus.groovy.transform.stc.StaticTypeCheckingVisitor;
 import org.codehaus.groovy.transform.stc.StaticTypesMarker;

--- a/src/main/org/codehaus/groovy/transform/sc/TemporaryVariableExpression.java
+++ b/src/main/org/codehaus/groovy/transform/sc/TemporaryVariableExpression.java
@@ -36,7 +36,7 @@ import org.codehaus.groovy.classgen.asm.WriterController;
  */
 public class TemporaryVariableExpression extends Expression {
 
-    private Expression expression;
+    private final Expression expression;
 
     private ExpressionAsVariableSlot variable;
 

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/BinaryExpressionTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/BinaryExpressionTransformer.java
@@ -248,7 +248,7 @@ public class BinaryExpressionTransformer {
         return staticCompilationTransformer.superTransform(bin);
     }
 
-    private BinaryExpression tryOptimizeCharComparison(final Expression left, final Expression right, final BinaryExpression bin) {
+    private static BinaryExpression tryOptimizeCharComparison(final Expression left, final Expression right, final BinaryExpression bin) {
         int op = bin.getOperation().getType();
         if (isCompareToBoolean(op) || op == COMPARE_EQUAL || op == COMPARE_NOT_EQUAL) {
             Character cLeft = tryCharConstant(left);
@@ -266,7 +266,7 @@ public class BinaryExpressionTransformer {
         return null;
     }
 
-    private Character tryCharConstant(final Expression expr) {
+    private static Character tryCharConstant(final Expression expr) {
         if (expr instanceof ConstantExpression) {
             ConstantExpression ce = (ConstantExpression) expr;
             if (ClassHelper.STRING_TYPE.equals(ce.getType())) {
@@ -279,7 +279,7 @@ public class BinaryExpressionTransformer {
         return null;
     }
 
-    private Expression transformDeclarationExpression(final BinaryExpression bin) {
+    private static Expression transformDeclarationExpression(final BinaryExpression bin) {
         Expression leftExpression = bin.getLeftExpression();
         if (leftExpression instanceof VariableExpression) {
             if (ClassHelper.char_TYPE.equals(((VariableExpression) leftExpression).getOriginType())) {
@@ -321,7 +321,7 @@ public class BinaryExpressionTransformer {
         return staticCompilationTransformer.transform(tExp);
     }
 
-    private DeclarationExpression optimizeConstantInitialization(
+    private static DeclarationExpression optimizeConstantInitialization(
             final BinaryExpression originalDeclaration,
             final Token operation,
             final ConstantExpression constant,

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/BooleanExpressionTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/BooleanExpressionTransformer.java
@@ -59,7 +59,7 @@ public class BooleanExpressionTransformer {
         return transformer.superTransform(booleanExpression);
     }
     
-    private static boolean isExtended(ClassNode owner, Iterator<InnerClassNode> classes) {
+    static boolean isExtended(ClassNode owner, Iterator<InnerClassNode> classes) {
         while (classes.hasNext()) {
             InnerClassNode next =  classes.next();
             if (next!=owner && next.isDerivedFrom(owner)) return true;

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/BooleanExpressionTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/BooleanExpressionTransformer.java
@@ -59,7 +59,7 @@ public class BooleanExpressionTransformer {
         return transformer.superTransform(booleanExpression);
     }
     
-    static boolean isExtended(ClassNode owner, Iterator<InnerClassNode> classes) {
+    private static boolean isExtended(ClassNode owner, Iterator<InnerClassNode> classes) {
         while (classes.hasNext()) {
             InnerClassNode next =  classes.next();
             if (next!=owner && next.isDerivedFrom(owner)) return true;

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/CastExpressionOptimizer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/CastExpressionOptimizer.java
@@ -68,7 +68,7 @@ public class CastExpressionOptimizer {
         return transformer.superTransform(cast);
     }
 
-    private boolean isOptimizable(final ClassNode exprInferredType, final ClassNode castType) {
+    private static boolean isOptimizable(final ClassNode exprInferredType, final ClassNode castType) {
         if (StaticTypeCheckingSupport.implementsInterfaceOrIsSubclassOf(exprInferredType, castType)) {
             return true;
         }

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/CompareIdentityExpression.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/CompareIdentityExpression.java
@@ -19,7 +19,6 @@
 package org.codehaus.groovy.transform.sc.transformers;
 
 import org.codehaus.groovy.ast.ClassHelper;
-import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.GroovyCodeVisitor;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.Expression;
@@ -62,8 +61,8 @@ public class CompareIdentityExpression extends BinaryExpression implements Opcod
         if (visitor instanceof AsmClassGenerator) {
             AsmClassGenerator acg = (AsmClassGenerator) visitor;
             WriterController controller = acg.getController();
-            ClassNode leftType = controller.getTypeChooser().resolveType(leftExpression, controller.getClassNode());
-            ClassNode rightType = controller.getTypeChooser().resolveType(rightExpression, controller.getClassNode());
+            controller.getTypeChooser().resolveType(leftExpression, controller.getClassNode());
+            controller.getTypeChooser().resolveType(rightExpression, controller.getClassNode());
             MethodVisitor mv = controller.getMethodVisitor();
             leftExpression.visit(acg);
             controller.getOperandStack().box();

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/ConstructorCallTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/ConstructorCallTransformer.java
@@ -93,11 +93,11 @@ public class ConstructorCallTransformer {
     }
 
     private static class MapStyleConstructorCall extends BytecodeExpression implements Opcodes {
-        private StaticCompilationTransformer staticCompilationTransformer;
+        private final StaticCompilationTransformer staticCompilationTransformer;
         private AsmClassGenerator acg;
-        ClassNode declaringClass;
-        private MapExpression map;
-        private ConstructorCallExpression orginalCall;
+        final ClassNode declaringClass;
+        private final MapExpression map;
+        private final ConstructorCallExpression orginalCall;
 
         public MapStyleConstructorCall(
                 final StaticCompilationTransformer transformer,

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/ConstructorCallTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/ConstructorCallTransformer.java
@@ -95,7 +95,7 @@ public class ConstructorCallTransformer {
     private static class MapStyleConstructorCall extends BytecodeExpression implements Opcodes {
         private StaticCompilationTransformer staticCompilationTransformer;
         private AsmClassGenerator acg;
-        private ClassNode declaringClass;
+        ClassNode declaringClass;
         private MapExpression map;
         private ConstructorCallExpression orginalCall;
 

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/MethodCallExpressionTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/MethodCallExpressionTransformer.java
@@ -133,7 +133,7 @@ public class MethodCallExpressionTransformer {
         return staticCompilationTransformer.superTransform(expr);
     }
 
-    private MethodCallExpression transformToMopSuperCall(final ClassNode superCallReceiver, final MethodCallExpression expr) {
+    private static MethodCallExpression transformToMopSuperCall(final ClassNode superCallReceiver, final MethodCallExpression expr) {
         MethodNode mn = expr.getNodeMetaData(StaticTypesMarker.DIRECT_METHOD_CALL_TARGET);
         String mopName = MopWriter.getMopMethodName(mn, false);
         MethodNode direct = new MethodNode(
@@ -158,7 +158,7 @@ public class MethodCallExpressionTransformer {
         return result;
     }
 
-    private boolean isCallOnClosure(final MethodCallExpression expr) {
+    private static boolean isCallOnClosure(final MethodCallExpression expr) {
         return expr.isImplicitThis()
                 && expr.getNodeMetaData(StaticTypesMarker.DIRECT_METHOD_CALL_TARGET) == StaticTypeCheckingVisitor.CLOSURE_CALL_VARGS
                 && !"call".equals(expr.getMethodAsString());

--- a/src/main/org/codehaus/groovy/transform/sc/transformers/VariableExpressionTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/VariableExpressionTransformer.java
@@ -45,7 +45,7 @@ public class VariableExpressionTransformer {
         return expr;
     }
 
-    private Expression tryTransformDelegateToProperty(VariableExpression expr) {
+    private static Expression tryTransformDelegateToProperty(VariableExpression expr) {
         // we need to transform variable expressions that go to a delegate
         // to a property expression, as ACG would loose the information
         // in processClassVariable before it reaches any makeCall, that could
@@ -64,7 +64,7 @@ public class VariableExpressionTransformer {
         return pexp;
     }
 
-    private Expression tryTransformPrivateFieldAccess(VariableExpression expr) {
+    private static Expression tryTransformPrivateFieldAccess(VariableExpression expr) {
         FieldNode field = expr.getNodeMetaData(StaticTypesMarker.PV_FIELDS_ACCESS);
         if (field == null) {
             field = expr.getNodeMetaData(StaticTypesMarker.PV_FIELDS_MUTATION);

--- a/src/main/org/codehaus/groovy/transform/stc/AbstractTypeCheckingExtension.java
+++ b/src/main/org/codehaus/groovy/transform/stc/AbstractTypeCheckingExtension.java
@@ -438,7 +438,7 @@ public class AbstractTypeCheckingExtension extends TypeCheckingExtension {
     private class TypeCheckingScope extends LinkedHashMap<String, Object> {
         private final AbstractTypeCheckingExtension.TypeCheckingScope parent;
 
-        private TypeCheckingScope(final AbstractTypeCheckingExtension.TypeCheckingScope parentScope) {
+        TypeCheckingScope(final AbstractTypeCheckingExtension.TypeCheckingScope parentScope) {
             this.parent = parentScope;
         }
 

--- a/src/main/org/codehaus/groovy/transform/stc/AbstractTypeCheckingExtension.java
+++ b/src/main/org/codehaus/groovy/transform/stc/AbstractTypeCheckingExtension.java
@@ -202,7 +202,7 @@ public class AbstractTypeCheckingExtension extends TypeCheckingExtension {
         return match;
     }
 
-    private boolean matchWithOrWithourBoxing(final ClassNode argType, final Class aClass) {
+    private static boolean matchWithOrWithourBoxing(final ClassNode argType, final Class aClass) {
         final boolean match;
         ClassNode type = ClassHelper.make(aClass);
         if (ClassHelper.isPrimitiveType(type) && !ClassHelper.isPrimitiveType(argType)) {

--- a/src/main/org/codehaus/groovy/transform/stc/GroovyTypeCheckingExtensionSupport.java
+++ b/src/main/org/codehaus/groovy/transform/stc/GroovyTypeCheckingExtensionSupport.java
@@ -64,7 +64,7 @@ import java.util.Map;
 public class GroovyTypeCheckingExtensionSupport extends AbstractTypeCheckingExtension {
 
     // method name to DSL name
-    static final Map<String, String> METHOD_ALIASES = Collections.unmodifiableMap(
+    private static final Map<String, String> METHOD_ALIASES = Collections.unmodifiableMap(
             new HashMap<String, String>() {{
                 put("onMethodSelection", "onMethodSelection");
                 put("afterMethodCall", "afterMethodCall");
@@ -86,7 +86,7 @@ public class GroovyTypeCheckingExtensionSupport extends AbstractTypeCheckingExte
     );
 
     // the following fields are closures executed in event-based methods
-    final Map<String, List<Closure>> eventHandlers = new HashMap<String, List<Closure>>();
+    private final Map<String, List<Closure>> eventHandlers = new HashMap<String, List<Closure>>();
 
     private final String scriptPath;
 
@@ -406,7 +406,7 @@ public class GroovyTypeCheckingExtensionSupport extends AbstractTypeCheckingExte
     // --------------------------------------------
 
     public abstract static class TypeCheckingDSL extends Script {
-        GroovyTypeCheckingExtensionSupport extension;
+        private GroovyTypeCheckingExtensionSupport extension;
 
         @Override
         public Object getProperty(final String property) {

--- a/src/main/org/codehaus/groovy/transform/stc/GroovyTypeCheckingExtensionSupport.java
+++ b/src/main/org/codehaus/groovy/transform/stc/GroovyTypeCheckingExtensionSupport.java
@@ -64,7 +64,7 @@ import java.util.Map;
 public class GroovyTypeCheckingExtensionSupport extends AbstractTypeCheckingExtension {
 
     // method name to DSL name
-    private static final Map<String, String> METHOD_ALIASES = Collections.unmodifiableMap(
+    static final Map<String, String> METHOD_ALIASES = Collections.unmodifiableMap(
             new HashMap<String, String>() {{
                 put("onMethodSelection", "onMethodSelection");
                 put("afterMethodCall", "afterMethodCall");
@@ -86,7 +86,7 @@ public class GroovyTypeCheckingExtensionSupport extends AbstractTypeCheckingExte
     );
 
     // the following fields are closures executed in event-based methods
-    private final Map<String, List<Closure>> eventHandlers = new HashMap<String, List<Closure>>();
+    final Map<String, List<Closure>> eventHandlers = new HashMap<String, List<Closure>>();
 
     private final String scriptPath;
 
@@ -406,7 +406,7 @@ public class GroovyTypeCheckingExtensionSupport extends AbstractTypeCheckingExte
     // --------------------------------------------
 
     public abstract static class TypeCheckingDSL extends Script {
-        private GroovyTypeCheckingExtensionSupport extension;
+        GroovyTypeCheckingExtensionSupport extension;
 
         @Override
         public Object getProperty(final String property) {

--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1897,7 +1897,7 @@ public abstract class StaticTypeCheckingSupport {
      * A DGM-like method which adds support for method calls which are handled
      * specifically by the Groovy compiler.
      */
-    private static class ObjectArrayStaticTypesHelper {
+    static class ObjectArrayStaticTypesHelper {
         public static <T> T getAt(T[] arr, int index) { return null;} 
         public static <T,U extends T> void putAt(T[] arr, int index, U object) { }
     }
@@ -1908,7 +1908,7 @@ public abstract class StaticTypeCheckingSupport {
      * extension modules has changed. It avoids recomputing the whole list each time we perform
      * a method lookup.
      */
-    private static class ExtensionMethodCache {
+    static class ExtensionMethodCache {
 
         private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
         private Map<String, List<MethodNode>> cachedMethods = null;

--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1897,7 +1897,7 @@ public abstract class StaticTypeCheckingSupport {
      * A DGM-like method which adds support for method calls which are handled
      * specifically by the Groovy compiler.
      */
-    static class ObjectArrayStaticTypesHelper {
+    private static class ObjectArrayStaticTypesHelper {
         public static <T> T getAt(T[] arr, int index) { return null;} 
         public static <T,U extends T> void putAt(T[] arr, int index, U object) { }
     }
@@ -1908,7 +1908,7 @@ public abstract class StaticTypeCheckingSupport {
      * extension modules has changed. It avoids recomputing the whole list each time we perform
      * a method lookup.
      */
-    static class ExtensionMethodCache {
+    private static class ExtensionMethodCache {
 
         private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
         private Map<String, List<MethodNode>> cachedMethods = null;

--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -4784,7 +4784,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         final String name;
         final List<MethodNode> setters;
 
-        private SetterInfo(final ClassNode receiverType, final String name, final List<MethodNode> setters) {
+        SetterInfo(final ClassNode receiverType, final String name, final List<MethodNode> setters) {
             this.receiverType = receiverType;
             this.setters = setters;
             this.name = name;

--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -331,7 +331,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
     }
 
     @SuppressWarnings("unchecked")
-    private void addPrivateFieldOrMethodAccess(Expression source, ClassNode cn, StaticTypesMarker type, ASTNode accessedMember) {
+    private static void addPrivateFieldOrMethodAccess(Expression source, ClassNode cn, StaticTypesMarker type, ASTNode accessedMember) {
         Set<ASTNode> set = (Set<ASTNode>) cn.getNodeMetaData(type);
         if (set==null) {
             set = new LinkedHashSet<ASTNode>();
@@ -398,7 +398,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
     /**
      * wrap type in Class&lt;&gt; if usingClass==true
      */
-    private ClassNode makeType(ClassNode cn, boolean usingClass) {
+    private static ClassNode makeType(ClassNode cn, boolean usingClass) {
         if (usingClass) {
             ClassNode clazzType = CLASS_Type.getPlainNodeReference();
             clazzType.setGenericsTypes(new GenericsType[] {new GenericsType(cn)});
@@ -867,7 +867,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return true;
     }
 
-    private ClassNode adjustTypeForSpreading(ClassNode inferredRightExpressionType, Expression leftExpression) {
+    private static ClassNode adjustTypeForSpreading(ClassNode inferredRightExpressionType, Expression leftExpression) {
         // imagine we have: list*.foo = 100
         // then the assignment must be checked against [100], not 100
         ClassNode wrappedRHS = inferredRightExpressionType;
@@ -2016,7 +2016,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         }
     }
 
-    private ClassNode wrapClosureType(final ClassNode returnType) {
+    private static ClassNode wrapClosureType(final ClassNode returnType) {
         ClassNode inferredType = CLOSURE_TYPE.getPlainNodeReference();
         inferredType.setGenericsTypes(new GenericsType[]{new GenericsType(wrapTypeIfNecessary(returnType))});
         return inferredType;
@@ -2755,7 +2755,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         }
     }
 
-    private void doAddDelegateReceiver(final List<Receiver<String>> receivers, final StringBuilder path, final ClassNode delegate) {
+    private static void doAddDelegateReceiver(final List<Receiver<String>> receivers, final StringBuilder path, final ClassNode delegate) {
         receivers.add(new Receiver<String>(delegate, path.toString()));
         if (isTraitHelper(delegate)) {
             receivers.add(new Receiver<String>(delegate.getOuterClass(), path.toString()));
@@ -3037,7 +3037,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
      *@param args the arguments of the method call
      * @param returnType the original return type, as inferred by the type checker   @return fixed return type if the selected method is {@link org.codehaus.groovy.runtime.DefaultGroovyMethods#withTraits(Object, Class[]) withTraits}
      */
-    private ClassNode adjustWithTraits(final MethodNode directMethodCallCandidate, final ClassNode receiver, final ClassNode[] args, final ClassNode returnType) {
+    private static ClassNode adjustWithTraits(final MethodNode directMethodCallCandidate, final ClassNode receiver, final ClassNode[] args, final ClassNode returnType) {
         if (directMethodCallCandidate instanceof ExtensionMethodNode) {
             ExtensionMethodNode emn = (ExtensionMethodNode) directMethodCallCandidate;
             if ("withTraits".equals(emn.getName()) && "DefaultGroovyMethods".equals(emn.getExtensionMethodNode().getDeclaringClass().getNameWithoutPackage())) {
@@ -3062,7 +3062,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
      * @param name  the name of the method
      * @param args the argument classes
      */
-    private void addArrayMethods(List<MethodNode> methods, ClassNode receiver, String name, ClassNode[] args) {
+    private static void addArrayMethods(List<MethodNode> methods, ClassNode receiver, String name, ClassNode[] args) {
         if (args.length!=1) return;
         if (!receiver.isArray()) return;
         if (!isIntCategory(getUnwrapper(args[0]))) return;
@@ -3133,7 +3133,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return owners;
     }
 
-    private void addSelfTypes(final ClassNode receiver, final List<Receiver<String>> owners) {
+    private static void addSelfTypes(final ClassNode receiver, final List<Receiver<String>> owners) {
         LinkedHashSet<ClassNode> selfTypes = new LinkedHashSet<ClassNode>();
         for (ClassNode selfType : Traits.collectSelfTypes(receiver, selfTypes)) {
             owners.add(Receiver.<String>make(selfType));
@@ -3568,7 +3568,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return null;
     }
 
-    private ClassNode inferSAMTypeGenericsInAssignment(ClassNode samUsage, MethodNode sam, ClassNode closureType, ClosureExpression closureExpression) {
+    private static ClassNode inferSAMTypeGenericsInAssignment(ClassNode samUsage, MethodNode sam, ClassNode closureType, ClosureExpression closureExpression) {
         // if the sam type or closure type do not provide generics information, 
         // we cannot infer anything, thus we simply return the provided samUsage
         GenericsType[] samGt = samUsage.getGenericsTypes();
@@ -3727,7 +3727,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return result;
     }
 
-    private List<MethodNode> addGeneratedMethods(final ClassNode receiver, final List<MethodNode> methods) {
+    private static List<MethodNode> addGeneratedMethods(final ClassNode receiver, final List<MethodNode> methods) {
         // using a comparator of parameters
         List<MethodNode> result = new LinkedList<MethodNode>();
         for (MethodNode method : methods) {
@@ -4094,7 +4094,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return ret;
     }
 
-    private ClassNode makeSelf(ClassNode trait) {
+    private static ClassNode makeSelf(ClassNode trait) {
         ClassNode ret = trait;
         LinkedHashSet<ClassNode> selfTypes = new LinkedHashSet<ClassNode>();
         Traits.collectSelfTypes(ret, selfTypes);
@@ -4300,7 +4300,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return applyGenericsContext(resolvedPlaceholders, returnType);
     }
 
-    private void resolvePlaceholdersFromExplicitTypeHints(final MethodNode method, final GenericsType[] explicitTypeHints, final Map<String, GenericsType> resolvedPlaceholders) {
+    private static void resolvePlaceholdersFromExplicitTypeHints(final MethodNode method, final GenericsType[] explicitTypeHints, final Map<String, GenericsType> resolvedPlaceholders) {
         if (explicitTypeHints!=null) {
             GenericsType[] methodGenericTypes = method.getGenericsTypes();
             if (methodGenericTypes!=null && methodGenericTypes.length==explicitTypeHints.length) {
@@ -4313,7 +4313,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         }
     }
 
-    private void extractGenericsConnectionsForSuperClassAndInterfaces(final Map<String, GenericsType> resolvedPlaceholders, final Map<String, GenericsType> connections) {
+    private static void extractGenericsConnectionsForSuperClassAndInterfaces(final Map<String, GenericsType> resolvedPlaceholders, final Map<String, GenericsType> connections) {
         for (GenericsType value : new HashSet<GenericsType>(connections.values())) {
             if (!value.isPlaceholder() && !value.isWildcard()) {
                 ClassNode valueType = value.getType();
@@ -4553,7 +4553,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return true;
     }
 
-    private String toMethodGenericTypesString(MethodNode node) {
+    private static String toMethodGenericTypesString(MethodNode node) {
         GenericsType[] genericsTypes = node.getGenericsTypes();
         if (genericsTypes ==null) return "";
         StringBuilder sb = new StringBuilder("<");
@@ -4582,11 +4582,11 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return sb.toString();
     }
 
-    private void putSetterInfo(Expression exp, SetterInfo info) {
+    private static void putSetterInfo(Expression exp, SetterInfo info) {
         exp.putNodeMetaData(SetterInfo.class, info);
     }
 
-    private SetterInfo removeSetterInfo(Expression exp) {
+    private static SetterInfo removeSetterInfo(Expression exp) {
         Object nodeMetaData = exp.getNodeMetaData(SetterInfo.class);
         if (nodeMetaData!=null) {
             exp.removeNodeMetaData(SetterInfo.class);

--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -171,7 +171,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
 
     protected final ReturnAdder.ReturnStatementListener returnListener = new ReturnAdder.ReturnStatementListener() {
         public void returnStatementAdded(final ReturnStatement returnStatement) {
-            ClassNode returnType = checkReturnType(returnStatement);
+            checkReturnType(returnStatement);
             if (returnStatement.getExpression().equals(ConstantExpression.NULL)) return;
             if (typeCheckingContext.getEnclosingClosure()!=null) {
                 addClosureReturnType(getType(returnStatement.getExpression()));
@@ -2044,7 +2044,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         for (VariableExpression ve : closureSharedExpressions) {
             // GROOVY-6921: We must force a call to getType in order to update closure shared variable which types are
             // inferred thanks to closure parameter type inference
-            ClassNode cn = getType(ve);
+            getType(ve);
             ListHashMap<StaticTypesMarker, Object> metadata = new ListHashMap<StaticTypesMarker, Object>();
             for (StaticTypesMarker marker : StaticTypesMarker.values()) {
                 Object value = ve.getNodeMetaData(marker);

--- a/src/main/org/codehaus/groovy/transform/stc/TraitTypeCheckingExtension.java
+++ b/src/main/org/codehaus/groovy/transform/stc/TraitTypeCheckingExtension.java
@@ -100,11 +100,11 @@ public class TraitTypeCheckingExtension extends AbstractTypeCheckingExtension {
         return NOTFOUND;
     }
 
-    private boolean isStaticTraitReceiver(final ClassNode receiver, final VariableExpression var) {
+    private static boolean isStaticTraitReceiver(final ClassNode receiver, final VariableExpression var) {
         return Traits.STATIC_THIS_OBJECT.equals(var.getName()) && isClassClassNodeWrappingConcreteType(receiver);
     }
 
-    private boolean isThisTraitReceiver(final VariableExpression var) {
+    private static boolean isThisTraitReceiver(final VariableExpression var) {
         return Traits.THIS_OBJECT.equals(var.getName());
     }
 

--- a/src/main/org/codehaus/groovy/transform/trait/NAryOperationRewriter.java
+++ b/src/main/org/codehaus/groovy/transform/trait/NAryOperationRewriter.java
@@ -127,7 +127,7 @@ class NAryOperationRewriter extends ClassCodeExpressionTransformer {
         return result;
     }
 
-    private int getOperationWithoutEqual(final int op) {
+    private static int getOperationWithoutEqual(final int op) {
         int token = -1;
         switch (op) {
             case LOGICAL_OR_EQUAL:

--- a/src/main/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
@@ -530,7 +530,7 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
         this.compilationUnit = unit;
     }
 
-    static class DefaultArgsMethodsAdder extends Verifier {
+    private static class DefaultArgsMethodsAdder extends Verifier {
 
         @Override
         public void addDefaultParameterMethods(final ClassNode node) {
@@ -539,7 +539,7 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
         }
     }
 
-    static class PostTypeCheckingExpressionReplacer extends ClassCodeExpressionTransformer {
+    private static class PostTypeCheckingExpressionReplacer extends ClassCodeExpressionTransformer {
         private final SourceUnit sourceUnit;
 
         PostTypeCheckingExpressionReplacer(final SourceUnit sourceUnit) {

--- a/src/main/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
@@ -530,7 +530,7 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
         this.compilationUnit = unit;
     }
 
-    private static class DefaultArgsMethodsAdder extends Verifier {
+    static class DefaultArgsMethodsAdder extends Verifier {
 
         @Override
         public void addDefaultParameterMethods(final ClassNode node) {
@@ -539,10 +539,10 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
         }
     }
 
-    private static class PostTypeCheckingExpressionReplacer extends ClassCodeExpressionTransformer {
+    static class PostTypeCheckingExpressionReplacer extends ClassCodeExpressionTransformer {
         private final SourceUnit sourceUnit;
 
-        private PostTypeCheckingExpressionReplacer(final SourceUnit sourceUnit) {
+        PostTypeCheckingExpressionReplacer(final SourceUnit sourceUnit) {
             this.sourceUnit = sourceUnit;
         }
 

--- a/src/main/org/codehaus/groovy/transform/trait/TraitComposer.java
+++ b/src/main/org/codehaus/groovy/transform/trait/TraitComposer.java
@@ -486,34 +486,6 @@ public abstract class TraitComposer {
         return false;
     }
 
-    /**
-     * An utility method which tries to find a method with default implementation (in the Java 8 semantics).
-     * @param cNode a class node
-     * @param name the name of the method
-     * @param params the parameters of the method
-     * @return a method node corresponding to a default method if it exists
-     */
-    private static MethodNode findDefaultMethodFromInterface(final ClassNode cNode, final String name, final Parameter[] params) {
-        if (cNode == null) {
-            return null;
-        }
-        if (cNode.isInterface()) {
-            MethodNode method = cNode.getMethod(name, params);
-            if (method!=null && !method.isAbstract()) {
-                // this is a Java 8 only behavior!
-                return method;
-            }
-        }
-        ClassNode[] interfaces = cNode.getInterfaces();
-        for (ClassNode anInterface : interfaces) {
-            MethodNode res = findDefaultMethodFromInterface(anInterface, name, params);
-            if (res!=null) {
-                return res;
-            }
-        }
-        return findDefaultMethodFromInterface(cNode.getSuperClass(), name, params);
-    }
-
     private static boolean isExistingProperty(final String methodName, final ClassNode cNode, final Parameter[] params) {
         String propertyName = methodName;
         boolean getter = false;

--- a/src/main/org/codehaus/groovy/transform/trait/TraitReceiverTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/trait/TraitReceiverTransformer.java
@@ -279,7 +279,7 @@ class TraitReceiverTransformer extends ClassCodeExpressionTransformer {
         return ret;
     }
 
-    private void markDynamicCall(final MethodCallExpression mce, final FieldNode fn, final boolean isStatic) {
+    private static void markDynamicCall(final MethodCallExpression mce, final FieldNode fn, final boolean isStatic) {
         if (isStatic) {
             mce.putNodeMetaData(TraitASTTransformation.DO_DYNAMIC, fn.getOriginType());
         }
@@ -307,7 +307,7 @@ class TraitReceiverTransformer extends ClassCodeExpressionTransformer {
                 transform(rightExpression));
     }
 
-    private FieldNode tryGetFieldNode(final ClassNode weavedType, final String fieldName) {
+    private static FieldNode tryGetFieldNode(final ClassNode weavedType, final String fieldName) {
         FieldNode fn = weavedType.getDeclaredField(fieldName);
         if (fn == null && ClassHelper.CLASS_Type.equals(weavedType)) {
             GenericsType[] genericsTypes = weavedType.getGenericsTypes();

--- a/src/main/org/codehaus/groovy/transform/trait/TraitReceiverTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/trait/TraitReceiverTransformer.java
@@ -44,7 +44,6 @@ import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
 import org.codehaus.groovy.ast.expr.TernaryExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.control.SourceUnit;
-import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.syntax.SyntaxException;
 import org.codehaus.groovy.syntax.Token;
 import org.codehaus.groovy.syntax.Types;
@@ -62,8 +61,6 @@ import java.util.List;
  * @since 2.3.0
  */
 class TraitReceiverTransformer extends ClassCodeExpressionTransformer {
-
-    private static final ClassNode INVOKERHELPER_CLASSNODE = ClassHelper.make(InvokerHelper.class);
 
     private final VariableExpression weaved;
     private final SourceUnit unit;

--- a/src/main/org/codehaus/groovy/util/AbstractConcurrentMapBase.java
+++ b/src/main/org/codehaus/groovy/util/AbstractConcurrentMapBase.java
@@ -292,7 +292,7 @@ public abstract class AbstractConcurrentMapBase {
             count = newCount;
         }
 
-        private void put(Entry ee, int index, Object[] tab) {
+        private static void put(Entry ee, int index, Object[] tab) {
             Object o = tab[index];
             if (o != null) {
                 if (o instanceof Entry) {
@@ -314,7 +314,7 @@ public abstract class AbstractConcurrentMapBase {
             tab[index] = ee;
         }
 
-        private Object put(Entry ee, Object o) {
+        private static Object put(Entry ee, Object o) {
             if (o != null) {
                 if (o instanceof Entry) {
                     Object arr [] = new Object [2];

--- a/src/main/org/codehaus/groovy/util/AbstractConcurrentMapBase.java
+++ b/src/main/org/codehaus/groovy/util/AbstractConcurrentMapBase.java
@@ -124,7 +124,6 @@ public abstract class AbstractConcurrentMapBase {
 
     public Collection values() {
         Collection result = new LinkedList();
-        int count = 0;
         for (int i = 0; i < segments.length; i++) {
             segments[i].lock();
             try {

--- a/src/main/org/codehaus/groovy/util/ArrayIterator.java
+++ b/src/main/org/codehaus/groovy/util/ArrayIterator.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 
 public class ArrayIterator<T> implements Iterator<T> {
     private final T[] array;
-    private int length;
+    private final int length;
     private int index;
 
     public ArrayIterator(T[] array) {

--- a/src/main/org/codehaus/groovy/util/ComplexKeyHashMap.java
+++ b/src/main/org/codehaus/groovy/util/ComplexKeyHashMap.java
@@ -107,7 +107,7 @@ public class ComplexKeyHashMap
       threshold = (6 * newLength) / 8;
   }
 
-  private int capacity(int expectedMaxSize) {
+  private static int capacity(int expectedMaxSize) {
       // Compute min capacity for expectedMaxSize given a load factor of 3/4
       int minCapacity = (8 * expectedMaxSize)/6;
 

--- a/src/main/org/codehaus/groovy/util/ComplexKeyHashMap.java
+++ b/src/main/org/codehaus/groovy/util/ComplexKeyHashMap.java
@@ -137,7 +137,6 @@ public class ComplexKeyHashMap
         return new EntryIterator() {
             Entry next;       // next entry to return
             int index;        // current slot
-            Entry current;    // current entry
 
             {
                 Entry[] t = table;
@@ -170,7 +169,7 @@ public class ComplexKeyHashMap
                     n = t[--i];
                 index = i;
                 next = n;
-                return current = e;
+                return e;
             }
         };
   }

--- a/src/main/org/codehaus/groovy/util/ManagedConcurrentMap.java
+++ b/src/main/org/codehaus/groovy/util/ManagedConcurrentMap.java
@@ -49,7 +49,7 @@ public class ManagedConcurrentMap<K,V> extends AbstractConcurrentMap<K,V> {
 
     public static class Entry<K,V> extends ManagedReference<K> implements AbstractConcurrentMap.Entry<K,V> {
         private final Segment segment;
-        private int hash;
+        private final int hash;
 
         public Entry(ReferenceBundle bundle, Segment segment, K key, int hash) {
             super(bundle, key);

--- a/src/main/org/codehaus/groovy/util/ManagedConcurrentValueMap.java
+++ b/src/main/org/codehaus/groovy/util/ManagedConcurrentValueMap.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @param <V> the value type
  */
 public class ManagedConcurrentValueMap<K,V> {
-    private final ConcurrentHashMap<K,ManagedReference<V>> internalMap;
+    final ConcurrentHashMap<K,ManagedReference<V>> internalMap;
     private ReferenceBundle bundle;
     public ManagedConcurrentValueMap(ReferenceBundle bundle){
         this.bundle = bundle;

--- a/src/main/org/codehaus/groovy/util/ManagedConcurrentValueMap.java
+++ b/src/main/org/codehaus/groovy/util/ManagedConcurrentValueMap.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @param <V> the value type
  */
 public class ManagedConcurrentValueMap<K,V> {
-    final ConcurrentHashMap<K,ManagedReference<V>> internalMap;
+    private final ConcurrentHashMap<K,ManagedReference<V>> internalMap;
     private ReferenceBundle bundle;
     public ManagedConcurrentValueMap(ReferenceBundle bundle){
         this.bundle = bundle;

--- a/src/main/org/codehaus/groovy/util/ManagedDoubleKeyMap.java
+++ b/src/main/org/codehaus/groovy/util/ManagedDoubleKeyMap.java
@@ -30,7 +30,7 @@ public class ManagedDoubleKeyMap<K1,K2,V> extends AbstractConcurrentDoubleKeyMap
     }
 
     static class Segment<K1,K2,V> extends AbstractConcurrentDoubleKeyMap.Segment<K1,K2,V>{
-        private ReferenceBundle bundle;
+        private final ReferenceBundle bundle;
         public Segment(ReferenceBundle bundle, int cap) {
             super(cap);
             this.bundle = bundle;

--- a/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
+++ b/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
@@ -87,7 +87,7 @@ public class ManagedLinkedList<T> {
 
     Element<T> tail;
     Element<T> head;
-    private ReferenceBundle bundle;
+    private final ReferenceBundle bundle;
 
     public ManagedLinkedList(ReferenceBundle bundle) {
         this.bundle = bundle;

--- a/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
+++ b/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
@@ -85,8 +85,8 @@ public class ManagedLinkedList<T> {
         }
     }
 
-    Element<T> tail;
-    Element<T> head;
+    private Element<T> tail;
+    private Element<T> head;
     private final ReferenceBundle bundle;
 
     public ManagedLinkedList(ReferenceBundle bundle) {

--- a/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
+++ b/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
@@ -85,8 +85,8 @@ public class ManagedLinkedList<T> {
         }
     }
 
-    private Element<T> tail;
-    private Element<T> head;
+    Element<T> tail;
+    Element<T> head;
     private ReferenceBundle bundle;
 
     public ManagedLinkedList(ReferenceBundle bundle) {

--- a/src/main/org/codehaus/groovy/util/ReferenceBundle.java
+++ b/src/main/org/codehaus/groovy/util/ReferenceBundle.java
@@ -21,8 +21,8 @@ package org.codehaus.groovy.util;
 import java.lang.ref.ReferenceQueue;
 
 public class ReferenceBundle{
-    private ReferenceManager manager;
-    private ReferenceType type;
+    private final ReferenceManager manager;
+    private final ReferenceType type;
     public ReferenceBundle(ReferenceManager manager, ReferenceType type){
         this.manager = manager;
         this.type = type;

--- a/src/main/org/codehaus/groovy/util/ReferenceManager.java
+++ b/src/main/org/codehaus/groovy/util/ReferenceManager.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ReferenceManager {
     private static class ThreadedReferenceManager extends ReferenceManager {
         private final Thread thread;
-        private volatile boolean shouldRun = true; 
+        volatile boolean shouldRun = true; 
         public ThreadedReferenceManager(ReferenceQueue queue) {
             super(queue);
             thread = new Thread() {

--- a/src/main/org/codehaus/groovy/util/ReleaseInfo.java
+++ b/src/main/org/codehaus/groovy/util/ReleaseInfo.java
@@ -35,9 +35,6 @@ public class ReleaseInfo {
     private static final Properties RELEASE_INFO = new Properties();
     private static final String RELEASE_INFO_FILE = "META-INF/groovy-release-info.properties";
     private static final String KEY_IMPLEMENTATION_VERSION = "ImplementationVersion";
-    private static final String KEY_BUNDLE_VERSION = "BundleVersion";
-    private static final String KEY_BUILD_DATE = "BuildDate";
-    private static final String KEY_BUILD_TIME = "BuildTime";
 
     static {
         URL url = null;

--- a/src/main/org/codehaus/groovy/vmplugin/v5/Java5.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v5/Java5.java
@@ -129,7 +129,7 @@ public class Java5 implements VMPlugin {
         }
     }
 
-    private ClassNode configureClass(Class c) {
+    private static ClassNode configureClass(Class c) {
         if (c.isPrimitive()) {
             return ClassHelper.make(c);
         } else {
@@ -341,7 +341,7 @@ public class Java5 implements VMPlugin {
         }
     }
 
-    private void setMethodDefaultValue(MethodNode mn, Method m) {
+    private static void setMethodDefaultValue(MethodNode mn, Method m) {
         Object defaultValue = m.getDefaultValue();
         ConstantExpression cExp = ConstantExpression.NULL;
         if (defaultValue!=null) cExp = new ConstantExpression(defaultValue);

--- a/src/main/org/codehaus/groovy/vmplugin/v5/Java5.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v5/Java5.java
@@ -61,7 +61,7 @@ import java.util.List;
  * @author Jochen Theodorou
  */
 public class Java5 implements VMPlugin {
-    private static Class[] EMPTY_CLASS_ARRAY = new Class[0];
+    private static final Class[] EMPTY_CLASS_ARRAY = new Class[0];
     private static final Class[] PLUGIN_DGM = {PluginDefaultGroovyMethods.class};
 
     public void setAdditionalClassInformation(ClassNode cn) {

--- a/src/main/org/codehaus/groovy/vmplugin/v7/IndyArrayAccess.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/IndyArrayAccess.java
@@ -96,29 +96,6 @@ public class IndyArrayAccess {
         return handle;
     }
 
-    private static int getLength(Object array) {
-        if (array instanceof Object[]) return ((Object[])array).length;
-        if (array instanceof boolean[]) return ((boolean[])array).length;
-        if (array instanceof byte[]) return ((byte[])array).length;
-        if (array instanceof char[]) return ((char[])array).length;
-        if (array instanceof short[]) return ((short[])array).length;
-        if (array instanceof int[]) return ((int[])array).length;
-        if (array instanceof long[]) return ((long[])array).length;
-        if (array instanceof float[]) return ((float[])array).length;
-        if (array instanceof double[]) return ((double[])array).length;
-        return 0;
-    }
-
-    private static int normalizeIndex(Object array, int i) {
-        int temp = i;
-        int size = getLength(array);
-        i += size;
-        if (i < 0) {
-            throw new ArrayIndexOutOfBoundsException("Negative array index [" + temp + "] too large for array size " + size);
-        }
-        return i;
-    }
-
     public static boolean notNegative(int index) {
         return index>=0;
     }

--- a/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
@@ -236,7 +236,6 @@ public class IndyInterface {
          * @since 2.5.0
          */
          public static CallSite staticArrayAccess(MethodHandles.Lookup lookup, String name, MethodType type) {
-            MethodHandle handle;
             if (type.parameterCount()==2) {
                 return new ConstantCallSite(IndyArrayAccess.arrayGet(type));
             } else {

--- a/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
@@ -104,7 +104,7 @@ public class IndyInterface {
         static {
             GroovySystem.getMetaClassRegistry().addMetaClassRegistryChangeEventListener(new MetaClassRegistryChangeEventListener() {
                 public void updateConstantMetaClass(MetaClassRegistryChangeEvent cmcu) {
-                	invalidateSwitchPoints();
+                    invalidateSwitchPoints();
                 }
             });
         }

--- a/src/main/org/codehaus/groovy/vmplugin/v7/Java7.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/Java7.java
@@ -67,7 +67,7 @@ public class Java7 extends Java6 {
 
     @Override
     public void invalidateCallSites() {
-    	IndyInterface.invalidateSwitchPoints();
+        IndyInterface.invalidateSwitchPoints();
     }
 
     @Override

--- a/src/main/org/codehaus/groovy/vmplugin/v7/Selector.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/Selector.java
@@ -113,7 +113,7 @@ public abstract class Selector {
      * always 2, the returned Object[] will have a size of 1+n, where n is the
      * number arguments.
      */
-    private static Object[] spread(Object[] args, boolean spreadCall) {
+    static Object[] spread(Object[] args, boolean spreadCall) {
         if (!spreadCall) return args;
         Object[] normalArguments = (Object[]) args[1];
         Object[] ret = new Object[normalArguments.length+1];
@@ -641,7 +641,7 @@ public abstract class Selector {
         /**
          * Helper method to manipulate the given type to replace Wrapper with Object.
          */
-        private MethodType removeWrapper(MethodType targetType) {
+        private static MethodType removeWrapper(MethodType targetType) {
             Class[] types = targetType.parameterArray();
             for (int i=0; i<types.length; i++) {
                 if (types[i]==Wrapper.class) {
@@ -841,7 +841,7 @@ public abstract class Selector {
             // special guards for receiver
             if (receiver instanceof GroovyObject) {
                 GroovyObject go = (GroovyObject) receiver;
-                MetaClass mc = (MetaClass) go.getMetaClass();
+                MetaClass mc = go.getMetaClass();
                 MethodHandle test = SAME_MC.bindTo(mc); 
                 // drop dummy receiver
                 test = test.asType(MethodType.methodType(boolean.class,targetType.parameterType(0)));
@@ -974,7 +974,7 @@ public abstract class Selector {
      * Unwraps the given object from a {@link Wrapper}. If not
      * wrapped, the given object is returned.
      */
-    private static Object unwrapIfWrapped(Object object) {
+    static Object unwrapIfWrapped(Object object) {
         if (object instanceof Wrapper) return unwrap(object);
         return object;
     }
@@ -996,7 +996,7 @@ public abstract class Selector {
     /**
      * Returns if a method is static
      */
-    private static boolean isStatic(Method m) {
+    static boolean isStatic(Method m) {
         int mods = m.getModifiers();
         return (mods & Modifier.STATIC) != 0;
     }
@@ -1006,7 +1006,7 @@ public abstract class Selector {
      * MetaClassImpl, AdaptingMetaClass or ClosureMetaClass. If
      * none of these cases matches, this method returns null.
      */
-    private static MetaClassImpl getMetaClassImpl(MetaClass mc, boolean includeEMC) {
+    static MetaClassImpl getMetaClassImpl(MetaClass mc, boolean includeEMC) {
         Class mcc = mc.getClass();
         boolean valid = mcc == MetaClassImpl.class ||
                          mcc == AdaptingMetaClass.class ||
@@ -1024,7 +1024,7 @@ public abstract class Selector {
      * Helper method to remove the receiver from the argument array
      * by producing a new array.
      */
-    private static Object[] removeRealReceiver(Object[] args) {
+    static Object[] removeRealReceiver(Object[] args) {
         Object[] ar = new Object[args.length-1];
         System.arraycopy(args, 1, ar, 0, args.length - 1);
         return ar;

--- a/src/main/org/codehaus/groovy/vmplugin/v7/Selector.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/Selector.java
@@ -113,7 +113,7 @@ public abstract class Selector {
      * always 2, the returned Object[] will have a size of 1+n, where n is the
      * number arguments.
      */
-    static Object[] spread(Object[] args, boolean spreadCall) {
+    private static Object[] spread(Object[] args, boolean spreadCall) {
         if (!spreadCall) return args;
         Object[] normalArguments = (Object[]) args[1];
         Object[] ret = new Object[normalArguments.length+1];
@@ -630,7 +630,7 @@ public abstract class Selector {
             }
         }
 
-        private MethodHandle correctClassForNameAndUnReflectOtherwise(Method m) throws IllegalAccessException {
+        MethodHandle correctClassForNameAndUnReflectOtherwise(Method m) throws IllegalAccessException {
             if (m.getDeclaringClass()==Class.class && m.getName().equals("forName") && m.getParameterTypes().length==1) {
                 return MethodHandles.insertArguments(CLASS_FOR_NAME, 1, true, sender.getClassLoader());
             } else {
@@ -974,7 +974,7 @@ public abstract class Selector {
      * Unwraps the given object from a {@link Wrapper}. If not
      * wrapped, the given object is returned.
      */
-    static Object unwrapIfWrapped(Object object) {
+    private static Object unwrapIfWrapped(Object object) {
         if (object instanceof Wrapper) return unwrap(object);
         return object;
     }
@@ -996,7 +996,7 @@ public abstract class Selector {
     /**
      * Returns if a method is static
      */
-    static boolean isStatic(Method m) {
+    private static boolean isStatic(Method m) {
         int mods = m.getModifiers();
         return (mods & Modifier.STATIC) != 0;
     }
@@ -1006,7 +1006,7 @@ public abstract class Selector {
      * MetaClassImpl, AdaptingMetaClass or ClosureMetaClass. If
      * none of these cases matches, this method returns null.
      */
-    static MetaClassImpl getMetaClassImpl(MetaClass mc, boolean includeEMC) {
+    private static MetaClassImpl getMetaClassImpl(MetaClass mc, boolean includeEMC) {
         Class mcc = mc.getClass();
         boolean valid = mcc == MetaClassImpl.class ||
                          mcc == AdaptingMetaClass.class ||
@@ -1024,7 +1024,7 @@ public abstract class Selector {
      * Helper method to remove the receiver from the argument array
      * by producing a new array.
      */
-    static Object[] removeRealReceiver(Object[] args) {
+    private static Object[] removeRealReceiver(Object[] args) {
         Object[] ar = new Object[args.length-1];
         System.arraycopy(args, 1, ar, 0, args.length - 1);
         return ar;

--- a/src/main/org/codehaus/groovy/vmplugin/v7/Selector.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/Selector.java
@@ -123,7 +123,7 @@ public abstract class Selector {
     }
 
     private static class CastSelector extends MethodSelector {
-        private Class<?> staticSourceType, staticTargetType;
+        private final Class<?> staticSourceType, staticTargetType;
 
         public CastSelector(MutableCallSite callSite, Object[] arguments) {
             super(callSite, Selector.class, "", CALL_TYPES.CAST, false, false, false, arguments);

--- a/src/main/org/codehaus/groovy/vmplugin/v7/TypeTransformers.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/TypeTransformers.java
@@ -46,7 +46,7 @@ import org.codehaus.groovy.transform.trait.Traits;
  * @author <a href="mailto:blackdrag@gmx.org">Jochen "blackdrag" Theodorou</a>
  */
 public class TypeTransformers {
-	private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
     private static final MethodHandle 
         TO_STRING, TO_BYTE,   TO_INT,     TO_LONG,    TO_SHORT,
         TO_FLOAT,  TO_DOUBLE, TO_BIG_INT, TO_BIG_DEC, AS_ARRAY,

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyStaticMethodsTest.java
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyStaticMethodsTest.java
@@ -29,7 +29,7 @@ public class DefaultGroovyStaticMethodsTest extends GroovyTestCase {
      *Tests System.currentTimeSeconds()
      */
     public void testCurrentTimeSeconds() {
-	long timeMillis = System.currentTimeMillis();
+    long timeMillis = System.currentTimeMillis();
         long timeSeconds = DefaultGroovyStaticMethods.currentTimeSeconds(null);
         long timeMillis2 = System.currentTimeMillis();
         assertTrue(timeMillis/1000 <= timeSeconds);


### PR DESCRIPTION
I went through the codebase of the root project and did the following refactorings:
- make private methods static when they are plain functions
- add @Deprecated when javadoc says the method is @deprecated
- remove unused code
- avoid synthetic accessors by making private fields/methods package-private
- make private fields final where possible
- fix some inconsistent whitespaces

None of this should change the behaviour in any way.