### PR TITLE
GROOVY-8042 groovyConsole gets confused with a slashy string with an escaped forward slash

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/text/GroovyFilter.java
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/text/GroovyFilter.java
@@ -57,7 +57,7 @@ public class GroovyFilter extends StructuredSyntaxDocumentFilter {
     public static final String SINGLE_QUOTES =
             "(?ms:'{3}(?!'{1,3}).*?(?:'{3}|\\z))|(?:'{1}.*?(?:'|\\z))";
 
-    public static final String SLASHY_QUOTES = "(?:/[^/*].*?/|(?ms:\\$/.*?(?:/\\$|\\z)))";
+    public static final String SLASHY_QUOTES = "(?:/[^/*].*?(?<!\\\\)/|(?ms:\\$/.*?(?:/\\$|\\z)))";
 
     public static final String DIGIT = "DIGIT";
     public static final String DECIMAL_INTEGER_LITERAL = "(?:0|[1-9](?:[_0-9]*[0-9])?)[lL]?";

--- a/subprojects/groovy-console/src/test/groovy/groovy/ui/text/GroovyFilterTests.groovy
+++ b/subprojects/groovy-console/src/test/groovy/groovy/ui/text/GroovyFilterTests.groovy
@@ -130,4 +130,16 @@ class GroovyFilterTests extends GroovyTestCase {
         '''"""
         assert multilineTripleSingleQuotes ==~ GroovyFilter.SINGLE_QUOTES
     }
+
+    void testSlashyQuotes() {
+        assert '/foo/' ==~ GroovyFilter.SLASHY_QUOTES
+        assert '/foo\\//' ==~ GroovyFilter.SLASHY_QUOTES
+        assert '/foo\\/bar\\//' ==~ GroovyFilter.SLASHY_QUOTES
+        assert '/foo\\/bar\\\\/\\//' ==~ GroovyFilter.SLASHY_QUOTES
+
+        assert '$/foo$/' ==~ GroovyFilter.SLASHY_QUOTES
+        assert '$/foo\nbar$/' ==~ GroovyFilter.SLASHY_QUOTES
+        assert '$/foo\n/bar//$/' ==~ GroovyFilter.SLASHY_QUOTES
+        assert '$/foo\n/bar//\n$/' ==~ GroovyFilter.SLASHY_QUOTES
+    }
 }


### PR DESCRIPTION
Hi, guys! Here is quite a simple fix for the case when a slashy string renders in yellow just up to the escaped slash, not the closing one (https://issues.apache.org/jira/browse/GROOVY-8042). If we can have more tests on this code, please let me know how we can achieve this. The tests which I've added are kind of regression tests.