### PR TITLE
GROOVY-8288 executeBatch() should not be called with batchCount == 0

### DIFF
--- a/subprojects/groovy-sql/src/main/java/groovy/sql/BatchingStatementWrapper.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/BatchingStatementWrapper.java
@@ -83,14 +83,27 @@ public class BatchingStatementWrapper extends GroovyObjectSupport {
     }
 
     public int[] executeBatch() throws SQLException {
-        int[] lastResult = delegate.executeBatch();
-        processResult(lastResult);
+        if (shouldCallDelegate()) {
+            int[] lastResult = delegate.executeBatch();
+            processResult(lastResult);
+        }
         int[] result = new int[results.size()];
         for (int i = 0; i < results.size(); i++) {
             result[i] = results.get(i);
         }
         reset();
         return result;
+    }
+
+    private boolean shouldCallDelegate() {
+        if (batchCount > 0) {
+            return true;
+        } else if (results.isEmpty()) {
+            log.warning("Nothing has been added to batch. This might cause the JDBC driver to throw an exception.");
+            return true;
+        }
+        // Nothing added since last delegate execution. No need to call the delegate this time.
+        return false;
     }
 
     protected void processResult(int[] lastResult) {


### PR DESCRIPTION
This is a first proposition of resolution for [GROOVY-8288](https://issues.apache.org/jira/browse/GROOVY-8288).
There still are open questions (see my comments on changes).

Thank you for your feedback.