### PR TITLE
GroovyRowResult.entrySet should return a Set of Entries

### DIFF
--- a/subprojects/groovy-sql/src/main/java/groovy/sql/GroovyRowResult.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/GroovyRowResult.java
@@ -132,7 +132,7 @@ public class GroovyRowResult extends GroovyObjectSupport implements Map {
         return result.containsValue(value);
     }
 
-    public Set entrySet() {
+    public Set<Map.Entry> entrySet() {
         return result.entrySet();
     }
 


### PR DESCRIPTION
Currently it returns a `Set`, I would prefer it if it returned a `Set<Map.Entry>` instead.