### PR TITLE
test cleanup: remove println calls

### DIFF
--- a/src/test/groovy/ArrayCoerceTest.groovy
+++ b/src/test/groovy/ArrayCoerceTest.groovy
@@ -28,12 +28,10 @@ class ArrayCoerceTest extends GroovyTestCase {
         int[] a = [1, 2, 3]
         assert a instanceof int[]
         assert a.length == 3
-        dump(a)
     }
 
     void testStaticallyTypedPrimitiveFieldArrays() {
         primitiveField = [1, 2, 3]
-        dump(primitiveField)
 
         assert primitiveField instanceof int[]
         assert primitiveField.length == 3
@@ -42,7 +40,6 @@ class ArrayCoerceTest extends GroovyTestCase {
 
     void testFoo2() {
         def x = [1, 2, 3] as Object[]
-        dump(x)
         assert x instanceof Object[]
         def c = x.getClass()
         def et = c.componentType
@@ -51,7 +48,6 @@ class ArrayCoerceTest extends GroovyTestCase {
 
     void testStaticallyTypedObjectArrays() {
         Object[] b = [1, 2, 3]
-        dump(b)
 
         assert b instanceof Object[]
         assert b.length == 3
@@ -63,7 +59,6 @@ class ArrayCoerceTest extends GroovyTestCase {
 
     void testStaticallyTypedArrays() {
         Integer[] b = [1, 2, 3]
-        dump(b)
 
         assert b instanceof Integer[]
         assert b.length == 3
@@ -75,7 +70,6 @@ class ArrayCoerceTest extends GroovyTestCase {
 
     void testStaticallyTypedObjectFieldArrays() {
         field = [1, 2, 3]
-        dump(field)
 
         assert field instanceof Object[]
         assert field.length == 3
@@ -83,7 +77,6 @@ class ArrayCoerceTest extends GroovyTestCase {
 
     void testStaticallyTypedFieldArrays() {
         numberField = [1, 2, 3]
-        dump(numberField)
 
         assert numberField instanceof Long[]
         assert numberField.length == 3
@@ -95,42 +88,34 @@ class ArrayCoerceTest extends GroovyTestCase {
         x = [1, 0, 1] as boolean[]
         assert x instanceof boolean[]
         assert x.length == 3
-        dump(x)
 
         x = [1, 2, 3] as byte[]
         assert x.length == 3
         assert x instanceof byte[]
-        dump(x)
 
         x = [1, 2, 3] as char[]
         assert x.length == 3
         assert x instanceof char[]
-        dump(x)
 
         x = [1, 2, 3] as short[]
         assert x.length == 3
         assert x instanceof short[]
-        dump(x)
 
         x = [1, 2, 3] as int[]
         assert x.length == 3
         assert x instanceof int[]
-        dump(x)
 
         x = [1, 2, 3] as long[]
         assert x.length == 3
         assert x instanceof long[]
-        dump(x)
 
         x = [1, 2, 3] as float[]
         assert x.length == 3
         assert x instanceof float[]
-        dump(x)
 
         x = [1, 2, 3] as double[]
         assert x.length == 3
         assert x instanceof double[]
-        dump(x)
     }
 
 
@@ -140,37 +125,31 @@ class ArrayCoerceTest extends GroovyTestCase {
         def c = x.getClass()
         def et = c.componentType
         assert et == Object.class
-        dump(x)
 
         Integer[] y = [1, 2, 3]
         c = y.getClass()
         et = c.componentType
         assert et == Integer.class
-        dump(y)
     }
 
     void testMakeArrayThenCoerceToAnotherType() {
         def x = [1, 2, 3] as int[]
         assert x.size() == 3
         assert x instanceof int[]
-        dump(x)
 
         // lets try coerce it into an array of longs
         def y = x as long[]
         assert y instanceof long[]
-        dump(y)
 
         def z = y as Object[]
         assert z instanceof Object[]
         def c = z.getClass()
         def et = c.componentType
         assert et == Object.class
-        dump(z)
 
         x = y as int[]
         assert x.size() == 3
         assert x instanceof int[]
-        dump(x)
     }
 
 
@@ -180,50 +159,34 @@ class ArrayCoerceTest extends GroovyTestCase {
         x = [1, 0, 1] as Boolean[]
         assert x instanceof Boolean[]
         assert x.length == 3
-        dump(x)
 
         x = [1, 2, 3] as Byte[]
         assert x.length == 3
         assert x instanceof Byte[]
-        dump(x)
 
         x = [1, 2, 3] as Character[]
         assert x.length == 3
         assert x instanceof Character[]
-        dump(x)
 
         x = [1, 2, 3] as Short[]
         assert x.length == 3
         assert x instanceof Short[]
-        dump(x)
 
         x = [1, 2, 3] as Integer[]
         assert x.length == 3
         assert x instanceof Integer[]
-        dump(x)
 
         x = [1, 2, 3] as Long[]
         assert x.length == 3
         assert x instanceof Long[]
-        dump(x)
 
         x = [1, 2, 3] as Float[]
         assert x.length == 3
         assert x instanceof Float[]
-        dump(x)
 
         x = [1, 2, 3] as Double[]
         assert x.length == 3
         assert x instanceof Double[]
-        dump(x)
-    }
-
-    void dump(array) {
-        println "Array is of type ${array.class} which has element type ${array.class.componentType}"
-        for (i in array) {
-            println "Contains entry $i of type ${i.class}"
-        }
-        println()
     }
 
 }

--- a/src/test/groovy/ArrayParamMethodTest.groovy
+++ b/src/test/groovy/ArrayParamMethodTest.groovy
@@ -29,15 +29,11 @@ class ArrayParamMethodTest extends GroovyTestCase implements DummyInterface {
     }
     
     void methodWithArrayParam(String[] args) {
-        println("first item: ${args[0]}")
-        
         // lets turn it into a list
         def list = args.toList()
         assert list instanceof java.util.List
         list[4] = "e"
         
         assert list == ["a", "b", "c", null, "e"]
-        
-        println("Created list ${list}")
     }
 }

--- a/src/test/groovy/ArrayTypeTest.groovy
+++ b/src/test/groovy/ArrayTypeTest.groovy
@@ -21,20 +21,18 @@ package groovy
 class ArrayTypeTest extends GroovyTestCase {
 
     void testClosureWithTypedParam() {
-        def c = {String[] foo->println("called with $foo") }
+        def c = {String[] foo-> assert !foo}
         c(null)
     }
 
     void testVariableType() {
         Object[] foo = methodThatReturnsArray()
-        println "foo is $foo"
-
+        assert !foo
     }
 
 
 
     Object[] methodThatReturnsArray() {
-        println "Invoked the method"
         return null
     }
 }

--- a/src/test/groovy/CastTest.groovy
+++ b/src/test/groovy/CastTest.groovy
@@ -25,8 +25,6 @@ class CastTest extends GroovyTestCase {
     void testCast() {
         def x = (Short) 5
 
-        println("Cast Integer to ${x} with type ${x.class}")
-        
         assert x.class == Short
         
         methodWithShort(x)
@@ -35,29 +33,20 @@ class CastTest extends GroovyTestCase {
     void testImplicitCast() {
         Short x = 6
         
-        println("Created ${x} with type ${x.class}")
-        
         assert x.class == Short , "Type is ${x.class}"
         
         methodWithShort(x)
         
         x = 7
-        
-        println("Updated ${x} with type ${x.class}")
-        
         assert x.class == Short , "Type is ${x.class}"
     }
 
     void testImplicitCastOfField() {
 
-        println("Field is ${b} with type ${b.class}")
-        
         assert b.class == Short , "Type is ${b.class}"
         
         b = 5
         
-        println("Updated field ${b} with type ${b.class}")
- 
         assert b.class == Short , "Type is ${b.class}"
     }
     
@@ -93,13 +82,10 @@ class CastTest extends GroovyTestCase {
     }
     
     void methodWithShort(Short s) {
-        println("Called with ${s} with type ${s.class}")
         assert s.class == Short
     }
     
     void methodWithChar(Character x) {
-        println("Called with ${x} with type ${s.class}")
-        
         def text = "text"
         def idx = text.indexOf(x)
         

--- a/src/test/groovy/ClassExpressionTest.groovy
+++ b/src/test/groovy/ClassExpressionTest.groovy
@@ -28,8 +28,6 @@ class ClassExpressionTest extends GroovyTestCase {
     void testUseOfClass() {
         def x = String
         
-        System.out.println("x: " + x)
-        
         assert x != null
 
         assert x.getName().endsWith('String')
@@ -48,8 +46,6 @@ class ClassExpressionTest extends GroovyTestCase {
         x = ClassExpressionTest
         
         assert x != null
-
-        System.out.println("x: " + x)
     }
 
     void testClassPsuedoProperty() {
@@ -59,8 +55,6 @@ class ClassExpressionTest extends GroovyTestCase {
         assert x.class != null
 
         assert x.class == x.getClass();
-
-        System.err.println( "x.class: " + x.class );
     }
     
     void testPrimitiveClasses() {

--- a/src/test/groovy/ClassTest.groovy
+++ b/src/test/groovy/ClassTest.groovy
@@ -22,17 +22,14 @@ class ClassTest extends GroovyTestCase {
 
     void testClassExpression() {
         def c = String.class
-        println c
         assert c instanceof Class
         assert c.name == "java.lang.String" , c.name
         
         c = GroovyTestCase.class
-        println c
         assert c instanceof Class
         assert c.name.endsWith("GroovyTestCase") , c.name
         
         c = ClassTest.class
-        println c
         assert c instanceof Class
         assert c.name.endsWith("ClassTest") , c.name
     }

--- a/src/test/groovy/ClosureDefaultParameterTest.groovy
+++ b/src/test/groovy/ClosureDefaultParameterTest.groovy
@@ -25,15 +25,19 @@ class ClosureDefaultParameterTest extends GroovyTestCase {
 
     void testClosureWithDefaultParams() {
 
-        def block = {a = 123, b = 456 -> println "value of a = $a and b = $b" }
-
-        block = { Integer a = 123, String b = "abc" ->
-                  println "value of a = $a and b = $b"; return "$a $b".toString() }
+        def block = {a = 123, b = 456 -> "$a $b".toString() }
 
         assert block.call(456, "def") == "456 def"
-        assert block.call() == "123 abc"
-        assert block(456) == "456 abc"
+        assert block.call() == "123 456"
+        assert block(456) == "456 456"
         assert block(456, "def") == "456 def"
+
+        def block2 = { Integer a = 123, String b = "abc" -> "$a $b".toString() }
+
+        assert block2.call(456, "def") == "456 def"
+        assert block2.call() == "123 abc"
+        assert block2(456) == "456 abc"
+        assert block2(456, "def") == "456 def"
     }
     
     void testClosureWithDefaultParamFromOuterScope() {

--- a/src/test/groovy/ClosureInClosureTest.groovy
+++ b/src/test/groovy/ClosureInClosureTest.groovy
@@ -37,7 +37,7 @@ class ClosureInClosureTest extends GroovyTestCase {
 
         l.each{
             it.each{
-                println(text)
+                assert text == 'test '
             }
         }
     }

--- a/src/test/groovy/ClosureMethodTest.groovy
+++ b/src/test/groovy/ClosureMethodTest.groovy
@@ -328,13 +328,11 @@ class ClosureMethodTest extends GroovyTestCase {
 
     void testDump() {
         def text = dump()
-        println("Dumping object ${text}")
         assert text != null && text.startsWith("<")
     }
 
     void testInspect() {
         def text = [1, 2, 'three'].inspect()
-        println("Inspecting ${text}")
         assert text == "[1, 2, 'three']"
     }
 

--- a/src/test/groovy/ClosureMethodsOnFileTest.groovy
+++ b/src/test/groovy/ClosureMethodsOnFileTest.groovy
@@ -37,11 +37,14 @@ class ClosureMethodsOnFileTest extends GroovyTestCase {
     }
 
     void testEachLine() {
-        file.eachLine { line -> println(line) }
+        file.eachLine { line -> assert line != null }
     }
 
     void testEachLineWithCount() {
-        file.eachLine { line, count -> println "$count > $line" }
+        int i = 0
+        file.eachLine { line, count ->
+            assert count == ++i && line != null
+        }
     }
 
     void testReadLines() {
@@ -51,8 +54,6 @@ class ClosureMethodsOnFileTest extends GroovyTestCase {
     }
 
     void testEachFile() {
-        println("Closure loop to display contents of dir: " + dir)
-        dir.eachFile { f -> println(f.getName()) }
-        println("")
+        dir.eachFile { f -> assert f.getName() }
     }
 }

--- a/src/test/groovy/ClosureMissingMethodTest.groovy
+++ b/src/test/groovy/ClosureMissingMethodTest.groovy
@@ -29,12 +29,10 @@ class ClosureMissingMethodTest extends GroovyTestCase {
           int count = 0
 
           foo = {
-            println "inside foo"
             count++
             bar()
           }
           baz = {
-            println "inside baz"
             foo()
           }
 
@@ -55,12 +53,10 @@ class ClosureMissingMethodTest extends GroovyTestCase {
       int count = 0
 
       def foo = {
-          println "inside foo"
           count++
           bar()
       }
       def baz = {
-          println "inside baz"
           foo()
       }
 
@@ -79,12 +75,10 @@ class ClosureMissingMethodTest extends GroovyTestCase {
           int count = 0
 
           foo = {
-            println "inside foo"
             count++
             bar()
           }
           baz = {
-            println "inside baz"
             foo()
           }
           mc = new ExpandoMetaClass(baz.getClass())
@@ -108,12 +102,10 @@ class ClosureMissingMethodTest extends GroovyTestCase {
       int count = 0
 
       def foo = {
-          println "inside foo"
           count++
           bar()
       }
       def baz = {
-          println "inside baz"
           foo()
       }
       MetaClass mc = new ExpandoMetaClass(baz.getClass())

--- a/src/test/groovy/ClosureTest.groovy
+++ b/src/test/groovy/ClosureTest.groovy
@@ -93,9 +93,9 @@ class ClosureTest extends GroovyTestCase {
 
         assert count == 1
 
-        block = System.out.&println
+        block = Math.&min
 
-        block.call("I just invoked a closure!")
+        assert block.call(3, 7) == 3
     }
   
     def incrementCallCount() {

--- a/src/test/groovy/ClosureUsingOuterVariablesTest.groovy
+++ b/src/test/groovy/ClosureUsingOuterVariablesTest.groovy
@@ -29,12 +29,9 @@ class ClosureUsingOuterVariablesTest extends GroovyTestCase {
         def y = "hello"
         
         def closure = { i ->
-            println("x ${x}")
-            println("y ${y}")
-            println("i ${i}")
-                
             assert x == 123
             assert y == 'hello'
+            assert i == 321
         }
         closure.call(321)
     }
@@ -74,7 +71,6 @@ class ClosureUsingOuterVariablesTest extends GroovyTestCase {
         def c = { b = a + it }
         c(5)
         
-        println(b)
         assert b == a + 5
     }    
 

--- a/src/test/groovy/ClosureWithDefaultParamTest.groovy
+++ b/src/test/groovy/ClosureWithDefaultParamTest.groovy
@@ -91,9 +91,7 @@ class ClosureWithDefaultParamTest extends GroovyTestCase {
         def keys = answer.collect {it.key }
         def values = answer.collect {it.value }
 
-        System.out.println("keys " + keys + " values " + values)
-        
-        // maps are in hash order so lets sort the results       
+        // maps are in hash order so lets sort the results
         keys.sort() 
         values.sort() 
         
@@ -147,11 +145,7 @@ class ClosureWithDefaultParamTest extends GroovyTestCase {
     void testEachLine() {
         def file = new File("src/test/groovy/Bar.groovy")
         
-        System.out.println("Contents of file: " + file)
-        
-        file.eachLine { println(it) }
-        
-        println("")
+        file.eachLine { assert it != null }
     }
     
     void testReadLines() {
@@ -161,17 +155,11 @@ class ClosureWithDefaultParamTest extends GroovyTestCase {
         
         assert lines != null
         assert lines.size() > 0
-
-        System.out.println("File has number of lines: " + lines.size())
     }
     
     void testEachFile() {
         def file = new File("src/test/groovy")
-        
-        System.out.println("Contents of dir: " + file)
-        
-        file.eachFile { println(it.getName()) }
-        
-        println("")
+
+        file.eachFile { assert it.getName() }
     }
 }

--- a/src/test/groovy/ClosureWithEmptyParametersTest.groovy
+++ b/src/test/groovy/ClosureWithEmptyParametersTest.groovy
@@ -25,13 +25,9 @@ class ClosureWithEmptyParametersTest extends GroovyTestCase {
 
     void testNoParams() {
 
-        def block = {-> println "hey I'm a closure!" }
-
-        println "About to call closure"
+        def block = {-> }
 
         block.call()
-
-        println "Done"
     }
 
 }

--- a/src/test/groovy/CompareEqualsTest.groovy
+++ b/src/test/groovy/CompareEqualsTest.groovy
@@ -33,12 +33,10 @@ class CompareEqualsTest extends GroovyTestCase {
 
 class Xyz {
     boolean equals(Xyz other) {
-        println "${other.class} TRUE"
         true
     }
 
     boolean equals(Object other) {
-        println "${other.class} FALSE"
         null
     }
 

--- a/src/test/groovy/CompileOrderTest.groovy
+++ b/src/test/groovy/CompileOrderTest.groovy
@@ -22,16 +22,13 @@ class CompileOrderTest extends GroovyTestCase {
    public void testCompileOrder() {
       def interfaceFile = File.createTempFile("TestOrderInterface", ".groovy", new File("target"))
       def concreteFile = File.createTempFile("TestOrderConcrete", ".groovy", new File("target"))
-
       def cl = new GroovyClassLoader(this.class.classLoader);
       def currentDir = concreteFile.parentFile.absolutePath
-      println currentDir
       cl.addClasspath(currentDir)
       cl.shouldRecompile = true
 
       try {
          // Create the interface
-         println "a"
          interfaceFile.deleteOnExit()
          def interfaceName = interfaceFile.name - ".groovy"
          interfaceFile.write "interface $interfaceName { }\n"
@@ -57,13 +54,11 @@ class CompileOrderTest extends GroovyTestCase {
 
         def cl = new GroovyClassLoader(this.class.classLoader);
         def currentDir = concreteFile.parentFile.absolutePath
-        println currentDir
         cl.addClasspath(currentDir)
         cl.shouldRecompile = true
 
         try {
             // Create the interface
-            println "a"
             interfaceFile.deleteOnExit()
             def interfaceName = interfaceFile.name - ".groovy"
             interfaceFile.write "interface $interfaceName { }\n"

--- a/src/test/groovy/CompilerErrorTest.groovy
+++ b/src/test/groovy/CompilerErrorTest.groovy
@@ -23,12 +23,8 @@ class CompilerErrorTest extends GroovyTestCase {
     void testBadMethodName() {
 
         shouldFail {
-            println "About to call shell script"
-            println "Really am about to call shell script"
-
             def shell = new GroovyShell()
             def text = 'badMethod(); println "Called method"'
-            println "About to test script ${text}"
             shell.evaluate(text)
         }
     }

--- a/src/test/groovy/Constructor2Test.groovy
+++ b/src/test/groovy/Constructor2Test.groovy
@@ -20,14 +20,11 @@ package groovy
 
 class Constructor2Test extends GroovyTestCase {
 
-    Constructor2Test() {
-        println "Hey"
-    }
+    Constructor2Test() { }
 
     void testConstructor() {
         def foo = new Constructor2Test()
         assert foo != null
-        println foo
     }
 
 }

--- a/src/test/groovy/ConstructorTest.groovy
+++ b/src/test/groovy/ConstructorTest.groovy
@@ -20,14 +20,11 @@ package groovy
 
 class ConstructorTest extends GroovyTestCase {
 
-    public ConstructorTest() {
-        println "Hey"
-    }
+    public ConstructorTest() { }
 
     public void testConstructor() {
         def foo = new ConstructorTest()
         assert foo != null
-        println foo
     }
 
 }

--- a/src/test/groovy/CurlyBracketLayoutTest.groovy
+++ b/src/test/groovy/CurlyBracketLayoutTest.groovy
@@ -26,7 +26,7 @@ class CurlyBracketLayoutTest extends GroovyTestCase
 
         if (foo.contains("b"))
         {
-            println "Worked a treat. foo = $foo"
+            // expected
         }
         else
         {
@@ -36,7 +36,7 @@ class CurlyBracketLayoutTest extends GroovyTestCase
         def list = [1, 2, 3]
         list.each
         {
-            println it
+            assert it >= 1 && it <= 3
         }
     }
 }

--- a/src/test/groovy/DefaultParamClosureTest.groovy
+++ b/src/test/groovy/DefaultParamClosureTest.groovy
@@ -23,7 +23,6 @@ class DefaultParamClosureTest extends GroovyTestCase {
     void testDefaultParameters() {
         // Default parameters working for closures 
     def doSomething = { a, b = 'defB', c = 'defC' ->
-            println "Called with a: ${a}, b ${b}, c ${c}"
             return a + "-" + b + "-" + c
         }
 
@@ -42,7 +41,6 @@ class DefaultParamClosureTest extends GroovyTestCase {
     void testDefaultTypedParameters() {
     // Handle typed parameters
     def doTypedSomething = { String a = 'defA', String b = 'defB', String c = 'defC' ->
-            println "Called typed method with a: ${a}, b ${b}, c ${c}"
             return a + "-" + b + "-" + c
         }
     

--- a/src/test/groovy/ExceptionInClosureTest.groovy
+++ b/src/test/groovy/ExceptionInClosureTest.groovy
@@ -34,8 +34,6 @@ class ExceptionInClosureTest extends GroovyTestCase {
             fail("Should have thrown an exception by now")
         }
         catch (MissingMethodException e) {
-               System.out.println("Caught: " + e)    
-               
                assert e.method == "foo"
             assert e.type == String               
         }

--- a/src/test/groovy/ExpandoPropertyTest.groovy
+++ b/src/test/groovy/ExpandoPropertyTest.groovy
@@ -38,7 +38,7 @@ class ExpandoPropertyTest extends GroovyTestCase {
         foo.cheese = "Cheddar"
         foo.fullName = "Gromit"
         foo.nameLength = { return fullName.length() }
-        foo.multiParam = { a, b, c -> println("Called with ${a}, ${b}, ${c}"); return a + b + c }
+        foo.multiParam = { a, b, c -> return a + b + c }
 
         assert foo.cheese == "Cheddar"
         assert foo.fullName == "Gromit"
@@ -64,7 +64,6 @@ class ExpandoPropertyTest extends GroovyTestCase {
 
     void testExpandoConstructorAndToString() {
         def foo = new Expando(type: "sometype", value: 42)
-        println foo
         assert foo.toString() == "{type=sometype, value=42}"
         assert "${foo}" == "{type=sometype, value=42}"
     }
@@ -74,7 +73,6 @@ class ExpandoPropertyTest extends GroovyTestCase {
         def foo = new Expando(type: "myfoo", value: 42, equals: equals)
         def bar = new Expando(type: "mybar", value: 43, equals: equals)
         def zap = new Expando(type: "myzap", value: 42, equals: equals)
-        println(foo)
 
         assert foo.equals(bar) == false
         assert foo.equals(zap) == true
@@ -82,7 +80,6 @@ class ExpandoPropertyTest extends GroovyTestCase {
         def list = []
         list << foo
         list << bar
-        println list
 
         assert list.contains(foo) == true
         assert list.contains(bar) == true
@@ -90,16 +87,10 @@ class ExpandoPropertyTest extends GroovyTestCase {
         assert list.indexOf(bar) == 1
         assert list.indexOf(foo) == 0
 
-        println "hashCode: " + foo.hashCode()
-
         foo.hashCode = { return value }
-        println("hashCode: " + foo.hashCode())
-
         assert foo.hashCode() == foo.value
-        println("toString: " + foo.toString())
 
         foo.toString = { return "Type: ${type}, Value: ${value}" }
-        println("toString: " + foo.toString())
         assert foo.toString() == "Type: myfoo, Value: 42"
     }
 

--- a/src/test/groovy/ForLoopTest.groovy
+++ b/src/test/groovy/ForLoopTest.groovy
@@ -91,8 +91,6 @@ class ForLoopTest extends gls.CompilableTestSupport {
     void testArray() {
         def array = (0..4).toArray()
 
-        println "Class: ${array.getClass()} for array ${array}"
-
         x = 0
 
         for (i in array) {
@@ -104,8 +102,6 @@ class ForLoopTest extends gls.CompilableTestSupport {
 
     void testIntArray() {
         def array = TestSupport.getIntArray()
-
-        println "Class: ${array.getClass()} for array ${array}"
 
         x = 0
 

--- a/src/test/groovy/GStringTest.groovy
+++ b/src/test/groovy/GStringTest.groovy
@@ -46,10 +46,10 @@ class GStringTest extends GroovyTestCase {
 
         check("hello $name how are you?", teststr)
         check("hello ${name} how are you?", teststr)
-        check("hello ${println "feep"; name} how are you?", teststr)
+        check("hello ${(name + '  ').trim()} how are you?", teststr)
         check(/hello $name how are you?/, teststr)
         check(/hello ${name} how are you?/, teststr)
-        check(/hello ${println "feep"; name} how are you?/, teststr)
+        check(/hello ${(name + '  ').trim()} how are you?/, teststr)
     }
 
     void testWithVariableAtEnd() {
@@ -238,12 +238,12 @@ class GStringTest extends GroovyTestCase {
         assertEquals(w.buffer.toString(), "5")
         assertEquals(g4.toString(), "5")
         try {
-            println g5
+            w << g5
             fail("should throw a GroovyRuntimeException")
         } catch (GroovyRuntimeException e) {
         }
         try {
-            println g5.toString()
+            g5.toString()
             fail("should throw a GroovyRuntimeException")
         } catch (GroovyRuntimeException e) {
         }

--- a/src/test/groovy/GeneratorTest.groovy
+++ b/src/test/groovy/GeneratorTest.groovy
@@ -44,8 +44,8 @@ class GeneratorTest extends GroovyTestCase {
 
     void testEach() {
         def x = this.&sampleGenerator
-
-        def value = x.each { println(it) }
+        def expected = ['A', 'B', 'C']
+        def value = x.each { assert it == expected.remove(0) }
     }
 
     void testMissingThisBug() {

--- a/src/test/groovy/GroovyClosureMethodsTest.groovy
+++ b/src/test/groovy/GroovyClosureMethodsTest.groovy
@@ -43,14 +43,11 @@ class GroovyClosureMethodsTest extends GroovyTestCase {
             oos.writeObject(it)
         }
 
-        println("Contents of file with multiple objects: " + file)
         int c = 0
         file.eachObject {
-            print "${it} "
             c++
         }
         assert list.size() == c
-        println ""
         //ensure to remove the created file
         file.delete()
     }
@@ -60,14 +57,11 @@ class GroovyClosureMethodsTest extends GroovyTestCase {
         def oos = new ObjectOutputStream(new FileOutputStream(file))
         oos.writeObject(file)
 
-        println("Contents of file with one object: " + file)
         int c = 0
         file.eachObject {
-            print "${it} "
             c++
         }
         assert c == 1
-        println ""
         //ensure to remove the created file
         file.delete()
     }
@@ -76,14 +70,12 @@ class GroovyClosureMethodsTest extends GroovyTestCase {
         def file = new File(filename)
         def oos = new ObjectOutputStream(new FileOutputStream(file))
 
-        println("Contents of empty file: " + file)
         int c = 0
         file.eachObject {
             print "${it} "
             c++
         }
         assert c == 0
-        println ""
         //ensure to remove the created file
         file.delete()
     }
@@ -95,14 +87,11 @@ class GroovyClosureMethodsTest extends GroovyTestCase {
         oos.writeObject("foo")
         oos.writeObject(null)
 
-        println("Contents of null file: " + file)
         int c = 0
         file.eachObject {
-            print "${it} "
             c++
         }
         assert c == 3
-        println ""
         //ensure to remove the created file
         file.delete()
     }
@@ -110,39 +99,33 @@ class GroovyClosureMethodsTest extends GroovyTestCase {
     void testEachDir() {
         def dir = new File(dirname_source)
 
-        println("Directories in: " + dir)
         int c = 0
         dir.eachDir {
-            print "${it} "
             c++
         }
-        println ""
         assert c > 0
     }
 
     void testEachFileMatch() {
         def file = new File(dirname_source)
 
-        print "Files with the text Groovy: "
-        file.eachFileMatch(~"^Groovy.*") {
-            print "${it} "
-        }
-        println ""
-
-        print "Files with the text Closure: "
-        file.eachFileMatch(~"^Closure.*") {
-            print "${it} "
-        }
-        println ""
-
-        print "This file is here: "
         int c = 0
+        file.eachFileMatch(~"^Groovy.*") {
+            c++
+        }
+        assert c > 0
+
+        c = 0
+        file.eachFileMatch(~"^Closure.*") {
+            c++
+        }
+        assert c > 0
+
+        c = 0
         file.eachFileMatch(~"^GroovyClosureMethodsTest.groovy") {
-            print "${it} "
             c++
         }
         assert c == 1
-        println ""
     }
 
     void testEachFileOnNonExistingDir() {

--- a/src/test/groovy/GroovyMethodsTest.groovy
+++ b/src/test/groovy/GroovyMethodsTest.groovy
@@ -433,15 +433,6 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert map.size() == 2
     }
 
-    void testDisplaySystemProperties() {
-        println "System properties are..."
-        def properties = System.properties
-        def keys = properties.keySet().sort()
-        for (k in keys) {
-            println "${k} = ${properties[k]}"
-        }
-    }
-
     void testInForLists() {
         def list = ['a', 'b', 'c']
         assert 'b' in list

--- a/src/test/groovy/IfPropertyTest.groovy
+++ b/src/test/groovy/IfPropertyTest.groovy
@@ -24,17 +24,14 @@ class IfPropertyTest extends GroovyTestCase {
 
     // This is because normal classes are not extensible, but scripts are extensible by default.
     Object get(String key) {
-        println("asking for def " + key)
         return dummy
     }
 
     void set(Object key, Object value) {
-        println("setting the def " + key + " to: " + value)
         dummy = value
     }
 
     void testIfNullPropertySet() {
-        def cheese = null
         if (cheese == null) {
             cheese = 1
         }
@@ -45,7 +42,6 @@ class IfPropertyTest extends GroovyTestCase {
     }
 
     void testIfNullPropertySetRecheck() {
-        def cheese = null
         if (cheese == null) {
             cheese = 1
         }

--- a/src/test/groovy/IfTest.groovy
+++ b/src/test/groovy/IfTest.groovy
@@ -24,7 +24,7 @@ class IfTest extends GroovyTestCase {
         def x = 1
 
         if (x) {
-            println "${x} is true"
+            // expected
         }
         else {
             fail("should not be false")
@@ -36,7 +36,7 @@ class IfTest extends GroovyTestCase {
             fail("should not be true")
         }
         else {
-            println "${x} is false"
+            // expected
         }
 
     }
@@ -45,7 +45,7 @@ class IfTest extends GroovyTestCase {
         def x = "abc"
 
         if (x) {
-            println "${x} is true"
+            // expected
         }
         else {
             fail("should not be false")
@@ -57,7 +57,7 @@ class IfTest extends GroovyTestCase {
             fail("should not be true")
         }
         else {
-            println "${x} is false"
+            // expected
         }
     }
 }

--- a/src/test/groovy/LeftShiftTest.groovy
+++ b/src/test/groovy/LeftShiftTest.groovy
@@ -27,8 +27,6 @@ class LeftShiftTest extends GroovyTestCase {
 
         def y = x << 2
 
-        println "Value is $y"
-
         assert y == 16
 
         assert x << 2 == 16
@@ -40,8 +38,6 @@ class LeftShiftTest extends GroovyTestCase {
         for (i in 1..10) {
             list << i
         }
-
-        println "List is $list"
     }
 
     void testLeftShiftOnExpression() {

--- a/src/test/groovy/LoopBreakTest.groovy
+++ b/src/test/groovy/LoopBreakTest.groovy
@@ -30,8 +30,6 @@ class LoopBreakTest extends GroovyTestCase {
 
             assert x < 10 , "Should never get here"
         }
-        
-        println "worked: while completed with value ${x}"
     }
     
     /**
@@ -65,7 +63,5 @@ class LoopBreakTest extends GroovyTestCase {
             }
             assert x < 10 , "Should never get here"
         }
-        
-        println "worked: for loop completed with value ${returnValue}"
     }
  }

--- a/src/test/groovy/MapConstructionTest.groovy
+++ b/src/test/groovy/MapConstructionTest.groovy
@@ -28,13 +28,10 @@ class MapConstructionTest extends GroovyTestCase {
     void testMap() {
         def m = [ 1 : 'abc', 2 : 'def', 3 : 'xyz' ]
 
-        println(m)
-
         def mtoo = [ 1 : [ "innerKey" : "innerValue" ], 2 : m ]
 
-        println(mtoo)
-
         assertMap(m)
+        assert mtoo[2][2] == 'def'
     }
 
     void testMapAsParameter() {

--- a/src/test/groovy/MethodCallTest.groovy
+++ b/src/test/groovy/MethodCallTest.groovy
@@ -21,8 +21,7 @@ package groovy
 class MethodCallTest extends GroovyTestCase {
 
     void testMethodCall() {
-        System.out.print("hello")
-        println("world!")
+        assert Math.max(5, 7) == 7
     }
 
     void testObjectMethodCall() {

--- a/src/test/groovy/MethodCallWithoutParenthesisTest.groovy
+++ b/src/test/groovy/MethodCallWithoutParenthesisTest.groovy
@@ -39,7 +39,6 @@ class MethodCallWithoutParenthesisTest extends GroovyTestCase {
     }
     
     void methodWithOneParam(text) {
-        println("Called method with parameter ${text}")
         assert text == "hello"
         flag = true
     }
@@ -61,7 +60,6 @@ class MethodCallWithoutParenthesisTest extends GroovyTestCase {
     }
 
     def methodWithTwoParams(a, b) {
-        println("Called method with parameters ${a} and ${b}")
         return a + b
     }
 }

--- a/src/test/groovy/MinMaxTest.groovy
+++ b/src/test/groovy/MinMaxTest.groovy
@@ -42,11 +42,7 @@ class MinMaxTest extends GroovyTestCase {
 
         def order = new OrderBy( { it.get('@cheese') } )
 
-        println("People ${people}")
-
         def p = people.min(order)
-
-        println("Found ${p}")
 
         assert p.get("@name") == "Joe" , "found person ${p}"
 

--- a/src/test/groovy/MultilineStringTest.groovy
+++ b/src/test/groovy/MultilineStringTest.groovy
@@ -27,7 +27,6 @@ efg
         hijk
         
 """
-        println(s)
         assert s != null
         def idx = s.indexOf("i")
         assert idx > 0

--- a/src/test/groovy/NewExpressionTest.groovy
+++ b/src/test/groovy/NewExpressionTest.groovy
@@ -26,8 +26,6 @@ class NewExpressionTest extends GroovyTestCase {
         def cheese = new String( "hey you hosers" )
         
         assert cheese != null
-        
-        println(cheese)
     }
 
     void testNewBeanNoArgs() {
@@ -56,8 +54,6 @@ class NewExpressionTest extends GroovyTestCase {
 
     void testNewInstanceWithFullyQualifiedNameNotImported() {
         def bean = new java.io.File("Foo")
-
-        println "Created $bean"
 
         assert bean != null
     }

--- a/src/test/groovy/SafeNavigationTest.groovy
+++ b/src/test/groovy/SafeNavigationTest.groovy
@@ -29,7 +29,6 @@ class SafeNavigationTest extends GroovyTestCase {
     void testNormalPropertyNavigation() {
         def x = ['a':456, 'foo':['bar':123, 'x':456], 'z':99]
         def y = x?.foo?.bar
-        println("found y ${x?.foo?.bar}")
         assert y == 123
     }
 

--- a/src/test/groovy/SimplePostfixTest.groovy
+++ b/src/test/groovy/SimplePostfixTest.groovy
@@ -23,8 +23,6 @@ class SimplePostfixTest extends GroovyTestCase {
     void testPostfix() {
         def x = 1
         ++x
-        println(x)
-
         assert x == 2
     }
 

--- a/src/test/groovy/SingletonBugTest.groovy
+++ b/src/test/groovy/SingletonBugTest.groovy
@@ -17,32 +17,24 @@
  *  under the License.
  */
 package groovy
-// TODO: GROOVY-435
+// GROOVY-435
 
 class SingletonBugTest extends GroovyTestCase {
 
     public void testPrivate() {
         def x = SingletonBugPrivate.getInstance()
         def y = SingletonBugPrivate.getInstance()
-        println "Get one private instance: $x"
-        println "Get another private instance: $y"
         assert x == y
 
-         println(SingletonBugPrivateSecond.getInstanceSecond())
-         println(SingletonBugPrivateSecond.doTestSecond())
-        // shouldFail { println(SingletonBugPrivateSecond.getInstanceSecond()) }
-        // shouldFail { println(SingletonBugPrivateSecond.doTestSecond()) }
+         SingletonBugPrivateSecond.getInstanceSecond() // shouldFail? - super class has single private constructor
+         SingletonBugPrivateSecond.doTestSecond()      // shouldFail? - super class has single private constructor
     }
 
     public void testProtected() {
         def x = SingletonBugProtected.getInstance()
         def y = SingletonBugProtected.getInstance()
-        println "Get one protected instance: $x"
-        println "Get another protected instance: $y"
         assert x == y
 
-        println(SingletonBugProtectedSecond.getInstanceSecond())
-        println(SingletonBugProtectedSecond.doTestSecond())
         x = SingletonBugProtectedSecond.getInstanceSecond()
         y = SingletonBugProtectedSecond.doTestSecond()
         assert x != y

--- a/src/test/groovy/SpreadDotTest.groovy
+++ b/src/test/groovy/SpreadDotTest.groovy
@@ -35,27 +35,28 @@ public class SpreadDotTest extends GroovyTestCase {
         def m2 = ["a":11, "b":22]
         def m3 = ["a":111, "b":222]
         def x = [m1,m2,m3]
-        println x*.a
-        println x*."a"
+        assert x*.a == [1, 11, 111]
+        assert x*."a" == [1, 11, 111]
         assert x == [m1, m2, m3]
 
         def m4 = null
         x << m4
-        println x*.a
-        println x*."a"
+        assert x*.a == [1, 11, 111, null]
+        assert x*."a" == [1, 11, 111, null]
         assert x == [m1, m2, m3, null]
 
+        Date checkDate = new Date()
         def d = new SpreadDotDemo()
         x << d
-        println x*."a"
+        assert x*."a"[4] >= checkDate
         assert x == [m1, m2, m3, null, d]
 
         def y = new SpreadDotDemo2()
-        println y."a"
-        println y.a
+        assert y."a" == 'Attribute Get a'
+        assert y.a == 'Attribute Get a'
 
         x << y
-        println x*."a"
+        assert x*."a"[5] == 'Attribute Get a'
         assert x == [m1, m2, m3, null, d, y]
     }
 

--- a/src/test/groovy/StringBufferTest.groovy
+++ b/src/test/groovy/StringBufferTest.groovy
@@ -38,7 +38,6 @@ class StringBufferTest extends GroovyTestCase {
         assert 'xx0123' == buf.toString(), 'border case left'
         buf = new StringBuffer('0123')
         buf[4..4] = 'xx'
-        println buf.toString()
         assert '0123xx' == buf.toString(), 'border case right'
         // more weird Ranges already tested in ListTest
     }

--- a/src/test/groovy/ThrowTest.groovy
+++ b/src/test/groovy/ThrowTest.groovy
@@ -26,7 +26,6 @@ class ThrowTest extends GroovyTestCase {
         }
         catch (Exception e) {
             assert e.message == "abcd"
-            println("Caught exception ${e}")
         }
     }
 }

--- a/src/test/groovy/ToArrayBugTest.groovy
+++ b/src/test/groovy/ToArrayBugTest.groovy
@@ -37,8 +37,6 @@ class ToArrayBugTest extends GroovyTestCase {
     }
     
     protected def callArrayMethod(array) {
-        System.out.println("Called method with ${array}")
-        
         def list = Arrays.asList(array)
         
         assert list.size() == 4

--- a/src/test/groovy/TripleQuotedStringTest.groovy
+++ b/src/test/groovy/TripleQuotedStringTest.groovy
@@ -27,7 +27,6 @@ class TripleQuotedStringTest extends GroovyTestCase {
     and some escaped \""" quoting and
     an ending""".trim()
 
-        println(s)
         assert s != null
         def idx = s.indexOf("quoting and")
         assert idx > 0

--- a/src/test/groovy/TryCatchTest.groovy
+++ b/src/test/groovy/TryCatchTest.groovy
@@ -38,7 +38,6 @@ class TryCatchTest extends CompilableTestSupport {
         afterTryCatch()
         assert exceptionCalled, "should have invoked the catch clause"
         assert finallyCalled, "should have invoked the finally clause"
-        println("After try/catch")
     }
 
     void testStandaloneTryBlockShouldNotCompile() {
@@ -73,7 +72,6 @@ class TryCatchTest extends CompilableTestSupport {
         }
         assert !exceptionCalled, "should not invoked the catch clause"
         assert finallyCalled, "should have invoked the finally clause"
-        println "After try/catch"
     }
 
     void failingMethod() {
@@ -96,7 +94,6 @@ class TryCatchTest extends CompilableTestSupport {
     void afterTryCatch() {
         assert exceptionCalled, "should have invoked the catch clause"
         assert finallyCalled, "should have invoked the finally clause"
-        println("After try/catch")
     }
 
     protected void setUp() {

--- a/src/test/groovy/WhileLoopTest.groovy
+++ b/src/test/groovy/WhileLoopTest.groovy
@@ -22,7 +22,7 @@ class WhileLoopTest extends GroovyTestCase {
 
     void testVerySimpleWhile() {
         def val = doWhileMethod(0, 5)
-        println(val)
+        assert val == 5
     }
 
     void testWhileWithEmptyBody() {

--- a/src/test/groovy/bugs/AmbiguousListOrMethodTest.groovy
+++ b/src/test/groovy/bugs/AmbiguousListOrMethodTest.groovy
@@ -24,35 +24,26 @@ class AmbiguousListOrMethodTest extends GroovyTestCase {
         def foo = [3, 2, 3]
 
         def val = foo [0]
-        println val
         assert val == 3
     }
 
     void testUndefinedPropertyVersion() {
-        try {
+        shouldFail(MissingPropertyException) {
             def val = this.foo [0]
-            println val
-        }
-        catch (MissingPropertyException e) {
-            println "Worked! Caught missing property $e"
         }
     }
 
     void testMethodCallVersion() {
         def val = foo([0])
-        println val
         assert val == 1
     }
 
 
     def foo(int val) {
-        println "Calling foo method with a int param of val"
-        println val
         return null
     }
 
     def foo(List myList) {
-        println "Calling foo method with a list param of $myList"
         return myList.size()
     }
 

--- a/src/test/groovy/bugs/AsBoolBug.groovy
+++ b/src/test/groovy/bugs/AsBoolBug.groovy
@@ -29,19 +29,15 @@ public class AsBoolBug extends GroovyTestCase {
 
     void testMapAsBool() {
         def a = ["A":123]
-        println ("$a : ${a as Boolean}")
         assert a as Boolean == true
         a = [:]
-        println ("$a : ${a as Boolean}")
         assert a as Boolean == false
     }
 
     void testListAsBool() {
         def b = [123]
-        println ("$b : ${b as Boolean}")
         assert b as Boolean == true
         b = []
-        println ("$b : ${b as Boolean}")
         assert b as Boolean == false
     }
 
@@ -57,32 +53,19 @@ public class AsBoolBug extends GroovyTestCase {
     // This is a test case against GROOVY-812
     void testStringAsBool() {
         def c = "false"
-        println ("$c : ${c as Boolean}")
         assert c as Boolean == true
         assert c as Boolean == (c != null && c.length() > 0)
         boolean z = c
-        println ("$z")
         assert z == true
-        if (c)
-           println "It is true!!"
-        else
-           println "It is false!!"
 
         c = "123"
-        println ("$c : ${c as Boolean}")
         assert c as Boolean == true
         assert c as Boolean == (c != null && c.length() > 0)
 
         c = "False"
-        println ("$c : ${c as Boolean}")
         assert c as Boolean == true
         assert c as Boolean == (c != null && c.length() > 0)
-        if (c)
-           println "It is true!!"
-        else
-           println "It is false!!"
         z = c
-        println ("$z")
         assert z
     }
 }

--- a/src/test/groovy/bugs/AssignmentInsideExpressionBug.groovy
+++ b/src/test/groovy/bugs/AssignmentInsideExpressionBug.groovy
@@ -25,11 +25,15 @@ class AssignmentInsideExpressionBug extends GroovyTestCase {
     void testBug() {
         def x
         if ((x = someMethod()) != null) {
-            println x
+            assert x == 'worked!'
+        } else {
+            fail('x should not be null')
         }
         def y
         if ((y = getFoo()) > 5) {
-            println "y is greater than 5"
+            assert y == 7
+        } else {
+            fail("y [${y}] should be greater than 5")
         }
         
         def a = 123, b = 123

--- a/src/test/groovy/bugs/BlockAsClosureBug.groovy
+++ b/src/test/groovy/bugs/BlockAsClosureBug.groovy
@@ -27,8 +27,6 @@ class BlockAsClosureBug extends GroovyTestCase {
             c = 9
         }
 
-        println(c)
-
         assert c == 9
     }
 
@@ -47,8 +45,6 @@ class BlockAsClosureBug extends GroovyTestCase {
             c = 9
         }
 
-        println(c)
-
         assert c == 9
     }
 
@@ -58,7 +54,6 @@ class BlockAsClosureBug extends GroovyTestCase {
         block: {
             c = 9
         }
-        println(c)
 
         assert c == 9
         return 5

--- a/src/test/groovy/bugs/Bytecode2Bug.groovy
+++ b/src/test/groovy/bugs/Bytecode2Bug.groovy
@@ -44,9 +44,7 @@ class Bytecode2Bug extends GroovyTestCase {
         assert m[2] == 2
         assert m[3] == 3
         assert m[4] == 4
-        
-        println("created: ${m}")
-        
+
         assert i == 5
     }
     
@@ -60,8 +58,6 @@ class Bytecode2Bug extends GroovyTestCase {
         assert m[2] == 2
         assert m[3] == 3
         assert m[4] == 4
-        
-        println("created: ${m}")
         
         assert i == 5
     }

--- a/src/test/groovy/bugs/ClosureVariableBug.groovy
+++ b/src/test/groovy/bugs/ClosureVariableBug.groovy
@@ -38,8 +38,6 @@ class ClosureVariableBug extends GroovyTestCase {
     
         assert foo.a != null
         
-        println "Foo has a = ${foo.a}"
-        
         def value = foo.a()
         assert value == 123
     }

--- a/src/test/groovy/bugs/ConstructorBug.groovy
+++ b/src/test/groovy/bugs/ConstructorBug.groovy
@@ -29,12 +29,8 @@ class ConstructorBug extends GroovyTestCase {
         def type = new GroovyClassLoader().parseClass(new File("src/test/groovy/bugs/TestBase.groovy"))
         assert type != null
 
-        println "created type: ${type}"
-        
         type = new GroovyClassLoader().parseClass(new File("src/test/groovy/bugs/TestDerived.groovy"))
         assert type != null
-
-        println "created type: ${type} of type: ${type.class}"
 
         def mytest = InvokerHelper.invokeConstructorOf(type, ["Hello"] as Object[])
         assert mytest.foo == "Hello"

--- a/src/test/groovy/bugs/ConstructorThisCallBug.groovy
+++ b/src/test/groovy/bugs/ConstructorThisCallBug.groovy
@@ -29,8 +29,7 @@ package groovy.bugs
 
 public class ConstructorThisCallBug extends GroovyTestCase {
     public void testCallA() {
-        println "Testing for a class without call()"
-        def a1 = new ConstructorCallA("foo") 
+        def a1 = new ConstructorCallA("foo")
         def a2 = new ConstructorCallA(9) 
         def a3 = new ConstructorCallA() 
     }
@@ -39,15 +38,12 @@ public class ConstructorThisCallBug extends GroovyTestCase {
 public class ConstructorCallA { 
     public ConstructorCallA() {
         this(19)               // call another constructor
-        println "(1) no argument consructor"
-    } 
+    }
 
     public ConstructorCallA(String a) {
-        println "(2) String value a = $a"
-    } 
+    }
 
     public ConstructorCallA(int a) {
         this("" + (a*a))       // call another constructor
-        println "(3) int value a = $a"
-    } 
+    }
 } 

--- a/src/test/groovy/bugs/ForLoopBug.groovy
+++ b/src/test/groovy/bugs/ForLoopBug.groovy
@@ -59,7 +59,6 @@ class ForLoopBug extends GroovyTestCase {
 
         def lastIndex
         for (i in a..b) {
-            println i
             lastIndex = i
         }
         a = lastIndex

--- a/src/test/groovy/bugs/GetterBug.groovy
+++ b/src/test/groovy/bugs/GetterBug.groovy
@@ -37,11 +37,7 @@ class GetterBug extends GroovyTestCase {
        }
     
     void testTypedGetterAndSetter() {
-        println "Running test"
-        
         def value = getFoo()
-        
-        println "Value is ${value}"
         
         assert value == "James"
         
@@ -65,11 +61,7 @@ class GetterBug extends GroovyTestCase {
     
     
     void testUntypedGetterAndSetter() {
-        println "Running test"
-        
         def value = getBar()
-        
-        println "Value is ${value}"
         
         assert value == "James"
         

--- a/src/test/groovy/bugs/Groovy2350Bug.groovy
+++ b/src/test/groovy/bugs/Groovy2350Bug.groovy
@@ -23,7 +23,6 @@ class Groovy2350Bug extends GroovyTestCase{
      void testNoArg () {
          shouldFail (org.codehaus.groovy.runtime.metaclass.MethodSelectionException) {
              def a = new DefaultNoArgCtor()
-             println a
          }
 
          assertEquals "NULL", new DefaultNoArgCtor2().value

--- a/src/test/groovy/bugs/Groovy2365Bug.java
+++ b/src/test/groovy/bugs/Groovy2365Bug.java
@@ -30,9 +30,7 @@ public class Groovy2365Bug extends Groovy2365Base {
         String path = createData();
 
         try {
-            System.out.println("Test started");
             for (int i = 0; i != 100; ++i ) {
-                    System.out.println("Iter " + i);
                     final GroovyClassLoader groovyLoader = new GroovyClassLoader ();
                     groovyLoader.addClasspath(path);
 

--- a/src/test/groovy/bugs/Groovy2490Bug.groovy
+++ b/src/test/groovy/bugs/Groovy2490Bug.groovy
@@ -20,8 +20,6 @@ package groovy.bugs
 
 class Groovy2490Bug extends GroovyTestCase {
     void test () {
-        System.out.println("One.foo = " + One.foo);
-        System.out.println("Two.foo = " + Two.foo);
         assertEquals One.foo, "hello"
         assertEquals Two.foo, "goodbye"
     }

--- a/src/test/groovy/bugs/Groovy2666Bug.groovy
+++ b/src/test/groovy/bugs/Groovy2666Bug.groovy
@@ -31,7 +31,7 @@ class Groovy2666Bug extends GroovyTestCase{
         try {
             ex ()
         } catch (org.codehaus.groovy.GroovyBugError e) {
-            println "caught"
+            // expected
             return
         } catch (NullPointerException e) {
         }

--- a/src/test/groovy/bugs/Groovy3156And2621Bug.groovy
+++ b/src/test/groovy/bugs/Groovy3156And2621Bug.groovy
@@ -44,7 +44,6 @@ class Groovy3156And2621Bug extends GroovyTestCase {
     }
 
     void convention(String arg) {
-        println 'called'
     }
     
     void failingExecute() {

--- a/src/test/groovy/bugs/Groovy3335Bug.groovy
+++ b/src/test/groovy/bugs/Groovy3335Bug.groovy
@@ -22,6 +22,6 @@ class Groovy3335Bug extends GroovyTestCase {
     void testClassToString() {
         // the following call was resulting in a MethodSelectionException
         // because Integer class defines static toString(int) and toString(int, int) methods
-        println Integer.class.toString()    
+        assert Integer.class.toString()
     }
 }

--- a/src/test/groovy/bugs/Groovy3403Bug.groovy
+++ b/src/test/groovy/bugs/Groovy3403Bug.groovy
@@ -50,7 +50,6 @@ class Groovy3403Bug extends GroovyTestCase {
 
 class Main3403 {
    static test(){
-       println "original call made"
    }
 }
 

--- a/src/test/groovy/bugs/Groovy3405Bug.groovy
+++ b/src/test/groovy/bugs/Groovy3405Bug.groovy
@@ -35,7 +35,5 @@ class Groovy3405Bug extends GroovyTestCase {
         String.metaClass.'static'.testStaticOneParam = { first = "foo" ->  return first }
         assert "baz" == "".testStaticOneParam("baz")
         assert "foo" == "".testStaticOneParam()
-
-        println "Done"
     }
 }

--- a/src/test/groovy/bugs/Groovy3410Bug.groovy
+++ b/src/test/groovy/bugs/Groovy3410Bug.groovy
@@ -78,6 +78,5 @@ class Groovy3410Bug extends GroovyTestCase {
             }   
             println new Groovy3405N5()     
         """
-        println "testClassVerificationErrorsWithBooleanExpUsingPrimitiveFields Done" 
     }
 }

--- a/src/test/groovy/bugs/Groovy3770Bug.groovy
+++ b/src/test/groovy/bugs/Groovy3770Bug.groovy
@@ -49,7 +49,7 @@ class Groovy3770Bug extends GroovyTestCase {
     
     void testCurriedClosuresShouldNotAffectParent() {
         // GROOVY-3875
-        def orig = { tmp -> println tmp }
+        def orig = { tmp -> assert tmp == 1 }
         def curriedOrig = orig.curry(1)
         assert orig != curriedOrig.getOwner()
     }

--- a/src/test/groovy/bugs/Groovy4393Bug.groovy
+++ b/src/test/groovy/bugs/Groovy4393Bug.groovy
@@ -23,9 +23,6 @@ import org.junit.Ignore
 @Ignore('requires a specific configuration, see: https://issues.apache.org/jira/browse/GROOVY-4393 for details')
 class Groovy4393Bug extends GroovyTestCase {
     void testIfSourceFilesWithOtherExtensionsGotCompiledFine() {
-        
-        println Groovy4393BugV1
-        
         assert Groovy4393BugV1 != null
     }
 }

--- a/src/test/groovy/bugs/Groovy6041Bug.groovy
+++ b/src/test/groovy/bugs/Groovy6041Bug.groovy
@@ -48,6 +48,5 @@ class Groovy6041Bug extends StringSourcesStubTestCase {
     @Override
     void verifyStubs() {
         def stubSource = stubJavaSourceFor('Tool')
-        println stubSource
     }
 }

--- a/src/test/groovy/bugs/Groovy770_Bug.groovy
+++ b/src/test/groovy/bugs/Groovy770_Bug.groovy
@@ -30,9 +30,6 @@ class Groovy770_Bug extends GroovyTestCase {
 
         def l1 = [a, b]
         def l2 = [c]
-        println (l1)
-        println (l2)
-        println (l1 - l2)
         assert l1 - l2 == l1
 
 
@@ -41,9 +38,6 @@ class Groovy770_Bug extends GroovyTestCase {
         c = new CPair(sym:"y")
         l1 = [a, b]
         l2 = [c]
-        println (l1)
-        println (l2)
-        println (l1 - l2)
         assert l1 - l2 == [a]
     }
 }

--- a/src/test/groovy/bugs/Groovy872Bug.groovy
+++ b/src/test/groovy/bugs/Groovy872Bug.groovy
@@ -35,6 +35,5 @@ class MyCalendar {
   void tryit ( )  {
     def cal = new GregorianCalendar ( )
     cal.set ( Calendar.DAY_OF_MONTH , 1 )
-    println ( cal.get ( Calendar.DAY_OF_MONTH ) )
   }
 }

--- a/src/test/groovy/bugs/InterfaceImplBug.groovy
+++ b/src/test/groovy/bugs/InterfaceImplBug.groovy
@@ -31,7 +31,6 @@ class InterfaceImplBug extends GroovyTestCase implements FooHandler {
     }
     
     void handle(Reader reader){
-        println("in handle method")
         def called = true
     }
 }

--- a/src/test/groovy/bugs/InvokeNormalMethodFromBuilder_Groovy657Bug.groovy
+++ b/src/test/groovy/bugs/InvokeNormalMethodFromBuilder_Groovy657Bug.groovy
@@ -47,11 +47,10 @@ class Builder extends BuilderSupport {
     Object createNode(Object name, Object value)   { return createNode(name, [:], value) }
 
     Object createNode(Object name, Map attributes, Object value) {
-        println "create ${name}"
         return callOtherStaticallyTypedMethod()
     }
 
-    String callNormalMethod()               { println "normalMethod"; return "first" }
-    String callOtherStaticallyTypedMethod() { println "otherMethod";  return "second" }
+    String callNormalMethod()               { return "first" }
+    String callOtherStaticallyTypedMethod() { return "second" }
     
 }

--- a/src/test/groovy/bugs/NestedClosure2Bug.groovy
+++ b/src/test/groovy/bugs/NestedClosure2Bug.groovy
@@ -40,19 +40,13 @@ class NestedClosure2Bug extends TestSupport {
         def a = 123
         def b = 456
         def closure = {
-            println b
             def c = 999
             return {
                 f = 2222111
                 
-                println f
-                
-                println c
                 def d = 678
                 return { 
-                    println f
                     assert f == 2222111
-                    println d
                     return a
                 }
             }

--- a/src/test/groovy/bugs/NestedClosureBug.groovy
+++ b/src/test/groovy/bugs/NestedClosureBug.groovy
@@ -25,8 +25,7 @@ class NestedClosureBug extends GroovyTestCase {
     void testBug() {
         def a = 123
         getValues().each { 
-            println it
-            it.each { 
+            it.each {
                 assert a == 123
             }
         }

--- a/src/test/groovy/bugs/POJOCallSiteBug.groovy
+++ b/src/test/groovy/bugs/POJOCallSiteBug.groovy
@@ -82,7 +82,6 @@ class POJOCallSiteBug extends GroovyTestCase {
         Double[][] a = new Double[10][10]
         for (def i = 0; i <= 9; i++ ) {
             for (def j = 0; j <= 9; j++ ) {
-                println("i=$i j=$j a[0][i]=$a[0][i]")
                 def o = a[0][i]
                 a[0][i] = o + 1
             }

--- a/src/test/groovy/bugs/PropertyNameBug.groovy
+++ b/src/test/groovy/bugs/PropertyNameBug.groovy
@@ -30,10 +30,6 @@ public class PropertyNameBug extends GroovyTestCase {
         map.put("foo.bar", "FooBar")
         map.put("foo.bar-bar", "FooBar-Bar")
         map.put("foo.=;&|^*-+-/\\'?.*:arbitrary()[]{}%#@!", "Any character")
-
-        println("foo.bar1 = ${map.get("foo.bar1")}")
-        println("foo.bar-bar = ${map.get("foo.bar-bar")}")
-        println("Specical Character Test: ${map.get("foo.=;&|^*-+-/\\'?.*:arbitrary()[]{}%#@!")}")
     }
 
     void testNonJavaIdentifierChacactersWithGroovySyntax() {
@@ -41,10 +37,6 @@ public class PropertyNameBug extends GroovyTestCase {
         map."foo.bar" = "FooBar"
         map."foo.bar-bar" = "FooBar-Bar"
         map."foo.=;&|^*-+-/\\'?.*:arbitrary()[]{}%#@!" = "Any character"
-
-        println("foo.bar1 = ${map."foo.bar1"}")
-        println("foo.bar-bar = ${map."foo.bar-bar"}")
-        println("Specical Character Test: ${map."foo.=;&|^*-+-/\\'?.*:arbitrary()[]{}%#@!"}")
     }
 }
 

--- a/src/test/groovy/bugs/RodsBug.groovy
+++ b/src/test/groovy/bugs/RodsBug.groovy
@@ -39,7 +39,6 @@ class RodsBug extends GroovyTestCase {
         if (x > 0) {
             //String name = "Rod"
             def name = "Rod"
-            println(name)
         }
     }
     

--- a/src/test/groovy/bugs/RussellsOptionalParenTest.groovy
+++ b/src/test/groovy/bugs/RussellsOptionalParenTest.groovy
@@ -23,7 +23,7 @@ class RussellsOptionalParenTest extends GroovyTestCase {
     void testMethodCallWithOneParam() {
         def adob = new ArrayList()
         adob.add "hello"
-        println adob.get(0)
-        println adob.size()
+        assert adob.get(0) == 'hello'
+        assert adob.size() == 1
     }
 }

--- a/src/test/groovy/bugs/SubscriptOnStringArrayBug.groovy
+++ b/src/test/groovy/bugs/SubscriptOnStringArrayBug.groovy
@@ -28,8 +28,6 @@ class SubscriptOnStringArrayBug extends TestSupport {
         array[0] = "d"
         
         assert array[0] == "d"
-        
-        println("Contents of array are ${array.inspect()}")
     }
     
     void testRobsTestCase() {

--- a/src/test/groovy/bugs/SynchronizedBytecodeBug.groovy
+++ b/src/test/groovy/bugs/SynchronizedBytecodeBug.groovy
@@ -31,21 +31,14 @@ class SynchronizedBytecodeBug extends GroovyTestCase {
         Integer foo = 0
 
         Thread.start{
-            println "sleeping for a moment"
             sleep 100
-            println "slept and synchronizing from thread"
             synchronized(foo) {
-                println "notifying"
                 foo.notify()
-                println "notified"
             }
         }
 
-        println "synchronizing"
         synchronized(foo) {
-            println "starting to wait"
             foo.wait()
-            println "waited"
         }
 
         // if this point is reached, the test worked :-)

--- a/src/test/groovy/bugs/TestSupport.java
+++ b/src/test/groovy/bugs/TestSupport.java
@@ -49,8 +49,6 @@ public abstract class TestSupport extends GroovyTestCase {
     }
 
     public Iterator iterator() {
-        System.out.println("Calling custom iterator() method for " + this);
-
         return Arrays.asList(getMockArguments()).iterator();
     }
 }

--- a/src/test/groovy/bugs/ToStringBug.groovy
+++ b/src/test/groovy/bugs/ToStringBug.groovy
@@ -23,13 +23,8 @@ package groovy.bugs
 class ToStringBug extends GroovyTestCase {
 
     void testBug() {
-        println "Starting test"
-
         def value = toString()
         assert value != null
-
-        println value
-        println "Found value ${value}"
     }
 
     String toString() {

--- a/src/test/groovy/execute/ExecuteTest.groovy
+++ b/src/test/groovy/execute/ExecuteTest.groovy
@@ -33,42 +33,36 @@ class ExecuteTest extends GroovyTestCase {
     }
 
     void testExecuteCommandLineProcessUsingAString() {
-        println "Executing String command: $cmd"
         StringBuffer sbout = new StringBuffer()
         StringBuffer sberr = new StringBuffer()
         def process = cmd.execute()
         process.waitForProcessOutput sbout, sberr
         def value = process.exitValue()
         int count = sbout.toString().readLines().size()
-        println "Exit value: $value, Err lines: ${sberr.toString().readLines().size()}, Out lines: $count"
         assert count > 1
         assert value == 0
     }
 
     void testExecuteCommandLineProcessUsingAStringArray() {
         def cmdArray = cmd.split(' ')
-        println "Executing String[] command: $cmdArray"
         StringBuffer sbout = new StringBuffer()
         StringBuffer sberr = new StringBuffer()
         def process = cmdArray.execute()
         process.waitForProcessOutput sbout, sberr
         def value = process.exitValue()
         int count = sbout.toString().readLines().size()
-        println "Exit value: $value, Err lines: ${sberr.toString().readLines().size()}, Out lines: $count"
         assert count > 1
         assert value == 0
     }
 
     void testExecuteCommandLineProcessUsingAList() {
         List<String> cmdList = Arrays.asList(cmd.split(' '))
-        println "Executing List<String> command: $cmdList"
         StringBuffer sbout = new StringBuffer()
         StringBuffer sberr = new StringBuffer()
         def process = cmdList.execute()
         process.waitForProcessOutput sbout, sberr
         def value = process.exitValue()
         int count = sbout.toString().readLines().size()
-        println "Exit value: $value, Err lines: ${sberr.toString().readLines().size()}, Out lines: $count"
         assert count > 1
         assert value == 0
     }
@@ -91,9 +85,6 @@ class ExecuteTest extends GroovyTestCase {
         terr.join()
         def value = process.exitValue()
         int count = sbout.toString().readLines().size()
-        println "Heaps of time case: Exit value: $value, Err lines: ${sberr.toString().readLines().size()}, Out lines: $count"
-        System.err.println 'std err: ' + sberr.toString()
-        System.err.println 'std out: ' + sbout.toString()
 //        assert sbout.toString().contains('Done'), "Expected 'Done' but found: " + sbout.toString() + " with error: " + sberr.toString()
         assert value == 0
 
@@ -108,20 +99,17 @@ class ExecuteTest extends GroovyTestCase {
         terr.join()
         value = process.exitValue()
         count = sbout.toString().readLines().size()
-        println "Insufficient time case: Exit value: $value, Err lines: ${sberr.toString().readLines().size()}, Out lines: $count"
         assert !sbout.toString().contains('Done')
         assert value != 0 // should have been killed
     }
 
     void testExecuteCommandLineUnderWorkingDirectory() {
-        println "Executing command in dir '..': $cmd"
         StringBuffer sbout = new StringBuffer()
         StringBuffer sberr = new StringBuffer()
         def process = cmd.execute(null, new File('..'))
         process.waitForProcessOutput sbout, sberr
         def value = process.exitValue()
         int count = sbout.toString().readLines().size()
-        println "Exit value: $value, Err lines: ${sberr.toString().readLines().size()}, Out lines: $count"
         assert count > 1
         assert value == 0
     }
@@ -135,14 +123,12 @@ class ExecuteTest extends GroovyTestCase {
                 "println(System.getenv('foo'))"]
         println "Executing this command:\n${java.join(' ')}"
         def props = ["foo=bar"]
-        println "With these props: $props"
         StringBuffer sbout = new StringBuffer()
         StringBuffer sberr = new StringBuffer()
         def process = java.execute(props, null)
         process.waitForProcessOutput sbout, sberr
         def value = process.exitValue()
         int count = sbout.toString().readLines().size()
-        println "Exit value: $value, Err lines: ${sberr.toString().readLines().size()}, Out lines: $count"
         assert sbout.toString().contains('bar')
         assert value == 0
     }

--- a/src/test/groovy/lang/ClassReloadingTest.groovy
+++ b/src/test/groovy/lang/ClassReloadingTest.groovy
@@ -125,7 +125,6 @@ class ClassReloadingTest extends GroovyTestCase {
               }
             """
             def groovyClass = cl.loadClass(className, true, false)
-            println System.identityHashCode(groovyClass)
             assert !groovyClass.declaredFields.any { it.name.contains('__timeStamp') }
             def message = groovyClass.newInstance().greeting
             assert "hello" == message
@@ -148,7 +147,6 @@ class ClassReloadingTest extends GroovyTestCase {
 
             // reload
             groovyClass = cl.loadClass(className, true, false)
-            println System.identityHashCode(groovyClass)
             assert groovyClass.declaredFields.any { it.name.contains('__timeStamp') }
             message = groovyClass.newInstance().greeting
             assert "goodbye" == message

--- a/src/test/groovy/lang/ExpandoMetaClassTest.groovy
+++ b/src/test/groovy/lang/ExpandoMetaClassTest.groovy
@@ -566,7 +566,6 @@ class ExpandoMetaClassTest extends GroovyTestCase {
     }
 
     void testBorrowByName() {
-        println 'testBorrowByName'
         def metaClass = new ExpandoMetaClass(EMCT_Class.class)
 
         def a = new EMCT_Another()

--- a/src/test/org/codehaus/groovy/runtime/MethodFailureTest.java
+++ b/src/test/org/codehaus/groovy/runtime/MethodFailureTest.java
@@ -38,7 +38,7 @@ public class MethodFailureTest extends GroovyTestCase {
             fail("Should have thrown an exception");
         }
         catch (GroovyRuntimeException e) {
-            System.out.println(e);
+            // expected
         }
     }
 
@@ -50,8 +50,7 @@ public class MethodFailureTest extends GroovyTestCase {
             fail("Should have thrown an exception");
         }
         catch (GroovyRuntimeException e) {
-            System.out.println(e);
-            //e.printStackTrace();
+            // expected
         }
     }
 
@@ -67,8 +66,7 @@ public class MethodFailureTest extends GroovyTestCase {
             fail("Should have thrown an exception");
         }
         catch (GroovyRuntimeException e) {
-            System.out.println(e);
-            //e.printStackTrace();
+            // expected
         }
     }
 

--- a/src/test/org/codehaus/groovy/runtime/NewStaticMetaMethodTest.java
+++ b/src/test/org/codehaus/groovy/runtime/NewStaticMetaMethodTest.java
@@ -49,15 +49,11 @@ public class NewStaticMetaMethodTest extends TestCase {
 
         Object answer = metaMethod.invoke("abc", new Object[]{"123"});
         assertEquals("abc123", answer);
-
-        System.out.println("Found: " + answer);
     }
 
     public void testInvokeDefaultGroovyMethodUsingMetaClass() {
         Object answer = InvokerHelper.invokeMethod("abc", "plus", new Object[]{"123"});
         assertEquals("abc123", answer);
-
-        System.out.println("Found: " + answer);
     }
 
     public static String dummyMethod(String foo, String bar) throws Exception {

--- a/src/test/org/codehaus/groovy/runtime/PropertyTest.java
+++ b/src/test/org/codehaus/groovy/runtime/PropertyTest.java
@@ -161,7 +161,6 @@ public class PropertyTest extends GroovyTestCase {
         Process process = ProcessGroovyMethods.execute(java);
         Object value = InvokerHelper.getProperty(process, "in");
         assertNotNull(value);
-        System.out.println("Found in: " + value);
         process.destroy();
     }
 

--- a/src/test/org/codehaus/groovy/runtime/StaticInitTest.java
+++ b/src/test/org/codehaus/groovy/runtime/StaticInitTest.java
@@ -29,7 +29,6 @@ class X {
 
     static {
         StaticInitTest.failed = true;
-        System.out.println("INIT");
     }
 }
 
@@ -38,12 +37,9 @@ public class StaticInitTest extends TestCase {
     static boolean failed;
 
     public void testInitOrder () throws NoSuchFieldException, IllegalAccessException, ClassNotFoundException {
-        System.out.println("GET FIELD");
         final Field f = new GroovyClassLoader().loadClass("org.codehaus.groovy.runtime.X", false, false, false).getField("field");
-        System.out.println(failed);
         assertTrue(!failed);
         f.getInt(null);
-        System.out.println(failed);
         assertTrue(failed);
     }
 }

--- a/src/test/org/codehaus/groovy/tools/TestDgmConverter.java
+++ b/src/test/org/codehaus/groovy/tools/TestDgmConverter.java
@@ -47,8 +47,6 @@ public class TestDgmConverter extends TestCase {
             File file = files[i];
             final String name = file.getName();
             if (name.startsWith("dgm$")) {
-                System.out.println(name);
-
                 final String className = "org.codehaus.groovy.runtime." + name.substring(0, name.length() - ".class".length());
                 try {
                     Class cls = Class.forName(className, false, DefaultGroovyMethods.class.getClassLoader());
@@ -72,9 +70,6 @@ public class TestDgmConverter extends TestCase {
     public void testRegistry () {
         final MetaClassRegistryImpl metaClassRegistry = new MetaClassRegistryImpl();
         final Object [] instanceMethods = metaClassRegistry.getInstanceMethods().getArray();
-        for (int i = 0; i < instanceMethods.length; i++) {
-            System.out.println(instanceMethods[i]);
-
-        }
+        assertTrue(instanceMethods.length > 0);
     }
 }

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/AnnotationMemberValuesResolutionV1StubsTest.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/AnnotationMemberValuesResolutionV1StubsTest.groovy
@@ -27,7 +27,6 @@ package org.codehaus.groovy.tools.stubgenerator
 class AnnotationMemberValuesResolutionV1StubsTest extends StringSourcesStubTestCase {
 
     Map<String, String> provideSources() {
-        println 'AnnotationMemberValuesResolutionStubsTestV1'
         [
             'foo/Foo4434V1.java': '''
                 package foo;

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/AnnotationMemberValuesResolutionV2StubsTest.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/AnnotationMemberValuesResolutionV2StubsTest.groovy
@@ -26,7 +26,6 @@ package org.codehaus.groovy.tools.stubgenerator
 class AnnotationMemberValuesResolutionV2StubsTest extends StringSourcesStubTestCase {
 
     Map<String, String> provideSources() {
-        println 'AnnotationMemberValuesResolutionStubsTestV2'
         [
             'foo/Foo4434V2.java': '''
                 package foo;

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/AnnotationMemberValuesResolutionV3StubsTest.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/AnnotationMemberValuesResolutionV3StubsTest.groovy
@@ -26,7 +26,6 @@ package org.codehaus.groovy.tools.stubgenerator
 class AnnotationMemberValuesResolutionV3StubsTest extends StringSourcesStubTestCase {
 
     Map<String, String> provideSources() {
-        println 'AnnotationMemberValuesResolutionStubsTestV3'
         [
             'foo/Foo4434V3.java': '''
                 package foo;

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/DuplicateMethodAdditionInStubsTest.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/DuplicateMethodAdditionInStubsTest.groovy
@@ -55,6 +55,5 @@ class DuplicateMethodAdditionInStubsTest extends StringSourcesStubTestCase {
     void verifyStubs() {
         assert classes.size() == 2
         assert classes['de.app.User4453'].methods['setName'].size() == 2
-        println 'DuplicateMethodAdditionInStubsTest - verified'
     }
 }

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/Groovy5859Bug.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/Groovy5859Bug.groovy
@@ -36,7 +36,6 @@ class TaggedsMap extends Groovy5859Support {
     @Override
     void verifyStubs() {
         def stubSource = stubJavaSourceFor('TaggedsMap')
-        println stubSource
         assert stubSource.contains('super ((java.util.SortedMap)null);')
     }
 }

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/StubGenerationForAnAnnotationStubsTest.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/StubGenerationForAnAnnotationStubsTest.groovy
@@ -47,7 +47,5 @@ class StubGenerationForAnAnnotationStubsTest extends StringSourcesStubTestCase {
         String annotationClassSource = stubJavaSourceFor('Foo4451')
         assert annotationClassSource.contains('public @interface Foo4451')
         assert !annotationClassSource.contains('java.lang.annotation.Annotation')
-
-        println 'StubGenerationForAnAnnotationStubsTest - verified'
     }
 }

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/StubGenerationForConstructorWithOptionalArgsStubsTest.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/StubGenerationForConstructorWithOptionalArgsStubsTest.groovy
@@ -26,7 +26,6 @@ package org.codehaus.groovy.tools.stubgenerator
 class StubGenerationForConstructorWithOptionalArgsStubsTest extends StringSourcesStubTestCase {
 
     Map<String, String> provideSources() {
-        println 'StubGenerationForConstructorWithOptionalArgsStubsTest'
         [
             'Base4508.java': '''
                 class Base4508 {

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/UnAmbigousSuperConstructorCallStubsTest.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/UnAmbigousSuperConstructorCallStubsTest.groovy
@@ -50,6 +50,5 @@ class UnAmbigousSuperConstructorCallStubsTest extends StringSourcesStubTestCase 
         assert classes['UserAuthException'] != null
         String stubSource = stubJavaSourceFor('UserAuthException')
         assert !stubSource.contains('super (null)')
-        println 'UnAmbigousSuperConstructorCallStubsTest - verified'
     }
 }

--- a/subprojects/groovy-xml/src/test/groovy/groovy/bugs/Groovy249_Bug.groovy
+++ b/subprojects/groovy-xml/src/test/groovy/groovy/bugs/Groovy249_Bug.groovy
@@ -28,8 +28,6 @@ class Groovy249_Bug extends GroovyTestCase {
     void testBug() {
         def t = new Bean249()
         t.b = "hello"
-        println t.b
-        println "test: ${t.b}"
         
         def xml = new MarkupBuilder()
         def root = xml.foo {


### PR DESCRIPTION
In many cases asserts were already in place to ensure the expected
output.  In places were asserts did not already exist, the println
calls were replaced by asserts.