### PR TITLE
GROOVY-7926 - Don't use a CastExpression if the return type is void.

### DIFF
--- a/src/main/org/codehaus/groovy/transform/trait/TraitComposer.java
+++ b/src/main/org/codehaus/groovy/transform/trait/TraitComposer.java
@@ -293,7 +293,8 @@ public abstract class TraitComposer {
 
         ClassNode[] exceptionNodes = correctToGenericsSpecRecurse(genericsSpec, copyExceptions(helperMethod.getExceptions()));
         ClassNode fixedReturnType = correctToGenericsSpecRecurse(genericsSpec, helperMethod.getReturnType());
-        Expression forwardExpression = genericsSpec.isEmpty()?mce:new CastExpression(fixedReturnType,mce);
+        boolean noCastRequired = genericsSpec.isEmpty() || fixedReturnType.getName().equals(ClassHelper.VOID_TYPE.getName());
+        Expression forwardExpression = noCastRequired ? mce : new CastExpression(fixedReturnType,mce);
         int access = helperMethod.getModifiers();
         // we could rely on the first parameter name ($static$self) but that information is not
         // guaranteed to be always present

--- a/src/test/org/codehaus/groovy/transform/traitx/Groovy7926Bug.groovy
+++ b/src/test/org/codehaus/groovy/transform/traitx/Groovy7926Bug.groovy
@@ -1,0 +1,50 @@
+package org.codehaus.groovy.transform.traitx
+
+import org.codehaus.groovy.classgen.asm.AbstractBytecodeTestCase
+import org.codehaus.groovy.classgen.asm.InstructionSequence
+
+/**
+ * Created by graemerocher on 08/09/2016.
+ */
+class Groovy7926Bug extends AbstractBytecodeTestCase {
+
+    void testThatVoidTypesFromTraitsWithGenericsWork() {
+        assertScript('''
+trait MyTrait<D> {
+    void delete() {
+        // no-op
+        println "works"
+    }
+}
+class MyImpl implements MyTrait<MyImpl> {
+}
+new MyImpl().delete()
+return true
+''')
+    }
+
+    void testThatVoidTypesAreNotUsedForVariableNamesInByteCode() {
+        def byteCode = compile([method:"delete", classNamePattern:"MyImpl"],"""\
+trait MyTrait<D> {
+    void delete() {
+        // no-op
+        println "works"
+    }
+}
+class MyImpl implements MyTrait<MyImpl> {
+}
+        """)
+
+        def instructions = byteCode.instructions
+        byteCode.instructions = instructions[
+                instructions.indexOf("public delete()V")..-1
+        ]
+        instructions = byteCode.instructions
+        byteCode.instructions = instructions[
+                0..instructions.indexOf( instructions.find { it == '--BEGIN----END--' } )
+        ]
+        assert !byteCode.hasSequence([
+                "CHECKCAST void"
+        ])
+    }
+}


### PR DESCRIPTION
As per https://issues.apache.org/jira/browse/GROOVY-7926 traits currently try to cast the void type which leads to mysterious exceptions on some JVMs (notably JRocket and the IBM JVM)