### PR TITLE
GROOVY-7728 - LAX parser: Commenting out key/val pairs doesn't work

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserLax.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserLax.java
@@ -72,16 +72,6 @@ public class JsonParserLax extends JsonParserCharArray {
             skipWhiteSpace();
 
             switch (__currentChar) {
-                case '/': /* */ //
-                    handleComment();
-                    startIndexOfKey = __index;
-                    break;
-
-                case '#':
-                    handleBashComment();
-                    startIndexOfKey = __index;
-                    break;
-
                 case ':':
                     char startChar = charArray[startIndexOfKey];
                     if (startChar == ',') {
@@ -161,10 +151,22 @@ public class JsonParserLax extends JsonParserCharArray {
                     }
 
                     break;
+            }
 
+            switch (__currentChar) {
                 case '}':
                     __index++;
                     break done;
+
+                case '/': /* */ //
+                    handleComment();
+                    startIndexOfKey = __index;
+                    break;
+
+                case '#':
+                    handleBashComment();
+                    startIndexOfKey = __index;
+                    break;
             }
         }
 

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
@@ -148,4 +148,23 @@ class JsonSlurperLaxTest extends JsonSlurperTest {
         assert parser.parseText('{"num": 6-}').num == '6-'
     }
 
+    void testGroovy7728() {
+        String jsonString = '''
+            {
+                "enterpriseDomain": "@example.com"
+                ,"enterpriseId": "123456"
+                ,"clientId": "abcdefghijklmnopqrstuvwxyz123456"
+                ,"clientSecret": "abcdefghijklmnopqrstuvwxyz123456"
+                ,"keyId": "12345678"
+                ,"keyFileName": "/etc/PrintToBox/PrintToBox_private_key.pem"
+                ,"keyPassword": "12345678901234567890"
+                // ,"appUserId": "123456789"
+
+                //  Optional parameters with defaults shown
+                // ,"baseFolderName": "PrintToBox"
+            }
+        '''
+        assert !parser.parseText(jsonString).containsKey('appUserId')
+    }
+
 }


### PR DESCRIPTION
Changed loop to process comments and end of object marker after processing
key/values because skipWhitespace leaves the cursor on the first
non-whitespace character and that character needs to be processed before
the loop increments the index counter.  This same logic is used by
JsonFastParser#decodeJsonObjectLazyFinalParse.