### PR TITLE
GROOVY-8352

### DIFF
--- a/src/main/groovy/transform/Generated.java
+++ b/src/main/groovy/transform/Generated.java
@@ -25,10 +25,6 @@ import java.lang.annotation.Target;
 
 /**
  * The Generated annotation is used to mark members that have been generated.
- *
- * @author Andres Almiray
- * @author Jochen Theodorou
- * @author Mark Hoffmann
  */
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/groovy/transform/Generated.java
+++ b/src/main/groovy/transform/Generated.java
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The Generated annotation is used to mark members that have been generated.
+ *
+ * @author Andres Almiray
+ * @author Jochen Theodorou
+ * @author Mark Hoffmann
+ */
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Generated {
+}

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -387,11 +387,13 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
     protected void addGroovyObjectInterfaceAndMethods(ClassNode node, final String classInternalName) {
         if (!node.isDerivedFromGroovyObject()) node.addInterface(ClassHelper.make(GroovyObject.class));
         FieldNode metaClassField = getMetaClassField(node);
-        AnnotationNode generatedAnnotation = new AnnotationNode(ClassHelper.make(GENERATED_ANNOTATION));
+
+        boolean shouldAnnotate = classNode.getModule().getContext() != null;
+        AnnotationNode generatedAnnotation = shouldAnnotate ? new AnnotationNode(ClassHelper.make(GENERATED_ANNOTATION)) : null;
 
         if (!node.hasMethod("getMetaClass", Parameter.EMPTY_ARRAY)) {
             metaClassField = setMetaClassFieldIfNotExists(node, metaClassField);
-            addMethod(node, !isAbstract(node.getModifiers()),
+            MethodNode methodNode = addMethod(node, !isAbstract(node.getModifiers()),
                     "getMetaClass",
                     ACC_PUBLIC,
                     ClassHelper.METACLASS_TYPE,
@@ -429,7 +431,8 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                             mv.visitInsn(ARETURN);
                         }
                     })
-            ).addAnnotation(generatedAnnotation);
+            );
+            if (shouldAnnotate) methodNode.addAnnotation(generatedAnnotation);
         }
 
         Parameter[] parameters = new Parameter[]{new Parameter(ClassHelper.METACLASS_TYPE, "mc")};
@@ -458,12 +461,13 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                 setMetaClassCode = new BytecodeSequence(list);
             }
 
-            addMethod(node, !isAbstract(node.getModifiers()),
+            MethodNode methodNode = addMethod(node, !isAbstract(node.getModifiers()),
                     "setMetaClass",
                     ACC_PUBLIC, ClassHelper.VOID_TYPE,
                     SET_METACLASS_PARAMS, ClassNode.EMPTY_ARRAY,
                     setMetaClassCode
-            ).addAnnotation(generatedAnnotation);
+            );
+            if (shouldAnnotate) methodNode.addAnnotation(generatedAnnotation);
         }
 
         if (!node.hasMethod("invokeMethod", INVOKE_METHOD_PARAMS)) {
@@ -473,7 +477,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
             blockScope.putReferencedLocalVariable(vMethods);
             blockScope.putReferencedLocalVariable(vArguments);
 
-            addMethod(node, !isAbstract(node.getModifiers()),
+            MethodNode methodNode = addMethod(node, !isAbstract(node.getModifiers()),
                     "invokeMethod",
                     ACC_PUBLIC,
                     ClassHelper.OBJECT_TYPE, INVOKE_METHOD_PARAMS,
@@ -489,11 +493,12 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                             mv.visitInsn(ARETURN);
                         }
                     })
-            ).addAnnotation(generatedAnnotation);
+            );
+            if (shouldAnnotate) methodNode.addAnnotation(generatedAnnotation);
         }
 
         if (!node.hasMethod("getProperty", GET_PROPERTY_PARAMS)) {
-            addMethod(node, !isAbstract(node.getModifiers()),
+            MethodNode methodNode = addMethod(node, !isAbstract(node.getModifiers()),
                     "getProperty",
                     ACC_PUBLIC,
                     ClassHelper.OBJECT_TYPE,
@@ -509,11 +514,12 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                             mv.visitInsn(ARETURN);
                         }
                     })
-            ).addAnnotation(generatedAnnotation);
+            );
+            if (shouldAnnotate) methodNode.addAnnotation(generatedAnnotation);
         }
 
         if (!node.hasMethod("setProperty", SET_PROPERTY_PARAMS)) {
-            addMethod(node, !isAbstract(node.getModifiers()),
+            MethodNode methodNode = addMethod(node, !isAbstract(node.getModifiers()),
                     "setProperty",
                     ACC_PUBLIC,
                     ClassHelper.VOID_TYPE,
@@ -530,7 +536,8 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                             mv.visitInsn(RETURN);
                         }
                     })
