### PR TITLE
GROOVY-7987: Type checker doesn't flag static method calls to instanc…

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -2987,6 +2987,12 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                     mn = disambiguateMethods(mn, chosenReceiver!=null?chosenReceiver.getType():null, args, call);
                     if (mn.size() == 1) {
                         MethodNode directMethodCallCandidate = mn.get(0);
+                        if (call.getNodeMetaData(StaticTypesMarker.DYNAMIC_RESOLUTION) == null &&
+                                !directMethodCallCandidate.isStatic() && objectExpression instanceof ClassExpression &&
+                                !"java.lang.Class".equals(directMethodCallCandidate.getDeclaringClass().getName())) {
+                            ClassNode owner = directMethodCallCandidate.getDeclaringClass();
+                            addStaticTypeError("Non static method " + owner.getName() + "#" + directMethodCallCandidate.getName() + " cannot be called from static context", call);
+                        }
                         if (chosenReceiver==null) {
                             chosenReceiver = Receiver.make(directMethodCallCandidate.getDeclaringClass());
                         }

--- a/src/test/groovy/bugs/Groovy7987Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7987Bug.groovy
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import gls.CompilableTestSupport
+
+class Groovy7987Bug extends CompilableTestSupport {
+    void testBindablePropertySettersHaveValidModifiersForMethod() {
+        def message = shouldNotCompile """
+            @groovy.transform.TypeChecked
+            class Foo {
+                def bar() { }
+            }
+
+            @groovy.transform.TypeChecked
+            def method() {
+                Foo.bar()
+            }
+
+            method()
+        """
+        assert message.contains('Non static method Foo#bar cannot be called from static context')
+    }
+}


### PR DESCRIPTION
…e methods with otherwise the same signature