### PR TITLE
GROOVY-7569: Use verbose formatting for PowerAsserts

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/powerassert/AssertionRenderer.java
+++ b/src/main/org/codehaus/groovy/runtime/powerassert/AssertionRenderer.java
@@ -21,6 +21,7 @@ package org.codehaus.groovy.runtime.powerassert;
 import java.util.*;
 
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.codehaus.groovy.runtime.InvokerHelper;
 
 /**
  * Creates a string representation of an assertion and its recorded values.
@@ -151,7 +152,7 @@ public final class AssertionRenderer {
         String toString;
 
         try {
-            toString = DefaultGroovyMethods.toString(value);
+            toString = InvokerHelper.format(value, true, -1, false);
         } catch (Exception e) {
             return String.format("%s (toString() threw %s)",
                     javaLangObjectToString(value), e.getClass().getName());

--- a/src/test/org/codehaus/groovy/runtime/powerassert/AssertionRenderingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/powerassert/AssertionRenderingTest.groovy
@@ -88,7 +88,7 @@ assert a.get(b) == null
         isRendered """
 assert [1]."\$x"(0) == null
            | |     |
-           1 get   false
+           1 'get' false
         """, {
             def x = "get"
             assert [1]."$x"(0) == null
@@ -378,7 +378,7 @@ assert holder.@x
 assert a.&"\$b" == null
        |    |  |
        []   |  false
-            get
+            'get'
         """, {
             def a = []
             def b = "get"
@@ -469,7 +469,7 @@ assert [1, *a] == null
         isRendered """
 assert one(*:m)
        |     |
-       0     [a:1, b:2]
+       0     ['a':1, 'b':2]
         """, {
             def m = [a:1, b:2]
             assert one(*:m)
@@ -479,7 +479,7 @@ assert one(*:m)
 assert [a:1, *:m] == null
                |  |
                |  false
-               [b:2, c:3]
+               ['b':2, 'c':3]
         """, {
             def m = [b:2, c:3]
             assert [a:1, *:m] == null

--- a/src/test/org/codehaus/groovy/runtime/powerassert/ValueRenderingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/powerassert/ValueRenderingTest.groovy
@@ -54,7 +54,7 @@ assert x == null
 assert x == null
        | |
        | false
-       foo
+       'foo'
         """, {
             def x = "foo"
             assert x == null
@@ -65,10 +65,7 @@ assert x == null
         isRendered """
 assert null == x
             |  |
-            |  one
-            |  two
-            |  three
-            |  four
+            |  'one\\ntwo\\rthree\\r\\nfour'
             false
         """, {
             def x = "one\ntwo\rthree\r\nfour"
@@ -93,7 +90,7 @@ assert x == null
 assert x == null
        | |
        | false
-       [one, two]
+       ['one', 'two']
         """, {
             def x = ["one", "two"] as String[]
             assert x == null
@@ -107,7 +104,7 @@ assert x == null
 assert x == null
        | |
        | false
-       ""
+       ''
         ''', {
             assert x == null
         }


### PR DESCRIPTION
See JIRA for more explanation. (https://issues.apache.org/jira/browse/GROOVY-7569)

This was based on the recently merged GROOVY-7563, so not sure if can be backported without those other commits.
