### PR TITLE
Fix running out of memory ("GC overhead limit exceeded") build proble…

### DIFF
--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -137,6 +137,7 @@ allprojects {
             xml.enabled = false
             html.enabled = true
         }
+        maxHeapSize = '2g'
     }
 }
 


### PR DESCRIPTION
…m that happens during findBugs analysis (I've encountered that personally - findBugs was definitely exhausting 1GB heap)