### PR TITLE
Make json output configurable to not write entries with null values

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonBuilder.java
@@ -348,6 +348,26 @@ public class JsonBuilder extends GroovyObjectSupport implements Writable {
     }
 
     /**
+     * Serializes the internal data structure built with the builder to a conformant JSON payload string
+     * <p>
+     * Example:
+     * <pre><code class="groovyTestCase">
+     * def json = new groovy.json.JsonBuilder()
+     * json { temperature 37 }
+     *
+     * assert json.toString() == '{"temperature":37}'
+     * </code></pre>
+     *
+     * @param writeNullValues flag to decide whether to write null values with the string 'null'
+     *                        or to omit writing the key and the value.
+     *
+     * @return a JSON output
+     */
+    public String toString(boolean writeNullValues) {
+        return JsonOutput.toJson(content, writeNullValues);
+    }
+
+    /**
      * Pretty-prints and formats the JSON payload.
      * <p>
      * This method calls the JsonLexer to parser the output of the builder,

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonBuilderTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonBuilderTest.groovy
@@ -17,7 +17,6 @@
  *  under the License.
  */
 package groovy.json
-
 /**
  * @author Guillaume Laforge
  */
@@ -402,4 +401,13 @@ class JsonBuilderTest extends GroovyTestCase {
         assert new JsonBuilder({'\1' 0}).toString() == '{"\\u0001":0}'
         assert new JsonBuilder({'\u0002' 0}).toString() == '{"\\u0002":0}'
     }
+
+    void testWhenFlagWhenWriteNullValuesIsFalseThenDoNotWriteNullValues() {
+        def Closure closureWithNullValues = {
+            optionalValue null
+            constantValue 37
+        }
+        assert new JsonBuilder(closureWithNullValues).toString(false)  == '{"constantValue":37}'
+    }
+
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -438,7 +438,7 @@ class JsonOutputTest extends GroovyTestCase {
         constantValue 37
     }
     def Expando  expandoWithNullValues = new Expando(optionalValue: null, constantValue: 37)
-    def Map<String, Integer> mapWithNullValues = new HashMap<String, Integer>()
+    def Map<String, Integer> mapWithNullValues = new TreeMap<>()
 
     void testGivenMapValuesAreNullWhenWriteNullValuesIsTrueThenWriteNullValues() {
         mapWithNullValues.put("optionalValue",null)
@@ -446,7 +446,7 @@ class JsonOutputTest extends GroovyTestCase {
 
         assert toJson(closureWithNullValues) == '{"optionalValue":null,"constantValue":37}'
         assert toJson(expandoWithNullValues) == '{"optionalValue":null,"constantValue":37}'
-        assert toJson(mapWithNullValues) == '{"optionalValue":null,"constantValue":37}'
+        assert toJson(mapWithNullValues) == '{"constantValue":37,"optionalValue":null}'
     }
 
     void testGivenMapValuesAreNullWhenWriteNullValuesIsFalseThenDoNotWriteKeyAndValue() {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -426,6 +426,38 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson(dir)
     }
 
+    void testWhenParameterWriteNullValuesIsSetToFalseStillWriteNullIfWholeObjectIsNull() {
+        assert toJson((Object) null, false) == "null"
+        assert toJson((Closure) null, false) == 'null'
+        assert toJson((Expando) null, false) == 'null'
+        assert toJson((Map) null, false) == 'null'
+    }
+
+    def Closure closureWithNullValues = {
+        optionalValue null
+        constantValue 37
+    }
+    def Expando  expandoWithNullValues = new Expando(optionalValue: null, constantValue: 37)
+    def Map<String, Integer> mapWithNullValues = new HashMap<String, Integer>()
+
+    void testGivenMapValuesAreNullWhenWriteNullValuesIsTrueThenWriteNullValues() {
+        mapWithNullValues.put("optionalValue",null)
+        mapWithNullValues.put("constantValue",37)
+
+        assert toJson(closureWithNullValues) == '{"optionalValue":null,"constantValue":37}'
+        assert toJson(expandoWithNullValues) == '{"optionalValue":null,"constantValue":37}'
+        assert toJson(mapWithNullValues) == '{"optionalValue":null,"constantValue":37}'
+    }
+
+    void testGivenMapValuesAreNullWhenWriteNullValuesIsFalseThenDoNotWriteKeyAndValue() {
+        mapWithNullValues.put("optionalValue",null)
+        mapWithNullValues.put("constantValue",37)
+
+        assert toJson(closureWithNullValues, false) == '{"constantValue":37}'
+        assert toJson(expandoWithNullValues, false) == '{"constantValue":37}'
+        assert toJson(mapWithNullValues, false) == '{"constantValue":37}'
+    }
+
 }
 
 @Canonical


### PR DESCRIPTION
Hi I would like to propose a simple solution for GROOVY-7858 / GROOVY-7780.

This is providing overriding methods with a boolean flag to skip writing entries with null values for Closure Map and Expando. 

If there are plans to have a more sophisticated solution e.g using some more general configuration I would be glad to support on that.
