### PR TITLE
GROOVY-8056: GroovyCodeSource(URL) can leak a file handler

### DIFF
--- a/src/main/groovy/lang/GroovyCodeSource.java
+++ b/src/main/groovy/lang/GroovyCodeSource.java
@@ -173,12 +173,7 @@ public class GroovyCodeSource {
         this.name = url.toExternalForm();
         this.codeSource = new CodeSource(url, (java.security.cert.Certificate[]) null);
         try {
-            String contentEncoding = url.openConnection().getContentEncoding();
-            if (contentEncoding != null) {
-                this.scriptText = ResourceGroovyMethods.getText(url, contentEncoding);
-            } else {
-                this.scriptText = ResourceGroovyMethods.getText(url); // falls-back on default encoding
-            }
+            this.scriptText = ResourceGroovyMethods.getText(url); // default encoding
         } catch (IOException e) {
             throw new RuntimeException("Impossible to read the text content from " + name, e);
         }

--- a/src/main/groovy/util/GroovyScriptEngine.java
+++ b/src/main/groovy/util/GroovyScriptEngine.java
@@ -563,8 +563,7 @@ public class GroovyScriptEngine implements ResourceConnector {
         try {
             if (isSourceNewer(entry)) {
                 try {
-                    String encoding = conn.getContentEncoding() != null ? conn.getContentEncoding() : config.getSourceEncoding();
-                    String content = IOGroovyMethods.getText(conn.getInputStream(), encoding);
+                    String content = IOGroovyMethods.getText(conn.getInputStream(), config.getSourceEncoding());
                     clazz = groovyLoader.parseClass(content, path);
                 } catch (IOException e) {
                     throw new ResourceException(e);

--- a/src/test/groovy/util/GroovyScriptEngineReloadingTest.groovy
+++ b/src/test/groovy/util/GroovyScriptEngineReloadingTest.groovy
@@ -482,10 +482,6 @@ class GroovyScriptEngineReloadingTest extends GroovyTestCase {
     }
     
     class MapUrlConnection extends URLConnection {
-        String getContentEncoding() {
-            return CHARSET
-        }
-    
         Object getContent() throws IOException {
             return super.content
         }


### PR DESCRIPTION
URLConnect.getContentEncoding returns the Content-Encoding
HTTP Header [1] which is not a charset.  Since this method would
have either returned null or an invalid charset, the code path
specifying the encoding would normally not have been executed.
The charset may be contained in the Content-Type header, but
rather than attempt to parse that string which would require
closing the connection, this fix avoids opening the connection
and relies on the default charset.

[1] https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11