### PR TITLE
GROOVY-7604: traits docs diamond problem explanation

### DIFF
--- a/src/spec/doc/core-traits.adoc
+++ b/src/spec/doc/core-traits.adoc
@@ -199,8 +199,7 @@ WARNING: While traits support public fields, it is not recommended to use them a
 
 == Composition of behaviors
 
-Traits can be used to implement multiple inheritance in a controlled way, avoiding the diamond issue. For example, we
-can have the following traits:
+Traits can be used to implement multiple inheritance in a controlled way. For example, we can have the following traits:
 
 [source,groovy]
 ----


### PR DESCRIPTION
Fixes a (very) tiny text issue raised in GROOVY-7604.
