### PR TITLE
Extra test cases for Collection .intersect() and .disjoint()

### DIFF
--- a/src/test/groovy/GroovyMethodsTest.groovy
+++ b/src/test/groovy/GroovyMethodsTest.groovy
@@ -1558,6 +1558,7 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert [] == [].intersect([4, 5, 6, 7, 8])
         assert [] == [1, 2, 3, 4, 5].intersect([])
         assert [4, 5] == [1, 2, 3, 4, 5].intersect([4, 5, 6, 7, 8])
+        assert [[0, 1]] == [[0, 0], [0, 1]].intersect([[0, 1], [1, 1]])
     }
 
     void testIntersectForIterables() {
@@ -1573,12 +1574,17 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert [4, 5] == iterableA.intersect(iterableB)
     }
 
-    // GROOVY-7602
     void testIntersectForMaps() {
+        // GROOVY-7602
         def list1 = [[language: 'Java'], [language: 'Groovy'], [language: 'Scala']]
         def list2 = [[language: 'Groovy'], [language: 'JRuby'], [language: 'Java']]
         def intersection = list1.intersect(list2)
         assert intersection == [[language: 'Groovy'], [language: 'Java']]
+
+        def locs1 = [[loc: [0, 1]], [loc: [1, 1]]]
+        def locs2 = [[loc: [2, 1]], [loc: [1, 1]]]
+        def locInter = [[loc: [1, 1]]]
+        assert [[loc: [1, 1]]] == locs1.intersect(locs2)
     }
 
     // GROOVY-7602
@@ -1590,11 +1596,15 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert c1.intersect(c2)
     }
 
-    // GROOVY-7530
     void testDisjointForMaps() {
+        // GROOVY-7530
         def list1 = [[language: 'Java'], [language: 'Groovy'], [language: 'Scala']]
         def list2 = [[language: 'Groovy'], [language: 'JRuby'], [language: 'Java']]
         assert !list1.disjoint(list2)
+
+        def locs1 = [[loc: [0, 1]], [loc: [1, 1]]]
+        def locs2 = [[loc: [2, 1]], [loc: [1, 1]]]
+        assert !locs1.disjoint(locs2)
     }
 
     class Foo {
@@ -1628,6 +1638,7 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert [1, 2, 3, 4, 5].disjoint([])
         assert ![1, 2, 3, 4, 5].disjoint([4, 5, 6, 7, 8])
         assert [1, 2, 3].disjoint([4, 5, 6, 7, 8])
+        assert ![[0, 0], [0, 1]].disjoint([[0, 1], [1, 1]])
     }
 
     void testDisjointForIterables() {


### PR DESCRIPTION
`Collection.intersect()` was partly broken (or at least utterly inconsistent) between versions `2.4.2` and `2.4.6`. Simple test case:

    def foo = [[0, 0], [0, 1]]
    def bar = [[0, 1], [1, 1]]
    assert [[0, 1]] == foo.intersect(bar)

would fail in the aforementioned versions as `[]` would be returned. This is fixed in `2.4.7` but to avoid future regressions, it is nice to have test covering this case, as suggested by @glaforge and @sbglasius on [Twitter](https://twitter.com/YouriAckx/status/769230038847918080?lang=en).

A basic search didn't reveal any similar test cases (some `Foo` intersection comparison can be found but it can be seen as a different test case).