### PR TITLE
Fix jigsaw failure IllegalAccessException cannot access JavacTool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,14 @@ allprojects {
     if (JavaVersion.current().java7Compatible) {
         apply from: "${rootProject.projectDir}/gradle/asciidoctor.gradle"
     }
+    if (JavaVersion.current().java9Compatible) {
+        tasks.withType(JavaCompile) {
+            options.forkOptions.jvmArgs << '-XaddExports:jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED'
+        }
+        tasks.withType(GroovyCompile) {
+            options.forkOptions.jvmArgs << '-XaddExports:jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED'
+        }
+    }
 }
 
 // todo: use the conventional "resources" directory for classpath resources


### PR DESCRIPTION
I noticed the TeamCity build still fails jigsaw builds:
http://ci.groovy-lang.org/viewLog.html?buildId=33662&buildTypeId=Groovy_Jdk9Build&tab=buildLog

    Caused by: java.lang.IllegalAccessException: class org.gradle.internal.reflect.DirectInstantiator cannot access class com.sun.tools.javac.api.JavacTool (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.api to unnamed module ...

Since I found a solution, I make this PR to save someone else's time.