### PR TITLE
Groovyc Resource Leaks

### DIFF
--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
@@ -291,7 +291,7 @@ public class Groovyc extends MatchingTask {
      * @param version the bytecode compatibility mode
      */
     public void setTargetBytecode(String version) {
-        
+
         for (String allowedJdk : CompilerConfiguration.ALLOWED_JDKS) {
             if (allowedJdk.equals(version)) {
                 this.targetBytecode = version;
@@ -304,8 +304,8 @@ public class Groovyc extends MatchingTask {
      * Retrieves the compiler bytecode compatibility mode.
      *
      * @return bytecode compatibility mode. Can be one of the values
-     *         <tt>1.8</tt>, <tt>1.7</tt>, <tt>1.6</tt>, <tt>1.5</tt> or
-     *         <tt>1.4</tt>.
+     * <tt>1.8</tt>, <tt>1.7</tt>, <tt>1.6</tt>, <tt>1.5</tt> or
+     * <tt>1.4</tt>.
      */
     public String getTargetBytecode() {
         return this.targetBytecode;
@@ -666,7 +666,7 @@ public class Groovyc extends MatchingTask {
      * Get the result of the groovyc task (success or failure).
      *
      * @return true if compilation succeeded, or
-     *         was not necessary, false if the compilation failed.
+     * was not necessary, false if the compilation failed.
      */
     public boolean getTaskSuccess() {
         return taskSuccess;
@@ -786,7 +786,7 @@ public class Groovyc extends MatchingTask {
 
     /**
      * Set the forceLookupUnnamedFiles flag. Defaults to false.
-     *
+     * <p>
      * The Groovyc Ant task is frequently used in the context of a build system
      * that knows the complete list of source files to be compiled. In such a
      * context, it is wasteful for the Groovy compiler to go searching the
@@ -1195,13 +1195,9 @@ public class Groovyc extends MatchingTask {
             }
 
             if (!fileNameErrors) {
-              GroovyClassLoader loader = buildClassLoaderFor();
-              try {
-                FileSystemCompiler.doCompilation(configuration, makeCompileUnit(loader), filenames, forceLookupUnnamedFiles);
-              } finally {
-                if (loader != null)
-                  loader.close();
-              }
+                try (GroovyClassLoader loader = buildClassLoaderFor()) {
+                    FileSystemCompiler.doCompilation(configuration, makeCompileUnit(loader), filenames, forceLookupUnnamedFiles);
+                }
             }
 
         } catch (Exception re) {
@@ -1265,6 +1261,14 @@ public class Groovyc extends MatchingTask {
         }
     }
 
+    /**
+     * @deprecated This method is not in use anymore. Use {@link Groovyc#makeCompileUnit(GroovyClassLoader)} instead.
+     */
+    @Deprecated
+    protected CompilationUnit makeCompileUnit() {
+        return makeCompileUnit(buildClassLoaderFor());
+    }
+
     protected CompilationUnit makeCompileUnit(GroovyClassLoader loader) {
         Map<String, Object> options = configuration.getJointCompilationOptions();
         if (options != null) {
@@ -1319,12 +1323,11 @@ public class Groovyc extends MatchingTask {
                  * may not exist in the classpath yet
                  */
                 if (!found && new File(cpEntry).exists()) {
-                	try {
-                		antLoader.addPathElement(cpEntry);
-                	}
-                	catch(BuildException e) {
-                		log.warn("The classpath entry " + cpEntry + " is not a valid Java resource");
-                	}
+                    try {
+                        antLoader.addPathElement(cpEntry);
+                    } catch (BuildException e) {
+                        log.warn("The classpath entry " + cpEntry + " is not a valid Java resource");
+                    }
                 }
             }
         }
@@ -1352,19 +1355,13 @@ public class Groovyc extends MatchingTask {
 
             Path classpath = getClasspath() != null ? getClasspath() : new Path(getProject());
             final String[] pe = classpath.list();
-            final GroovyClassLoader loader = new GroovyClassLoader(getClass().getClassLoader());
-            try {
-              for (String file : pe) {
-                loader.addClasspath(file);
-              }
-              scriptExtensions.addAll(SourceExtensionHandler.getRegisteredExtensions(loader));
-            } finally {
-              try {
-                loader.close();
-              }
-              catch ( IOException e ) {
-                throw new RuntimeException( e );
-              }
+            try (GroovyClassLoader loader = new GroovyClassLoader(getClass().getClassLoader())) {
+                for (String file : pe) {
+                    loader.addClasspath(file);
+                }
+                scriptExtensions.addAll(SourceExtensionHandler.getRegisteredExtensions(loader));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
         }
     }


### PR DESCRIPTION
Building multiple ant projects in a row within the same JVM sometimes fails on windows with locked jars. This is e.g. the case if two build projects has circle dependencies.

Relates to https://issues.apache.org/jira/browse/GROOVY-7573