### PR TITLE
GROOVY-8377 Equals and hash code ast performance

### DIFF
--- a/src/main/org/codehaus/groovy/ast/tools/GeneralUtils.java
+++ b/src/main/org/codehaus/groovy/ast/tools/GeneralUtils.java
@@ -72,6 +72,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.codehaus.groovy.syntax.Types.COMPARE_NOT_IDENTICAL;
+
 /**
  * Handy methods when working with the Groovy AST
  */
@@ -79,6 +81,7 @@ public class GeneralUtils {
     public static final Token ASSIGN = Token.newSymbol(Types.ASSIGN, -1, -1);
     public static final Token EQ = Token.newSymbol(Types.COMPARE_EQUAL, -1, -1);
     public static final Token NE = Token.newSymbol(Types.COMPARE_NOT_EQUAL, -1, -1);
+    public static final Token NOT_IDENTICAL = Token.newSymbol(COMPARE_NOT_IDENTICAL, -1, -1);
     public static final Token LT = Token.newSymbol(Types.COMPARE_LESS_THAN, -1, -1);
     public static final Token AND = Token.newSymbol(Types.LOGICAL_AND, -1, -1);
     public static final Token OR = Token.newSymbol(Types.LOGICAL_OR, -1, -1);
@@ -563,6 +566,10 @@ public class GeneralUtils {
 
     public static BinaryExpression ltX(Expression lhv, Expression rhv) {
         return new BinaryExpression(lhv, LT, rhv);
+    }
+
+    public static BinaryExpression notIdenticalX(Expression lhv, Expression rhv) {
+        return new BinaryExpression(lhv, NOT_IDENTICAL, rhv);
     }
 
     /**

--- a/src/main/org/codehaus/groovy/transform/EqualsAndHashCodeASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/EqualsAndHashCodeASTTransformation.java
@@ -131,7 +131,7 @@ public class EqualsAndHashCodeASTTransformation extends AbstractASTTransformatio
             Expression getter = getterThisX(cNode, pNode);
             final Expression current = callX(HASHUTIL_TYPE, "updateHash", args(result, getter));
             body.addStatement(ifS(
-                    notX(sameX(getter, varX("this"))),
+                    notIdenticalX(getter, varX("this")),
                     assignS(result, current)));
 
         }
@@ -141,7 +141,7 @@ public class EqualsAndHashCodeASTTransformation extends AbstractASTTransformatio
             final Expression fieldExpr = varX(fNode);
             final Expression current = callX(HASHUTIL_TYPE, "updateHash", args(result, fieldExpr));
             body.addStatement(ifS(
-                    notX(sameX(fieldExpr, varX("this"))),
+                    notIdenticalX(fieldExpr, varX("this")),
                     assignS(result, current)));
         }
         if (callSuper) {

--- a/src/test/org/codehaus/groovy/transform/CanonicalComponentsTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/CanonicalComponentsTransformTest.groovy
@@ -761,6 +761,21 @@ class CanonicalComponentsTransformTest extends GroovyShellTestCase {
             assert d1 == d2
         """
     }
+
+    void testHashCodeForInstanceWithNullPropertyAndField() {
+        new GroovyShell().evaluate """
+            import groovy.transform.*
+            
+            @EqualsAndHashCode(includeFields = true)
+            class FieldAndPropertyIncludedInHashCode {            
+                private String field
+                String property            
+            }
+            
+            assert new FieldAndPropertyIncludedInHashCode().hashCode() == 442087
+        """
+    }
+
 }
 
 @TupleConstructor

--- a/subprojects/performance/build.gradle
+++ b/subprojects/performance/build.gradle
@@ -30,7 +30,7 @@ configurations {
 
 dependencies {
     jmh rootProject
-    testCompile 'org.codehaus.groovy:groovy-all:2.4.7'
+    testCompile 'org.codehaus.groovy:groovy-all:2.4.12'
     stats 'org.apache.commons:commons-math3:3.6'
 }
 

--- a/subprojects/performance/src/jmh/java/org/apache/groovy/bench/GeneratedHashCodeBench.java
+++ b/subprojects/performance/src/jmh/java/org/apache/groovy/bench/GeneratedHashCodeBench.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.bench;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class GeneratedHashCodeBench {
+
+    @Benchmark
+    public int generated_hashcode_on_instance_with_null_properties() {
+        return new GeneratedHashCode().hashCode();
+    }
+
+}

--- a/subprojects/performance/src/test/groovy/org/apache/groovy/bench/GeneratedHashCode.groovy
+++ b/subprojects/performance/src/test/groovy/org/apache/groovy/bench/GeneratedHashCode.groovy
@@ -1,0 +1,30 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.groovy.bench
+
+import groovy.transform.EqualsAndHashCode
+
+@EqualsAndHashCode(includeFields = true)
+class GeneratedHashCode {
+
+    private String field
+    String property
+
+}


### PR DESCRIPTION
See [GROOVY-8377](https://issues.apache.org/jira/browse/GROOVY-8377) for the rationale behind this PR.

Given how simple the fix is and its impact (from 3k ops/ms to 30k ops/ms on my machine) I'd suggest considering backporting of it to 2.4.x, 2.5.x and 2.6.x lines.

`<rant>`
Working on this was harder then it should be down to:
- the build takes a minute(!) to configure, I believe it is down to [this code](https://github.com/apache/groovy/blob/1c42f421edd91f31aa35a3e7b7113910718b35d5/build.gradle#L93)
- the jmh benchmarks for Groovy code are broken and [needed fixing as part of my PR](https://github.com/erdi/groovy/commit/fc1d085a120bd7a542edeb7c1ff4b06816b776b2)

I understand that I worked against master, but the experience was highly unwelcoming.
`</rant>`