### PR TITLE
Call iterators hasNext as last when simpler checks can be done first

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -9836,7 +9836,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         }
 
         public boolean hasNext() {
-            return delegate.hasNext() && num > 0;
+            return num > 0 && delegate.hasNext();
         }
 
         public E next() {
@@ -9911,7 +9911,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 2.4.0
      */
     public static <T> Collection<T> takeRight(Iterable<T> self, int num) {
-        if (!self.iterator().hasNext() || num <= 0) {
+        if (num <= 0 || !self.iterator().hasNext()) {
             return self instanceof Collection ? createSimilarCollection((Collection<T>) self, 0) : new ArrayList<T>();
         }
         Collection<T> selfCol = self instanceof Collection ? (Collection<T>) self : toList(self);

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -255,6 +255,19 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertEquals(1, iterableAsType[0])
     }
 
+    // GROOVY-8271
+    public void testTake() {
+        int hasNextCount = 0
+        int nextCount = 0
+        def iterator = [
+            hasNext: { -> hasNextCount++; true },
+            next: { -> nextCount++ }
+        ] as Iterator<Integer>
+        iterator.take(3).toList()
+        assertEquals(3, hasNextCount)
+        assertEquals(3, nextCount)
+    }
+
     private static class MyList extends ArrayList {
         public MyList() {}
     }


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/GROOVY-8271