### PR TITLE
GROOVY-7723 - propertyMissing(String,Object) called for missing getter

### DIFF
--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -872,11 +872,14 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 
         try {
             if (!(instance instanceof Class)) {
-                if (isGetter && propertyMissingGet != null) {
-                    return propertyMissingGet.invoke(instance, new Object[]{propertyName});
+                if (isGetter) {
+                    if (propertyMissingGet != null) {
+                        return propertyMissingGet.invoke(instance, new Object[]{propertyName});
+                    }
                 } else {
-                    if (propertyMissingSet != null)
+                    if (propertyMissingSet != null) {
                         return propertyMissingSet.invoke(instance, new Object[]{propertyName, optionalValue});
+                    }
                 }
             }
         } catch (InvokerInvocationException iie) {

--- a/src/test/groovy/lang/PropertyMissingTest.groovy
+++ b/src/test/groovy/lang/PropertyMissingTest.groovy
@@ -75,6 +75,28 @@ class PropertyMissingTest extends GroovyTestCase {
         assertEquals "FOO", PMTest1.FOO
     }
 
+    // GROOVY-7723
+    void testPropertyMissingSetterWithNoGetter() {
+        def t = new PMTest3()
+
+        assert t.foo == 'bar'
+
+        shouldFail(MissingPropertyException) {
+            t.notfound
+        }
+
+        assert t.foo == 'bar'
+
+        t.notfound = 'baz'
+        assert t.foo == 'notfound-baz'
+
+        t.metaClass.propertyMissing = { String name ->
+            "get-${foo}"
+        }
+        assert t.notfound == 'get-notfound-baz'
+
+    }
+
 }
 
 class PMTest1 {
@@ -90,4 +112,11 @@ class PMTest1 {
 
 class PMTest2 {
     String foo = "bar"
+}
+
+class PMTest3 {
+    String foo = 'bar'
+    void propertyMissing(String name, value) {
+        foo = "${name}-${value}"
+    }
 }


### PR DESCRIPTION
Looks like commit 97a45dfb3e3c5212c36 introduced [this change] (https://github.com/apache/groovy/commit/97a45dfb3e3c5212c3610cd90fe1e7434614b260#diff-c1354c0d7df171ad8cafcb3d1bf63857L535). The original code would not have delegated to the setter method. I don't think the intent of the commit was to change the behavior but resulted inadvertently due to the refactoring.