### PR TITLE
GROOVY-7291 Declaration of double variable without value assignment referrenced in closure

### DIFF
--- a/src/test/groovy/bugs/Groovy7291Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7291Bug.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+class Groovy7291Bug extends GroovyShellTestCase {
+    void testPrimitiveDouble() {
+        evaluate('''
+double a;
+def b = {
+   a = a + 1;
+}
+b();
+        ''');
+    }
+
+    void testDouble() {
+        shouldFail('''
+Double a;
+def b = {
+   a = a + 1;
+}
+b();
+        ''');
+    }
+}


### PR DESCRIPTION
According to [GROOVY-5570](https://issues.apache.org/jira/browse/GROOVY-5570), a variable referenced by closure must be non-primitive type, and it results in [GROOVY-7291](https://issues.apache.org/jira/browse/GROOVY-7291). In this case, I replace the EmptyExpression to a ConstantExpression with value 0.