### PR TITLE
Fix for GROOVY-6454

### DIFF
--- a/src/main/groovy/lang/Delegate.java
+++ b/src/main/groovy/lang/Delegate.java
@@ -206,4 +206,12 @@ public @interface Delegate {
      * @since 2.3.0
      */
     Class[] includeTypes() default {Undefined.CLASS.class};
+
+    /**
+     * Whether to apply the delegate pattern to all methods, including those with names that are considered internal.
+     *
+     * @return true if owner class should delegate to methods which have internal names
+     * @since 2.5.0
+     */
+    boolean allNames() default false;
 }

--- a/src/main/groovy/transform/EqualsAndHashCode.java
+++ b/src/main/groovy/transform/EqualsAndHashCode.java
@@ -265,4 +265,12 @@ public @interface EqualsAndHashCode {
      * Generate a canEqual method to be used by equals.
      */
     boolean useCanEqual() default true;
+
+    /**
+     * Whether to include all fields and/or properties in equals and hashCode calculations, including those
+     * with names that are considered internal.
+     *
+     * @since 2.5.0
+     */
+    boolean allNames() default false;
 }

--- a/src/main/groovy/transform/MapConstructor.java
+++ b/src/main/groovy/transform/MapConstructor.java
@@ -120,4 +120,11 @@ public @interface MapConstructor {
      * A Closure containing statements which will be appended to the end of the generated constructor. Useful for validation steps or tweaking the populated fields/properties.
      */
     Class post();
+
+    /**
+     * Whether to include all fields and/or properties within the constructor, including those with names that are considered internal.
+     *
+     * @since 2.5.0
+     */
+    boolean allNames() default false;
 }

--- a/src/main/groovy/transform/ToString.java
+++ b/src/main/groovy/transform/ToString.java
@@ -328,4 +328,11 @@ public @interface ToString {
      */
     boolean cache() default false;
 
+    /**
+     * Whether to include all fields and/or properties in the generated toString, including those with names that
+     * are considered internal.
+     *
+     * @since 2.5.0
+     */
+    boolean allNames() default false;
 }

--- a/src/main/groovy/transform/TupleConstructor.java
+++ b/src/main/groovy/transform/TupleConstructor.java
@@ -251,4 +251,12 @@ public @interface TupleConstructor {
      * made null-safe wrt the parameter.
      */
     boolean useSetters() default false;
+
+    /**
+     * Whether to include all fields and/or properties within the constructor, including those with names that are
+     * considered internal.
+     *
+     * @since 2.5.0
+     */
+    boolean allNames() default false;
 }

--- a/src/main/groovy/transform/builder/Builder.java
+++ b/src/main/groovy/transform/builder/Builder.java
@@ -140,4 +140,11 @@ public @interface Builder {
      * Generate builder methods for properties from super classes.
      */
     boolean includeSuperProperties() default false;
+
+    /**
+     * Whether the generated builder should support all properties, including those with names that are considered internal.
+     *
+     * @since 2.5.0
+     */
+    boolean allNames() default false;
 }

--- a/src/main/groovy/transform/builder/DefaultStrategy.java
+++ b/src/main/groovy/transform/builder/DefaultStrategy.java
@@ -200,7 +200,8 @@ public class DefaultStrategy extends BuilderASTTransformation.AbstractBuilderStr
         ClassNode builder = createBuilder(anno, buildee);
         createBuilderFactoryMethod(anno, buildee, builder);
         List<FieldNode> fields = getFields(transform, anno, buildee);
-        List<FieldNode> filteredFields = selectFieldsFromExistingClass(fields, includes, excludes);
+        boolean allNames = transform.memberHasValue(anno, "allNames", true);
+        List<FieldNode> filteredFields = selectFieldsFromExistingClass(fields, includes, excludes, allNames);
         for (FieldNode fieldNode : filteredFields) {
             ClassNode correctedType = getCorrectedType(buildee, fieldNode);
             String fieldName = fieldNode.getName();
@@ -283,10 +284,10 @@ public class DefaultStrategy extends BuilderASTTransformation.AbstractBuilderStr
         return new FieldNode(fieldName, ACC_PRIVATE, fieldType, buildee, DEFAULT_INITIAL_VALUE);
     }
 
