### PR TITLE
GROOVY-7995: @CS short syntax closure call from closure

### DIFF
--- a/src/main/org/codehaus/groovy/transform/sc/transformers/MethodCallExpressionTransformer.java
+++ b/src/main/org/codehaus/groovy/transform/sc/transformers/MethodCallExpressionTransformer.java
@@ -75,6 +75,7 @@ public class MethodCallExpressionTransformer {
                 result.setSafe(expr.isSafe());
                 result.setSpreadSafe(expr.isSpreadSafe());
                 result.setMethodTarget(StaticTypeCheckingVisitor.CLOSURE_CALL_VARGS);
+                result.copyNodeMetaData(expr);
                 return result;
             }
         }
@@ -159,9 +160,12 @@ public class MethodCallExpressionTransformer {
     }
 
     private static boolean isCallOnClosure(final MethodCallExpression expr) {
+        MethodNode target = expr.getNodeMetaData(StaticTypesMarker.DIRECT_METHOD_CALL_TARGET);
         return expr.isImplicitThis()
-                && expr.getNodeMetaData(StaticTypesMarker.DIRECT_METHOD_CALL_TARGET) == StaticTypeCheckingVisitor.CLOSURE_CALL_VARGS
-                && !"call".equals(expr.getMethodAsString());
+                && !"call".equals(expr.getMethodAsString())
+                && (target == StaticTypeCheckingVisitor.CLOSURE_CALL_VARGS
+                    || target == StaticTypeCheckingVisitor.CLOSURE_CALL_NO_ARG
+                    || target == StaticTypeCheckingVisitor.CLOSURE_CALL_ONE_ARG);
     }
 
     /**

--- a/src/test/groovy/bugs/Groovy7995Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7995Bug.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+class Groovy7995Bug extends GroovyTestCase{
+
+    void testClosureShortSyntaxCallFromOtherClosure(){
+        assertScript('''
+            @groovy.transform.CompileStatic
+            class Foo {
+                Closure c = { 'ok' }
+                Closure wrap = {
+                    c()
+                }
+            
+                def run() {
+                    wrap()
+                }
+            }
+            
+            assert new Foo().run()=='ok'
+        ''')
+    }
+
+}


### PR DESCRIPTION
Short syntax of closure call invokes wrong closure if wrapped in another
closure. This fix includes a combination of the contributed commit from
PR #460 along with the patch (see PR comments) provided by Jochen.