### PR TITLE
GROOVY-6792: ClassFormatError if a method has dots within its name

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -54,7 +54,7 @@ import static org.objectweb.asm.Opcodes.*;
  * </ul>
  */
 public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
-
+    private static final String[] INVALID_NAME_CHARS = {".", ":", "/", ";", "[", "<", ">"};
     private ClassNode currentClass;
     private final SourceUnit source;
     private boolean inConstructor = false;
@@ -78,6 +78,7 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
             checkAbstractMethodVisibility(node);
             checkClassForOverwritingFinal(node);
             checkMethodsForIncorrectModifiers(node);
+            checkMethodsForIncorrectName(node);
             checkMethodsForWeakerAccess(node);
             checkMethodsForOverridingFinal(node);
             checkNoAbstractMethodsNonabstractClass(node);
@@ -285,6 +286,21 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
             cn = anInterface;
             if (!cn.isInterface()) {
                 addError("You are not allowed to implement the " + getDescription(cn) + ", use extends instead.", node);
+            }
+        }
+    }
+
+    private void checkMethodsForIncorrectName(ClassNode cn) {
+        List<MethodNode> methods = cn.getAllDeclaredMethods();
+        for (MethodNode mNode : methods) {
+            String name = mNode.getName();
+            if (name.equals("<init>") || name.equals("<clinit>")) continue;
+            // Groovy allows more characters than Character.isValidJavaIdentifier() would allow
+            // if we find a good way to encode special chars we could remove (some of) these checks
+            for (String ch : INVALID_NAME_CHARS) {
+                if (name.contains(ch)) {
+                    addError("You are not allowed to have '" + ch + "' in a method name", mNode);
+                }
             }
         }
     }

--- a/src/test/groovy/bugs/Groovy6792Bug.groovy
+++ b/src/test/groovy/bugs/Groovy6792Bug.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import gls.CompilableTestSupport
+
+class Groovy6792Bug extends CompilableTestSupport {
+    void testMethodWithSpecialCharsInName() {
+        assertScript """
+            class Foo {
+                static ",{}()|!?foo@#\\\$%^&*-=]\\\\bar'\\""(){ Foo.name }
+            }
+            assert Foo.",{}()|!?foo@#\\\$%^&*-=]\\\\bar'\\""() == 'Foo'
+        """
+    }
+
+    void testMethodWithInvalidName() {
+        def message = shouldNotCompile """
+            class Foo {
+                def "bar.baz"(){}
+            }
+        """
+        assert message.contains("You are not allowed to have '.' in a method name")
+    }
+}


### PR DESCRIPTION
Provide a friendly error message for now - we can remove (some of) the checks if we find a good way to encode special chars