### PR TITLE
GROOVY-7646 - Classes generated by Eval() never collected from Permgen/Metaspace

### DIFF
--- a/src/main/groovy/lang/GroovyShell.java
+++ b/src/main/groovy/lang/GroovyShell.java
@@ -515,7 +515,11 @@ public class GroovyShell extends GroovyObjectSupport {
      */
     public Object run(GroovyCodeSource source, String[] args) throws CompilationFailedException {
         Class scriptClass = parseClass(source);
-        return runScriptOrMainOrTestOrRunnable(scriptClass, args);
+        try {
+            return runScriptOrMainOrTestOrRunnable(scriptClass, args);
+        } finally {
+            InvokerHelper.removeClass(scriptClass);
+        }
     }
 
     /**
@@ -563,7 +567,11 @@ public class GroovyShell extends GroovyObjectSupport {
                     }
         });
         Class scriptClass = parseClass(gcs);
-        return runScriptOrMainOrTestOrRunnable(scriptClass, args);
+        try {
+            return runScriptOrMainOrTestOrRunnable(scriptClass, args);
+        } finally {
+            InvokerHelper.removeClass(scriptClass);
+        }
     }
 
     public Object getVariable(String name) {
@@ -582,7 +590,11 @@ public class GroovyShell extends GroovyObjectSupport {
      */
     public Object evaluate(GroovyCodeSource codeSource) throws CompilationFailedException {
         Script script = parse(codeSource);
-        return script.run();
+        try {
+            return script.run();
+        } finally {
+            InvokerHelper.removeClass(script.getClass());
+        }
     }
 
     /**

--- a/src/main/org/codehaus/groovy/reflection/ClassInfo.java
+++ b/src/main/org/codehaus/groovy/reflection/ClassInfo.java
@@ -115,6 +115,22 @@ public class ClassInfo {
         return globalClassValue.get(cls);
     }
 
+    /**
+     * Removes a {@code ClassInfo} from the cache.
+     *
+     * This is useful in cases where the Class is parsed from a script, such as when
+     * using GroovyClassLoader#parseClass, and is executed for its result but the Class
+     * is not retained or cached.  Removing the {@code ClassInfo} associated with the Class
+     * will make the Class and its ClassLoader eligible for garbage collection sooner that
+     * it would otherwise.
+     *
+     * @param cls the Class associated with the ClassInfo to remove
+     *            from cache
+     */
+    public static void remove(Class<?> cls) {
+        globalClassValue.remove(cls);
+    }
+
     public static Collection<ClassInfo> getAllClassInfo () {
         return getAllGlobalClassInfo();
     }

--- a/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -35,6 +35,7 @@ import groovy.lang.SpreadMap;
 import groovy.lang.SpreadMapEvaluatingException;
 import groovy.lang.Tuple;
 import groovy.lang.Writable;
+import org.codehaus.groovy.reflection.ClassInfo;
 import org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl;
 import org.codehaus.groovy.runtime.metaclass.MissingMethodExecutionFailed;
 import org.codehaus.groovy.runtime.powerassert.PowerAssertionError;
@@ -83,6 +84,7 @@ public class InvokerHelper {
 
     public static void removeClass(Class clazz) {
         metaRegistry.removeMetaClass(clazz);
+        ClassInfo.remove(clazz);
         Introspector.flushFromCaches(clazz);
     }
 


### PR DESCRIPTION
This is also fixed by PR #219 but that requires SoftReferences to be collected (because of beaninfocache).   It seems for cases where a Script class is parsed, executed for its result and the Script class is not retained we can be more aggressive about clearing it from caches so it doesn't require the heap to fill before being collected.

A test is included just to demonstrate the changes do allow the classes to be GC'd but is not a test that is meant to be included if the PR is accepted.
