### PR TITLE
GROOVY-7781 - Cannot retrieve XML attribute with namespace

### DIFF
--- a/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/Attribute.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/Attribute.java
@@ -75,7 +75,7 @@ public class Attribute extends GPathResult {
      * @return the namespace of this Attribute
      */
     public String namespaceURI() {
-        if (namespacePrefix == null) return "";
+        if (namespacePrefix == null || namespacePrefix.isEmpty()) return "";
         String uri = namespaceTagHints.get(namespacePrefix);
         return uri == null ? "" : uri;
     }

--- a/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/GPathResult.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/GPathResult.java
@@ -260,6 +260,10 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
      * @return the namespace of the prefix
      */
     public String lookupNamespace(final String prefix) {
+        Object namespace = namespaceMap.get(prefix);
+        if (namespace != null) {
+            return namespace.toString();
+        }
         return this.namespaceTagHints.isEmpty() ? prefix : this.namespaceTagHints.get(prefix);
     }
 

--- a/subprojects/groovy-xml/src/test/groovy/groovy/util/XmlSlurperTest.groovy
+++ b/subprojects/groovy-xml/src/test/groovy/groovy/util/XmlSlurperTest.groovy
@@ -138,9 +138,9 @@ class XmlSlurperTest extends GroovyTestCase {
             <ChildElement ItemId="FirstItemId" two:ItemId="SecondItemId">Child element data</ChildElement>
         </RootElement>"""
         def root = new XmlSlurper().parseText(xml).declareNamespace(one:"http://www.ivan.com/ns1", two: "http://www.ivan.com/ns2")
+        // Default namespace declarations do not apply to attribute names, see https://www.w3.org/TR/xml-names/#defaulting
         assert root.ChildElement.@ItemId == 'FirstItemId'
-        assert root.ChildElement.@ItemId[0].namespaceURI() == 'http://www.ivan.com/ns1'
-        assert root.ChildElement.@'one:ItemId' == 'FirstItemId'
+        assert root.ChildElement.@ItemId[0].namespaceURI() == ''
         assert root.ChildElement.@'two:ItemId' == 'SecondItemId'
         assert root.ChildElement.@'two:ItemId'[0].namespaceURI() == 'http://www.ivan.com/ns2'
     }
@@ -214,5 +214,18 @@ class XmlSlurperTest extends GroovyTestCase {
 
         // execute a DGM on the Iterable
         assert root.first() == 'Child element data'
+    }
+
+    // GROOVY-7781
+    void testNamespacedAttributesAccessedWithDifferentPrefix() {
+        def xml = '''
+        <x:root xmlns:x="blah">
+            <x:child x:id="1">c</x:child>
+        </x:root>
+        '''
+
+        def root = new XmlSlurper(false, true).parseText(xml).declareNamespace(t: 'blah')
+        assert root.'t:child'.text() == 'c'
+        assert root.'t:child'.@'t:id' == '1'
     }
 }


### PR DESCRIPTION
This change broke another test that asserted that an unprefixed attribute's namespace is the default namespace, but default namespace declarations do not apply to attribute names, see https://www.w3.org/TR/xml-names/#defaulting.

> The namespace name for an unprefixed attribute name always has no value.