### PR TITLE
GROOVY-7952: Property expressions for extension methods starting with…

### DIFF
--- a/src/main/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/org/codehaus/groovy/ast/ClassNode.java
@@ -1092,10 +1092,12 @@ public class ClassNode extends AnnotatedNode implements Opcodes {
 
     public MethodNode getGetterMethod(String getterName, boolean searchSuperClasses) {
         MethodNode getterMethod = null;
+        boolean booleanReturnOnly = getterName.startsWith("is");
         for (MethodNode method : getDeclaredMethods(getterName)) {
             if (getterName.equals(method.getName())
                     && ClassHelper.VOID_TYPE!=method.getReturnType()
-                    && method.getParameters().length == 0) {
+                    && method.getParameters().length == 0
+                    && (!booleanReturnOnly || ClassHelper.Boolean_TYPE.equals(ClassHelper.getWrapper(method.getReturnType())))) {
                 // GROOVY-7363: There can be multiple matches for a getter returning a generic parameter type, due to
                 // the generation of a bridge method. The real getter is really the non-bridge, non-synthetic one as it
                 // has the most specific and exact return type of the two. Picking the bridge method results in loss of

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
@@ -158,19 +158,24 @@ public class StaticTypesCallSiteWriter extends CallSiteWriter implements Opcodes
 
         // GROOVY-5580, it is still possible that we're calling a superinterface property
         String getterName = "get" + MetaClassHelper.capitalize(methodName);
+        String altGetterName = "is" + MetaClassHelper.capitalize(methodName);
         if (receiverType.isInterface()) {
             Set<ClassNode> allInterfaces = receiverType.getAllInterfaces();
             MethodNode getterMethod = null;
             for (ClassNode anInterface : allInterfaces) {
                 getterMethod = anInterface.getGetterMethod(getterName);
-                if (getterMethod!=null) break;
+                if (getterMethod == null) getterMethod = anInterface.getGetterMethod(altGetterName);
+                if (getterMethod != null) break;
             }
             // GROOVY-5585
-            if (getterMethod==null) {
+            if (getterMethod == null) {
                 getterMethod = OBJECT_TYPE.getGetterMethod(getterName);
             }
+            if (getterMethod == null) {
+                getterMethod = OBJECT_TYPE.getGetterMethod(altGetterName);
+            }
 
-            if (getterMethod!=null) {
+            if (getterMethod != null) {
                 MethodCallExpression call = new MethodCallExpression(
                         receiver,
                         getterName,
@@ -188,13 +193,16 @@ public class StaticTypesCallSiteWriter extends CallSiteWriter implements Opcodes
 
         // GROOVY-5568, we would be facing a DGM call, but instead of foo.getText(), have foo.text
         List<MethodNode> methods = findDGMMethodsByNameAndArguments(controller.getSourceUnit().getClassLoader(), receiverType, getterName, ClassNode.EMPTY_ARRAY);
+        for (MethodNode m: findDGMMethodsByNameAndArguments(controller.getSourceUnit().getClassLoader(), receiverType, altGetterName, ClassNode.EMPTY_ARRAY)) {
+            if (Boolean_TYPE.equals(getWrapper(m.getReturnType()))) methods.add(m);
+        }
         if (!methods.isEmpty()) {
             List<MethodNode> methodNodes = chooseBestMethod(receiverType, methods, ClassNode.EMPTY_ARRAY);
-            if (methodNodes.size()==1) {
+            if (methodNodes.size() == 1) {
                 MethodNode getter = methodNodes.get(0);
                 MethodCallExpression call = new MethodCallExpression(
                         receiver,
-                        getterName,
+                        getter.getName(),
                         ArgumentListExpression.EMPTY_ARGUMENTS
                 );
                 call.setMethodTarget(getter);

--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -1315,6 +1315,9 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             }
             // GROOVY-5568, the property may be defined by DGM
             List<MethodNode> methods = findDGMMethodsByNameAndArguments(getTransformLoader(), testClass, "get" + capName, ClassNode.EMPTY_ARRAY);
+            for (MethodNode m: findDGMMethodsByNameAndArguments(getTransformLoader(), testClass, "is" + capName, ClassNode.EMPTY_ARRAY)) {
+                if (Boolean_TYPE.equals(getWrapper(m.getReturnType()))) methods.add(m);
+            }
             if (!methods.isEmpty()) {
                 List<MethodNode> methodNodes = chooseBestMethod(testClass, methods, ClassNode.EMPTY_ARRAY);
                 if (methodNodes.size() == 1) {

--- a/src/test/groovy/transform/stc/DefaultGroovyMethodsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/DefaultGroovyMethodsSTCTest.groovy
@@ -144,5 +144,12 @@ class DefaultGroovyMethodsSTCTest extends StaticTypeCheckingTestCase {
             assert list[0] == 3 && list[0].class == Long
         '''
     }
+
+    // GROOVY-7952
+    void testIsGetterMethodAsProperty() {
+        assertScript '''
+            assert !'abc'.allWhitespace
+        '''
+    }
 }
 

--- a/src/test/groovy/transform/stc/MethodCallsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/MethodCallsSTCTest.groovy
@@ -690,6 +690,39 @@ class MethodCallsSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    void testIsGetterAsPropertyFromSuperInterface() {
+        assertScript '''interface Upper { boolean isBar() }
+        interface Lower extends Upper {}
+        boolean foo(Lower impl) {
+            impl.bar // isBar() called with the property notation
+        }
+        assert foo({ true } as Lower)
+        '''
+    }
+
+    void testIsGetterAsPropertyFromSuperInterfaceUsingConcreteImpl() {
+        assertScript '''interface Upper { boolean isBar() }
+        interface Lower extends Upper {}
+        class Foo implements Lower { boolean isBar() { true } }
+        boolean foo(Foo impl) {
+            impl.bar // isBar() called with the property notation
+        }
+        assert foo(new Foo())
+        '''
+    }
+
+    void testIsGetterAsPropertyFromSuperInterfaceUsingConcreteImplSubclass() {
+        assertScript '''interface Upper { boolean isBar() }
+        interface Lower extends Upper {}
+        class Foo implements Lower { boolean isBar() { true } }
+        class Bar extends Foo {}
+        boolean foo(Bar impl) {
+            impl.bar // isBar() called with the property notation
+        }
+        assert foo(new Bar())
+        '''
+    }
+
     // GROOVY-5580: getName variant
     void testGetNameFromSuperInterface() {
         assertScript '''interface Upper { String getName() }


### PR DESCRIPTION
… 'is' fail STC

* Add support for 'is' getter method variants of GROOVY-5580