### PR TITLE
avoid rebuilding bootstrapJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -397,7 +397,7 @@ task bootstrapJar {
         )
     }
     inputs.property('indy', useIndy())
-    inputs.files fileTree('src')
+    inputs.files sourceSets.main.allJava
     outputs.file archivePath
 }
 


### PR DESCRIPTION
When you just worked on tests in the root project, the bootstrapJar (as well as all groovy classes in the root project) were recompiled. I changed to behaviour to only trigger this process for non-test source changes.