### PR TITLE
@TailRecursive doc should read "Method annotation ..."

### DIFF
--- a/src/main/groovy/transform/TailRecursive.groovy
+++ b/src/main/groovy/transform/TailRecursive.groovy
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
 
 /**
- * Class annotation used to transform method with tail recursive calls into iterative methods automagically
+ * Method annotation used to transform methods with tail recursive calls into iterative methods automagically
  * since the JVM cannot do this itself. This works for both static and non-static methods.
  * <p/>
  * It allows you to write a method like this:


### PR DESCRIPTION
Minor text fixes to TailRecursive annotation's documentation:
 - it is a method annotation, not a class annotation
 - since I was already here, added an 's' to make pluralization of "recursive calls" consistent