### PR TITLE
GROOVY-7646: remove classes via InvokerHelper when closing the GroovyClassLoader or flushing its cache

### DIFF
--- a/src/main/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/lang/GroovyClassLoader.java
@@ -983,9 +983,7 @@ public class GroovyClassLoader extends URLClassLoader {
     @Override
     public void close() throws IOException {
         super.close();
-        for (Class cl : classCache.values()) {
-            InvokerHelper.removeClass(cl);
-        }
+        clearCache();
     }
 
     private static class TimestampAdder extends CompilationUnit.PrimaryClassNodeOperation implements Opcodes {

--- a/src/main/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/lang/GroovyClassLoader.java
@@ -34,6 +34,7 @@ import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.classgen.GeneratorContext;
 import org.codehaus.groovy.classgen.Verifier;
 import org.codehaus.groovy.control.*;
+import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.runtime.IOGroovyMethods;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -969,10 +970,21 @@ public class GroovyClassLoader extends URLClassLoader {
      */
     public void clearCache() {
         synchronized (classCache) {
+            for (Class cl : classCache.values()) {
+                InvokerHelper.removeClass(cl);
+            }
             classCache.clear();
         }
         synchronized (sourceCache) {
             sourceCache.clear();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        for (Class cl : classCache.values()) {
+            InvokerHelper.removeClass(cl);
         }
     }
 


### PR DESCRIPTION
See #325, this ensures that classes are properly cleaned up after when their ClassLoader or its cache are discarded. Together with #444, this should allow classes to be GC'ed as soon as they are not used anymore.