### PR TITLE
Removed JDK 6 from the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@
 language: groovy
 
 jdk:
-  - openjdk6
   - oraclejdk7
 
 install: true


### PR DESCRIPTION
For some reason JDK 8 wasn't working either

This should be merged before https://github.com/apache/groovy/pull/360 and https://github.com/apache/groovy/pull/358, to make the builds pass