### PR TITLE
GROOVY-7822 - Redundant computation in ObservableSet

### DIFF
--- a/src/main/groovy/util/ObservableSet.java
+++ b/src/main/groovy/util/ObservableSet.java
@@ -251,6 +251,10 @@ public class ObservableSet<E> implements Set<E> {
         }
 
         List values = new ArrayList();
+        // GROOVY-7822 use Set for O(1) performance for contains
+        if (!(c instanceof Set)) {
+            c = new HashSet<Object>(c);
+        }
         for (Object element : delegate) {
             if (!c.contains(element)) {
                 values.add(element);


### PR DESCRIPTION
Related to PR #314, performance significantly improved for `retainAll`, similar change to `removeAll` did not yield any significant performance difference.