-            ).addAnnotation(generatedAnnotation);
+            );
+            if (shouldAnnotate) methodNode.addAnnotation(generatedAnnotation);
         }
     }
 

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -155,8 +155,8 @@ public class JavaStubGenerator {
                     doAddMethod(method);
                 }
                 protected void addReturnIfNeeded(MethodNode node) {}
-                protected void addMethod(ClassNode node, boolean shouldBeSynthetic, String name, int modifiers, ClassNode returnType, Parameter[] parameters, ClassNode[] exceptions, Statement code) {
-                    doAddMethod(new MethodNode(name, modifiers, returnType, parameters, exceptions, code));
+                protected MethodNode addMethod(ClassNode node, boolean shouldBeSynthetic, String name, int modifiers, ClassNode returnType, Parameter[] parameters, ClassNode[] exceptions, Statement code) {
+                    return doAddMethod(new MethodNode(name, modifiers, returnType, parameters, exceptions, code));
                 }
 
                 protected void addConstructor(Parameter[] newParams, ConstructorNode ctor, Statement code, ClassNode node) {
@@ -184,13 +184,15 @@ public class JavaStubGenerator {
                     }
                 }
 
-                private void doAddMethod(MethodNode method) {
+                private MethodNode doAddMethod(MethodNode method) {
                     String sig = method.getTypeDescriptor();
 
-                    if (propertyMethodsWithSigs.containsKey(sig)) return;
+                    if (propertyMethodsWithSigs.containsKey(sig)) return method;
 
                     propertyMethods.add(method);
                     propertyMethodsWithSigs.put(sig, method);
+
+                    return method;
                 }
 
                 @Override

--- a/src/test/org/codehaus/groovy/transform/GeneratedTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/GeneratedTransformTest.groovy
@@ -1,0 +1,81 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.transform
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestName
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import static org.junit.Assume.assumeTrue
+
+/**
+ * Tests for the @Generated annotation.
+ */
+@RunWith(JUnit4)
+class GeneratedTransformTest extends GroovyShellTestCase {
+    @Rule public TestName nameRule = new TestName()
+
+    @Before
+    void setUp() {
+        super.setUp()
+        // check java version requirements
+        def v = System.getProperty("java.specification.version")
+        assert v
+        assumeTrue('Test requires jre8+', nameRule.methodName.endsWith('_vm8').implies(new BigDecimal(v) >= 1.8))
+    }
+
+    @After
+    void tearDown() {
+        super.tearDown()
+    }
+
+    @Test
+    void testDefaultGroovyMethodsAreAnnotatedWithGenerated() {
+        def person = evaluate('''
+            class Person {
+                String name
+            }
+            new Person()
+        ''')
+
+        GroovyObject.declaredMethods.each { m ->
+            def method = person.class.declaredMethods.find { it.name == m.name }
+            assert method.annotations*.annotationType().name == ['groovy.transform.Generated']
+        }
+    }
+
+    @Test
+    void testOverridenDefaultGroovyMethodsAreNotAnnotatedWithGenerated() {
+        def person = evaluate('''
+            class Person {
+                String name
+                
+                def invokeMethod(String name, args) { }
+            }
+            new Person()
+        ''')
+
+        def method = person.class.declaredMethods.find { it.name == 'invokeMethod' }
+        assert !('groovy.transform.Generated' in method.annotations*.annotationType().name)
+    }
+}

--- a/src/test/org/codehaus/groovy/transform/GeneratedTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/GeneratedTransformTest.groovy
@@ -26,8 +26,6 @@ import org.junit.rules.TestName
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import static org.junit.Assume.assumeTrue
-
 /**
  * Tests for the @Generated annotation.
  */
@@ -38,10 +36,6 @@ class GeneratedTransformTest extends GroovyShellTestCase {
     @Before
     void setUp() {
         super.setUp()
-        // check java version requirements
-        def v = System.getProperty("java.specification.version")
-        assert v
-        assumeTrue('Test requires jre8+', nameRule.methodName.endsWith('_vm8').implies(new BigDecimal(v) >= 1.8))
     }
 
     @After


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/GROOVY-8352

Retention policy is set to `RUNTIME`in order to allow frameworks and libraries to have access to the new metadata.

There's a breaking change in `Verifier`, a protected method now returns `MethodNode` instead of `void`. This change was reviewed with @blackdrag and deemed the better solution among alternatives (such as duplicate method & deprecate old).

The JaCoCo team has done their part to prepare their project for this new annotation (see https://github.com/jacoco/jacoco/pull/610).