### PR TITLE
Document error fix: instantiation using wrong parameter

### DIFF
--- a/src/spec/test/DesignPatternsTest.groovy
+++ b/src/spec/test/DesignPatternsTest.groovy
@@ -204,7 +204,7 @@ class DesignPatternsTest extends CompilableTestSupport {
             // tag::adapter_inheritance_usage[]
             def hole = new RoundHole(radius: 4.0)
             (4..7).each { w ->
-                def peg = new SquarePegAdapter(peg: new SquarePeg(width: w))
+                def peg = new SquarePegAdapter(width: w)
                 if (hole.pegFits(peg)) {
                     println "peg $peg fits in hole $hole"
                 } else {


### PR DESCRIPTION
Fixed 1 error of code in this page: [Design patterns in Groovy](http://groovy-lang.org/design-patterns.html), under section 1.2.2.