### PR TITLE
GROOVY-7793: Compiler compiles class with private abstract method

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -68,6 +68,7 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
         if (source != null && !source.getErrorCollector().hasErrors()) {
             checkClassForIncorrectModifiers(node);
             checkInterfaceMethodVisibility(node);
+            checkAbstractMethodVisibility(node);
             checkClassForOverwritingFinal(node);
             checkMethodsForIncorrectModifiers(node);
             checkMethodsForWeakerAccess(node);
@@ -123,6 +124,21 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
                 addError("Method '" + method.getName() + "' is private but should be public in " + getDescription(currentClass) + ".", method);
             } else if (method.isProtected()) {
                 addError("Method '" + method.getName() + "' is protected but should be public in " + getDescription(currentClass) + ".", method);
+            }
+        }
+    }
+
+    private void checkAbstractMethodVisibility(ClassNode node) {
+        // we only do check abstract classes (including enums), no interfaces or non-abstract classes
+        if (!isAbstract(node.getModifiers()) || isInterface(node.getModifiers())) return;
+
+        List<MethodNode> abstractMethods = node.getAbstractMethods();
+        if (abstractMethods == null || abstractMethods.isEmpty()) return;
+
+        for (MethodNode method : abstractMethods) {
+            if (method.isPrivate()) {
+                addError("Method '" + method.getName() + "' from " + getDescription(node) +
+                        " must not be private as it is declared as abstract method.", method);
             }
         }
     }

--- a/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -138,7 +138,7 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
         for (MethodNode method : abstractMethods) {
             if (method.isPrivate()) {
                 addError("Method '" + method.getName() + "' from " + getDescription(node) +
-                        " must not be private as it is declared as abstract method.", method);
+                        " must not be private as it is declared as an abstract method.", method);
             }
         }
     }

--- a/src/test/groovy/AbstractClassAndInterfaceTest.groovy
+++ b/src/test/groovy/AbstractClassAndInterfaceTest.groovy
@@ -267,7 +267,7 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
                 private abstract void y()
             }
         """
-        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as abstract method.")
+        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as an abstract method.")
     }
 
     void testAbstractClassWithPrivateAbstractMethods() {
@@ -277,8 +277,8 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
                 private abstract void z()
             }
         """
-        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as abstract method.")
-        assert msg.contains("Method 'z' from class 'X' must not be private as it is declared as abstract method.")
+        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as an abstract method.")
+        assert msg.contains("Method 'z' from class 'X' must not be private as it is declared as an abstract method.")
     }
 
     void testAbstractNestedClassWithPrivateAbstractMethod() {
@@ -289,7 +289,7 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
                 }
             }
         """
-        assert msg.contains("Method 'y' from class 'Z\$X' must not be private as it is declared as abstract method.")
+        assert msg.contains("Method 'y' from class 'Z\$X' must not be private as it is declared as an abstract method.")
     }
 
     void testClassWithPrivateAbstractMethod() {
@@ -298,7 +298,7 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
                 private abstract void y()
             }
         """
-        assert !msg.contains("Method 'y' from class 'X' must not be private as it is declared as abstract method.")
+        assert !msg.contains("Method 'y' from class 'X' must not be private as it is declared as an abstract method.")
         assert msg.contains("Can't have an abstract method in a non-abstract class. The class 'X' must be declared abstract or the method 'void y()' must be implemented.")
     }
 
@@ -312,7 +312,7 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
                 private abstract void y()
             }
         """
-        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as abstract method.")
+        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as an abstract method.")
     }
 
     void testInterfaceWithPrivateAbstractMethod() {

--- a/src/test/groovy/AbstractClassAndInterfaceTest.groovy
+++ b/src/test/groovy/AbstractClassAndInterfaceTest.groovy
@@ -260,4 +260,67 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
         """
         shouldNotCompile scriptStr
     }
