### PR TITLE
GROOVY-7951: MethodCallExpression.transformExpression does not copy generic types

### DIFF
--- a/src/main/org/codehaus/groovy/ast/expr/MethodCallExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/MethodCallExpression.java
@@ -72,6 +72,7 @@ public class MethodCallExpression extends Expression implements MethodCall {
         answer.setSafe(safe);
         answer.setSpreadSafe(spreadSafe);
         answer.setImplicitThis(implicitThis);
+        answer.setGenericsTypes(genericsTypes);
         answer.setSourcePosition(this);
         answer.setMethodTarget(target);
         answer.copyNodeMetaData(this);

--- a/src/test/groovy/bugs/Groovy7951Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7951Bug.groovy
@@ -1,0 +1,75 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import org.codehaus.groovy.ast.ClassCodeExpressionTransformer
+import org.codehaus.groovy.ast.ClassCodeVisitorSupport
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.SourceUnit
+import org.codehaus.groovy.control.customizers.CompilationCustomizer
+import org.codehaus.groovy.classgen.GeneratorContext
+
+import static org.codehaus.groovy.control.CompilePhase.CANONICALIZATION
+import static org.codehaus.groovy.control.CompilePhase.INSTRUCTION_SELECTION
+
+class Groovy7951Bug extends GroovyTestCase {
+
+    void testTransformMethodCallExpressionPassesGenericTypes() {
+
+        def config = new CompilerConfiguration()
+
+        // Just visiting the transform method on each expression is enough to verify
+        // that the checker is able to see the generic types in the later phase.
+        def transformer = new CompilationCustomizer(CANONICALIZATION) {
+            @Override void call(SourceUnit src, GeneratorContext ctxt, ClassNode cn) {
+                new ClassCodeExpressionTransformer() {
+                    @Override SourceUnit getSourceUnit() { src }
+                }.visitClass(cn)
+            }
+        }
+
+        boolean assertWasChecked
+        def checker = new CompilationCustomizer(INSTRUCTION_SELECTION) {
+            void call(SourceUnit src, GeneratorContext ctxt, ClassNode cn) {
+                new ClassCodeVisitorSupport() {
+                    @Override void visitMethodCallExpression(MethodCallExpression mce) {
+                        if (mce.objectExpression.text == 'java.util.Collections' &&
+                                mce.method.text == 'emptyList') {
+                            assert mce.genericsTypes != null && mce.genericsTypes*.name == ['Date']
+                            assertWasChecked = true
+                        }
+                        super.visitMethodCallExpression(mce)
+                    }
+                    @Override SourceUnit getSourceUnit() { src }
+                }.visitClass(cn)
+            }
+        }
+
+        config.addCompilationCustomizers(transformer, checker)
+
+        new GroovyShell(config).parse '''
+            Collections.<Date>emptyList()
+        '''
+
+        assert assertWasChecked
+    }
+
+}


### PR DESCRIPTION
PR created from patch supplied in [GROOVY-7951](https://issues.apache.org/jira/browse/GROOVY-7951).  It seems like a reasonable change to make, though I did have trouble thinking up a way to test it that would be meaningful.  If anyone can nudge me in the right direction I can try to write up a test if you think it's warranted in this case.

I considered whether `genericsTypes.clone()` should be used, but it didn't seem to be common and most uses of the array seem to be read only.