### PR TITLE
GROOVY-7872 Fix nested calls between @Lazy static properties

### DIFF
--- a/src/main/org/codehaus/groovy/transform/LazyASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/LazyASTTransformation.java
@@ -115,7 +115,14 @@ public class LazyASTTransformation extends AbstractASTTransformation {
         final String fullName = declaringClass.getName() + "$" + fieldType.getNameWithoutPackage() + "Holder_" + fieldNode.getName().substring(1);
         final InnerClassNode holderClass = new InnerClassNode(declaringClass, fullName, visibility, ClassHelper.OBJECT_TYPE);
         final String innerFieldName = "INSTANCE";
-        holderClass.addField(innerFieldName, ACC_PRIVATE | ACC_STATIC | ACC_FINAL, fieldType, initExpr);
+
+        final String initializeMethodName = fullName + "_initExpr";
+        declaringClass.addMethod(initializeMethodName, ACC_PRIVATE | ACC_STATIC | ACC_FINAL, fieldType,
+                Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, returnS(initExpr));
+
+        holderClass.addField(innerFieldName, ACC_PRIVATE | ACC_STATIC | ACC_FINAL, fieldType,
+                callX(declaringClass, initializeMethodName));
+
         final Expression innerField = propX(classX(holderClass), innerFieldName);
         declaringClass.getModule().addClass(holderClass);
         body.addStatement(returnS(innerField));

--- a/src/test/org/codehaus/groovy/transform/LazyTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/LazyTransformTest.groovy
@@ -181,4 +181,26 @@ class LazyTransformTest extends GroovyShellTestCase {
         assertTrue res.@'$list' instanceof SoftReference
         assertEquals([1,2,3], res.list)
     }
+
+    void testNestedLazyCalls() {
+        def res = evaluate("""
+            class X {
+              @Lazy def smallSet = [1, 2, 3]
+              @Lazy def biggerSet = (smallSet + [4, 5, 6])
+            }
+            new X().biggerSet
+        """)
+        assertEquals([1,2,3,4,5,6], res)
+    }
+
+    void testNestedStaticLazyCalls() {
+        def res = evaluate("""
+            class X {
+              @Lazy static final SMALL_SET = [1, 2, 3]
+              @Lazy static final BIGGER_SET = (SMALL_SET + [4, 5, 6])
+            }
+            X.BIGGER_SET
+        """)
+        assertEquals([1,2,3,4,5,6], res)
+    }
 }


### PR DESCRIPTION
Variable expressions lost owner class context cause they are wrapped into the holder class. Now variable initialization is handled by a private static method in the owning class.