### PR TITLE
add JMH to performance subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -455,7 +455,8 @@ allprojects {
                 rootProject.bootstrapJar.archivePath
         )
 
-        classpath = classpath + groovyClasspath
+        // TODO: this null check was required after adding JMH plugin to performance project
+        classpath = (classpath != null) ? classpath + groovyClasspath : groovyClasspath
     }
 
     if (useIndy()) {

--- a/subprojects/performance/README.adoc
+++ b/subprojects/performance/README.adoc
@@ -1,3 +1,24 @@
+//////////////////////////////////////////
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+
+//////////////////////////////////////////
+
 = Performance
 
 This subproject contains two sets of performance related tests.  The first

--- a/subprojects/performance/README.adoc
+++ b/subprojects/performance/README.adoc
@@ -1,0 +1,18 @@
+= Performance
+
+This subproject contains two sets of performance related tests.  The first
+are compiler tests that can be run using the following Gradle task:
+
+    ./gradlew :perf:performanceTests
+
+This will compile various source files using several past version of Apache
+Groovy in addition to the current source version.
+
+This subproject also contains `JMH` Benchmarks which can be run using:
+
+    ./gradlew :perf:jmh
+
+In order to run the benchmarks against InvokeDynamic generated classes use
+the `indy` property:
+
+    ./gradlew -Pindy=true :perf:jmh

--- a/subprojects/performance/README.adoc
+++ b/subprojects/performance/README.adoc
@@ -26,7 +26,7 @@ are compiler tests that can be run using the following Gradle task:
 
     ./gradlew :perf:performanceTests
 
-This will compile various source files using several past version of Apache
+This will compile various source files using several past versions of Apache
 Groovy in addition to the current source version.
 
 This subproject also contains `JMH` Benchmarks which can be run using:

--- a/subprojects/performance/build.gradle
+++ b/subprojects/performance/build.gradle
@@ -40,6 +40,7 @@ jmh {
     includeTests = true
     resultsFile = project.file("target/results${useIndy() ? '_indy' : ''}.txt")
 }
+jmhClasses.dependsOn clean
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/subprojects/performance/build.gradle
+++ b/subprojects/performance/build.gradle
@@ -19,14 +19,26 @@
 
 import java.text.DecimalFormat
 
+plugins {
+    id "me.champeau.gradle.jmh" version "0.4.2"
+}
+
 configurations {
     stats
     testCompile.extendsFrom(stats)
 }
 
 dependencies {
+    jmh rootProject
     testCompile 'org.codehaus.groovy:groovy:2.4.7'
     stats 'org.apache.commons:commons-math3:3.6'
+}
+
+jmh {
+    jmhVersion = '1.19'
+    include = ['.*']
+    includeTests = true
+    resultsFile = project.file("target/results${useIndy() ? '_indy' : ''}.txt")
 }
 
 sourceCompatibility = 1.8

--- a/subprojects/performance/src/jmh/java/org/apache/groovy/bench/dispatch/CallsiteBench.java
+++ b/subprojects/performance/src/jmh/java/org/apache/groovy/bench/dispatch/CallsiteBench.java
@@ -1,0 +1,132 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.bench.dispatch;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class CallsiteBench {
+
+    @Benchmark
+    public void dispatch_1_monomorphic_groovy(MonomorphicState state, Blackhole bh) {
+        Callsite.dispatch(state.receivers, bh);
+    }
+
+    @Benchmark
+    public void dispatch_1_monomorphic_java(MonomorphicState state, Blackhole bh) {
+        dispatch(state.receivers, bh);
+    }
+
+    @Benchmark
+    public void dispatch_3_polymorphic_groovy(PolymorphicState state, Blackhole bh) {
+        Callsite.dispatch(state.receivers, bh);
+    }
+
+    @Benchmark
+    public void dispatch_3_polymorphic_java(PolymorphicState state, Blackhole bh) {
+        dispatch(state.receivers, bh);
+    }
+
+    @Benchmark
+    public void dispatch_8_megamorphic_groovy(MegamorphicState state, Blackhole bh) {
+        Callsite.dispatch(state.receivers, bh);
+    }
+
+    @Benchmark
+    public void dispatch_8_megamorphic_java(MegamorphicState state, Blackhole bh) {
+        dispatch(state.receivers, bh);
+    }
+
+    private void dispatch(Object[] receivers, Blackhole bh) {
+        for (Object receiver : receivers) {
+            bh.consume(receiver.toString());
+        }
+    }
+
+    private static final int RECEIVER_COUNT = 1024;
+
+    @State(Scope.Thread)
+    public static class MonomorphicState {
+        Object[] receivers;
+        @Setup(Level.Trial)
+        public void setUp() {
+            receivers = new Object[RECEIVER_COUNT];
+            for (int i = 0; i < RECEIVER_COUNT; i++) {
+                receivers[i] = i;
+            }
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class PolymorphicState {
+        Object[] receivers;
+        @Setup(Level.Trial)
+        public void setUp() {
+            receivers = new Object[RECEIVER_COUNT];
+            for (int i = 0; i < RECEIVER_COUNT; i++) {
+                switch (i % 3) {
+                    case 0:
+                        receivers[i] = 7;
+                        break;
+                    case 1:
+                        receivers[i] = new ArrayList<>();
+                        break;
+                    case 2:
+                        receivers[i] = "Test String";
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+            }
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class MegamorphicState {
+        Object[] receivers;
+        @Setup(Level.Trial)
+        public void setUp() {
+            Object[] suspects = new Object[] {
+                    9,
+                    new Object(),
+                    "Hello World",
+                    new ArrayList<>(),
+                    123.456f,
+                    new HashMap<>(),
+                    true,
+                    new Date()
+            };
+            receivers = new Object[RECEIVER_COUNT];
+            for (int i = 0; i < RECEIVER_COUNT; i++) {
+                receivers[i] = suspects[i % suspects.length];
+            }
+        }
+    }
+
+}

--- a/subprojects/performance/src/jmh/java/org/apache/groovy/bench/dispatch/CallsiteBench.java
+++ b/subprojects/performance/src/jmh/java/org/apache/groovy/bench/dispatch/CallsiteBench.java
@@ -21,16 +21,15 @@ package org.apache.groovy.bench.dispatch;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 @Fork(3)
 @BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class CallsiteBench {
 
     @Benchmark
@@ -69,7 +68,12 @@ public class CallsiteBench {
         }
     }
 
-    private static final int RECEIVER_COUNT = 1024;
+    private static final int RECEIVER_COUNT = 64;
+
+    private static final Object[] RECEIVERS = new Object[] {
+            new Receiver1(), new Receiver2(), new Receiver3(), new Receiver4(),
+            new Receiver5(), new Receiver6(), new Receiver7(), new Receiver8()
+    };
 
     @State(Scope.Thread)
     public static class MonomorphicState {
@@ -77,56 +81,66 @@ public class CallsiteBench {
         @Setup(Level.Trial)
         public void setUp() {
             receivers = new Object[RECEIVER_COUNT];
-            for (int i = 0; i < RECEIVER_COUNT; i++) {
-                receivers[i] = i;
-            }
+            Arrays.fill(receivers, RECEIVERS[0]);
         }
     }
 
     @State(Scope.Thread)
     public static class PolymorphicState {
+        final Random random = new Random();
         Object[] receivers;
-        @Setup(Level.Trial)
+        @Setup(Level.Iteration)
         public void setUp() {
             receivers = new Object[RECEIVER_COUNT];
             for (int i = 0; i < RECEIVER_COUNT; i++) {
-                switch (i % 3) {
-                    case 0:
-                        receivers[i] = 7;
-                        break;
-                    case 1:
-                        receivers[i] = new ArrayList<>();
-                        break;
-                    case 2:
-                        receivers[i] = "Test String";
-                        break;
-                    default:
-                        throw new IllegalStateException();
-                }
+                receivers[i] = RECEIVERS[random.nextInt(3)];
             }
         }
     }
 
     @State(Scope.Thread)
     public static class MegamorphicState {
+        final Random random = new Random();
         Object[] receivers;
-        @Setup(Level.Trial)
+        @Setup(Level.Iteration)
         public void setUp() {
-            Object[] suspects = new Object[] {
-                    9,
-                    new Object(),
-                    "Hello World",
-                    new ArrayList<>(),
-                    123.456f,
-                    new HashMap<>(),
-                    true,
-                    new Date()
-            };
             receivers = new Object[RECEIVER_COUNT];
             for (int i = 0; i < RECEIVER_COUNT; i++) {
-                receivers[i] = suspects[i % suspects.length];
+                receivers[i] = RECEIVERS[random.nextInt(8)];
             }
         }
+    }
+
+    private static class Receiver1 {
+        @Override public String toString() { return "receiver1"; }
+    }
+
+    private static class Receiver2 {
+        @Override public String toString() { return "receiver2"; }
+    }
+
+    private static class Receiver3 {
+        @Override public String toString() { return "receiver3"; }
+    }
+
+    private static class Receiver4 {
+        @Override public String toString() { return "receiver4"; }
+    }
+
+    private static class Receiver5 {
+        @Override public String toString() { return "receiver5"; }
+    }
+
+    private static class Receiver6 {
+        @Override public String toString() { return "receiver6"; }
+    }
+
+    private static class Receiver7 {
+        @Override public String toString() { return "receiver7"; }
+    }
+
+    private static class Receiver8 {
+        @Override public String toString() { return "receiver8"; }
     }
 
 }

--- a/subprojects/performance/src/test/groovy/org/apache/groovy/bench/dispatch/Callsite.groovy
+++ b/subprojects/performance/src/test/groovy/org/apache/groovy/bench/dispatch/Callsite.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.bench.dispatch
+
+class Callsite {
+
+    static void dispatch(Object[] receivers, bh) {
+        for (Object receiver : receivers) {
+            bh.consume(receiver.toString())
+        }
+    }
+
+}


### PR DESCRIPTION
Just a proposal to add JMH capability to the `performance` subproject.  Many projects seem to have a separate repo for benchmarks, but think it might be nice to have the structure in place to be able run them against master.

And here the results from the one benchmark added:

Legacy callsite caching:
```
Benchmark                                     Mode  Cnt     Score    Error   Units
CallsiteBench.dispatch_1_monomorphic_groovy  thrpt   15   959.451 ± 48.088  ops/ms
CallsiteBench.dispatch_1_monomorphic_java    thrpt   15  1971.941 ± 94.755  ops/ms
CallsiteBench.dispatch_3_polymorphic_groovy  thrpt   15   123.890 ± 10.586  ops/ms
CallsiteBench.dispatch_3_polymorphic_java    thrpt   15   984.045 ± 63.225  ops/ms
CallsiteBench.dispatch_8_megamorphic_groovy  thrpt   15   101.954 ±  5.226  ops/ms
CallsiteBench.dispatch_8_megamorphic_java    thrpt   15   825.800 ± 39.782  ops/ms
```

Indy
```
Benchmark                                     Mode  Cnt     Score     Error   Units
CallsiteBench.dispatch_1_monomorphic_groovy  thrpt   15  1875.221 ± 131.977  ops/ms
CallsiteBench.dispatch_1_monomorphic_java    thrpt   15  1705.517 ± 359.714  ops/ms
CallsiteBench.dispatch_3_polymorphic_groovy  thrpt   15     1.881 ±   0.277  ops/ms
CallsiteBench.dispatch_3_polymorphic_java    thrpt   15   919.500 ± 148.737  ops/ms
CallsiteBench.dispatch_8_megamorphic_groovy  thrpt   15     1.344 ±   0.322  ops/ms
CallsiteBench.dispatch_8_megamorphic_java    thrpt   15   787.619 ± 111.614  ops/ms
```