### PR TITLE
GROOVY-8220: SC GroovyCastException on parameter flow typing

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -668,6 +668,9 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                 if (typeCheckingContext.ifElseForWhileAssignmentTracker != null && leftExpression instanceof VariableExpression
                         && !isNullConstant(rightExpression)) {
                     Variable accessedVariable = ((VariableExpression) leftExpression).getAccessedVariable();
+                    if (accessedVariable instanceof Parameter) {
+                        accessedVariable = new ParameterVariableExpression((Parameter) accessedVariable);
+                    }
                     if (accessedVariable instanceof VariableExpression) {
                         VariableExpression var = (VariableExpression) accessedVariable;
                         List<ClassNode> types = typeCheckingContext.ifElseForWhileAssignmentTracker.get(var);
@@ -4843,4 +4846,65 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         }
     }
 
+    /**
+     * Wrapper for a Parameter so it can be treated like a VariableExpression
+     * and tracked in the ifElseForWhileAssignmentTracker.
+     *
+     * This class purposely does not adhere to the normal equals and hashCode
+     * contract on the Object class and delegates those calls to the wrapped
+     * variable.
+     */
+    private static class ParameterVariableExpression extends VariableExpression {
+
+        private final Parameter parameter;
+
+        ParameterVariableExpression(Parameter parameter) {
+            super(parameter);
+            this.parameter = parameter;
+            ClassNode inferred = parameter.getNodeMetaData(StaticTypesMarker.INFERRED_TYPE);
+            if (inferred == null) {
+                parameter.setNodeMetaData(StaticTypesMarker.INFERRED_TYPE, parameter.getOriginType());
+            }
+        }
+
+        @Override
+        public void copyNodeMetaData(ASTNode other) {
+            parameter.copyNodeMetaData(other);
+        }
+
+        @Override
+        public Object putNodeMetaData(Object key, Object value) {
+            return parameter.putNodeMetaData(key, value);
+        }
+
+        @Override
+        public void removeNodeMetaData(Object key) {
+            parameter.removeNodeMetaData(key);
+        }
+
+        @Override
+        public Map<?, ?> getNodeMetaData() {
+            return parameter.getNodeMetaData();
+        }
+
+        @Override
+        public <T> T getNodeMetaData(Object key) {
+            return parameter.getNodeMetaData(key);
+        }
+
+        @Override
+        public void setNodeMetaData(Object key, Object value) {
+            parameter.setNodeMetaData(key, value);
+        }
+
+        @Override
+        public int hashCode() {
+            return parameter.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return parameter.equals(other);
+        }
+    }
 }

--- a/src/test/groovy/transform/stc/STCAssignmentTest.groovy
+++ b/src/test/groovy/transform/stc/STCAssignmentTest.groovy
@@ -446,6 +446,21 @@ class STCAssignmentTest extends StaticTypeCheckingTestCase {
         ''', 'Cannot find matching method java.io.Serializable#toInteger()'
     }
 
+    void testIfElseBranchParameter() {
+        shouldFailWithMessages '''
+            def foo(x) {
+                def y = 'foo'
+                if (y) {
+                    x = new HashSet()
+                } else {
+                    x = '123'
+                }
+                x.toInteger()
+            }
+            foo('bar')
+        ''', 'Cannot find matching method java.lang.Object#toInteger()'
+    }
+
     void testIfOnly() {
         shouldFailWithMessages '''
             def x = '123'
@@ -455,6 +470,20 @@ class STCAssignmentTest extends StaticTypeCheckingTestCase {
             }
             x.toInteger()
         ''', 'Cannot find matching method java.io.Serializable#toInteger()'
+    }
+
+    void testIfOnlyParameter() {
+        shouldFailWithMessages '''
+            def foo(x) {
+                def y = 'foo'
+                if (y) {
+                    x = new HashSet()
+                    assert x.isEmpty()
+                }
+                x.toInteger()
+            }
+            foo('123')
+        ''', 'Cannot find matching method java.lang.Object#toInteger()'
     }
 
     void testIfWithCommonInterface() {
@@ -872,5 +901,62 @@ class STCAssignmentTest extends StaticTypeCheckingTestCase {
         }            
         '''
     }
-}
 
+    // GROOVY-8220
+    void testFlowTypingParameterTempTypeAssignmentTracking() {
+        assertScript '''
+            class Foo {
+                CharSequence makeEnv( env, StringBuilder result = new StringBuilder() ) {
+                    if (env instanceof File) {
+                        env = env.toPath()
+                    }
+                    if (env instanceof String && env.contains('=')) {
+                        result << 'export ' << env << ';'
+                    }
+                    return result.toString()
+                }
+            }
+            assert new Foo().makeEnv('X=1') == 'export X=1;'
+        '''
+        // GROOVY-8237
+        assertScript '''
+            class Foo {
+                String parse(Reader reader) {
+                    if (reader == null)
+                        reader = new BufferedReader(reader)
+                    int i = reader.read()
+                    return (i != -1) ? 'bar' : 'baz'
+                }
+            }
+            assert new Foo().parse(new StringReader('foo')) == 'bar'
+        '''
+    }
+
+    void testFlowTypingParameterTempTypeAssignmentTrackingWithGenerics() {
+        assertScript '''
+            class M {
+                Map<String, List<Object>> mvm = new HashMap<String, List<Object>>()
+                void setProperty(String name, value) {
+                    if (value instanceof File) {
+                        value = new File(value, 'bar.txt')
+                    }
+                    else if (value instanceof URL) {
+                        value = value.toURI()
+                    }
+                    else if (value instanceof InputStream) {
+                        value = new BufferedInputStream(value)
+                    }
+                    else if (value instanceof GString) {
+                        value = value.toString()
+                    }
+                    if (mvm[name]) {
+                        mvm[name].add value
+                    } else {
+                        mvm.put(name, [value])
+                    }
+                }
+            }
+            new M().setProperty('foo', 'bar')
+        '''
+    }
+}


### PR DESCRIPTION
GROOVY-8157 introduced flow typing for parameters and this fix is
required in order to track their assignments in `if` branches for
temporary type assignments.