### PR TITLE
GROOVY-7697: GroovyScriptEngine.loadScriptByName doesn't support envi…

### DIFF
--- a/src/main/org/codehaus/groovy/control/XStreamUtils.java
+++ b/src/main/org/codehaus/groovy/control/XStreamUtils.java
@@ -21,17 +21,44 @@ package org.codehaus.groovy.control;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.StaxDriver;
 
+import java.io.File;
 import java.io.FileWriter;
+import java.net.URI;
 
 public abstract class XStreamUtils {
+
     public static void serialize(final String name, final Object ast) {
+        if (name == null || name.length() == 0) return;
+
         XStream xstream = new XStream(new StaxDriver());
         try {
-            xstream.toXML(ast, new FileWriter(name + ".xml"));
+            File astFile = astFile(name);
+            if (astFile == null) {
+                System.out.println("File-name for writing " + name + " AST could not be determined!");
+                return;
+            }
+
+            xstream.toXML(ast, new FileWriter(astFile, false));
             System.out.println("Written AST to " + name + ".xml");
+
         } catch (Exception e) {
             System.out.println("Couldn't write to " + name + ".xml");
             e.printStackTrace();
+        }
+    }
+
+    /**
+     * Takes the incoming file-name and checks whether this is a URI using the <tt>file:</tt> protocol or a non-URI and treats
+     * it accordingly.
+     *
+     * @return a file-name {@link java.io.File} representation or <tt>null</tt> if the file-name was in an invalid URI format
+     */
+    private static File astFile(final String uriOrFileName) {
+        try {
+            final String astFileName = uriOrFileName + ".xml";
+            return uriOrFileName.startsWith("file:") ? new File(URI.create(astFileName)) : new File(astFileName);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 }

--- a/src/test/groovy/ui/GroovyMainTest.groovy
+++ b/src/test/groovy/ui/GroovyMainTest.groovy
@@ -137,6 +137,29 @@ assert new MyConcreteClass() != null"""
         }
     }
 
+    void testGroovyASTDump() {
+
+        def temporaryDirectory = new File("target/tmp/testGroovyXMLAstGeneration/")
+        temporaryDirectory.mkdirs()
+
+        def scriptFile = new File(temporaryDirectory, "Script1.groovy")
+        scriptFile.deleteOnExit()
+
+        scriptFile << "assert 1 + 1 == 2"
+
+        try {
+            System.setProperty('groovy.ast', 'xml')
+
+            GroovyMain.main([scriptFile.absolutePath] as String[])
+
+            assert new File(temporaryDirectory, scriptFile.name + '.xml').exists()
+        } finally {
+            temporaryDirectory.deleteDir()
+
+            System.clearProperty('groovy.ast')
+        }
+    }
+
     // This works for a URL in the classpath, but there isn't a way to do this from the command line.
 //    public void testConfigURIClasspath() {
 //        URI baseURI = new URI("https://raw.github.com/jimwhite/groovy-snippets/master/GROOVY-6451/")

--- a/src/test/groovy/util/GroovyScriptEngineTest.groovy
+++ b/src/test/groovy/util/GroovyScriptEngineTest.groovy
@@ -1,0 +1,70 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.util
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * @author Andre Steingress
+ */
+@RunWith(JUnit4)
+class GroovyScriptEngineTest extends GroovyTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    void createASTDumpWhenScriptIsLoadedByName() {
+
+        def scriptFile = temporaryFolder.newFile('Script1.groovy')
+
+        scriptFile << "assert 1 + 1 == 2" // the script just has to have _some_ content
+
+        try {
+            System.setProperty('groovy.ast', 'xml')
+
+            def clazz = new GroovyScriptEngine([temporaryFolder.root.toURL()] as URL[]).loadScriptByName('Script1.groovy')
+
+            assert new File(temporaryFolder.root, scriptFile.name + '.xml').exists()
+            assert clazz != null
+
+        } finally {
+            System.clearProperty('groovy.ast')
+        }
+    }
+
+    @Test
+    void whenSystemPropertyIsMissingDontCreateASTDump() {
+
+        def scriptFile = temporaryFolder.newFile('Script1.groovy')
+
+        scriptFile << "assert 1 + 1 == 2" // the script just has to have _some_ content
+
+        System.clearProperty('groovy.ast')
+
+        def clazz = new GroovyScriptEngine([temporaryFolder.root.toURL()] as URL[]).loadScriptByName('Script1.groovy')
+        assert clazz != null
+
+        assert !new File(temporaryFolder.root, scriptFile.name + '.xml').exists()
+    }
+}


### PR DESCRIPTION
…ronment variable "groovy.ast"

This PR fixes an issue where the "groovy.ast" dump (only god, its author and the ticket author knew this existed) would not be saved when a script was loaded by name via the GSE. In that case, the `XStreamUtils` instance was given an URI (String) instead of an absolute path and the code there broke.

Regarding error handling in `XStreamUtils` (as this was also mentioned in the ticket): I did not change anything into that direction as I am not convinced that such a secondary "add-on" feature should in any way influence behaviour in `SourceUnit#convert`.