### PR TITLE
GROOVY-7888: Type checker infers wrong type on compound assignment (e…

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionMultiTypeDispatcher.java
@@ -33,6 +33,7 @@ import org.codehaus.groovy.classgen.AsmClassGenerator;
 import org.codehaus.groovy.runtime.BytecodeInterface8;
 
 import static org.codehaus.groovy.ast.ClassHelper.*;
+import static org.codehaus.groovy.syntax.TokenUtil.removeAssignment;
 import static org.codehaus.groovy.syntax.Types.*;
 import static org.codehaus.groovy.ast.tools.WideningCategories.*;
 
@@ -40,8 +41,6 @@ import static org.codehaus.groovy.ast.tools.WideningCategories.*;
  * This class is for internal use only!
  * This class will dispatch to the right type adapters according to the 
  * kind of binary expression that is provided.
- * @author <a href="mailto:blackdrag@gmx.org">Jochen "blackdrag" Theodorou</a>
- * @author Roshan Dawrani
  */
 public class BinaryExpressionMultiTypeDispatcher extends BinaryExpressionHelper {
     
@@ -243,28 +242,7 @@ public class BinaryExpressionMultiTypeDispatcher extends BinaryExpressionHelper 
         if (leftBinExpr.getOperation().getType() != LEFT_SQUARE_BRACKET) return false;
         return true;
     }
-    
-    private static int removeAssignment(int op) {
-        switch (op) {
-            case PLUS_EQUAL: return PLUS;
-            case MINUS_EQUAL: return MINUS;
-            case MULTIPLY_EQUAL: return MULTIPLY;
-            case LEFT_SHIFT_EQUAL: return LEFT_SHIFT;
-            case RIGHT_SHIFT_EQUAL: return RIGHT_SHIFT;
-            case RIGHT_SHIFT_UNSIGNED_EQUAL: return RIGHT_SHIFT_UNSIGNED;
-            case LOGICAL_OR_EQUAL: return LOGICAL_OR;
-            case LOGICAL_AND_EQUAL: return LOGICAL_AND;
-            case MOD_EQUAL: return MOD;
-            case DIVIDE_EQUAL: return DIVIDE;
-            case INTDIV_EQUAL: return INTDIV;
-            case POWER_EQUAL: return POWER;
-            case BITWISE_OR_EQUAL: return BITWISE_OR;
-            case BITWISE_AND_EQUAL: return BITWISE_AND;
-            case BITWISE_XOR_EQUAL: return BITWISE_XOR;
-            default: return op;
-        }
-    }
-    
+
     private boolean doAssignmentToArray(BinaryExpression binExp) {
         if (!isAssignmentToArray(binExp)) return false;
         // we need to handle only assignment to arrays combined with an operation

--- a/src/main/org/codehaus/groovy/syntax/TokenUtil.java
+++ b/src/main/org/codehaus/groovy/syntax/TokenUtil.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.codehaus.groovy.syntax;
+
+import static org.codehaus.groovy.syntax.Types.*;
+
+public class TokenUtil {
+    private TokenUtil() {
+    }
+
+    public static int removeAssignment(int op) {
+        switch (op) {
+            case PLUS_EQUAL: return PLUS;
+            case MINUS_EQUAL: return MINUS;
+            case MULTIPLY_EQUAL: return MULTIPLY;
+            case LEFT_SHIFT_EQUAL: return LEFT_SHIFT;
+            case RIGHT_SHIFT_EQUAL: return RIGHT_SHIFT;
+            case RIGHT_SHIFT_UNSIGNED_EQUAL: return RIGHT_SHIFT_UNSIGNED;
+            case LOGICAL_OR_EQUAL: return LOGICAL_OR;
+            case LOGICAL_AND_EQUAL: return LOGICAL_AND;
+            case MOD_EQUAL: return MOD;
+            case DIVIDE_EQUAL: return DIVIDE;
+            case INTDIV_EQUAL: return INTDIV;
+            case POWER_EQUAL: return POWER;
+            case BITWISE_OR_EQUAL: return BITWISE_OR;
+            case BITWISE_AND_EQUAL: return BITWISE_AND;
+            case BITWISE_XOR_EQUAL: return BITWISE_XOR;
+            default: return op;
+        }
+    }
+}

--- a/src/test/groovy/transform/stc/Groovy7888Bug.groovy
+++ b/src/test/groovy/transform/stc/Groovy7888Bug.groovy
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform.stc
+
+class Groovy7888Bug extends GroovyTestCase {
+    void testCompoundAssignmentUsesCorrectType() {
+        assertScript '''
+            class ContainsSet {
+                private Set<File> files = new HashSet<File>()
+                Set<File> getFiles() { files }
+                void setFiles(Set<File> files) { this.files = files }
+            }
+
+            @groovy.transform.TypeChecked
+            def modifyIdeaModel(ContainsSet set, File foo) {
+                set.files += foo
+            }
+
+            def cs = new ContainsSet()
+            modifyIdeaModel(cs, new File('foo'))
+            assert cs.files.size() == 1
+        '''
+    }
+}


### PR DESCRIPTION
….g. += for collection) for property