### PR TITLE
GROOVY-7810 fix XmlSlurper default ctor doc

### DIFF
--- a/subprojects/groovy-xml/src/main/java/groovy/util/XmlSlurper.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/util/XmlSlurper.java
@@ -92,7 +92,7 @@ public class XmlSlurper extends DefaultHandler {
     private boolean namespaceAware = false;
 
     /**
-     * Creates a non-validating and non-namespace-aware <code>XmlSlurper</code> which does not allow DOCTYPE declarations in documents.
+     * Creates a non-validating and namespace-aware <code>XmlSlurper</code> which does not allow DOCTYPE declarations in documents.
      *
      * @throws ParserConfigurationException if no parser which satisfies the requested configuration can be created.
      * @throws SAXException for SAX errors.


### PR DESCRIPTION
Javadoc for default constructor says it creates a non-namespace-aware slurper, when it creates a namespace-aware one.