### PR TITLE
GROOVY-7291 - Declaration of double variable without value assignment referrenced in closure

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionHelper.java
@@ -297,7 +297,8 @@ public class BinaryExpressionHelper {
                 !(leftExpression instanceof TupleExpression) )
         {
             VariableExpression ve = (VariableExpression) leftExpression;
-            BytecodeVariable var = compileStack.defineVariable(ve, controller.getTypeChooser().resolveType(ve, controller.getClassNode()), false);
+            ClassNode veType = ClassHelper.isPrimitiveType(ve.getOriginType()) ? ve.getOriginType() : lhsType;
+            BytecodeVariable var = compileStack.defineVariable(ve, veType, false);
             operandStack.loadOrStoreVariable(var, false);
             return;
         }

--- a/src/test/groovy/bugs/Groovy7291Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7291Bug.groovy
@@ -1,0 +1,32 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+class Groovy7291Bug extends GroovyTestCase {
+
+    void testPrimitiveDeclarationWithoutAssignmentWhenUsedInClosure() {
+        assertScript '''
+            double a
+            def b = {
+                a = a + 1
+            }
+            b()
+        '''
+    }
+}


### PR DESCRIPTION
Commit e08c389d67809a421f4f33c27012c54294f98259 made the change that broke this by resolving the type (Double) whereas the original method call resolved to `getOriginType` (double).  This change tries to preserve the call to the type resolver where the origin is not a primitive.  It should also be noted that fully reverting the call back to the original (`compileStack.defineVariable(ve, false)`) version prior to commit e08c389d67809a421f4f33c27012c54294f98259  also passes all tests.