### PR TITLE
[GROOVY-8261] Adding some getText overrides

### DIFF
--- a/src/main/org/codehaus/groovy/ast/stmt/ExpressionStatement.java
+++ b/src/main/org/codehaus/groovy/ast/stmt/ExpressionStatement.java
@@ -51,7 +51,7 @@ public class ExpressionStatement extends Statement {
     }
 
     public String getText() {
-        return this.toString();
+        return expression.getText();
     }
 
     public String toString() {

--- a/src/test/org/codehaus/groovy/ast/stmt/ExpressionStatementTest.groovy
+++ b/src/test/org/codehaus/groovy/ast/stmt/ExpressionStatementTest.groovy
@@ -16,39 +16,20 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.codehaus.groovy.ast.stmt;
+package org.codehaus.groovy.ast.stmt
 
-import org.codehaus.groovy.ast.GroovyCodeVisitor;
-import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.expr.ArgumentListExpression
+import org.codehaus.groovy.ast.expr.ConstructorCallExpression
 
+class ExpressionStatementTest extends GroovyTestCase {
 
-/**
- * Represents a throw statement
- * 
- * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
- */
-public class ThrowStatement extends Statement {
-
-    private Expression expression;
-    
-    public ThrowStatement(Expression expression) {
-        this.expression = expression;
-    }
-    
-    public Expression getExpression() {
-        return expression;
-    }
-
-    public void visit(GroovyCodeVisitor visitor) {
-        visitor.visitThrowStatement(this);
-    }
-    public void setExpression(Expression expression) {
-        this.expression = expression;
-    }
-
-    @Override
-    public String getText() {
-        return "throw " + expression.getText();
+    void testGetText() {
+        assert new ExpressionStatement(
+            new ConstructorCallExpression(
+                new ClassNode(Object),
+                new ArgumentListExpression())).
+            text == 'new java.lang.Object()'
     }
 
 }

--- a/src/test/org/codehaus/groovy/ast/stmt/ThrowStatementTest.groovy
+++ b/src/test/org/codehaus/groovy/ast/stmt/ThrowStatementTest.groovy
@@ -16,39 +16,22 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.codehaus.groovy.ast.stmt;
+package org.codehaus.groovy.ast.stmt
 
-import org.codehaus.groovy.ast.GroovyCodeVisitor;
-import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.expr.ArgumentListExpression
+import org.codehaus.groovy.ast.expr.ConstantExpression
+import org.codehaus.groovy.ast.expr.ConstructorCallExpression
 
+class ThrowStatementTest extends GroovyTestCase {
 
-/**
- * Represents a throw statement
- * 
- * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
- */
-public class ThrowStatement extends Statement {
-
-    private Expression expression;
-    
-    public ThrowStatement(Expression expression) {
-        this.expression = expression;
-    }
-    
-    public Expression getExpression() {
-        return expression;
-    }
-
-    public void visit(GroovyCodeVisitor visitor) {
-        visitor.visitThrowStatement(this);
-    }
-    public void setExpression(Expression expression) {
-        this.expression = expression;
-    }
-
-    @Override
-    public String getText() {
-        return "throw " + expression.getText();
+    void testGetText() {
+        assert new ThrowStatement(
+            new ConstructorCallExpression(
+                new ClassNode(Exception),
+                new ArgumentListExpression(
+                    new ConstantExpression('oops')))).
+            text == 'throw new java.lang.Exception(oops)'
     }
 
 }


### PR DESCRIPTION
[GROOVY-8261](https://issues.apache.org/jira/browse/GROOVY-8261)

While debugging a `CompilationCustomizer` I noticed some cases where `getText` was less than helpful.

@reviewbybees for my colleagues