+
+    void testAbstractClassWithPrivateAbstractMethod() {
+        def msg = shouldNotCompile """
+            abstract class X {
+                private abstract void y()
+            }
+        """
+        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as abstract method.")
+    }
+
+    void testAbstractClassWithPrivateAbstractMethods() {
+        def msg = shouldNotCompile """
+            abstract class X {
+                private abstract void y()
+                private abstract void z()
+            }
+        """
+        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as abstract method.")
+        assert msg.contains("Method 'z' from class 'X' must not be private as it is declared as abstract method.")
+    }
+
+    void testAbstractNestedClassWithPrivateAbstractMethod() {
+        def msg = shouldNotCompile """
+            class Z {
+                abstract class X {
+                    private abstract void y()
+                }
+            }
+        """
+        assert msg.contains("Method 'y' from class 'Z\$X' must not be private as it is declared as abstract method.")
+    }
+
+    void testClassWithPrivateAbstractMethod() {
+        def msg = shouldNotCompile """
+            class X {
+                private abstract void y()
+            }
+        """
+        assert !msg.contains("Method 'y' from class 'X' must not be private as it is declared as abstract method.")
+        assert msg.contains("Can't have an abstract method in a non-abstract class. The class 'X' must be declared abstract or the method 'void y()' must be implemented.")
+    }
+
+    void testEnumWithPrivateAbstractMethod() {
+        def msg = shouldNotCompile """
+            enum X {
+                CONST {
+                    private void y() { }
+                }
+
+                private abstract void y()
+            }
+        """
+        assert msg.contains("Method 'y' from class 'X' must not be private as it is declared as abstract method.")
+    }
+
+    void testInterfaceWithPrivateAbstractMethod() {
+        def msg = shouldNotCompile """
+            interface X {
+                private abstract void y()
+            }
+        """
+        assert msg.contains("Method 'y' is private but should be public in interface 'X'.")
+    }
 }

--- a/src/test/org/codehaus/groovy/classgen/ClassCompletionVerifierTest.java
+++ b/src/test/org/codehaus/groovy/classgen/ClassCompletionVerifierTest.java
@@ -73,11 +73,20 @@ public class ClassCompletionVerifierTest extends TestSupport {
             "Method 'prom' is protected but should be public in interface 'zzz'.";
     private static final String EXPECTED_PRIVATE_METHOD_ERROR_MESSAGE =
             "Method 'prim' is private but should be public in interface 'zzz'.";
+    private static final String EXPECTED_ABSTRACT_PRIVATE_METHOD_ERROR_MESSAGE =
+            "Method 'y' from class 'X' must not be private as it is declared as abstract method.";
 
     protected void setUp() throws Exception {
         super.setUp();
         source = SourceUnit.create("dummy.groovy", "");
         verifier = new ClassCompletionVerifier(source);
+    }
+
+    public void testDetectsAbstractPrivateMethod() throws Exception {
+        ClassNode node = new ClassNode("X", ACC_ABSTRACT, ClassHelper.OBJECT_TYPE);
+        node.addMethod(new MethodNode("y", ACC_PRIVATE | ACC_ABSTRACT, ClassHelper.VOID_TYPE, new Parameter[0], ClassNode.EMPTY_ARRAY, null));
+        verifier.visitClass(node);
+        checkErrorMessage(EXPECTED_ABSTRACT_PRIVATE_METHOD_ERROR_MESSAGE);
     }
 
     public void testDetectsFinalAbstractClass() throws Exception {

--- a/src/test/org/codehaus/groovy/classgen/ClassCompletionVerifierTest.java
+++ b/src/test/org/codehaus/groovy/classgen/ClassCompletionVerifierTest.java
@@ -74,7 +74,7 @@ public class ClassCompletionVerifierTest extends TestSupport {
     private static final String EXPECTED_PRIVATE_METHOD_ERROR_MESSAGE =
             "Method 'prim' is private but should be public in interface 'zzz'.";
     private static final String EXPECTED_ABSTRACT_PRIVATE_METHOD_ERROR_MESSAGE =
-            "Method 'y' from class 'X' must not be private as it is declared as abstract method.";
+            "Method 'y' from class 'X' must not be private as it is declared as an abstract method.";
 
     protected void setUp() throws Exception {
         super.setUp();


### PR DESCRIPTION
This PR adds some logic to the class completion verifier that adds an error to the error collector when private abstract methods are detected in abstract classes or enums (for interfaces such a check is already available).