### PR TITLE
GROOVY-8067: Possible deadlock when creating new ClassInfo entries in the cache

### DIFF
--- a/src/main/org/codehaus/groovy/util/ManagedConcurrentLinkedQueue.java
+++ b/src/main/org/codehaus/groovy/util/ManagedConcurrentLinkedQueue.java
@@ -1,0 +1,180 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * A queue that stores values wrapped in a Reference, the type of which is
+ * determined by the provided {@link ReferenceBundle}. References stored
+ * in this queue will be removed when reference processing occurs.
+ * <p>
+ * This queue is backed by a {@link ConcurrentLinkedQueue} and is thread safe.
+ * The iterator will only return non-null values (reachable) and is based on
+ * the "weakly consistent" iterator of the underlying {@link ConcurrentLinkedQueue}.
+ *
+ * @param <T> the type of values to store
+ */
+public class ManagedConcurrentLinkedQueue<T> implements Iterable<T> {
+
+    private final ReferenceBundle bundle;
+    private final ConcurrentLinkedQueue<Element<T>> queue;
+
+    /**
+     * Creates an empty ManagedConcurrentLinkedQueue that will use the provided
+     * {@code ReferenceBundle} to store values as the given Reference
+     * type.
+     *
+     * @param bundle used to create the appropriate Reference type
+     *               for the values stored
+     */
+    public ManagedConcurrentLinkedQueue(ReferenceBundle bundle) {
+        this.bundle = bundle;
+        this.queue = new ConcurrentLinkedQueue<Element<T>>();
+    }
+
+    /**
+     * Adds the specified value to the queue.
+     *
+     * @param value the value to add
+     */
+    public void add(T value) {
+        Element<T> e = new Element<T>(value);
+        queue.offer(e);
+    }
+
+    /**
+     * Returns {@code true} if this queue contains no elements.
+     * <p>
+     * This method does not check the elements to verify they contain
+     * non-null reference values.
+     */
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    /**
+     * Returns an array containing all values from this queue in the sequence they
+     * were added.
+     *
+     * @param tArray the array to populate if big enough, else a new array with
+     *               the same runtime type
+     * @return an array containing all non-null values in this queue
+     */
+    public T[] toArray(T[] tArray) {
+        return values().toArray(tArray);
+    }
+
+    /**
+     * Returns a list containing all values from this queue in the
+     * sequence they were added.
+     */
+    public List<T> values() {
+        List<T> result = new ArrayList<T>();
+        for (Iterator<T> itr = iterator(); itr.hasNext(); ) {
+            result.add(itr.next());
+        }
+        return result;
+    }
+
+    /**
+     * Returns an iterator over all non-null values in this queue.  The values should be
+     * returned in the order they were added.
+     */
+    @Override
+    public Iterator<T> iterator() {
+        return new Itr(queue.iterator());
+    }
+
+    private class Element<V> extends ManagedReference<V> {
+
+        Element(V value) {
+            super(bundle, value);
+        }
+
+        @Override
+        public void finalizeReference() {
+            queue.remove(this);
+            super.finalizeReference();
+        }
+
+    }
+
+    private class Itr implements Iterator<T> {
+
+        final Iterator<Element<T>> wrapped;
+
+        T value;
+        Element<T> current;
+        boolean exhausted;
+
+        Itr(Iterator<Element<T>> wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (!exhausted && value == null) {
+                advance();
+            }
+            return value != null;
+        }
+
+        @Override
+        public T next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            T next = value;
+            value = null;
+            return next;
+        }
+
+        @Override
+        public void remove() {
+            if (current == null || value != null) {
+                throw new IllegalStateException("Next method has not been called");
+            }
+            wrapped.remove();
+            current = null;
+        }
+
+        private void advance() {
+            while (wrapped.hasNext()) {
+                Element<T> e = wrapped.next();
+                T v = e.get();
+                if (v != null) {
+                    current = e;
+                    value = v;
+                    return;
+                }
+                wrapped.remove();
+            }
+            value = null;
+            current = null;
+            exhausted = true;
+        }
+
+    }
+
+}

--- a/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
+++ b/src/main/org/codehaus/groovy/util/ManagedLinkedList.java
@@ -29,7 +29,9 @@ import java.util.List;
  *
  * @author Jochen Theodorou
  * @since 1.6
