### PR TITLE
cache GroovyRunnerRegistry values

### DIFF
--- a/subprojects/performance/README.adoc
+++ b/subprojects/performance/README.adoc
@@ -21,15 +21,21 @@
 
 = Performance
 
-This subproject contains two sets of performance related tests.  The first
-are compiler tests that can be run using the following Gradle task:
+This subproject contains two sets of performance related tests, compiler tests
+and benchmarks.
+
+== Compiler Performance Tests
+
+The compiler tests can be run using the following Gradle task:
 
     ./gradlew :perf:performanceTests
 
 This will compile various source files using several past versions of Apache
 Groovy in addition to the current source version.
 
-This subproject also contains `JMH` Benchmarks which can be run using:
+== Benchmarks
+
+JMH Benchmarks can be run using:
 
     ./gradlew :perf:jmh
 
@@ -37,3 +43,15 @@ In order to run the benchmarks against InvokeDynamic generated classes use
 the `indy` property:
 
     ./gradlew -Pindy=true :perf:jmh
+
+Groovy and Java sources placed in `src/test` will also be available to the
+benchmarks.
+
+To run a single benchmark or a matched set of benchmarks, use the
+`benchInclude` property:
+
+    ./gradlew -PbenchInclude=CallsiteBench :perf:jmh
+
+The `benchInclude` property will perform a partial match against package
+names or class names. It is equivalent to `.*${benchInclude}.*`.
+

--- a/subprojects/performance/build.gradle
+++ b/subprojects/performance/build.gradle
@@ -36,7 +36,9 @@ dependencies {
 
 jmh {
     jmhVersion = '1.19'
-    include = ['.*']
+    if (project.hasProperty('benchInclude')) {
+        include = ['.*' + project.benchInclude + '.*']
+    }
     includeTests = true
     resultsFile = project.file("target/results${useIndy() ? '_indy' : ''}.txt")
 }

--- a/subprojects/performance/src/jmh/java/org/apache/groovy/plugin/GroovyRunnerRegistryBench.java
+++ b/subprojects/performance/src/jmh/java/org/apache/groovy/plugin/GroovyRunnerRegistryBench.java
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.plugin;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class GroovyRunnerRegistryBench {
+
+    static List<Object> control = new LinkedList<>();
+    static GroovyRunnerRegistry registry = GroovyRunnerRegistry.getInstance();
+    static {
+        control.add(new Object());
+        control.add(new Object());
+        control.add(new Object());
+        registry.load(GroovyRunnerRegistryBench.class.getClassLoader());
+    }
+
+    @Benchmark
+    public void registryIterator(Blackhole bh) {
+        for (GroovyRunner runner : registry) {
+            bh.consume(runner);
+        }
+    }
+
+    @Benchmark
+    public void linkedListIterator(Blackhole bh) {
+        for (Object obj : control) {
+            bh.consume(obj);
+        }
+    }
+
+}


### PR DESCRIPTION
The registry should be read heavy and most use made of the iterator.  Few writes/loads should occur, so values should be cached in order to optimize iteration.

Benchmarked the change against using a read lock but `volatile` was significantly faster.