### PR TITLE
require JDK 8+ for release builds (2_5_X/2_6_X)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -470,18 +470,17 @@ compileTestGroovy {
     groovyOptions.fork(memoryMaximumSize: groovycTest_mx)
 }
 
-// TODO superfluous to check for JDK7 for Gradle version 3.2+ but leave for future?
 task checkCompatibility {
     doLast {
-        assert JavaVersion.current().java7Compatible
+        assert JavaVersion.current().isJava8Compatible()
     }
 }
 
-if (!JavaVersion.current().java7Compatible) {
+if (!JavaVersion.current().isJava8Compatible()) {
     logger.lifecycle '''
     **************************************** WARNING ********************************************
-    ******   You are running the build with an older JDK. NEVER try to release with 1.6.   ******
-    ******   You must use a JDK 1.7+ in order to compile all features of the language.     ******
+    ******   You are running the build with an older JDK. NEVER try to release with 1.7.   ******
+    ******   You must use a JDK 1.8+ in order to compile all features of the language.     ******
     *********************************************************************************************
 '''
 }

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -160,6 +160,8 @@ task docGDK {
                     arg(value: 'subprojects/groovy-swing/src/main/java/org/codehaus/groovy/runtime/SwingGroovyMethods.java')
                     arg(value: 'subprojects/groovy-xml/src/main/java/org/codehaus/groovy/runtime/XmlGroovyMethods.java')
                     arg(value: 'subprojects/groovy-nio/src/main/java/org/codehaus/groovy/runtime/NioGroovyMethods.java')
+                    arg(value: 'subprojects/groovy-jsr223/src/main/java/org/codehaus/groovy/jsr223/ScriptExtensions.java')
+                    arg(value: 'subprojects/groovy-jsr223/src/main/java/org/codehaus/groovy/jsr223/ScriptStaticExtensions.java')
                 }
             }
         } finally {


### PR DESCRIPTION
For 2_5_X and 2_6_X in order to compile all features JDK 8+ is required for building releases (related to PR #545). 

Also included a commit to add JSR223 DGMs in the GDK docs.  These methods were moved from `org.codehaus.groovy.vmplugin.v6.PluginDefaultGroovyMethods` and `org.codehaus.groovy.vmplugin.v6.PluginStaticGroovyMethods` but the docs build was not updated to include the new files.