### PR TITLE
[Sql] Factorizes batchCount incrementation and thus executeBatch() execution

### DIFF
--- a/subprojects/groovy-sql/src/main/java/groovy/sql/BatchingPreparedStatementWrapper.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/BatchingPreparedStatementWrapper.java
@@ -60,11 +60,6 @@ public class BatchingPreparedStatementWrapper extends BatchingStatementWrapper {
             sql.setParameters(parameters, delegate);
         }
         delegate.addBatch();
-        batchCount++;
-        if (batchCount == batchSize /* never true for batchSize of 0 */) {
-            int[] result = delegate.executeBatch();
-            processResult(result);
-            batchCount = 0;
-        }
+        incrementBatchCount();
     }
 }

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/BatchingStatementWrapper.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/BatchingStatementWrapper.java
@@ -59,6 +59,14 @@ public class BatchingStatementWrapper extends GroovyObjectSupport {
 
     public void addBatch(String sql) throws SQLException {
         delegate.addBatch(sql);
+        incrementBatchCount();
+    }
+
+    /**
+     * Increments batch count (after addBatch(..) has been called)
+     * and execute {@code delegate.executeBatch()} if batchSize has been reached.
+     */
+    protected void incrementBatchCount() throws SQLException {
         batchCount++;
         if (batchCount == batchSize /* never true for batchSize of 0 */) {
             int[] result = delegate.executeBatch();


### PR DESCRIPTION
Code duplication.

We could restrain "batchCount" and "batchSize" visibility, but this would be a possible API breakage.
Also `incrementBatchCount()` method could be package-private, so that it is not published as part of the inherited API, but I couldn't find a good reason why. It could be final, but as `processResult(int[])` isn't, I sticked to the same logic.