### PR TITLE
Safe number parsing methods for more convenient XML parsing

### DIFF
--- a/src/main/groovy/util/Node.java
+++ b/src/main/groovy/util/Node.java
@@ -26,10 +26,13 @@ import groovy.lang.Tuple2;
 import groovy.xml.QName;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codehaus.groovy.runtime.InvokerHelper;
+import org.codehaus.groovy.runtime.StringGroovyMethods;
 import org.codehaus.groovy.util.ListHashMap;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -783,5 +786,81 @@ public class Node implements Serializable, Cloneable {
      */
     public void print(PrintWriter out) {
         new NodePrinter(out).print(this);
+    }
+
+    /**
+     * Converts the text of this GPathResult to a Integer object.
+     *
+     * @return the GPathResult, converted to a <code>Integer</code>
+     */
+    public Integer toInteger() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
+        return StringGroovyMethods.toInteger(text());
+    }
+
+    /**
+     * Converts the text of this GPathResult to a Long object.
+     *
+     * @return the GPathResult, converted to a <code>Long</code>
+     */
+    public Long toLong() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
+        return StringGroovyMethods.toLong(text());
+    }
+
+    /**
+     * Converts the text of this GPathResult to a Float object.
+     *
+     * @return the GPathResult, converted to a <code>Float</code>
+     */
+    public Float toFloat() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
+        return StringGroovyMethods.toFloat(text());
+    }
+
+    /**
+     * Converts the text of this GPathResult to a Double object.
+     *
+     * @return the GPathResult, converted to a <code>Double</code>
+     */
+    public Double toDouble() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
+        return StringGroovyMethods.toDouble(text());
+    }
+
+    /**
+     * Converts the text of this GPathResult to a BigDecimal object.
+     *
+     * @return the GPathResult, converted to a <code>BigDecimal</code>
+     */
+    public BigDecimal toBigDecimal() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
+        return StringGroovyMethods.toBigDecimal(text());
+    }
+
+    /**
+     * Converts the text of this GPathResult to a BigInteger object.
+     *
+     * @return the GPathResult, converted to a <code>BigInteger</code>
+     */
+    public BigInteger toBigInteger() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
+        return StringGroovyMethods.toBigInteger(text());
+    }
+
+    private boolean textIsEmptyOrNull() {
+        return text() == null || text().equals("");
     }
 }

--- a/subprojects/groovy-xml/src/test/groovy/groovy/util/SafeNumberParsingNodeTest.groovy
+++ b/subprojects/groovy-xml/src/test/groovy/groovy/util/SafeNumberParsingNodeTest.groovy
@@ -1,0 +1,38 @@
+package groovy.util
+
+class SafeNumberParsingNodeTest extends GroovyTestCase {
+
+    void testSafetyWhenConvertingToNumbers() {
+        def xmlText = '''
+                <someNumberValues>
+                <someBigDecimal>123.4</someBigDecimal>
+                <someEmptyBigDecimal></someEmptyBigDecimal>
+                <someLong>123</someLong>
+                <someEmptyLong></someEmptyLong>
+                <someFloat>123.4</someFloat>
+                <someEmptyFloat></someEmptyFloat>
+                <someDouble>123.4</someDouble>
+                <someEmptyDouble></someEmptyDouble>
+                <someInteger>123</someInteger>
+                <someEmptyInteger></someEmptyInteger>
+            </someNumberValues>
+                '''
+        def xml = new XmlParser().parseText(xmlText)
+
+        assert xml.'**'.find { it.name() == 'someBigDecimal' }.toBigDecimal() == 123.4
+        assert xml.'**'.find { it.name() == 'someEmptyBigDecimal' }.toBigDecimal() == null
+        assert xml.'**'.find { it.name() == 'someMissingBigDecimal' }?.toBigDecimal() == null
+        assert xml.'**'.find { it.name() == 'someLong' }.toLong() == 123
+        assert xml.'**'.find { it.name() == 'someEmptyLong' }.toLong() == null
+        assert xml.'**'.find { it.name() == 'someMissingLong' }?.toLong() == null
+        assert xml.'**'.find { it.name() == 'someFloat' }.toFloat() == 123.4.toFloat()
+        assert xml.'**'.find { it.name() == 'someEmptyFloat' }.toFloat() == null
+        assert xml.'**'.find { it.name() == 'someMissingFloat' }?.toFloat() == null
+        assert xml.'**'.find { it.name() == 'someDouble' }.toDouble() == 123.4.toDouble()
+        assert xml.'**'.find { it.name() == 'someEmptyDouble' }.toDouble() == null
+        assert xml.'**'.find { it.name() == 'someMissingDouble' }?.toDouble() == null
+        assert xml.'**'.find { it.name() == 'someInteger' }.toInteger() == 123
+        assert xml.'**'.find { it.name() == 'someEmptyInteger' }.toInteger() == null
+        assert xml.'**'.find { it.name() == 'someMissingInteger' }?.toInteger() == null
+    }
+}


### PR DESCRIPTION
Added 
```
toBigInteger()
toBigDecimal()
toDouble()
toBigLong()
toBigFloat()
```
To _groovy.util.Node_

If the element content is empty or null the methods will return _null_

This is now possible:
```
xml.'**'.find { it.name() == 'someEmptyBigDecimal' }?.toBigDecimal()
```