### PR TITLE
GROOVY-7721: Static type checking fails when compiling against a Java interface call

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1149,11 +1149,18 @@ public abstract class StaticTypeCheckingSupport {
     private static void removeMethodWithSuperReturnType(List<MethodNode> toBeRemoved, MethodNode one, MethodNode two) {
         ClassNode oneRT = one.getReturnType();
         ClassNode twoRT = two.getReturnType();
-        if (oneRT.isDerivedFrom(twoRT) || oneRT.implementsInterface(twoRT)) {
+        if (isCovariant(oneRT, twoRT)) {
             toBeRemoved.add(two);
-        } else if (twoRT.isDerivedFrom(oneRT) || twoRT.implementsInterface(oneRT)) {
+        } else if (isCovariant(twoRT, oneRT)) {
             toBeRemoved.add(one);
         }
+    }
+
+    private static boolean isCovariant(ClassNode left, ClassNode right) {
+        if (left.isArray() && right.isArray()) {
+            return isCovariant(left.getComponentType(), right.getComponentType());
+        }
+        return left.isDerivedFrom(right) || left.implementsInterface(right);
     }
 
     private static boolean areOverloadMethodsInSameClass(MethodNode one, MethodNode two) {

--- a/src/test/groovy/bugs/Groovy7721Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7721Bug.groovy
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+
+package groovy.bugs
+
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.tools.javac.JavaAwareCompilationUnit
+
+class Groovy7721Bug extends GroovyTestCase {
+    void testCovariantArrayAtOverriding() {
+        def config = new CompilerConfiguration()
+        config.with {
+            targetDirectory = createTempDir()
+            jointCompilationOptions = [stubDir: createTempDir()]
+        }
+
+        File parentDir = createTempDir()
+        try {
+            def a = new File(parentDir, 'A.java')
+            a.write '''
+                    package pack;
+                    interface A {
+                        Object[] bar();
+                    }
+
+                '''
+            def b = new File(parentDir, 'B.java')
+            b.write '''
+                    package pack;
+                    interface B extends A {
+                        @Override
+                        String[] bar();
+                    }
+                '''
+
+            def c = new File(parentDir, 'C.groovy')
+            c.write '''
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class C {
+                static def bar(pack.B b) {
+                    b.bar()
+                }
+            }
+            '''
+            def loader = new GroovyClassLoader(this.class.classLoader)
+            def cu = new JavaAwareCompilationUnit(config, loader)
+            cu.addSources([a, b, c] as File[])
+            cu.compile()
+        } finally {
+            parentDir.deleteDir()
+            config.targetDirectory?.deleteDir()
+            config.jointCompilationOptions.stubDir?.deleteDir()
+        }
+
+    }
+
+    private static File createTempDir() {
+        File.createTempDir("groovyTest${System.currentTimeMillis()}", "")
+    }
+
+}


### PR DESCRIPTION
Arrays is also covariants in java, so they should be also compared. 
Can't find exact documentation, but  JLS 15.12.2.5 says:
– Otherwise, if all the maximally specific methods are abstract or default, and
the signatures of all of the maximally specific methods have the same erasure
(§4.6), then the most specific method is chosen arbitrarily among the subset
of the maximally specific methods that have the most specific return type.