### PR TITLE
GROOVY-7640: AST Builder should include superclass properties

### DIFF
--- a/src/main/groovy/transform/builder/Builder.java
+++ b/src/main/groovy/transform/builder/Builder.java
@@ -135,4 +135,9 @@ public @interface Builder {
      * made null-safe wrt the parameter.
      */
     boolean useSetters() default false;
+
+    /**
+     * Generate builder methods for properties from super classes.
+     */
+    boolean includeSuperProperties() default false;
 }

--- a/src/main/groovy/transform/builder/DefaultStrategy.java
+++ b/src/main/groovy/transform/builder/DefaultStrategy.java
@@ -43,7 +43,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.callX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.declS;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.getInstancePropertyFields;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.getSuperPropertyFields;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.param;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.params;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
@@ -201,7 +201,7 @@ public class DefaultStrategy extends BuilderASTTransformation.AbstractBuilderStr
         if (includes.size() == 1 && Undefined.isUndefined(includes.get(0))) includes = null;
         ClassNode builder = createBuilder(anno, buildee);
         createBuilderFactoryMethod(anno, buildee, builder);
-        List<FieldNode> fields = getInstancePropertyFields(buildee);
+        List<FieldNode> fields = getSuperPropertyFields(buildee);
         List<FieldNode> filteredFields = selectFieldsFromExistingClass(fields, includes, excludes);
         for (FieldNode fieldNode : filteredFields) {
             ClassNode correctedType = getCorrectedType(buildee, fieldNode);

--- a/src/main/groovy/transform/builder/DefaultStrategy.java
+++ b/src/main/groovy/transform/builder/DefaultStrategy.java
@@ -43,7 +43,6 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.callX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.declS;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.getSuperPropertyFields;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.param;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.params;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
@@ -201,7 +200,7 @@ public class DefaultStrategy extends BuilderASTTransformation.AbstractBuilderStr
         if (includes.size() == 1 && Undefined.isUndefined(includes.get(0))) includes = null;
         ClassNode builder = createBuilder(anno, buildee);
         createBuilderFactoryMethod(anno, buildee, builder);
-        List<FieldNode> fields = getSuperPropertyFields(buildee);
+        List<FieldNode> fields = getFields(transform, anno, buildee);
         List<FieldNode> filteredFields = selectFieldsFromExistingClass(fields, includes, excludes);
         for (FieldNode fieldNode : filteredFields) {
             ClassNode correctedType = getCorrectedType(buildee, fieldNode);

--- a/src/main/groovy/transform/builder/ExternalStrategy.java
+++ b/src/main/groovy/transform/builder/ExternalStrategy.java
@@ -49,6 +49,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.returnS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.stmt;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.newClass;
+import static org.codehaus.groovy.transform.AbstractASTTransformation.shouldSkip;
 import static org.codehaus.groovy.transform.BuilderASTTransformation.MY_TYPE_NAME;
 import static org.codehaus.groovy.transform.BuilderASTTransformation.NO_EXCEPTIONS;
 import static org.codehaus.groovy.transform.BuilderASTTransformation.NO_PARAMS;
@@ -122,7 +123,7 @@ public class ExternalStrategy extends BuilderASTTransformation.AbstractBuilderSt
         if (buildee.getModule() == null) {
             props = getPropertyInfoFromBeanInfo(buildee, includes, excludes);
         } else {
-            props = getPropertyInfoFromClassNode(buildee, includes, excludes);
+            props = getPropertyInfoFromClassNode(transform, anno, buildee, includes, excludes);
         }
         if (includes != null) {
             for (String name : includes) {
@@ -171,6 +172,15 @@ public class ExternalStrategy extends BuilderASTTransformation.AbstractBuilderSt
         } catch (IntrospectionException ignore) {
         }
         return result;
+    }
+
+    private List<PropertyInfo> getPropertyInfoFromClassNode(BuilderASTTransformation transform, AnnotationNode anno, ClassNode cNode, List<String> includes, List<String> excludes) {
+        List<PropertyInfo> props = new ArrayList<PropertyInfo>();
+        for (FieldNode fNode : getFields(transform, anno, cNode)) {
+            if (shouldSkip(fNode.getName(), excludes, includes)) continue;
+            props.add(new PropertyInfo(fNode.getName(), fNode.getType()));
+        }
+        return props;
     }
 
     private static Expression initializeInstance(ClassNode sourceClass, List<PropertyInfo> props, BlockStatement body) {

--- a/src/main/groovy/transform/builder/InitializerStrategy.java
+++ b/src/main/groovy/transform/builder/InitializerStrategy.java
@@ -50,7 +50,6 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorSuperS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorThisS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorX;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.getSuperPropertyFields;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.param;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.params;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
@@ -147,7 +146,7 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
         includes.add(Undefined.STRING);
         if (!getIncludeExclude(transform, anno, buildee, excludes, includes)) return;
         if (includes.size() == 1 && Undefined.isUndefined(includes.get(0))) includes = null;
-        List<FieldNode> fields = getSuperPropertyFields(buildee);
+        List<FieldNode> fields = getFields(transform, anno, buildee);
         List<FieldNode> filteredFields = filterFields(fields, includes, excludes);
         if (filteredFields.isEmpty()) {
             transform.addError("Error during " + BuilderASTTransformation.MY_TYPE_NAME +

--- a/src/main/groovy/transform/builder/InitializerStrategy.java
+++ b/src/main/groovy/transform/builder/InitializerStrategy.java
@@ -50,7 +50,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorSuperS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorThisS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorX;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.getInstancePropertyFields;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.getSuperPropertyFields;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.param;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.params;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
@@ -147,7 +147,7 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
         includes.add(Undefined.STRING);
         if (!getIncludeExclude(transform, anno, buildee, excludes, includes)) return;
         if (includes.size() == 1 && Undefined.isUndefined(includes.get(0))) includes = null;
-        List<FieldNode> fields = getInstancePropertyFields(buildee);
+        List<FieldNode> fields = getSuperPropertyFields(buildee);
         List<FieldNode> filteredFields = filterFields(fields, includes, excludes);
         if (filteredFields.isEmpty()) {
             transform.addError("Error during " + BuilderASTTransformation.MY_TYPE_NAME +

--- a/src/main/groovy/transform/builder/SimpleStrategy.java
+++ b/src/main/groovy/transform/builder/SimpleStrategy.java
@@ -92,6 +92,7 @@ public class SimpleStrategy extends BuilderASTTransformation.AbstractBuilderStra
         if (unsupportedAttribute(transform, anno, "buildMethodName")) return;
         if (unsupportedAttribute(transform, anno, "builderMethodName")) return;
         if (unsupportedAttribute(transform, anno, "forClass")) return;
+        if (unsupportedAttribute(transform, anno, "includeSuperProperties")) return;
         boolean useSetters = transform.memberHasValue(anno, "useSetters", true);
 
         List<String> excludes = new ArrayList<String>();
@@ -100,7 +101,7 @@ public class SimpleStrategy extends BuilderASTTransformation.AbstractBuilderStra
         if (!getIncludeExclude(transform, anno, buildee, excludes, includes)) return;
         if (includes.size() == 1 && Undefined.isUndefined(includes.get(0))) includes = null;
         String prefix = getMemberStringValue(anno, "prefix", "set");
-        List<FieldNode> fields = getInstancePropertyFields(buildee);
+        List<FieldNode> fields = getFields(transform, anno, buildee);
         if (includes != null) {
             for (String name : includes) {
                 checkKnownField(transform, anno, name, fields);
@@ -120,5 +121,10 @@ public class SimpleStrategy extends BuilderASTTransformation.AbstractBuilderStra
                 );
             }
         }
+    }
+
+    @Override
+    protected List<FieldNode> getFields(BuilderASTTransformation transform, AnnotationNode anno, ClassNode buildee) {
+        return getInstancePropertyFields(buildee);
     }
 }

--- a/src/main/org/codehaus/groovy/transform/BuilderASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/BuilderASTTransformation.java
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static groovy.transform.Undefined.isUndefined;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.getInstancePropertyFields;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.getSuperPropertyFields;
 
 /**
  * Handles generation of code for the {@link Builder} annotation.
@@ -78,7 +78,7 @@ public class BuilderASTTransformation extends AbstractASTTransformation implemen
     public abstract static class AbstractBuilderStrategy implements BuilderStrategy {
         protected static List<PropertyInfo> getPropertyInfoFromClassNode(ClassNode cNode, List<String> includes, List<String> excludes) {
             List<PropertyInfo> props = new ArrayList<PropertyInfo>();
-            for (FieldNode fNode : getInstancePropertyFields(cNode)) {
+            for (FieldNode fNode : getSuperPropertyFields(cNode)) {
                 if (shouldSkip(fNode.getName(), excludes, includes)) continue;
                 props.add(new PropertyInfo(fNode.getName(), fNode.getType()));
             }

--- a/src/main/org/codehaus/groovy/transform/BuilderASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/BuilderASTTransformation.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static groovy.transform.Undefined.isUndefined;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.getInstancePropertyFields;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.getSuperPropertyFields;
 
 /**
@@ -78,7 +79,7 @@ public class BuilderASTTransformation extends AbstractASTTransformation implemen
     public abstract static class AbstractBuilderStrategy implements BuilderStrategy {
         protected static List<PropertyInfo> getPropertyInfoFromClassNode(ClassNode cNode, List<String> includes, List<String> excludes) {
             List<PropertyInfo> props = new ArrayList<PropertyInfo>();
-            for (FieldNode fNode : getSuperPropertyFields(cNode)) {
+            for (FieldNode fNode : getInstancePropertyFields(cNode)) {
                 if (shouldSkip(fNode.getName(), excludes, includes)) continue;
                 props.add(new PropertyInfo(fNode.getName(), fNode.getType()));
             }
@@ -154,6 +155,11 @@ public class BuilderASTTransformation extends AbstractASTTransformation implemen
             }
             List<String> includesToCheck = includes.size() == 1 && isUndefined(includes.get(0)) ? null : includes;
             return transform.checkIncludeExcludeUndefinedAware(anno, excludes, includesToCheck, MY_TYPE_NAME);
+        }
+
+        protected List<FieldNode> getFields(BuilderASTTransformation transform, AnnotationNode anno, ClassNode buildee) {
+           boolean includeSuperProperties = transform.memberHasValue(anno, "includeSuperProperties", true);
+           return includeSuperProperties ? getSuperPropertyFields(buildee) : getInstancePropertyFields(buildee);
         }
 
         protected static class PropertyInfo {

--- a/src/spec/doc/core-metaprogramming.adoc
+++ b/src/spec/doc/core-metaprogramming.adoc
@@ -1224,11 +1224,11 @@ strategy class. The following table lists the available strategies that are bund
 configuration options each strategy supports.
 
 |================================
-| Strategy | Description | builderClassName | builderMethodName |buildMethodName | prefix | includes/excludes
-| `SimpleStrategy` | chained setters | n/a | n/a | n/a | yes, default "set" | yes
-| `ExternalStrategy` | explicit builder class, class being built untouched | n/a | n/a | yes, default "build" | yes, default "" | yes
-| `DefaultStrategy` | creates a nested helper class | yes, default __<TypeName>__Builder | yes, default "builder" | yes, default "build" | yes, default "" | yes
-| `InitializerStrategy` | creates a nested helper class providing type-safe fluent creation | yes, default __<TypeName>__Initializer | yes, default "createInitializer" | yes, default "create" but usually only used internally | yes, default "" | yes
+| Strategy | Description | builderClassName | builderMethodName |buildMethodName | prefix | includes/excludes | includeSuperProperties
+| `SimpleStrategy` | chained setters | n/a | n/a | n/a | yes, default "set" | yes | n/a
+| `ExternalStrategy` | explicit builder class, class being built untouched | n/a | n/a | yes, default "build" | yes, default "" | yes | yes, default `false`
+| `DefaultStrategy` | creates a nested helper class | yes, default __<TypeName>__Builder | yes, default "builder" | yes, default "build" | yes, default "" | yes | yes, default `false`
+| `InitializerStrategy` | creates a nested helper class providing type-safe fluent creation | yes, default __<TypeName>__Initializer | yes, default "createInitializer" | yes, default "create" but usually only used internally | yes, default "" | yes | yes, default `false`
 |================================
 
 .SimpleStrategy
@@ -1275,7 +1275,7 @@ annotation aliases which combine `@TupleConstructor` such as `@Canonical`.
 The annotation attribute `useSetters` can be used if you have a setter which you want called as part of the
 construction process. See the JavaDoc for details.
 
-The annotation attributes `builderClassName`, `buildMethodName`, `builderMethodName` and `forClass` are not supported for this strategy.
+The annotation attributes `builderClassName`, `buildMethodName`, `builderMethodName`, `forClass` and `includeSuperProperties` are not supported for this strategy.
 
 NOTE: Groovy already has built-in building mechanisms. Don't rush to using `@Builder` if the built-in mechanisms meet your needs. Some examples:
 [source,groovy]

--- a/src/test/org/codehaus/groovy/transform/BuilderTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/BuilderTransformTest.groovy
@@ -78,6 +78,15 @@ class BuilderTransformTest extends CompilableTestSupport {
         assert message.contains("Annotation attribute 'buildMethodName' not supported")
     }
 
+    void testSimpleBuilderInvalidUseOfIncludeSuperProperties() {
+        def message = shouldNotCompile """
+            import groovy.transform.builder.*
+            @Builder(builderStrategy=SimpleStrategy, includeSuperProperties=true)
+            class Person { }
+        """
+        assert message.contains("Annotation attribute 'includeSuperProperties' not supported")
+    }
+
     void testSimpleBuilderCustomPrefix() {
         assertScript """
             import groovy.transform.builder.*
@@ -147,31 +156,6 @@ class BuilderTransformTest extends CompilableTestSupport {
             // normal Groovy non-chained version
             assert Person.getMethod("setAge", Integer.TYPE).returnType.name == 'void'
         '''
-    }
-
-    void testSimpleBuilderShouldInheritFromParent() {
-        assertScript """
-            import groovy.transform.builder.*
-            import groovy.transform.*
-
-            class Mamal {
-                int age
-            }
-            @Builder(builderStrategy=SimpleStrategy)
-            class Person extends Mamal {
-                String firstName
-                String lastName
-            }
-
-            @CompileStatic
-            def parentBuilder() {
-                def person = new Person().setAge(21).setFirstName("Robert").setLastName("Lewandowski")
-                assert person.firstName == "Robert"
-                assert person.lastName == "Lewandowski"
-                assert person.age == 21
-            }
-            parentBuilder()
-         """
     }
 
     void testDefaultBuilder() {
@@ -328,7 +312,7 @@ class BuilderTransformTest extends CompilableTestSupport {
         assert message.contains("includes/excludes only allowed on classes")
     }
 
-    void testDefaultBuilderShoulInheritFromParent() {
+    void testDefaultBuilderIncludeSuperProperties() {
         assertScript """
             import groovy.transform.builder.*
             import groovy.transform.*
@@ -337,7 +321,7 @@ class BuilderTransformTest extends CompilableTestSupport {
             class Mamal {
                 int age
             }
-            @Builder
+            @Builder(includeSuperProperties=true)
             class Person extends Mamal {
                 String firstName
                 String lastName
@@ -479,7 +463,7 @@ class BuilderTransformTest extends CompilableTestSupport {
         '''
     }
 
-    void testExternalBuilderInheritsFromParent() {
+    void testExternalBuilderIncludeSuperProperties() {
         assertScript """
             import groovy.transform.builder.*
             import groovy.transform.*
@@ -492,7 +476,7 @@ class BuilderTransformTest extends CompilableTestSupport {
                 String lastName
             }
 
-            @Builder(builderStrategy=ExternalStrategy, forClass = Person)
+            @Builder(builderStrategy=ExternalStrategy, forClass=Person, includeSuperProperties=true)
             class PersonBuilder { }
 
             @CompileStatic
@@ -634,7 +618,7 @@ class BuilderTransformTest extends CompilableTestSupport {
         '''
     }
 
-    void testInitializerStrategyInheritsFromParent() {
+    void testInitializerStrategyIncludeSuperProperties() {
         assertScript '''
             import groovy.transform.builder.*
             import groovy.transform.*
@@ -643,8 +627,8 @@ class BuilderTransformTest extends CompilableTestSupport {
                 int age
             }
 
-            @ToString(includeSuperProperties = true)
-            @Builder(builderStrategy=InitializerStrategy)
+            @ToString(includeSuperProperties=true)
+            @Builder(builderStrategy=InitializerStrategy, includeSuperProperties=true)
             class Person extends Mamal {
                 String firstName
                 String lastName
@@ -668,7 +652,7 @@ class BuilderTransformTest extends CompilableTestSupport {
             }
 
             @ToString
-            @Builder(builderStrategy=InitializerStrategy)
+            @Builder(builderStrategy=InitializerStrategy, includeSuperProperties=true)
             class Person extends Mamal {
                 String firstName
                 String lastName


### PR DESCRIPTION
The code is really ugly, but this is caused by `getPropertyInfoFromClassNode` with is in `BuilderASTTransformation` but should have been in `ExternalStrategy`, because it is only used by  `ExternalStrategy`. Now it can not be moved/modified for this feature without breaking binary compatibility.

The pull request is still missing documentation. I will add that if it is accepted.