### PR TITLE
GROOVY-7842 - MarkupTemplateEngine Totally Broken

### DIFF
--- a/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/MarkupTemplateEngine.java
+++ b/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/MarkupTemplateEngine.java
@@ -201,7 +201,7 @@ public class MarkupTemplateEngine extends TemplateEngine {
         @SuppressWarnings("unchecked")
         public MarkupTemplateMaker(final Reader reader, String sourceName, Map<String, String> modelTypes) {
             String name = sourceName != null ? sourceName : "GeneratedMarkupTemplate" + counter.getAndIncrement();
-            templateClass = groovyClassLoader.parseClass(new GroovyCodeSource(reader, name, ""), modelTypes);
+            templateClass = groovyClassLoader.parseClass(new GroovyCodeSource(reader, name, "x"), modelTypes);
             this.modeltypes = modelTypes;
         }
 


### PR DESCRIPTION
When running under a Security Manager an exception would be thrown because
the empty codebase value was added as a Permission name which can not be
empty.  So use the same codebase value that is used by GStringTemplateEngine
and StreamingTemplateEngine for unnamed code sources.