### PR TITLE
Fix test case and documentation

### DIFF
--- a/src/spec/test/PrimitiveTest.groovy
+++ b/src/spec/test/PrimitiveTest.groovy
@@ -26,7 +26,7 @@ class PrimitiveTest extends GroovyTestCase {
             }
 
             assert Foo.class.getDeclaredField('i').type == int.class
-            assert Foo.i != int.class && Foo.i.class == Integer.class
+            assert Foo.i.class != int.class && Foo.i.class == Integer.class
             // end::primitive_references[]
         '''
     }


### PR DESCRIPTION
`Foo.i` is a field; only `Foo.i.class` could be `int.class`