### PR TITLE
GROOVY-7833: let grape ignore runner lines with hash to enable comments.

### DIFF
--- a/src/main/groovy/grape/GrapeIvy.groovy
+++ b/src/main/groovy/grape/GrapeIvy.groovy
@@ -339,7 +339,10 @@ class GrapeIvy implements GrapeEngine {
 
     void processRunners(InputStream is, String name, ClassLoader loader) {
         is.text.readLines().each {
-            GroovySystem.RUNNER_REGISTRY[name] = loader.loadClass(it.trim()).newInstance()
+            def line = it.trim()
+            if (!line.startsWith("#")) {
+                GroovySystem.RUNNER_REGISTRY[name] = loader.loadClass(line).newInstance()
+            }
         }
     }
 


### PR DESCRIPTION
When getting a groovy jar via grab, there will be a TestNG runner configuration in the jar. This configuration contains the Apache License 2 text, as required by the foundation. The code expected the class only. With this change the comments will be ignored.