### PR TITLE
Android: Remove Invoke Dynamic Call

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -247,6 +247,7 @@ allprojects {
                         if (isRootProject) {
                             zipfileset(src: rootProject.configurations.runtime.files.find { it.name.startsWith('openbeans') }, excludes: 'META-INF/*')
                         }
+                        zap pattern: 'org.codehaus.groovy.vmplugin.v7.IndyInterface'
                         rule pattern: 'com.googlecode.openbeans.**', result: 'groovyjarjaropenbeans.@1'
                         rule pattern: 'org.apache.harmony.beans.**', result: 'groovyjarjarharmonybeans.@1'
                         rule pattern: 'java.beans.**', result: 'groovyjarjaropenbeans.@1'


### PR DESCRIPTION
Uses jarjar to remove org.codehaus.groovy.vmplugin.v7.IndyInterface
which has a invoke dynamic call. This call causes android compilation
to fail when targeting sdk level 26 or above but the minSdk is less
than 26.

Fixes: GROOVY-8366