### PR TITLE
GROOVY-6514: groovysh: Add :grab command

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommand.groovy
@@ -1,0 +1,92 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.shell.commands
+
+import java.util.prefs.PreferenceChangeEvent
+import groovy.grape.Grape
+import org.codehaus.groovy.tools.GrapeUtil
+import org.codehaus.groovy.tools.shell.*
+import org.codehaus.groovy.tools.shell.util.PackageHelper
+import jline.console.completer.*
+
+/**
+ * The 'grab' command.
+ *
+ * @author <a href="mailto:jake.gage@gmail.com">Jake Gage</a>
+ */
+class GrabCommand
+    extends CommandSupport
+{
+    public static final String COMMAND_NAME = ':grab'
+
+    private static final java.util.prefs.Preferences PREFERENCES =
+        java.util.prefs.Preferences.userRoot().node('/org/codehaus/groovy/tools/shell')
+
+    public GrabCommand(org.codehaus.groovy.tools.shell.Groovysh shell) {
+        super(shell, COMMAND_NAME, ':g')
+    }
+
+    @Override protected List<Completer> createCompleters() {
+        [ new FileNameCompleter(), null ]
+    }
+
+    @Override Object execute(List<String> args) {
+        validate(args)
+        grab(getDependency(args))
+        if ( importCompletionEnabled() ) { reloadImportCompletion() }
+    }
+
+    private void validate(List<String> args) {
+        if ( args?.size() != 1 && args?.size() != 3 ) {
+            fail("usage: @|bold ${COMMAND_NAME}|@ ${usage}")
+        }
+    }
+
+    private String getDependency(List<String> args) {
+        if ( args.size() == 3 ) {
+            def (group, name, version) = args
+            "${group}:${name}:${version}"
+        } else {
+            args[0]
+        }
+    }
+
+    private void grab(String dependency) {
+        Map<String, Object> dependencyMap = GrapeUtil.getIvyParts(dependency)
+        Grape.grab([classLoader: shell.interp.classLoader.parent,
+                    refObject: shell.interp],
+                   dependencyMap)
+    }
+
+    private Boolean importCompletionEnabled() {
+        ! Boolean.valueOf(org.codehaus.groovy.tools.shell.util.Preferences.get(PackageHelper.IMPORT_COMPLETION_PREFERENCE_KEY))
+    }
+
+    private void reloadImportCompletion() {
+        shell.packageHelper.preferenceChange(ignorePackageCompletion(true))
+        shell.packageHelper.preferenceChange(ignorePackageCompletion(false))
+    }
+
+    private PreferenceChangeEvent ignorePackageCompletion(Boolean complete) {
+        new PreferenceChangeEvent(PREFERENCES,
+                                  PackageHelper.IMPORT_COMPLETION_PREFERENCE_KEY,
+                                  complete as String)
+    }
+
+}

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/DefaultCommandsRegistrar.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/DefaultCommandsRegistrar.groovy
@@ -26,6 +26,7 @@ import org.codehaus.groovy.tools.shell.commands.DisplayCommand
 import org.codehaus.groovy.tools.shell.commands.DocCommand
 import org.codehaus.groovy.tools.shell.commands.EditCommand
 import org.codehaus.groovy.tools.shell.commands.ExitCommand
+import org.codehaus.groovy.tools.shell.commands.GrabCommand
 import org.codehaus.groovy.tools.shell.commands.HelpCommand
 import org.codehaus.groovy.tools.shell.commands.HistoryCommand
 import org.codehaus.groovy.tools.shell.commands.ImportCommand
@@ -76,6 +77,7 @@ class DefaultCommandsRegistrar
                 new HistoryCommand(shell),
                 new AliasCommand(shell),
                 new SetCommand(shell),
+                new GrabCommand(shell),
                 // does not do anything
                 //new ShadowCommand(shell),
                 new RegisterCommand(shell),

--- a/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/GrabCommand.properties
+++ b/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/GrabCommand.properties
@@ -1,0 +1,21 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+command.description=Add a dependency to the shell environment
+command.usage=( <dependency> | <group> <name> <version> )
+command.help=Fetch a dependency, and add it to the Groovy Shell environment.

--- a/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
+++ b/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
@@ -202,6 +202,7 @@ Available commands:
   :history   (:H ) Display, manage and recall edit-line history
   :alias     (:a ) Create an alias
   :set       (:= ) Set (or list) preferences
+  :grab      (:g ) Add a dependency to the shell environment
   :register  (:rc) Register a new command with the shell
   :doc       (:D ) Open a browser window displaying the doc for the argument
 
@@ -238,6 +239,20 @@ but the shell will complain about an abnormal shutdown of the JVM.
 Add a custom import which will be included for all shell evaluations.
 
 This command can be given at any time to add new imports.
+
+[[GroovyShell-grab]]
+===== `grab`
+
+Grab a dependency (Maven, Ivy, etc.) from Internet sources or cache,
+and add it to the Groovy Shell environment.
+
+----
+groovy:000> :grab 'com.google.guava:guava:19.0'
+groovy:000> import com.google.common.collect.BiMap 
+===> com.google.common.collect.BiMap
+----
+
+This command can be given at any time to add new dependencies.
 
 [[GroovyShell-display]]
 ===== `display`

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommandTest.groovy
@@ -1,0 +1,32 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.shell.commands
+
+/**
+ * Tests for the {@link GrabCommand} class.
+ *
+ * @author <a href="mailto:jake.gage@gmail.com">Jake Gage</a>
+ */
+class GrabCommandTest
+    extends CommandTestSupport
+{
+    void testGrab() {
+        shell.execute(GrabCommand.COMMAND_NAME)
+    }
+}


### PR DESCRIPTION
This commit adds a first revision `:grab` command to the Groovy Shell.

@tkruse Sorry— I know @PascalSchumacher was asking me to fork from your fork, but I couldn't quite square that circle.  So I created a new branch, and added you as a collaborator (you should be able to force push here, so you can rebase the commits if you like, as well).

In any case, we should be able to see some diffs here and at least critique the approach.  I've tested it, and it does appear to work well.

do not like: The only reliable way I could find to send a message to the existing `ImportCommand` was to invoke property changes (to which it's registered as a listener).  We could make `ImportCommand` open by registering another type of event listener, but this seems like overkill to me.

I did add the bit that verifies that the import completion property has been set before sending the disable/enable events (to force the reload).

Let me know what you think.

Cheers,
Jake