### PR TITLE
GROOVY-7902: collate() infinite loop with zeroed step

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -3055,6 +3055,9 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         if (size <= 0 || selfList.isEmpty()) {
             answer.add(selfList);
         } else {
+            if (step == 0) {
+                step = size;
+            }
             for (int pos = 0; pos < selfList.size() && pos > -1; pos += step) {
                 if (!keepRemainder && pos > selfList.size() - size) {
                     break ;

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -3047,6 +3047,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @param step          the number of elements to step through for each sub-list
      * @param keepRemainder if true, any remaining elements are returned as sub-lists.  Otherwise they are discarded
      * @return a List containing the data collated into sub-lists
+     * @throws IllegalArgumentException if the step is zero.
      * @since 2.4.0
      */
     public static <T> List<List<T>> collate(Iterable<T> self, int size, int step, boolean keepRemainder) {
@@ -3055,9 +3056,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         if (size <= 0 || selfList.isEmpty()) {
             answer.add(selfList);
         } else {
-            if (step == 0) {
-                step = size;
-            }
+            if (step == 0) throw new IllegalArgumentException("step cannot be zero");
             for (int pos = 0; pos < selfList.size() && pos > -1; pos += step) {
                 if (!keepRemainder && pos > selfList.size() - size) {
                     break ;

--- a/src/test/groovy/CollateTest.groovy
+++ b/src/test/groovy/CollateTest.groovy
@@ -91,6 +91,10 @@ class CollateTest extends GroovyTestCase {
     assert [ 1, 2, 3 ].collate( 2, -1 ) == [[ 1, 2 ]]
   }
 
+  void testZeroedStep() {
+    assert [ 1, 2, 3 ].collate( 2, 0 ) == [[1, 2], [3]]
+  }
+
   void testChaining() {
     def list = 1..15
     def expected = [ [ [ 1, 2, 3],  [ 4, 5, 6] ],

--- a/src/test/groovy/CollateTest.groovy
+++ b/src/test/groovy/CollateTest.groovy
@@ -92,7 +92,10 @@ class CollateTest extends GroovyTestCase {
   }
 
   void testZeroedStep() {
-    assert [ 1, 2, 3 ].collate( 2, 0 ) == [[1, 2], [3]]
+    String message = shouldFail (IllegalArgumentException) {
+      [ 1, 2, 3 ].collate( 2, 0 )
+    }
+    assert message == 'step cannot be zero'
   }
 
   void testChaining() {


### PR DESCRIPTION
Fixing infinite loop in `Iterable.collate` method when `step` parameter is equals to zero.

Example:
```groovy
[ 1, 2, 3 ].collate( 2, 0 )
```
The result is a infinite loop because the step parameter is used directly in the for increment: `pos += step` 

In the fixing  I assumed that the `step` parameter should be equals to `size` parameter, looks like in the `collate(self, size, size, keepRemainder)` overloaded method, with absence of `step` and I considered backward compatibility with negative steps.

Thks.
Felipe Mamud