### PR TITLE
GROOVY-6175: invoking Closure property like method fails because of doCall

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/memoize/Memoize.java
+++ b/src/main/org/codehaus/groovy/runtime/memoize/Memoize.java
@@ -137,6 +137,10 @@ public abstract class Memoize {
             }
             return result == MEMOIZE_NULL ? null : (V) result;
         }
+
+        public V doCall(final Object... args) {
+            return call(args);
+        }
     }
     
     private static class SoftReferenceMemoizeFunction<V> extends MemoizeFunction<V> {


### PR DESCRIPTION
Per the Closure class docs, to be able to use a Closure in short form, e.g., c(), in subclasses, you need to provide a doCall method with any signature you want to. This ensures that getMaximumNumberOfParameters() and getParameterTypes() will work too without any additional code. If no doCall method is provided a closure must be used in its long form, e.g., c.call().