### PR TITLE
Remove outdated parser loading logic.

### DIFF
--- a/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -698,7 +698,7 @@ public class CompilerConfiguration {
 
     public ParserPluginFactory getPluginFactory() {
         if (pluginFactory == null) {
-            pluginFactory = ParserPluginFactory.newInstance(true);
+            pluginFactory = ParserPluginFactory.newInstance();
         }
         return pluginFactory;
     }

--- a/src/main/org/codehaus/groovy/control/ParserPluginFactory.java
+++ b/src/main/org/codehaus/groovy/control/ParserPluginFactory.java
@@ -25,40 +25,26 @@ import org.codehaus.groovy.antlr.AntlrParserPluginFactory;
  *
  */
 public abstract class ParserPluginFactory {
-    public static ParserPluginFactory newInstance(boolean useNewParser) {
-        if (useNewParser) {
-            Class type = null;
-            String name = "org.codehaus.groovy.antlr.AntlrParserPluginFactory";
-            try {
-                type = Class.forName(name);
-            }
-            catch (ClassNotFoundException e) {
-                try {
-                    type = ParserPluginFactory.class.getClassLoader().loadClass(name);
-                }
-                catch (ClassNotFoundException e1) {
-                    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-                    if (contextClassLoader != null) {
-                        try {
-                            type = contextClassLoader.loadClass(name);
-                        }
-                        catch (ClassNotFoundException e2) {
-                            // ignore
-                        }
-                    }
-                }
-            }
 
-            if (type != null) {
-                try {
-                    return (ParserPluginFactory) type.newInstance();
-                }
-                catch (Exception e) {
-                    throw new RuntimeException("Could not create AntlrParserPluginFactory: " + e, e);
-                }
-            }
-            // can't find Antlr parser, so lets use the Classic one
-        }
+    /**
+     * Creates a new instance of {@link ParserPluginFactory}.
+     *
+     * <p>The <code>useNewParser</code> parameter is not used, and this method
+     * is kept for backward compatibility.
+     *
+     * @param useNewParser unused.
+     * @return the new parser factory.
+     */
+    public static ParserPluginFactory newInstance(boolean useNewParser) {
+        return newInstance();
+    }
+
+    /**
+     * Creates a new instance of {@link ParserPluginFactory}.
+     *
+     * @return the new parser factory.
+     */
+    public static ParserPluginFactory newInstance() {
         return new AntlrParserPluginFactory();
     }
 

--- a/src/test/org/codehaus/groovy/control/CompilerConfigurationTest.java
+++ b/src/test/org/codehaus/groovy/control/CompilerConfigurationTest.java
@@ -130,7 +130,7 @@ public class CompilerConfigurationTest extends GroovyTestCase {
         initJoint.put("somekey", "somevalue");
         init.setJointCompilationOptions(initJoint);
 
-        final ParserPluginFactory initPPF = ParserPluginFactory.newInstance(true);
+        final ParserPluginFactory initPPF = ParserPluginFactory.newInstance();
         init.setPluginFactory(initPPF);
 
         assertEquals(WarningMessage.POSSIBLE_ERRORS, init.getWarningLevel());


### PR DESCRIPTION
It looks like a long time ago there were two Groovy parsers, a “Classic”
and Antlr.  The Antlr one was loaded using reflection, while the classic
one was simply instantiated.  The reflection logic was kept after
definitely switching to Antlr (cf. ebeff74), although it is still
normally instantiated if reflection fails.

This commit simply removes all the reflection stuff.