### PR TITLE
GROOVY-8213: Closures are maybe not Threadsafe

### DIFF
--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -105,7 +105,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     protected MetaClassRegistry registry;
     private ClassNode classNode;
     private FastArray constructors;
-    private boolean initialized;
+    private volatile boolean initialized;
     private MetaMethod genericGetMethod;
     private MetaMethod genericSetMethod;
     private MetaMethod propertyMissingGet;

--- a/src/main/org/codehaus/groovy/runtime/metaclass/ClosureMetaClass.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/ClosureMetaClass.java
@@ -53,7 +53,7 @@ import java.util.*;
  * @since 1.5
  */
 public final class ClosureMetaClass extends MetaClassImpl {
-    private boolean initialized;
+    private volatile boolean initialized;
     private final FastArray closureMethods = new FastArray(3);
     private Map<String, CachedField> attributes = new HashMap<String, CachedField>();
     private MethodChooser chooser;


### PR DESCRIPTION
To address @blackdrag 's comment in the JIRA I created a JMH benchmark to test a volatile read vs a recheck and sync, https://github.com/jwagenleitner/testing-groovy/tree/master/issues/groovy8213.
 Based on my runs the volatile read is very close to a normal read. Doing a branched check (without needing to sync) was actually worse in terms of performance.

It seems with the `--parallel` feature in Gradle and builds being run on large many core servers this problem seems to be coming up more frequently. See https://github.com/gradle/gradle/issues/1420.

While I do believe the publication of the `initialized` variable is an issue and should be addressed, another possible cause of this sort of problem could be related to the way the [`respondTo` methods are implemented by unsetting the `initialized` variable during a call to `super.initialize()` in the `loadMetaInfo() ` method](https://github.com/apache/groovy/blob/7b101dd98ffc04b1bfd2447bbe277340d8954add/src/main/org/codehaus/groovy/runtime/metaclass/ClosureMetaClass.java#L724-L740). But in this case and the referenced Gradle issue I'm not sure the `respondTo` methods are in play.

