### PR TITLE
GROOVY-8200 - Shorthand |= results in NPE

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -15760,8 +15760,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean and(Boolean left, Boolean right) {
-        right = Boolean.TRUE.equals(right);
-        return left && right;
+        return left && Boolean.TRUE.equals(right);
     }
 
     /**
@@ -15773,8 +15772,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean or(Boolean left, Boolean right) {
-        right = Boolean.TRUE.equals(right);
-        return left || right;
+        return left || Boolean.TRUE.equals(right);
     }
 
     /**
@@ -15786,8 +15784,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.8.3
      */
     public static Boolean implies(Boolean left, Boolean right) {
-        right = Boolean.TRUE.equals(right);
-        return !left || right;
+        return !left || Boolean.TRUE.equals(right);
     }
 
     /**
@@ -15799,8 +15796,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean xor(Boolean left, Boolean right) {
-        right = Boolean.TRUE.equals(right);
-        return left ^ right;
+        return left ^ Boolean.TRUE.equals(right);
     }
 
 //    public static Boolean negate(Boolean left) {

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -15760,9 +15760,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean and(Boolean left, Boolean right) {
-        if (right == null) {
-            right = Boolean.FALSE;
-        }
+        right = Boolean.TRUE.equals(right);
         return left && right;
     }
 
@@ -15775,9 +15773,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean or(Boolean left, Boolean right) {
-        if (right == null) {
-            right = Boolean.FALSE;
-        }
+        right = Boolean.TRUE.equals(right);
         return left || right;
     }
 
@@ -15790,9 +15786,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.8.3
      */
     public static Boolean implies(Boolean left, Boolean right) {
-        if (right == null) {
-            right = Boolean.FALSE;
-        }
+        right = Boolean.TRUE.equals(right);
         return !left || right;
     }
 
@@ -15805,9 +15799,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean xor(Boolean left, Boolean right) {
-        if (right == null) {
-            right = Boolean.FALSE;
-        }
+        right = Boolean.TRUE.equals(right);
         return left ^ right;
     }
 

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -15760,6 +15760,9 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean and(Boolean left, Boolean right) {
+        if (right == null) {
+            right = Boolean.FALSE;
+        }
         return left && right;
     }
 
@@ -15772,6 +15775,9 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean or(Boolean left, Boolean right) {
+        if (right == null) {
+            right = Boolean.FALSE;
+        }
         return left || right;
     }
 
@@ -15784,6 +15790,9 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.8.3
      */
     public static Boolean implies(Boolean left, Boolean right) {
+        if (right == null) {
+            right = Boolean.FALSE;
+        }
         return !left || right;
     }
 
@@ -15796,6 +15805,9 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean xor(Boolean left, Boolean right) {
+        if (right == null) {
+            right = Boolean.FALSE;
+        }
         return left ^ right;
     }
 

--- a/src/spec/test/OperatorsTest.groovy
+++ b/src/spec/test/OperatorsTest.groovy
@@ -607,4 +607,46 @@ assert (b1 + 11).size == 15
             assert str1 == str2
             '''
     }
+
+    void testBooleanOr() {
+        assertScript '''
+boolean trueValue1 = true, trueValue2 = true, trueValue3 = true
+boolean falseValue1 = false, falseValue2 = false, falseValue3 = false
+
+assert (trueValue1 |= true)
+assert (trueValue2 |= false)
+assert (trueValue3 |= null)
+assert (falseValue1 |= true)
+assert !(falseValue2 |= false)
+assert !(falseValue3 |= null)
+'''
+    }
+
+    void testBooleanAnd() {
+        assertScript '''
+boolean trueValue1 = true, trueValue2 = true, trueValue3 = true
+boolean falseValue1 = false, falseValue2 = false, falseValue3 = false
+
+assert (trueValue1 &= true)
+assert !(trueValue2 &= false)
+assert !(trueValue3 &= null)
+assert !(falseValue1 &= true)
+assert !(falseValue2 &= false)
+assert !(falseValue3 &= null)
+'''
+    }
+
+    void testBooleanXor() {
+        assertScript '''
+boolean trueValue1 = true, trueValue2 = true, trueValue3 = true
+boolean falseValue1 = false, falseValue2 = false, falseValue3 = false
+
+assert !(trueValue1 ^= true)
+assert (trueValue2 ^= false)
+assert (trueValue3 ^= null)
+assert (falseValue1 ^= true)
+assert !(falseValue2 ^= false)
+assert !(falseValue3 ^= null)
+'''
+    }
 }

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -269,10 +269,10 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
 
     public void testBooleanImplication() {
         assertTrue(DefaultGroovyMethods.implies(true, true))
-        assertTrue(DefaultGroovyMethods.xor(true, false))
-        assertTrue(DefaultGroovyMethods.xor(false, true))
-        assertFalse(DefaultGroovyMethods.xor(false, false))
-        assertFalse(DefaultGroovyMethods.xor(false, null))
-        assertTrue(DefaultGroovyMethods.xor(true, null))
+        assertFalse(DefaultGroovyMethods.implies(true, false))
+        assertTrue(DefaultGroovyMethods.implies(false, true))
+        assertTrue(DefaultGroovyMethods.implies(false, false))
+        assertTrue(DefaultGroovyMethods.implies(false, null))
+        assertFalse(DefaultGroovyMethods.implies(true, null))
     }
 }

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -239,4 +239,40 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
     private static class MyList extends ArrayList {
         public MyList() {}
     }
+
+    public void testBooleanOr() {
+        assertTrue(DefaultGroovyMethods.or(true, true))
+        assertTrue(DefaultGroovyMethods.or(true, false))
+        assertTrue(DefaultGroovyMethods.or(false, true))
+        assertFalse(DefaultGroovyMethods.or(false, false))
+        assertFalse(DefaultGroovyMethods.or(false, null))
+        assertTrue(DefaultGroovyMethods.or(true, null))
+    }
+
+    public void testBooleanAnd() {
+        assertTrue(DefaultGroovyMethods.and(true, true))
+        assertFalse(DefaultGroovyMethods.and(true, false))
+        assertFalse(DefaultGroovyMethods.and(false, true))
+        assertFalse(DefaultGroovyMethods.and(false, false))
+        assertFalse(DefaultGroovyMethods.and(false, null))
+        assertFalse(DefaultGroovyMethods.and(true, null))
+    }
+
+    public void testBooleanXor() {
+        assertFalse(DefaultGroovyMethods.xor(true, true))
+        assertTrue(DefaultGroovyMethods.xor(true, false))
+        assertTrue(DefaultGroovyMethods.xor(false, true))
+        assertFalse(DefaultGroovyMethods.xor(false, false))
+        assertFalse(DefaultGroovyMethods.xor(false, null))
+        assertTrue(DefaultGroovyMethods.xor(true, null))
+    }
+
+    public void testBooleanImplication() {
+        assertTrue(DefaultGroovyMethods.implies(true, true))
+        assertTrue(DefaultGroovyMethods.xor(true, false))
+        assertTrue(DefaultGroovyMethods.xor(false, true))
+        assertFalse(DefaultGroovyMethods.xor(false, false))
+        assertFalse(DefaultGroovyMethods.xor(false, null))
+        assertTrue(DefaultGroovyMethods.xor(true, null))
+    }
 }


### PR DESCRIPTION
Fixing the NPE with an explicit test and assignment of the right-hand boolean operator.
Assigning a primitive boolean variable with null, like `boolean x = null`, will end up as `false`.
I think it only makes sense to apply the same behavior to the right hand operator.