### PR TITLE
Adds documentation around 'remove' method Integer/Object ambiguity

### DIFF
--- a/src/spec/doc/working-with-collections.adoc
+++ b/src/spec/doc/working-with-collections.adoc
@@ -138,22 +138,34 @@ The {gdk} also contains methods allowing you to easily remove elements from a li
 include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=list_gdk3,indent=0]
 ----------------------------------------------------------------------------
 
-It is also possible to remove an element by referring to its index, in which case the list is mutated:
+It is also possible to remove an element by passing its index to the `remove` method, in which case the list is mutated:
 
 [source,groovy]
 ----------------------------------------------------------------------------
-include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=list_gdk4,indent=0]
+include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=list_gdk_remove_index,indent=0]
 ----------------------------------------------------------------------------
 
 In case you only want to remove the first element having the same value in a list, instead of removing all
-elements, you call call the `remove` method:
+elements, you call call the `remove` method passing the value:
 
 [source,groovy]
 ----------------------------------------------------------------------------
 include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=list_gdk5,indent=0]
 ----------------------------------------------------------------------------
 
-And removing all the elements in a list can be done by calling the `clear` method:
+As you can see, there are two `remove` methods available.  One that takes an integer and removes an element
+by its index, and another that will remove the first element that matches the passed value.  So what should we 
+do when we have a list of integers?  In this case, you may wish to use `removeAt` to remove an element by its
+index, and `removeElement` to remove the first element that matches a value.
+
+[source,groovy]
+----------------------------------------------------------------------------
+include::{projectdir}/src/spec/test/gdk/WorkingWithCollectionsTest.groovy[tags=list_gdk4,indent=0]
+----------------------------------------------------------------------------
+
+Of course, `removeAt` and `removeElement` will work with lists of any type.
+
+Additionally, removing all the elements in a list can be done by calling the `clear` method:
 
 [source,groovy]
 ----------------------------------------------------------------------------

--- a/src/spec/test/gdk/WorkingWithCollectionsTest.groovy
+++ b/src/spec/test/gdk/WorkingWithCollectionsTest.groovy
@@ -238,10 +238,28 @@ class WorkingWithCollectionsTest extends GroovyTestCase {
         '''
 
         assertScript '''
+            // tag::list_gdk_remove_index[]
+            def list = ['a','b','c','d','e','f','b','b','a']
+            assert list.remove(2) == 'c'        // remove the third element, and return it
+            assert list == ['a','b','d','e','f','b','b','a']
+            // end::list_gdk_remove_index[]
+        '''
+        
+        assertScript '''
             // tag::list_gdk4[]
             def list = [1,2,3,4,5,6,2,2,1]
-            assert list.remove(2) == 3          // remove the third element, and return it
+
+            assert list.remove(2) == 3          // this removes the element at index 2, and returns it
             assert list == [1,2,4,5,6,2,2,1]
+
+            assert list.removeElement(2)        // remove first 2 and return true
+            assert list == [1,4,5,6,2,2,1]
+
+            assert ! list.removeElement(8)      // return false because 8 is not in the list
+            assert list == [1,4,5,6,2,2,1]
+
+            assert list.removeAt(1) == 4        // remove element at index 1, and return it
+            assert list == [1,5,6,2,2,1]
             // end::list_gdk4[]
         '''
 


### PR DESCRIPTION
I'm decently new to Groovy and was recently caught off-guard by attempting to use the `remove` method on a list of Integers, so I thought I'd try to update the document to add `removeAt` and `removeElement` to that section.