### PR TITLE
GROOVY-8252: AIOOBE in combination of ncurry and rcurry

### DIFF
--- a/src/main/groovy/lang/Closure.java
+++ b/src/main/groovy/lang/Closure.java
@@ -556,6 +556,10 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
      * assert halver(8) == 4
      * </pre>
      *
+     * The position of the curried parameters will be calculated lazily, for example,
+     * if two overloaded doCall methods are available, the supplied arguments plus the
+     * curried arguments will be concatenated and the result used for method selection.
+     *
      * @param arguments the arguments to bind
      * @return the new closure with its arguments bound
      * @see #curry(Object...)
@@ -599,6 +603,10 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
      * // [BEE, ant, dog]       Not found but would belong in position 2
      * // [BEE, Cat, ant, dog]  Not found but would belong in position 3
      * </pre>
+     *
+     * The position of the curried parameters will be calculated eagerly
+     * and implies all arguments prior to the specified n index are supplied.
+     * Default parameter values prior to the n index will not be available.
      *
      * @param n the index from which to bind parameters (may be -ve in which case it will be normalized)
      * @param arguments the arguments to bind

--- a/src/main/org/codehaus/groovy/runtime/CurriedClosure.java
+++ b/src/main/org/codehaus/groovy/runtime/CurriedClosure.java
@@ -39,15 +39,25 @@ import groovy.lang.Closure;
  * assert new CurriedClosure(unitAdder, "six", "ty")("minutes") == "sixty minutes"
  * </pre>
  *
- * @author Jochen Theodorou
- * @author Paul King
+ * Notes:
+ * <ul>
+ *     <li>Caters for Groovy's lazy (rcurry) and eager (ncurry) calculation of argument position</li>
+ * </ul>
  */
 public final class CurriedClosure<V> extends Closure<V> {
 
     private final Object[] curriedParams;
+    private final int minParamsExpected;
     private int index;
     private Class varargType = null;
 
+    /**
+     * Creates the curried closure.
+     *
+     * @param index the position where the parameters should be injected (-ve for lazy)
+     * @param uncurriedClosure the closure to be called after the curried parameters are injected
+     * @param arguments the supplied parameters
+     */
     public CurriedClosure(int index, Closure<V> uncurriedClosure, Object... arguments) {
         super(uncurriedClosure.clone());
         curriedParams = arguments;
@@ -65,6 +75,9 @@ public final class CurriedClosure<V> extends Closure<V> {
             if (index < 0) {
                 // normalise
                 this.index += origMaxLen;
+                minParamsExpected = 0;
+            } else {
+                minParamsExpected = index + arguments.length;
             }
             if (maximumNumberOfParameters < 0) {
                 throw new IllegalArgumentException("Can't curry " + arguments.length + " arguments for a closure with " + origMaxLen + " parameters.");
@@ -77,6 +90,8 @@ public final class CurriedClosure<V> extends Closure<V> {
                 throw new IllegalArgumentException("To curry " + arguments.length + " argument(s) expect index range 0.." +
                         maximumNumberOfParameters + " but found " + index);
             }
+        } else {
+            minParamsExpected = 0;
         }
     }
 
@@ -98,8 +113,13 @@ public final class CurriedClosure<V> extends Closure<V> {
                 System.arraycopy(arguments, normalizedIndex, newCurriedParams, curriedParams.length + normalizedIndex, arguments.length - normalizedIndex);
             return newCurriedParams;
         }
+        if (curriedParams.length + arguments.length < minParamsExpected) {
+            throw new IllegalArgumentException("When currying expected at least " + index + " argument(s) to be supplied before known curried arguments but found " + arguments.length);
+        }
         final Object newCurriedParams[] = new Object[curriedParams.length + arguments.length];
         int newIndex = Math.min(index, curriedParams.length + arguments.length - 1);
+        // rcurried arguments are done lazily to allow normal method selection between overloaded alternatives
+        newIndex = Math.min(newIndex, arguments.length);
         System.arraycopy(arguments, 0, newCurriedParams, 0, newIndex);
         System.arraycopy(curriedParams, 0, newCurriedParams, newIndex, curriedParams.length);
         if (arguments.length - newIndex > 0)


### PR DESCRIPTION
Because of the way method selection works with overloaded methods, the position of params when applying `rcurry` is calculated lazily. E.g. for a method closure for the `foo` method, if there are two foo variants `foo(String, String)` and `foo(String, String, String)`, then right currying a single string parameter and supplying a single string argument will result in the `foo(String, String)` method being called but supplying two string arguments will call the 3 param variant to be called.

It doesn't make sense to do this for `ncurry` since a specific index is being supplied. I have clarified the documentation and implementation to capture those aspects of the current design and introduced some checking to avoid the AIOOBE when using `ncurry` when those assumptions are violated and instead throw an `IllegalArgumentException`.