### PR TITLE
GROOVY-6514: groovysh: Add :grab command

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommand.groovy
@@ -1,0 +1,74 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.shell.commands
+
+import groovy.grape.Grape
+import jline.console.completer.Completer;
+
+import org.codehaus.groovy.tools.shell.CommandSupport
+
+import java.util.List;
+
+import org.codehaus.groovy.tools.GrapeUtil
+import org.codehaus.groovy.tools.shell.Groovysh
+
+/**
+ * The 'grab' command.
+ *
+ * @author <a href="mailto:jake.gage@gmail.com">Jake Gage</a>
+ */
+class GrabCommand extends CommandSupport {
+
+    public static final String COMMAND_NAME = ':grab'
+
+    public GrabCommand(Groovysh shell) {
+        super(shell, COMMAND_NAME, ':g')
+    }
+
+    @Override protected List<Completer> createCompleters() { [ null ] }
+
+    @Override Object execute(List<String> args) {
+        validate(args)
+        grab(dependency(args))
+        shell.packageHelper.reset()
+    }
+
+    private void validate(List<String> args) {
+        if ( args?.size() != 1 || 
+             !( args[0] ==~ /^(\w|\.|-)+:(\w|\.|-)+(\w|\.|-)(:+(\w|\.|-|\*)+){0,2}$/ ) ) {
+            fail("usage: @|bold ${COMMAND_NAME}|@ ${usage}")
+        }
+    }
+
+    private String dependency(List<String> args) {
+        validate(args)
+        args[0]
+    }
+
+    private Map<String, Object> dependencyMap(String dependency) {
+        GrapeUtil.getIvyParts(dependency)
+    }
+
+    private void grab(String dependency) {
+        Grape.grab([classLoader: shell.interp.classLoader.parent,
+                    refObject: shell.interp],
+                   dependencyMap(dependency))
+    }
+
+}

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/DefaultCommandsRegistrar.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/DefaultCommandsRegistrar.groovy
@@ -26,6 +26,7 @@ import org.codehaus.groovy.tools.shell.commands.DisplayCommand
 import org.codehaus.groovy.tools.shell.commands.DocCommand
 import org.codehaus.groovy.tools.shell.commands.EditCommand
 import org.codehaus.groovy.tools.shell.commands.ExitCommand
+import org.codehaus.groovy.tools.shell.commands.GrabCommand
 import org.codehaus.groovy.tools.shell.commands.HelpCommand
 import org.codehaus.groovy.tools.shell.commands.HistoryCommand
 import org.codehaus.groovy.tools.shell.commands.ImportCommand
@@ -76,6 +77,7 @@ class DefaultCommandsRegistrar
                 new HistoryCommand(shell),
                 new AliasCommand(shell),
                 new SetCommand(shell),
+                new GrabCommand(shell),
                 // does not do anything
                 //new ShadowCommand(shell),
                 new RegisterCommand(shell),

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/PackageHelper.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/PackageHelper.groovy
@@ -23,4 +23,7 @@ interface PackageHelper {
     public static final String IMPORT_COMPLETION_PREFERENCE_KEY = 'disable-import-completion'
 
     Set<String> getContents(final String packagename)
+
+    void reset()
+
 }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/PackageHelperImpl.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/PackageHelperImpl.groovy
@@ -44,10 +44,18 @@ class PackageHelperImpl implements PreferenceChangeListener, PackageHelper {
 
     PackageHelperImpl(final ClassLoader groovyClassLoader=null) {
         this.groovyClassLoader = groovyClassLoader
-        if (! Boolean.valueOf(Preferences.get(IMPORT_COMPLETION_PREFERENCE_KEY))) {
-            rootPackages = initializePackages(groovyClassLoader)
-        }
+        initializePackages()
         Preferences.addChangeListener(this)
+    }
+
+    void reset() {
+        initializePackages()
+    }
+
+    private void initializePackages() {
+        if (! Boolean.valueOf(Preferences.get(IMPORT_COMPLETION_PREFERENCE_KEY))) {
+            rootPackages = getPackages(this.groovyClassLoader)
+        }
     }
 
     @Override
@@ -56,12 +64,12 @@ class PackageHelperImpl implements PreferenceChangeListener, PackageHelper {
             if (Boolean.valueOf(evt.getNewValue())) {
                 rootPackages = null
             } else if (rootPackages == null) {
-                rootPackages = initializePackages(groovyClassLoader)
+                initializePackages()
             }
         }
     }
 
