### PR TITLE
GROOVY-7654: Iterable as List and Iterable.asList() have different semantics

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -11001,12 +11001,16 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @param iterable a Iterable
      * @param clazz    the desired class
      * @return the object resulting from this type conversion
-     * @see #asType(Collection, Class) 
+     * @see #asType(Collection, Class)
      * @since 2.4.12
      */
     @SuppressWarnings("unchecked")
     public static <T> T asType(Iterable iterable, Class<T> clazz) {
-          return asType((Collection) toList(iterable), clazz);
+        if (Collection.class.isAssignableFrom(clazz)) {
+            return asType((Collection) toList(iterable), clazz);
+        }
+
+        return asType((Object) iterable, clazz);
     }
 
     /**

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -10996,6 +10996,20 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Converts the given iterable to another type.
+     *
+     * @param iterable a Iterable
+     * @param clazz    the desired class
+     * @return the object resulting from this type conversion
+     * @see #asType(Collection, Class) 
+     * @since 2.4.12
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T asType(Iterable iterable, Class<T> clazz) {
+          return asType((Collection) toList(iterable), clazz);
+    }
+
+    /**
      * Converts the given collection to another type. A default concrete
      * type is used for List, Set, or SortedSet. If the given type has
      * a constructor taking a collection, that is used. Otherwise, the

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -236,7 +236,28 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertEquals(3, list.get(2));
     }
 
+    // GROOVY-7654
+    public void testIterableAsList() {
+        def list = [1, 2, 3]
+        def iterable = new IterableWrapper(delegate: list)
+
+        def iterableAsList = iterable.asList()
+        def iterableAsType = iterable as List
+        
+        assertEquals(iterableAsList, iterableAsType)
+        assertEquals(1, iterableAsList[0])
+        assertEquals(1, iterableAsType[0])
+    }
+
     private static class MyList extends ArrayList {
         public MyList() {}
+    }
+
+    private static class IterableWrapper implements Iterable {
+        Iterable delegate
+
+        Iterator iterator() {
+            delegate.iterator()
+        }
     }
 }

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -241,9 +241,15 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         def list = [1, 2, 3]
         def iterable = new IterableWrapper(delegate: list)
 
+        def iterableAsIterable = iterable as Iterable
+        assertTrue(iterableAsIterable.is(iterable))
+
+        def iterableAsIterableWrapper = iterable as IterableWrapper
+        assertTrue(iterableAsIterableWrapper.is(iterable))
+
         def iterableAsList = iterable.asList()
         def iterableAsType = iterable as List
-        
+
         assertEquals(iterableAsList, iterableAsType)
         assertEquals(1, iterableAsList[0])
         assertEquals(1, iterableAsType[0])


### PR DESCRIPTION
Introduce DefaultGroovyMethods.asType(Iterable, Class) to handle correctly 'asType' to iterables