### PR TITLE
Replaced deprecated padLeft call in BaseDuration

### DIFF
--- a/src/main/groovy/time/BaseDuration.java
+++ b/src/main/groovy/time/BaseDuration.java
@@ -108,9 +108,10 @@ public abstract class BaseDuration implements Comparable<BaseDuration> {
         if (this.minutes != 0) buffer.add(this.minutes + " minutes");
 
         if (this.seconds != 0 || this.millis != 0) {
-            int norm_millis = millis % 1000;
-            int norm_seconds = seconds + DefaultGroovyMethods.intdiv(millis - norm_millis, 1000).intValue();
-            buffer.add((norm_seconds == 0 ? (norm_millis < 0 ? "-0" : "0") : norm_seconds) + "." + StringGroovyMethods.padLeft("" + Math.abs(norm_millis), 3, "0") + " seconds");
+            int norm_millis = this.millis % 1000;
+            int norm_seconds = this.seconds + DefaultGroovyMethods.intdiv(this.millis - norm_millis, 1000).intValue();
+            CharSequence millisToPad = "" + Math.abs(norm_millis);
+            buffer.add((norm_seconds == 0 ? (norm_millis < 0 ? "-0" : "0") : norm_seconds) + "." + StringGroovyMethods.padLeft(millisToPad, 3, "0") + " seconds");
         }
 
         if (!buffer.isEmpty()) {

--- a/src/test/groovy/time/DurationTest.groovy
+++ b/src/test/groovy/time/DurationTest.groovy
@@ -35,9 +35,14 @@ class DurationTest extends GroovyTestCase {
 
     void testDurationToString() {
         use(TimeCategory) {
-            def duration = 4.days + 2.hours + 5.minutes + 12.milliseconds
-
-            assert "4 days, 2 hours, 5 minutes, 0.012 seconds" == duration.toString()
+            assert (0.years).toString() == "0"
+            assert (3.years + 8.months + 4.days + 2.hours + 5.minutes + 12.milliseconds).toString() == "3 years, 8 months, 4 days, 2 hours, 5 minutes, 0.012 seconds"
+            assert (4.days + 2.hours + 5.minutes + 12.milliseconds).toString() == "4 days, 2 hours, 5 minutes, 0.012 seconds"
+            assert (4.days + 2.hours + 5.minutes).toString() == "4 days, 2 hours, 5 minutes"
+            assert (5.seconds).toString() == "5.000 seconds"
+            assert ((-12).milliseconds).toString() == "-0.012 seconds"
+            assert (5.seconds + 12.milliseconds).toString() == "5.012 seconds"
+            assert (5.seconds + 1012.milliseconds).toString() == "6.012 seconds"
         }
     }
 


### PR DESCRIPTION
`StringGroovyMethods.padLeft(String, Number, String)` is deprecated. I converted this to use the recommended `StringGroovyMethods.padLeft(CharSequence, Number, CharSequence)`.

Added `this` to `millis` and `seconds` in the `toString()` method to be consistent.

Added additional tests for different `toString()` cases to cover missing features.
* The default of 0 is returned when there is 0 time passes in
* `year`, `month`, and `seconds` are tested now
* missing both `milliseconds` and `milliseconds`
* having `seconds` but missing `milliseconds`
* negative `milliseconds` with 0 `seconds`
* `seconds` and `milliseconds` both present
* `milliseconds` greater than 1000