### PR TITLE
Add tests for valid and invalid integer literals (shouldCompile/shouldNotCompile)

### DIFF
--- a/src/spec/test/SyntaxTest.groovy
+++ b/src/spec/test/SyntaxTest.groovy
@@ -153,6 +153,33 @@ class SyntaxTest extends CompilableTestSupport {
         '''
     }
 
+    void testValidIntegerLiterals() {
+        shouldCompile '''
+             def a = 2147483647I
+             def b = -2147483648I
+             def c = -2147483647I
+             def d = 9223372036854775807L
+             def e = -9223372036854775808L
+             def f = -9223372036854775807L
+         '''
+    }
+
+    void testInvalidIntegerLiteral() {
+        shouldNotCompile '''
+            // tag::invalid_integer_literal[]
+            def n = 2147483648I
+            // end::invalid_integer_literal[]
+        '''
+    }
+
+    void testInvalidLongLiteral() {
+        shouldNotCompile '''
+            // tag::invalid_long_literal[]
+            def n = 9223372036854775808L
+            // end::invalid_long_literal[]
+        '''
+    }
+
     void testAllKeywordsAreValidIdentifiersFollowingADot() {
         shouldCompile '''
         def foo = [:]


### PR DESCRIPTION
Add tests for integer literals that `shouldCompile` and `shouldNotCompile`.

Some of these tests currently fail because of [GROOVY-7385](https://issues.apache.org/jira/browse/GROOVY-7385).

I'm not sure what the right way is to submit failing tests, so please let me know if I should change things up. This PR was submitted earlier, but was lost when GROOVY-7385 was closed -- before it was reopened.

