### PR TITLE
More useful error message in NodeList.replaceNode method

### DIFF
--- a/src/main/groovy/util/NodeList.java
+++ b/src/main/groovy/util/NodeList.java
@@ -187,7 +187,8 @@ public class NodeList extends ArrayList {
 
     public Node replaceNode(Closure c) {
         if (size() <= 0 || size() > 1) {
-            throw new GroovyRuntimeException("replaceNode() can only be used to replace a single node.");
+            throw new GroovyRuntimeException(
+                    "replaceNode() can only be used to replace a single node, but was applied to " + size() + " nodes");
         }
         return ((Node)get(0)).replaceNode(c);
     }


### PR DESCRIPTION
I ran into this unhelpful message when using one of plugins for Gradle that patched config files. Knowing the actual number of nodes would help to identify the issue.