-    static Map<String, CachedPackage> initializePackages(final ClassLoader groovyClassLoader) throws IOException {
+    private static Map<String, CachedPackage> getPackages(final ClassLoader groovyClassLoader) throws IOException {
         Map<String, CachedPackage> rootPackages = new HashMap()
         Set<URL> urls = new HashSet<URL>()
 

--- a/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/GrabCommand.properties
+++ b/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/commands/GrabCommand.properties
@@ -1,0 +1,21 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+command.description=Add a dependency to the shell environment
+command.usage=<group>:<module>[:<version>|*[:classifier]
+command.help=Fetch a dependency, and add it to the Groovy Shell environment.

--- a/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
+++ b/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
@@ -202,6 +202,7 @@ Available commands:
   :history   (:H ) Display, manage and recall edit-line history
   :alias     (:a ) Create an alias
   :set       (:= ) Set (or list) preferences
+  :grab      (:g ) Add a dependency to the shell environment
   :register  (:rc) Register a new command with the shell
   :doc       (:D ) Open a browser window displaying the doc for the argument
 
@@ -238,6 +239,20 @@ but the shell will complain about an abnormal shutdown of the JVM.
 Add a custom import which will be included for all shell evaluations.
 
 This command can be given at any time to add new imports.
+
+[[GroovyShell-grab]]
+===== `grab`
+
+Grab a dependency (Maven, Ivy, etc.) from Internet sources or cache,
+and add it to the Groovy Shell environment.
+
+----
+groovy:000> :grab 'com.google.guava:guava:19.0'
+groovy:000> import com.google.common.collect.BiMap 
+===> com.google.common.collect.BiMap
+----
+
+This command can be given at any time to add new dependencies.
 
 [[GroovyShell-display]]
 ===== `display`

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ImportCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ImportCompletorTest.groovy
@@ -39,6 +39,9 @@ class MockPackageHelper implements PackageHelper {
     Set<String> getContents(String packagename) {
         return mockContents
     }
+
+    @Override
+    void reset() { }
 }
 
 class ImportCompleterUnitTest extends GroovyTestCase {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/GrabCommandTest.groovy
@@ -1,0 +1,85 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.shell.commands
+
+import groovy.grape.Grape
+import groovy.mock.interceptor.StubFor
+import org.codehaus.groovy.tools.shell.Groovysh
+import org.codehaus.groovy.tools.shell.util.PackageHelperImpl
+
+/**
+ * Tests for the {@link GrabCommand} class.
+ *
+ * @author <a href="mailto:jake.gage@gmail.com">Jake Gage</a>
+ */
+class GrabCommandTest extends CommandTestSupport {
+
+    protected GrabCommand command
+    def grapeStub = new StubFor(Grape.class)
+
+    void setUp() {
+        Groovysh groovysh = new Groovysh()
+        PackageHelperImpl packageHelper = new PackageHelperImpl()
+        packageHelper.metaClass.reset = { }
+        groovysh.metaClass.packageHelper = packageHelper
+        command = new GrabCommand(groovysh)
+        command.metaClass.fail = { String message -> 
+            throw new RuntimeException("fail(${message}) called")
+        }
+        def stubber = new StubFor(Grape.class)
+    }
+
+    void testWrongNumberOfArguments() {
+        shouldFail(RuntimeException) { command.execute([]) }
+        shouldFail(RuntimeException) { command.execute(['alpha', 'beta']) }
+    }
+
+    void testInvalidDependencyFormat() {
+        shouldFail(RuntimeException) { command.execute(['net.sf.json-lib']) }
+    }
+
+    void testGroup_Module() {
+        grapeStub.demand.grab()  { arg1, arg2 -> }
+        grapeStub.use {
+            command.execute(['net.sf.json-lib:json-lib'])
+        }
+    }
+
+    void testGroupModuleVersion() {
+        grapeStub.demand.grab()  { arg1, arg2 -> }
+        grapeStub.use {
+            command.execute(['net.sf.json-lib:json-lib:2.2.3'])
+        }
+    }
+
+    void testGroupModuleVersionWildcard() {
+        grapeStub.demand.grab()  { arg1, arg2 -> }
+        grapeStub.use {
+            command.execute(['net.sf.json-lib:json-lib:*'])
+        }
+    }
+
+    void testGroupModuleVersionClassifier() {
+        grapeStub.demand.grab()  { arg1, arg2 -> }
+        grapeStub.use {
+            command.execute(['net.sf.json-lib:json-lib:2.2.3:jdk15'])
+        }
+    }
+
+}


### PR DESCRIPTION
Take two— notes mostly copied from the first Pull request.

This commit adds a first revision `:grab` command to the Groovy Shell.

@tkruse Sorry— I know @PascalSchumacher was asking me to fork from your fork, but I couldn't quite square that circle.  So I created a new branch, and added you as a collaborator (you should be able to force push here, so you can rebase the commits if you like, as well).

In any case, we should be able to see some diffs here and at least critique the approach.  I've tested it, and it does appear to work well.

do not like: The only reliable way I could find to send a message to the existing `ImportCommand` was to invoke property changes (to which it's registered as a listener).  We could make `ImportCommand` open by registering another type of event listener, but this seems like overkill to me.

I did add the bit that verifies that the import completion property has been set before sending the disable/enable events (to force the reload).

Two changes: I removed an unneeded package specification, and replaced the completer (which gives the user a nice ' ' following the command, but doesn't suggest files as completions for `:grab`.

Let me know what you think.

Cheers,
Jake