### PR TITLE
GROOVY-5985 - Invalid hash key serialVersionUID

### DIFF
--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -2656,6 +2656,14 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
 
         //----------------------------------------------------------------------
+        // turn setProperty on a Map to put on the Map itself
+        //----------------------------------------------------------------------
+        if (method == null && !isStatic && this.isMap) {
+            ((Map) object).put(name, newValue);
+            return;
+        }
+
+        //----------------------------------------------------------------------
         // field
         //----------------------------------------------------------------------
         if (method == null && field != null) {
@@ -2700,14 +2708,6 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
                 arguments[1] = newValue;
             }
             method.doMethodInvoke(object, arguments);
-            return;
-        }
-
-        //----------------------------------------------------------------------
-        // turn setProperty on a Map to put on the Map itself
-        //----------------------------------------------------------------------
-        if (!isStatic && this.isMap) {
-            ((Map) object).put(name, newValue);
             return;
         }
 

--- a/src/test/groovy/MapPropertyTest.groovy
+++ b/src/test/groovy/MapPropertyTest.groovy
@@ -61,6 +61,34 @@ class MapPropertyTest extends GroovyTestCase {
         assert c.class == 1
         assert c.getClass() != 1
     }
+
+    // GROOVY-5985
+    void testMapPutAtWithKeyMatchingReadOnlyProperty() {
+        def map = [serialVersionUID:123]
+        assert map["serialVersionUID"] == 123
+        assert map.serialVersionUID == 123
+
+        map.put("serialVersionUID", 789)
+        assert map["serialVersionUID"] == 789
+        assert map.serialVersionUID == 789
+
+        map.putAt("serialVersionUID", 333)
+        assert map.serialVersionUID == 333
+
+        map = new MyMapClassWithReadOnlyProperties()
+
+        assert map['classVar'] == null
+        assert map.@classVar == 'class var'
+
+        map['classVar'] = 'map var'
+        assert map['classVar'] == 'map var'
+
+        assert map['instanceVar'] == null
+        assert map.@instanceVar == 77
+
+        map['instanceVar'] = 42
+        assert map['instanceVar'] == 42
+    }
 }
 
 class MyClass extends HashMap {
@@ -68,4 +96,9 @@ class MyClass extends HashMap {
         assert id == "hello"
         assert this.class == 1
     }
+}
+
+class MyMapClassWithReadOnlyProperties extends HashMap {
+    private static final String classVar = 'class var'
+    private final int instanceVar = 77
 }


### PR DESCRIPTION
Using a map key with the same name as a read-only property on the Map
class would throw a groovy.lang.ReadOnlyPropertyException.  The fix for
GROOVY-3471 (commit 18f6f8271ed3bfb) moved the map handling
below the handling for read-only properties.  In order to avoid the
issue in GROOVY-3471 we also need to check and make sure the
method is null so we are not in a setX call.