+ * @deprecated replaced by {@link ManagedConcurrentLinkedQueue}
  */
+@Deprecated
 public class ManagedLinkedList<T> {
 
     private final class Element<V> extends ManagedReference<V> {

--- a/src/test/org/codehaus/groovy/util/ManagedConcurrentLinkedQueueTest.groovy
+++ b/src/test/org/codehaus/groovy/util/ManagedConcurrentLinkedQueueTest.groovy
@@ -1,0 +1,88 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.util
+
+class ManagedConcurrentLinkedQueueTest extends GroovyTestCase {
+
+    def queue
+
+    void setUp() {
+        def manager = ReferenceManager.createIdlingManager(null)
+        def bundle = new ReferenceBundle(manager, ReferenceType.HARD)
+        queue = new ManagedConcurrentLinkedQueue(bundle)
+    }
+
+    void testElementAdd() {
+        queue.add(1)
+        def i = 0
+        queue.each {
+            assert it==1
+            i++
+        }
+        assert i ==1
+    }
+
+    void testEmptylist() {
+        assert queue.isEmpty()
+    }
+
+    void testRemoveinTheMiddle() {
+        queue.add(1)
+        queue.add(2)
+        queue.add(3)
+        queue.add(4)
+        queue.add(5)
+        def iter = queue.iterator()
+        while (iter.hasNext()) {
+            if (iter.next()==3) iter.remove()
+        }
+        def val = queue.inject(0){value, it-> value+it}
+        assert val == 12
+    }
+
+    void testAddRemove() {
+        10.times {
+            queue.add(it)
+            def iter = queue.iterator()
+            while (iter.hasNext()) {
+                if (iter.next()==it) iter.remove()
+            }
+        }
+        assert queue.isEmpty()
+    }
+
+    void testIteratorThrowsNoSuchElementException() {
+        shouldFail(NoSuchElementException) {
+            queue.add(1)
+            def iter = queue.iterator()
+            assert iter.next() == 1
+            iter.next()
+        }
+    }
+
+    void testIteratorThrowsOnRemoveIfNextNotCalled() {
+        shouldFail(IllegalStateException) {
+            queue.add(1)
+            def iter = queue.iterator()
+            assert iter.hasNext()
+            iter.remove()
+        }
+    }
+
+}

--- a/subprojects/stress/README.adoc
+++ b/subprojects/stress/README.adoc
@@ -1,0 +1,19 @@
+= Stress Tests
+
+Tests in this subproject are used for stress testing.  These types of tests
+will normally involve calls to `System.gc()`, spinning up many threads, and
+may attempt to create OutOfMemory errors.
+
+These tests can be long running and may be prone to failure on different
+platforms, so in order to run these tests you must enable them as follows:
+
+    ./gradlew -PstressTests :stress:test
+
+You can run a single test with the following command:
+
+    ./gradlew -PstressTests :stress:test --tests org.codehaus.groovy.util.SomeTest
+
+Or run all tests under in a given package and subpackages:
+
+    ./gradlew -PstressTests :stress:test --tests org.codehaus.*
+

--- a/subprojects/stress/build.gradle
+++ b/subprojects/stress/build.gradle
@@ -16,35 +16,15 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-def subprojects = ['groovy-ant',
-        'groovy-bsf',
-        'groovy-console',
-        'groovy-docgenerator',
-        'groovy-groovydoc',
-        'groovy-groovysh',
-        'groovy-jmx',
-        'groovy-json',
-        'groovy-jsr223',
-        'groovy-nio',
-        'groovy-servlet',
-        'groovy-sql',
-        'groovy-swing',
-        'groovy-templates',
-        'groovy-test',
-        'groovy-testng',
-        'groovy-xml',
-        'groovy-macro',
-        'stress'
-]
-
-if (JavaVersion.current().isJava8Compatible()) {
-    subprojects << 'performance'
+dependencies {
+    testCompile project(':groovy-test')
 }
 
-include(subprojects as String[])
-        
-rootProject.children.each { prj ->
-    prj.projectDir = new File("$rootDir/subprojects/$prj.name")
+test {
+    minHeapSize = '512m'
+    maxHeapSize = '512m'
+    onlyIf {
+        project.hasProperty('stressTests')
+    }
+    outputs.upToDateWhen { false }
 }
-
-rootProject.name = 'groovy' // TODO should this be groovy-core?

--- a/subprojects/stress/src/test/java/org/apache/groovy/stress/util/GCUtils.java
+++ b/subprojects/stress/src/test/java/org/apache/groovy/stress/util/GCUtils.java
@@ -16,35 +16,24 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-def subprojects = ['groovy-ant',
-        'groovy-bsf',
-        'groovy-console',
-        'groovy-docgenerator',
-        'groovy-groovydoc',
-        'groovy-groovysh',
-        'groovy-jmx',
-        'groovy-json',
-        'groovy-jsr223',
-        'groovy-nio',
-        'groovy-servlet',
-        'groovy-sql',
-        'groovy-swing',
-        'groovy-templates',
-        'groovy-test',
-        'groovy-testng',
-        'groovy-xml',
-        'groovy-macro',
-        'stress'
-]
+package org.apache.groovy.stress.util;
 
-if (JavaVersion.current().isJava8Compatible()) {
-    subprojects << 'performance'
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+
+public class GCUtils {
+
+    private GCUtils() { }
+
+    public static void gc() {
+        Reference<Object> dummy = new WeakReference<Object>(new Object());
+        System.gc();
+        int max = 0;
+        while (dummy.get() != null && max++ < 10) {
+            System.gc();
+        }
+        if (dummy.get() != null) {
+            throw new Error("GC attempt failed");
+        }
+    }
 }
-
-include(subprojects as String[])
-        
-rootProject.children.each { prj ->
-    prj.projectDir = new File("$rootDir/subprojects/$prj.name")
-}
-
-rootProject.name = 'groovy' // TODO should this be groovy-core?

--- a/subprojects/stress/src/test/java/org/apache/groovy/stress/util/ThreadUtils.java
+++ b/subprojects/stress/src/test/java/org/apache/groovy/stress/util/ThreadUtils.java
@@ -16,35 +16,28 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-def subprojects = ['groovy-ant',
-        'groovy-bsf',
-        'groovy-console',
-        'groovy-docgenerator',
-        'groovy-groovydoc',
-        'groovy-groovysh',
-        'groovy-jmx',
-        'groovy-json',
-        'groovy-jsr223',
-        'groovy-nio',
-        'groovy-servlet',
-        'groovy-sql',
-        'groovy-swing',
-        'groovy-templates',
-        'groovy-test',
-        'groovy-testng',
-        'groovy-xml',
-        'groovy-macro',
-        'stress'
-]
+package org.apache.groovy.stress.util;
 
-if (JavaVersion.current().isJava8Compatible()) {
-    subprojects << 'performance'
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+
+public class ThreadUtils {
+
+    private ThreadUtils() { }
+
+    public static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new Error(e);
+        }
+    }
+
+    public static void await(CyclicBarrier barrier) {
+        try {
+            barrier.await();
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
 }
-
-include(subprojects as String[])
-        
-rootProject.children.each { prj ->
-    prj.projectDir = new File("$rootDir/subprojects/$prj.name")
-}
-
-rootProject.name = 'groovy' // TODO should this be groovy-core?

--- a/subprojects/stress/src/test/java/org/codehaus/groovy/reflection/ClassInfoDeadlockStressTest.java
+++ b/subprojects/stress/src/test/java/org/codehaus/groovy/reflection/ClassInfoDeadlockStressTest.java
@@ -1,0 +1,138 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.reflection;
+
+import groovy.lang.GroovyClassLoader;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.groovy.stress.util.GCUtils;
+import org.apache.groovy.stress.util.ThreadUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for deadlocks in the ClassInfo caching.
+ *
+ */
+public class ClassInfoDeadlockStressTest {
+
+    private static final int DEADLOCK_TRIES = 8;
+    private static final int THREAD_COUNT = 8;
+
+    private final CountDownLatch startLatch = new CountDownLatch(1);
+    private final CountDownLatch completeLatch = new CountDownLatch(THREAD_COUNT);
+    private final GroovyClassLoader gcl = new GroovyClassLoader();
+    private final AtomicInteger counter = new AtomicInteger();
+
+    /**
+     * We first generate a large number of ClassInfo instances for classes
+     * that are no longer reachable.  Then queue up threads to all request
+     * ClassInfo instances for new classes simultaneously to ensure that
+     * clearing the old references wont deadlock the creation of new
+     * instances.
+     * <p>
+     * GROOVY-8067
+     */
+    @Test
+    public void testDeadlock() throws Exception {
+        for (int i = 1; i <= DEADLOCK_TRIES; i++) {
+            System.out.println("Test Number: " + i);
+            generateGarbage();
+            GCUtils.gc();
+            attemptDeadlock(null);
+        }
+    }
+
+    @Test
+    public void testRequestsForSameClassInfo() throws Exception {
+        Class<?> newClass = createRandomClass();
+        for (int i = 1; i <= DEADLOCK_TRIES; i++) {
+            System.out.println("Test Number: " + i);
+            generateGarbage();
+            GCUtils.gc();
+            attemptDeadlock(newClass);
+        }
+        ClassInfo newClassInfo = ClassInfo.getClassInfo(newClass);
+        for (ClassInfo ci : ClassInfo.getAllClassInfo()) {
+            if (ci.getTheClass() == newClass && ci != newClassInfo) {
+                fail("Found multiple ClassInfo instances for class");
+            }
+        }
+    }
+
+    private void attemptDeadlock(final Class<?> cls) throws Exception {
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            Runnable runnable = new Runnable() {
+                @Override
+                public void run() {
+                    Class<?> newClass = (cls == null) ? createRandomClass() : cls;
+                    ThreadUtils.await(startLatch);
+                    ClassInfo ci = ClassInfo.getClassInfo(newClass);
+                    assertEquals(newClass, ci.getTheClass());
+                    completeLatch.countDown();
+                }
+            };
+            Thread t = new Thread(runnable);
+            t.setDaemon(true);
+            t.start();
+        }
+        startLatch.countDown();
+        completeLatch.await(10L, TimeUnit.SECONDS);
+        if (completeLatch.getCount() != 0) {
+            System.err.println("Possible deadlock, grab a thread dump now");
+            completeLatch.await(1L, TimeUnit.MINUTES);
+            if (completeLatch.getCount() == 0) {
+                System.out.println("No deadlock, but took longer than expected");
+            } else {
+                fail("Deadlock occurred");
+            }
+        } else {
+            System.out.println("No deadlock detected");
+        }
+    }
+
+    // This may deadlock so run in a separate thread
+    private void generateGarbage() throws Exception {
+        System.out.println("Generating garbage");
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < 5000; i++) {
+                    Class<?> c = createRandomClass();
+                    ClassInfo ci = ClassInfo.getClassInfo(c);
+                }
+            }
+        };
+        Thread t = new Thread(runnable, "GenerateGarbageThread");
+        t.setDaemon(true);
+        t.start();
+        t.join(TimeUnit.SECONDS.toMillis(120L));
+        if (t.isAlive()) {
+            fail("Deadlock detected while generating garbage");
+        }
+    }
+
+    private Class<?> createRandomClass() {
+        return gcl.parseClass("println foo-" + counter.incrementAndGet(), "Script1.groovy");
+    }
+
+}

--- a/subprojects/stress/src/test/java/org/codehaus/groovy/util/ManagedConcurrentLinkedQueueStressTest.java
+++ b/subprojects/stress/src/test/java/org/codehaus/groovy/util/ManagedConcurrentLinkedQueueStressTest.java
@@ -1,0 +1,164 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.util;
+
+import org.apache.groovy.stress.util.GCUtils;
+import org.apache.groovy.stress.util.ThreadUtils;
+import org.junit.*;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class ManagedConcurrentLinkedQueueStressTest {
+
+    static final int ENTRY_COUNT = 8196;
+    static final ReferenceBundle bundle = ReferenceBundle.getWeakBundle();
+
+    ManagedConcurrentLinkedQueue<Object> queue = new ManagedConcurrentLinkedQueue<Object>(bundle);
+
+    @Test
+    public void testQueueRemovesCollectedEntries() {
+        // Keep a hardref so we can test get later
+        List<Object> elements = populate();
+        assertEquals("should contain all entries", ENTRY_COUNT, queue.values().size());
+
+        Object o = elements.get(ENTRY_COUNT / 2);
+        assertTrue("should contain an element", queue.values().contains(o));
+        o = null;
+
+        elements.remove(0);
+        GCUtils.gc();
+        assertEquals("should have one less element", ENTRY_COUNT - 1, queue.values().size());
+
+        elements.clear();
+        GCUtils.gc();
+
+        // Add an entries to force ReferenceManager.removeStaleEntries
+        Object last = new Object();
+        queue.add(last);
+        assertEquals("should only contain last added", 1, queue.values().size());
+    }
+
+    @Test
+    public void testQueueRemovesCollectedEntriesOnIteration() {
+        List<Object> elements = populate();
+        assertEquals("should contain all entries", ENTRY_COUNT, queue.values().size());
+        elements.clear();
+        GCUtils.gc();
+        assertFalse("Iterator should remove collected elements", queue.iterator().hasNext());
+    }
+
+    @Test
+    public void testQueueIterationManyThreadsWithRemove() throws Exception {
+        List<Object> elements = populate();
+        assertEquals("should contain all entries", ENTRY_COUNT, queue.values().size());
+        multipleIterateAndRemove(8, ENTRY_COUNT);
+    }
+
+    @Test
+    public void testQueueIterationManyThreadsWithRemoveWithGC() throws Exception {
+        List<Object> elements = populate();
+        assertEquals("should contain all entries", ENTRY_COUNT, queue.values().size());
+        // Remove some refs so GC will work in order to test multiple iterating threads
+        // removing collected references
+        int i = 0;
+        for (Iterator<Object> itr = elements.iterator(); itr.hasNext();) {
+            itr.next();
+            if (i++ % 8 == 0) {
+                itr.remove();
+            }
+        }
+        GCUtils.gc();
+        multipleIterateAndRemove(8, elements.size());
+    }
+
+    @Test
+    public void testQueueRemoveCalledByMultipleThreadsOnSameElement() throws Exception {
+        final Object value1 = new Object();
+        final Object value2 = new Object();
+        queue.add(value1);
+        queue.add(value2);
+        final int threadCount = 8;
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    Iterator<Object> itr = queue.iterator();
+                    Object o = itr.next();
+                    assertEquals(value1, o);
+                    ThreadUtils.await(barrier);
+                    itr.remove();
+                    ThreadUtils.await(barrier);
+                }
+            });
+            t.setDaemon(true);
+            t.start();
+        }
+        ThreadUtils.await(barrier); // start
+        barrier.await(1L, TimeUnit.MINUTES);
+        Iterator<Object> itr = queue.iterator();
+        assertTrue(itr.hasNext());
+        assertEquals(value2, itr.next());
+        assertFalse(itr.hasNext());
+    }
+
+    private void multipleIterateAndRemove(final int threadCount, final int expectCount) throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    int elementCount = 0;
+                    Iterator<Object> itr = queue.iterator();
+                    ThreadUtils.await(barrier);
+                    while (itr.hasNext()) {
+                        itr.next();
+                        if (elementCount++ == idx) {
+                            itr.remove();
+                        }
+                    }
+                    assertTrue(elementCount >= (expectCount - threadCount));
+                    ThreadUtils.await(barrier);
+                }
+            });
+            t.setDaemon(true);
+            t.start();
+        }
+        ThreadUtils.await(barrier); //start
+        barrier.await(1L, TimeUnit.MINUTES);
+    }
+
+    private List<Object> populate() {
+        List<Object> elements = new ArrayList<Object>(ENTRY_COUNT);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            Object o = new Object();
+            elements.add(o);
+            queue.add(o);
+        }
+        return elements;
+    }
+
+}


### PR DESCRIPTION
As suggested in PR #484 removed the locking on the `ManagedLinkedList` by creating a new `ManagedConcurrentLinkedQueue`.

Also added a `stress` subproject for tests that employ many threads, need GC, or just in general try to break things and take a long time.  These require a special property to be set in order to run, otherwise they will be skipped.  I tried to work it out in the `performance` subproject, but that seems to be very specialized for the compiler tests.  Open to suggestions on a better way to handle these types of tests.