### PR TITLE
cleanup now that jdk7 is baseline

### DIFF
--- a/gradle/indy.gradle
+++ b/gradle/indy.gradle
@@ -21,14 +21,7 @@
 // with regards to invoke dynamic support (indy)
 
 rootProject.ext.indyCapable = {
-    boolean capable = true
-    try {
-        Class.forName('java.lang.invoke.MethodHandle')
-    } catch (e) {
-        capable = false
-    }
-
-    capable && !rootProject.hasProperty('skipIndy')
+    !rootProject.hasProperty('skipIndy')
 }
 
 rootProject.ext.useIndy = {

--- a/src/main/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -256,23 +256,7 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
                 "IO Exception attempting to load global transforms:" + e.getMessage(),
                 null));
         }
-        try {
-            Class.forName("java.lang.annotation.Annotation"); // test for 1.5 JVM
-        } catch (Exception e) {
-            // we failed, notify the user
-            StringBuilder sb = new StringBuilder();
-            sb.append("Global ASTTransformations are not enabled in retro builds of groovy.\n");
-            sb.append("The following transformations will be ignored:");
-            for (Map.Entry<String, URL> entry : transformNames.entrySet()) {
-                sb.append('\t');
-                sb.append(entry.getKey());
-                sb.append('\n');
-            }
-            compilationUnit.getErrorCollector().addWarning(new WarningMessage(
-                WarningMessage.POSSIBLE_ERRORS, sb.toString(), null, null));
-            return;
-        }
-        
+
         // record the transforms found in the first scan, so that in the 2nd scan, phase operations 
         // can be added for only for new transforms that have come in 
         if(isFirstScan) {


### PR DESCRIPTION
Avoids reflective checks/constructions where it is no longer needed since 7 is now baseline in 2_5_X and master.