-    private static List<FieldNode> selectFieldsFromExistingClass(List<FieldNode> fieldNodes, List<String> includes, List<String> excludes) {
+    private static List<FieldNode> selectFieldsFromExistingClass(List<FieldNode> fieldNodes, List<String> includes, List<String> excludes, boolean allNames) {
         List<FieldNode> fields = new ArrayList<FieldNode>();
         for (FieldNode fNode : fieldNodes) {
-            if (shouldSkipUndefinedAware(fNode.getName(), excludes, includes)) continue;
+            if (shouldSkipUndefinedAware(fNode.getName(), excludes, includes, allNames)) continue;
             fields.add(fNode);
         }
         return fields;

--- a/src/main/groovy/transform/builder/ExternalStrategy.java
+++ b/src/main/groovy/transform/builder/ExternalStrategy.java
@@ -120,10 +120,11 @@ public class ExternalStrategy extends BuilderASTTransformation.AbstractBuilderSt
         if (unsupportedAttribute(transform, anno, "builderClassName")) return;
         if (unsupportedAttribute(transform, anno, "builderMethodName")) return;
         List<PropertyInfo> props;
+        boolean allNames = transform.memberHasValue(anno, "allNames", true);
         if (buildee.getModule() == null) {
-            props = getPropertyInfoFromBeanInfo(buildee, includes, excludes);
+            props = getPropertyInfoFromBeanInfo(buildee, includes, excludes, allNames);
         } else {
-            props = getPropertyInfoFromClassNode(transform, anno, buildee, includes, excludes);
+            props = getPropertyInfoFromClassNode(transform, anno, buildee, includes, excludes, allNames);
         }
         if (includes != null) {
             for (String name : includes) {
@@ -159,12 +160,12 @@ public class ExternalStrategy extends BuilderASTTransformation.AbstractBuilderSt
         return new FieldNode(propName.equals("class") ? "clazz" : propName, ACC_PRIVATE, newClass(prop.getType()), builderClass, DEFAULT_INITIAL_VALUE);
     }
 
-    public static List<PropertyInfo> getPropertyInfoFromBeanInfo(ClassNode cNode, List<String> includes, List<String> excludes) {
+    public static List<PropertyInfo> getPropertyInfoFromBeanInfo(ClassNode cNode, List<String> includes, List<String> excludes, boolean allNames) {
         final List<PropertyInfo> result = new ArrayList<PropertyInfo>();
         try {
             BeanInfo beanInfo = Introspector.getBeanInfo(cNode.getTypeClass());
             for (PropertyDescriptor descriptor : beanInfo.getPropertyDescriptors()) {
-                if (AbstractASTTransformation.shouldSkipUndefinedAware(descriptor.getName(), excludes, includes)) continue;
+                if (AbstractASTTransformation.shouldSkipUndefinedAware(descriptor.getName(), excludes, includes, allNames)) continue;
                 // skip hidden and read-only props
                 if (descriptor.isHidden() || descriptor.getWriteMethod() == null) continue;
                 result.add(new PropertyInfo(descriptor.getName(), ClassHelper.make(descriptor.getPropertyType())));
@@ -174,10 +175,10 @@ public class ExternalStrategy extends BuilderASTTransformation.AbstractBuilderSt
         return result;
     }
 
-    private List<PropertyInfo> getPropertyInfoFromClassNode(BuilderASTTransformation transform, AnnotationNode anno, ClassNode cNode, List<String> includes, List<String> excludes) {
+    private List<PropertyInfo> getPropertyInfoFromClassNode(BuilderASTTransformation transform, AnnotationNode anno, ClassNode cNode, List<String> includes, List<String> excludes, boolean allNames) {
         List<PropertyInfo> props = new ArrayList<PropertyInfo>();
         for (FieldNode fNode : getFields(transform, anno, cNode)) {
-            if (shouldSkip(fNode.getName(), excludes, includes)) continue;
+            if (shouldSkip(fNode.getName(), excludes, includes, allNames)) continue;
             props.add(new PropertyInfo(fNode.getName(), fNode.getType()));
         }
         return props;

--- a/src/main/groovy/transform/builder/InitializerStrategy.java
+++ b/src/main/groovy/transform/builder/InitializerStrategy.java
@@ -133,21 +133,22 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
     public void build(BuilderASTTransformation transform, AnnotatedNode annotatedNode, AnnotationNode anno) {
         if (unsupportedAttribute(transform, anno, "forClass")) return;
         boolean useSetters = transform.memberHasValue(anno, "useSetters", true);
+        boolean allNames = transform.memberHasValue(anno, "allNames", true);
         if (annotatedNode instanceof ClassNode) {
-            createBuilderForAnnotatedClass(transform, (ClassNode) annotatedNode, anno, useSetters);
+            createBuilderForAnnotatedClass(transform, (ClassNode) annotatedNode, anno, useSetters, allNames);
         } else if (annotatedNode instanceof MethodNode) {
             createBuilderForAnnotatedMethod(transform, (MethodNode) annotatedNode, anno, useSetters);
         }
     }
 
-    private void createBuilderForAnnotatedClass(BuilderASTTransformation transform, ClassNode buildee, AnnotationNode anno, boolean useSetters) {
+    private void createBuilderForAnnotatedClass(BuilderASTTransformation transform, ClassNode buildee, AnnotationNode anno, boolean useSetters, boolean allNames) {
         List<String> excludes = new ArrayList<String>();
         List<String> includes = new ArrayList<String>();
         includes.add(Undefined.STRING);
         if (!getIncludeExclude(transform, anno, buildee, excludes, includes)) return;
         if (includes.size() == 1 && Undefined.isUndefined(includes.get(0))) includes = null;
         List<FieldNode> fields = getFields(transform, anno, buildee);
-        List<FieldNode> filteredFields = filterFields(fields, includes, excludes);
+        List<FieldNode> filteredFields = filterFields(fields, includes, excludes, allNames);
         if (filteredFields.isEmpty()) {
             transform.addError("Error during " + BuilderASTTransformation.MY_TYPE_NAME +
                     " processing: at least one property is required for this strategy", anno);
@@ -359,10 +360,10 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
         return new FieldNode(fNode.getName(), fNode.getModifiers(), correctedType, buildee, DEFAULT_INITIAL_VALUE);
     }
 
-    private static List<FieldNode> filterFields(List<FieldNode> fieldNodes, List<String> includes, List<String> excludes) {
+    private static List<FieldNode> filterFields(List<FieldNode> fieldNodes, List<String> includes, List<String> excludes, boolean allNames) {
         List<FieldNode> fields = new ArrayList<FieldNode>();
         for (FieldNode fNode : fieldNodes) {
-            if (AbstractASTTransformation.shouldSkipUndefinedAware(fNode.getName(), excludes, includes)) continue;
+            if (AbstractASTTransformation.shouldSkipUndefinedAware(fNode.getName(), excludes, includes, allNames)) continue;
             fields.add(fNode);
         }
         return fields;

--- a/src/main/groovy/transform/builder/SimpleStrategy.java
+++ b/src/main/groovy/transform/builder/SimpleStrategy.java
@@ -94,6 +94,7 @@ public class SimpleStrategy extends BuilderASTTransformation.AbstractBuilderStra
         if (unsupportedAttribute(transform, anno, "forClass")) return;
         if (unsupportedAttribute(transform, anno, "includeSuperProperties")) return;
         boolean useSetters = transform.memberHasValue(anno, "useSetters", true);
+        boolean allNames = transform.memberHasValue(anno, "allNames", true);
 
         List<String> excludes = new ArrayList<String>();
         List<String> includes = new ArrayList<String>();
@@ -109,7 +110,7 @@ public class SimpleStrategy extends BuilderASTTransformation.AbstractBuilderStra
         }
         for (FieldNode field : fields) {
             String fieldName = field.getName();
-            if (!AbstractASTTransformation.shouldSkipUndefinedAware(fieldName, excludes, includes)) {
+            if (!AbstractASTTransformation.shouldSkipUndefinedAware(fieldName, excludes, includes, allNames)) {
                 String methodName = getSetterName(prefix, fieldName);
                 Parameter parameter = param(field.getType(), fieldName);
                 buildee.addMethod(methodName, Opcodes.ACC_PUBLIC, newClass(buildee), params(parameter), NO_EXCEPTIONS, block(

--- a/src/main/org/codehaus/groovy/transform/AbstractASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/AbstractASTTransformation.java
@@ -260,11 +260,23 @@ public abstract class AbstractASTTransformation implements Opcodes, ASTTransform
     }
 
     public static boolean shouldSkipUndefinedAware(String name, List<String> excludes, List<String> includes) {
-        return (excludes != null && excludes.contains(name)) || deemedInternalName(name) || (includes != null && !includes.contains(name));
+        return shouldSkipUndefinedAware(name, excludes, includes, false);
+    }
+
+    public static boolean shouldSkipUndefinedAware(String name, List<String> excludes, List<String> includes, boolean allNames) {
+        return (excludes != null && excludes.contains(name)) ||
+            (!allNames && deemedInternalName(name)) ||
+            (includes != null && !includes.contains(name));
     }
 
     public static boolean shouldSkip(String name, List<String> excludes, List<String> includes) {
-        return (excludes != null && excludes.contains(name)) || deemedInternalName(name) || (includes != null && !includes.isEmpty() && !includes.contains(name));
+        return shouldSkip(name, excludes, includes, false);
+    }
+
+    public static boolean shouldSkip(String name, List<String> excludes, List<String> includes, boolean allNames) {
+        return (excludes != null && excludes.contains(name)) ||
+            (!allNames && deemedInternalName(name)) ||
+            (includes != null && !includes.isEmpty() && !includes.contains(name));
     }
 
     @Deprecated

--- a/src/main/org/codehaus/groovy/transform/BuilderASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/BuilderASTTransformation.java
@@ -78,9 +78,13 @@ public class BuilderASTTransformation extends AbstractASTTransformation implemen
 
     public abstract static class AbstractBuilderStrategy implements BuilderStrategy {
         protected static List<PropertyInfo> getPropertyInfoFromClassNode(ClassNode cNode, List<String> includes, List<String> excludes) {
+            return getPropertyInfoFromClassNode(cNode, includes, excludes, false);
+        }
+
+        protected static List<PropertyInfo> getPropertyInfoFromClassNode(ClassNode cNode, List<String> includes, List<String> excludes, boolean allNames) {
             List<PropertyInfo> props = new ArrayList<PropertyInfo>();
             for (FieldNode fNode : getInstancePropertyFields(cNode)) {
-                if (shouldSkip(fNode.getName(), excludes, includes)) continue;
+                if (shouldSkip(fNode.getName(), excludes, includes, allNames)) continue;
                 props.add(new PropertyInfo(fNode.getName(), fNode.getType()));
             }
             return props;

--- a/src/main/org/codehaus/groovy/transform/MapConstructorASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/MapConstructorASTTransformation.java
@@ -90,6 +90,7 @@ public class MapConstructorASTTransformation extends AbstractASTTransformation {
             boolean useSetters = memberHasValue(anno, "useSetters", true);
             List<String> excludes = getMemberStringList(anno, "excludes");
             List<String> includes = getMemberStringList(anno, "includes");
+            boolean allNames = memberHasValue(anno, "allNames", true);
             if (!checkIncludeExcludeUndefinedAware(anno, excludes, includes, MY_TYPE_NAME)) return;
             if (!checkPropertyList(cNode, includes, "includes", anno, MY_TYPE_NAME, includeFields)) return;
             if (!checkPropertyList(cNode, excludes, "excludes", anno, MY_TYPE_NAME, includeFields)) return;
@@ -107,7 +108,7 @@ public class MapConstructorASTTransformation extends AbstractASTTransformation {
                 return;
             }
 
-            createConstructor(cNode, includeFields, includeProperties, includeSuperProperties, useSetters, excludes, includes, (ClosureExpression) pre, (ClosureExpression) post, source);
+            createConstructor(cNode, includeFields, includeProperties, includeSuperProperties, useSetters, excludes, includes, (ClosureExpression) pre, (ClosureExpression) post, source, allNames);
             if (pre != null) {
                 anno.setMember("pre", new ClosureExpression(new Parameter[0], new EmptyStatement()));
             }
@@ -117,7 +118,7 @@ public class MapConstructorASTTransformation extends AbstractASTTransformation {
         }
     }
 
-    public static void createConstructor(ClassNode cNode, boolean includeFields, boolean includeProperties, boolean includeSuperProperties, boolean useSetters, List<String> excludes, List<String> includes, ClosureExpression pre, ClosureExpression post, SourceUnit source) {
+    public static void createConstructor(ClassNode cNode, boolean includeFields, boolean includeProperties, boolean includeSuperProperties, boolean useSetters, List<String> excludes, List<String> includes, ClosureExpression pre, ClosureExpression post, SourceUnit source, boolean allNames) {
         List<ConstructorNode> constructors = cNode.getDeclaredConstructors();
         boolean foundEmpty = constructors.size() == 1 && constructors.get(0).getFirstStatement() == null;
         // HACK: JavaStubGenerator could have snuck in a constructor we don't want
@@ -145,12 +146,12 @@ public class MapConstructorASTTransformation extends AbstractASTTransformation {
         }
         for (FieldNode fNode : superList) {
             String name = fNode.getName();
-            if (shouldSkip(name, excludes, includes)) continue;
+            if (shouldSkip(name, excludes, includes, allNames)) continue;
             assignField(useSetters, map, body, name);
         }
         for (FieldNode fNode : list) {
             String name = fNode.getName();
-            if (shouldSkip(name, excludes, includes)) continue;
+            if (shouldSkip(name, excludes, includes, allNames)) continue;
             assignField(useSetters, map, body, name);
         }
         if (post != null) {

--- a/src/spec/doc/contributors.adoc
+++ b/src/spec/doc/contributors.adoc
@@ -34,6 +34,7 @@ The Groovy team would like to thank the contributors of this documentation (by a
 * https://github.com/tobia[Tobia Conforto]
 * https://github.com/ddimtirov[Dimitar Dimitrov]
 * http://twitter.com/werdnagreb[Andrew Eisenberg]
+* https://github.com/erdi[Marcin Erdmann]
 * https://github.com/christoph-frick[Christoph Frick]
 * http://twitter.com/marioggar[Mario García]
 * https://github.com/davidmichaelkarr[David Michael Karr]

--- a/src/spec/doc/core-metaprogramming.adoc
+++ b/src/spec/doc/core-metaprogramming.adoc
@@ -826,6 +826,10 @@ include::{projectdir}/src/spec/test/CodeGenerationASTTransformsTest.groovy[tags=
 ----
 include::{projectdir}/src/spec/test/CodeGenerationASTTransformsTest.groovy[tags=tostring_example_cache,indent=0]
 ----
+|allNames|False|Should fields and/or properties with internal names be included in the generated toString|
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/CodeGenerationASTTransformsTest.groovy[tags=tostring_example_allNames,indent=0]
 
 |=======================================================================
 
@@ -871,6 +875,11 @@ include::{projectdir}/src/spec/test/CodeGenerationASTTransformsTest.groovy[tags=
 include::{projectdir}/src/spec/test/CodeGenerationASTTransformsTest.groovy[tags=equalshashcode_example_cache,indent=0]
 ----
 |useCanEqual|True|Should equals call canEqual helper method.|See http://www.artima.com/lejava/articles/equality.html
+|allNames|False|Should fileds and/or properties with internal names be included in equals and hashCode calculations|
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/CodeGenerationASTTransformsTest.groovy[tags=equalshashcode_example_allNames,indent=0]
+----
 |=======================================================================
 
 [[xform-TupleConstructor]]
@@ -965,6 +974,11 @@ Set to false to obtain exactly one constructor but with initial value support an
 [source,groovy]
 ----
 include::{projectdir}/src/spec/test/CodeGenerationASTTransformsTest.groovy[tags=tupleconstructor_example_defaults_false,indent=0]
+----
+|allNames|False|Should fields and/or properties with internal names be included within the constructor|
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/CodeGenerationASTTransformsTest.groovy[tags=tupleconstructor_example_allNames,indent=0]
 ----
 |=======================================================================
 
@@ -1226,11 +1240,11 @@ strategy class. The following table lists the available strategies that are bund
 configuration options each strategy supports.
 
 |================================
-| Strategy | Description | builderClassName | builderMethodName |buildMethodName | prefix | includes/excludes | includeSuperProperties
-| `SimpleStrategy` | chained setters | n/a | n/a | n/a | yes, default "set" | yes | n/a
-| `ExternalStrategy` | explicit builder class, class being built untouched | n/a | n/a | yes, default "build" | yes, default "" | yes | yes, default `false`
-| `DefaultStrategy` | creates a nested helper class | yes, default __<TypeName>__Builder | yes, default "builder" | yes, default "build" | yes, default "" | yes | yes, default `false`
-| `InitializerStrategy` | creates a nested helper class providing type-safe fluent creation | yes, default __<TypeName>__Initializer | yes, default "createInitializer" | yes, default "create" but usually only used internally | yes, default "" | yes | yes, default `false`
+| Strategy | Description | builderClassName | builderMethodName |buildMethodName | prefix | includes/excludes | includeSuperProperties | allNames
+| `SimpleStrategy` | chained setters | n/a | n/a | n/a | yes, default "set" | yes | n/a | yes, default `false`
+| `ExternalStrategy` | explicit builder class, class being built untouched | n/a | n/a | yes, default "build" | yes, default "" | yes | yes, default `false`| yes, default `false`
+| `DefaultStrategy` | creates a nested helper class | yes, default __<TypeName>__Builder | yes, default "builder" | yes, default "build" | yes, default "" | yes | yes, default `false`| yes, default `false`
+| `InitializerStrategy` | creates a nested helper class providing type-safe fluent creation | yes, default __<TypeName>__Initializer | yes, default "createInitializer" | yes, default "create" but usually only used internally | yes, default "" | yes | yes, default `false`| yes, default `false`
 |================================
 
 .SimpleStrategy
@@ -1486,6 +1500,11 @@ include::{projectdir}/src/spec/test/ClassDesignASTTransformsTest.groovy[tags=del
 ----
 include::{projectdir}/src/spec/test/ClassDesignASTTransformsTest.groovy[tags=delegate_example_includeTypes_header,indent=0]
 include::{projectdir}/src/spec/test/ClassDesignASTTransformsTest.groovy[tags=delegate_example_includeTypes_footer,indent=0]
+----
+|allNames|False|Should the delegate pattern be also applied to methods with internal names|
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/ClassDesignASTTransformsTest.groovy[tags=delegate_example_allNames,indent=0]
 ----
 |=======================================================================
 

--- a/src/spec/test/ClassDesignASTTransformsTest.groovy
+++ b/src/spec/test/ClassDesignASTTransformsTest.groovy
@@ -189,14 +189,14 @@ class NumberBooleanBuilder {
     StringBuilder nums = new StringBuilder()
     @Delegate(includeTypes=[AppendFloatSelector], interfaces=false)
     StringBuilder bools = new StringBuilder()
-    String result() { "${nums.toString()} | ${bools.toString()}" }
+    String result() { "${nums.toString()} ~ ${bools.toString()}" }
 }
 def b = new NumberBooleanBuilder()
 b.append(true)
 b.append(3.14f)
 b.append(false)
 b.append(0.0f)
-assert b.result() == "truefalse | 3.140.0"
+assert b.result() == "truefalse ~ 3.140.0"
 // end::delegate_example_includeTypes_header[]
 groovy.test.GroovyAssert.shouldFail {
 // tag::delegate_example_includeTypes_footer[]
@@ -224,6 +224,19 @@ usb.append('hello')
 usb.append(true)
 assert usb.toString() == '3.5trueHELLO'
 // end::delegate_example_excludeTypes[]
+'''
+
+        assertScript '''
+// tag::delegate_example_allNames[]
+class Worker {
+    void task$() {}
+}
+class Delegating {
+    @Delegate(allNames=true) Worker worker = new Worker()
+}
+def d = new Delegating()
+d.task$() //passes
+// end::delegate_example_allNames[]
 '''
     }
 

--- a/src/spec/test/CodeGenerationASTTransformsTest.groovy
+++ b/src/spec/test/CodeGenerationASTTransformsTest.groovy
@@ -214,6 +214,20 @@ assert p.toString() == 'acme.Person(firstName:Jack, lastName:Nicholson)'
 
 '''
 
+        assertScript '''package acme
+import groovy.transform.ToString
+
+// tag::tostring_example_allNames[]
+@ToString(allNames=true)
+class Person {
+    String $firstName
+}
+
+def p = new Person($firstName: "Jack")
+assert p.toString() == 'acme.Person(Jack)'
+// end::tostring_example_allNames[]
+
+'''
     }
 
 
@@ -296,6 +310,24 @@ def p2 = new Person(race: 'Human beeing', firstName: 'Jack', lastName: 'Nicholso
 assert p1!=p2
 assert p1.hashCode() != p2.hashCode()
 // end::equalshashcode_example_super[]
+
+'''
+
+        assertScript '''
+// tag::equalshashcode_example_allNames[]
+import groovy.transform.EqualsAndHashCode
+
+@EqualsAndHashCode(allNames=true)
+class Person {
+    String $firstName
+}
+
+def p1 = new Person($firstName: 'Jack')
+def p2 = new Person($firstName: 'Bob')
+
+assert p1 != p2
+assert p1.hashCode() != p2.hashCode()
+// end::equalshashcode_example_allNames[]
 
 '''
 
@@ -673,6 +705,21 @@ assert new Book(2015, false).toString() == 'Book(year:2015, fiction:false)'
 assert new Book("Regina", false).toString() == 'Book(name:Regina, fiction:false)'
 assert Book.constructors.size() == 3
 // end::tupleconstructor_example_defaults_multipleIncludes[]
+'''
+
+        assertScript '''
+// tag::tupleconstructor_example_allNames[]
+import groovy.transform.TupleConstructor
+
+@TupleConstructor(allNames=true)
+class Person {
+    String $firstName
+}
+
+def p = new Person('Jack')
+
+assert p.$firstName == 'Jack'
+// end::tupleconstructor_example_allNames[]
 '''
     }
 

--- a/src/test/org/codehaus/groovy/transform/BuilderTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/BuilderTransformTest.groovy
@@ -703,4 +703,58 @@ class BuilderTransformTest extends CompilableTestSupport {
         assert message.contains('at least one parameter is required for this strategy')
     }
 
+    void testInternalFieldsAreIncludedIfRequestedForSimpleStrategy_GROOVY6454() {
+        assertScript '''
+            import groovy.transform.builder.*
+
+            @Builder(builderStrategy = SimpleStrategy, allNames = true)
+            class HasInternalPropertyWithSimpleStrategy {
+                String $internal
+            }
+            assert new HasInternalPropertyWithSimpleStrategy().set$internal("foo").$internal == "foo"
+         '''
+    }
+
+    void testInternalFieldsAreIncludedIfRequestedForExternalStrategy_GROOVY6454() {
+        assertScript '''
+            import groovy.transform.builder.*
+
+            class HasInternalProperty {
+                String $internal
+            }
+
+            @Builder(builderStrategy = ExternalStrategy, forClass = HasInternalProperty, allNames = true)
+            class HasInternalPropertyBuilder { }
+
+            assert new HasInternalPropertyBuilder().$internal("foo").build().$internal == "foo"
+         '''
+    }
+
+    void testInternalFieldsAreIncludedIfRequestedForDefaultStrategy_GROOVY6454() {
+        assertScript '''
+            import groovy.transform.builder.*
+
+            @Builder(allNames = true)
+            class HasInternalProperty {
+                String $internal
+            }
+
+            assert HasInternalProperty.builder().$internal("foo").$internal == "foo"
+         '''
+    }
+
+    void testInternalFieldsAreIncludedIfRequestedForInitializerStrategyStrategy_GROOVY6454() {
+        assertScript '''
+            import groovy.transform.builder.*
+
+            @Builder(builderStrategy = InitializerStrategy, allNames = true)
+            class HasInternalProperty {
+                String $internal
+            }
+
+            def initializer = HasInternalProperty.createInitializer()
+            assert new HasInternalProperty(initializer.$internal("foo")).$internal == "foo"
+         '''
+    }
+
 }

--- a/src/test/org/codehaus/groovy/transform/DelegateTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/DelegateTransformTest.groovy
@@ -694,6 +694,57 @@ assert foo.dm.x == '123'
             assert f.internalDelegate == ['bar', 'baz']
         '''
     }
+
+    // GROOVY-6454
+    void testMethodsWithInternalNameShouldNotBeDelegatedTo() {
+        assertScript '''
+            class HasMethodWithInternalName {
+                void $() {
+                }
+            }
+
+            class DelegatesToHasMethodWithInternalName {
+                @Delegate
+                HasMethodWithInternalName hasMethodWithInternalName
+            }
+
+            assert !new DelegatesToHasMethodWithInternalName().respondsTo('$')
+        '''
+    }
+
+    // GROOVY-6454
+    void testMethodsWithInternalNameShouldBeDelegatedToIfRequested() {
+        assertScript '''
+            interface HasMethodWithInternalName {
+                void $()
+            }
+
+            class DelegatesToHasMethodWithInternalName {
+                @Delegate(allNames = true)
+                HasMethodWithInternalName hasMethodWithInternalName
+            }
+
+            assert new DelegatesToHasMethodWithInternalName().respondsTo('$')
+        '''
+    }
+
+    // GROOVY-6454
+    void testProperitesWithInternalNameShouldBeDelegatedToIfRequested() {
+        assertScript '''
+            class HasPropertyWithInternalName {
+                def $
+            }
+
+            class DelegatesToHasPropertyWithInternalName {
+                @Delegate(allNames = true)
+                HasPropertyWithInternalName hasPropertyWithInternalName
+            }
+
+            def delegates = new DelegatesToHasPropertyWithInternalName()
+            assert delegates.respondsTo('get$')
+            assert delegates.respondsTo('set$')
+        '''
+    }
 }
 
 interface DelegateFoo {

--- a/src/test/org/codehaus/groovy/transform/EqualsAndHashCodeTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/EqualsAndHashCodeTransformTest.groovy
@@ -87,4 +87,20 @@ class EqualsAndHashCodeTransformTest extends GroovyShellTestCase {
         assert message.contains("Error during @EqualsAndHashCode processing: 'excludes' property 'sirName' does not exist.")
     }
 
+    void testIncludesInternalPropertyNamesIfRequested() {
+        assertScript '''
+            import groovy.transform.EqualsAndHashCode
+
+            @EqualsAndHashCode(allNames = true)
+            class HasInternalNameProperty {
+                String $
+            }
+
+            def a = new HasInternalNameProperty($: "a")
+            def b = new HasInternalNameProperty($: "b")
+            assert a != b
+            assert a.hashCode() != b.hashCode()
+        '''
+    }
+
 }

--- a/src/test/org/codehaus/groovy/transform/MapConstructorTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/MapConstructorTransformTest.groovy
@@ -186,4 +186,18 @@ class MapConstructorTransformTest extends GroovyShellTestCase {
         }
         assert message.contains("Error during @MapConstructor processing: 'excludes' property 'sirName' does not exist.")
     }
+
+    void testInternalFieldsAreIncludedIfRequested() {
+        assertScript '''
+            import groovy.transform.*
+
+            @MapConstructor(allNames = true)
+            class HasInternalProperty {
+                final String $
+            }
+
+            assert new HasInternalProperty($: "foo").$ == "foo"
+        '''
+    }
+
 }

--- a/src/test/org/codehaus/groovy/transform/ToStringTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/ToStringTransformTest.groovy
@@ -436,4 +436,16 @@ class ToStringTransformTest extends GroovyShellTestCase {
         '''
     }
 
+    void testInternalFieldsAreIncludedIfRequested() {
+        evaluate '''
+            import groovy.transform.*
+
+            @ToString(allNames = true)
+            class HasInternalProperty {
+                String $
+            }
+            assert new HasInternalProperty($: "foo").toString() == 'HasInternalProperty(foo)'
+        '''
+    }
+
 }

--- a/src/test/org/codehaus/groovy/transform/TupleConstructorTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/TupleConstructorTransformTest.groovy
@@ -164,4 +164,17 @@ class TupleConstructorTransformTest extends GroovyShellTestCase {
         '''
     }
 
+    void testInternalFieldsAreIncludedIfRequested_groovy6454() {
+        assertScript '''
+            import groovy.transform.*
+
+            @TupleConstructor(allNames = true)
+            class HasInternalName {
+                String $internal
+            }
+
+            assert new HasInternalName("foo").$internal == "foo"
+        '''
+    }
+
 }


### PR DESCRIPTION
Add allNames option which allows to include fields/properties/methods with internal names in code generated by Builder, Delegate, EqualsAndHashCode, MapConstructor, ToString and TupleConstructor AST transformations.

I've added tests and updated javadocs and the guide around these new options.

Please let me know if there is anything that needs to be changed, especially in the area of documentation, I'm happy to rework it.