### PR TITLE
Documentation fixes to The Groocy Development Kit

### DIFF
--- a/src/spec/doc/working-with-collections.adoc
+++ b/src/spec/doc/working-with-collections.adoc
@@ -433,7 +433,7 @@ It is worth noting that negative indices are allowed, to extract more easily fro
 
 [source,groovy]
 ---------------------------------
-include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=subscript_3,indent=0]
+include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=subscript_4,indent=0]
 ---------------------------------
 
 You can use negative indices to count from the end of the List, array,
@@ -441,7 +441,7 @@ String etc.
 
 [source,groovy]
 --------------------------------
-include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=subscript_4,indent=0]
+include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=subscript_4a,indent=0]
 --------------------------------
 
 Eventually, if you use a backwards range (the starting index is greater than

--- a/src/spec/doc/working-with-collections.adoc
+++ b/src/spec/doc/working-with-collections.adoc
@@ -431,6 +431,11 @@ include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=s
 
 It is worth noting that negative indices are allowed, to extract more easily from the end of a collection:
 
+[source,groovy]
+---------------------------------
+include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=subscript_3,indent=0]
+---------------------------------
+
 You can use negative indices to count from the end of the List, array,
 String etc.
 

--- a/src/spec/test/gdk/WorkingWithCollectionsTest.groovy
+++ b/src/spec/test/gdk/WorkingWithCollectionsTest.groovy
@@ -443,7 +443,7 @@ class WorkingWithCollectionsTest extends GroovyTestCase {
     void testMapPropertyNotation() {
         // tag::map_property[]
         def map = [name: 'Gromit', likes: 'cheese', id: 1234]
-        assert map.name == 'Gromit'     // can be used instead of map.get('Gromit')
+        assert map.name == 'Gromit'     // can be used instead of map.get('name')
         assert map.id == 1234
 
         def emptyMap = [:]
@@ -721,10 +721,12 @@ class WorkingWithCollectionsTest extends GroovyTestCase {
         text = "nice cheese gromit!"
         x = text[-1]
         assert x == "!"
+        // end::subscript_4[]
 
+        // tag::subscript_4a[]
         def name = text[-7..-2]
         assert name == "gromit"
-        // end::subscript_4[]
+        // end::subscript_4a[]
 
         // tag::subscript_5[]
         text = "nice cheese gromit!"


### PR DESCRIPTION
Documentation fixes to [The Groocy Development Kit](http://groovy-lang.org/groovy-dev-kit.html) section on Working with collections
- property access comment targets entry instead of key
- two introductions followed by two corresponding code sections