### PR TITLE
GROOVY-8096 setScriptBaseClass with Java class breaks @Field Binding init due to call to super() instead of super(Binding)

### DIFF
--- a/src/test/groovy/lang/BindingScript.java
+++ b/src/test/groovy/lang/BindingScript.java
@@ -1,0 +1,32 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.lang;
+
+/**
+ * A Script which requires a Binding passed in the constructor and disallows calling the default constructor.
+ */
+public abstract class BindingScript extends Script {
+    protected BindingScript() {
+        throw new UnsupportedOperationException("\n\t*******\n\tBindingScript() should not be called! Should be calling BindingScript(Binding)!\n\t*******");
+    }
+
+    protected BindingScript(Binding binding) {
+        super(binding);
+    }
+}

--- a/src/test/groovy/lang/GroovyShellTest2.groovy
+++ b/src/test/groovy/lang/GroovyShellTest2.groovy
@@ -43,6 +43,60 @@ class GroovyShellTest2 extends GroovyTestCase {
         assert result == arg0
     }
 
+    void testBindingsInFieldInitializersWithAnnotatedJavaBaseScript() {
+        def shell = new GroovyShell();
+        def scriptText = '''
+        @groovy.transform.BaseScript groovy.lang.BindingScript baseScript
+        @groovy.transform.Field def script_args = getProperty('args')
+
+        assert script_args[0] == 'Hello Groovy'
+        script_args[0]
+'''
+
+        def arg0 = 'Hello Groovy'
+        def result = shell.run scriptText, 'TestBindingsInFieldInitializersWithAnnotatedJavaBaseScript.groovy', [arg0]
+        assert result == arg0
+    }
+
+    /**
+     This test fails because {@link org.codehaus.groovy.ast.ModuleNode#setScriptBaseClassFromConfig(org.codehaus.groovy.ast.ClassNode)}
+     calls .setSuperClass(ClassHelper.make(baseClassName)) on the Scripts ClassNode.
+
+     The ClassNode created for this scriptBaseClass has lazyInitDone = true and constructors = null so when
+     .getSuperClass().getDeclaredConstructor(SCRIPT_CONTEXT_CTOR) is called by {@link org.codehaus.groovy.ast.ModuleNode#createStatementsClass()}
+     then ClassNode.constructors is set to an empty ArrayList in {@link org.codehaus.groovy.ast.ClassNode#getDeclaredConstructors()}
+
+     The script constructor is then generated as
+         Constructor(Binding context) {
+             super();                                    // Fields are initialized after the call to super()
+             setBinding(context);                        // Fields are initalized before the call to setBinding(context)
+         }
+
+     instead of
+         Constructor(Binding context) {
+             super(context);                             // Fields are initialized after the call to super(context)
+         }
+
+     Fields are initialized between the call to super() and the setBinding(context)
+     which means Field initializers don't have access to the Binding context.
+     */
+    void testBindingsInFieldInitializersWithConfigJavaBaseScript() {
+        def config = new org.codehaus.groovy.control.CompilerConfiguration()
+        config.scriptBaseClass = BindingScript.class.name
+
+        def shell = new GroovyShell(config);
+        def scriptText = '''
+        @groovy.transform.Field def script_args = getProperty('args')
+
+        assert script_args[0] == 'Hello Groovy'
+        script_args[0]
+'''
+
+        def arg0 = 'Hello Groovy'
+        def result = shell.run scriptText, 'TestBindingsInFieldInitializersWithConfigJavaBaseScript.groovy', [arg0]
+        assert result == arg0
+    }
+
     void testBindingsInScriptFieldInitializers() {
         def shell = new GroovyShell();
         def scriptText = '''


### PR DESCRIPTION
This test fails because `ClassNode.getSuperClass().getDeclaredConstructor(SCRIPT_CONTEXT_CTOR)` doesn't see the constructors in the Java base class.

`ModuleNode.setScriptBaseClassFromConfig(ClassNode)`
calls `.setSuperClass(ClassHelper.make(baseClassName))` on the `scriptDummy` `ClassNode`.

 The `ClassNode` created for this script's base class has `.lazyInitDone = true` and `.constructors = null` so when `.getSuperClass().getDeclaredConstructor(SCRIPT_CONTEXT_CTOR)` is called by `ModuleNode.createStatementsClass()`, then `ClassNode.constructors` is set to an empty ArrayList in `ClassNode.getDeclaredConstructors()`

The script constructor is then generated as

         Constructor(Binding context) {
             super();                   // Fields are initialized after the call to super()
                                        // Fields are initialized here
             setBinding(context);       // Fields are initialized before the call to setBinding(context)
         }

instead of

         Constructor(Binding context) {
             super(context);            // Fields are initialized after the call to super(context)
         }

Fields are initialized between the call to super() and the setBinding(context)
which means Field initializers don't have access to the Binding context.

This leads to `MissingPropertyException` because we're trying to look up variables from the `new Binding()` created in the default constructor, instead of the binding we passed in.