### PR TITLE
Travis CI - run with latest JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,16 @@
 
 language: groovy
 
-jdk:
-  - oraclejdk7
-  - oraclejdk8
+sudo: false
+
+matrix:
+  include:
+    - jdk: oraclejdk7
+    - jdk: oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
 
 install: true
 


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/4042

This updates the jdk8 version from the default 1.8.0_31 to 1.8.0_91 and seems to speed up the test with that jdk by several minutes in my testing.