### PR TITLE
GROOVY-7841: Assert fails when accessing particular primitive values …

### DIFF
--- a/src/main/org/codehaus/groovy/transform/sc/transformers/BooleanExpressionTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/BooleanExpressionTransformer.java
@@ -134,15 +134,19 @@ public class BooleanExpressionTransformer {
                             // int on stack
                         } else if (top.equals(ClassHelper.long_TYPE)) {
                             MethodVisitor mv = controller.getMethodVisitor();
-                            mv.visitInsn(L2I);
+                            mv.visitInsn(LCONST_0);
+                            mv.visitInsn(LCMP);
                             controller.getOperandStack().replace(ClassHelper.boolean_TYPE);
                         } else if (top.equals(ClassHelper.float_TYPE)) {
                             MethodVisitor mv = controller.getMethodVisitor();
-                            mv.visitInsn(F2I);
+                            mv.visitInsn(F2D);
+                            mv.visitInsn(DCONST_0);
+                            mv.visitInsn(DCMPG);
                             controller.getOperandStack().replace(ClassHelper.boolean_TYPE);
                         } else if (top.equals(ClassHelper.double_TYPE)) {
                             MethodVisitor mv = controller.getMethodVisitor();
-                            mv.visitInsn(D2I);
+                            mv.visitInsn(DCONST_0);
+                            mv.visitInsn(DCMPG);
                             controller.getOperandStack().replace(ClassHelper.boolean_TYPE);
                         }
                         return;

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
@@ -22,8 +22,6 @@ import groovy.transform.stc.BugsSTCTest
 
 /**
  * Unit tests for static type checking : bugs.
- *
- * @author Cedric Champeau
  */
 class BugsStaticCompileTest extends BugsSTCTest implements StaticCompilationTestSupport {
 
@@ -1437,6 +1435,15 @@ println someInt
             assert !(foo?.bar == 7)
             assert !(foo?.bar > 7)
             assert foo?.bar < 7
+        '''
+    }
+
+    // GROOVY-7841
+    void testAssertionOfNonZeroPrimitiveEdgeCases() {
+        assertScript '''
+            assert 4294967296
+            assert 0.1f
+            assert 0.1d
         '''
     }
 }


### PR DESCRIPTION
…with @CompileStatic