### PR TITLE
Update DefaultGroovyMethods boolean operations

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -15959,7 +15959,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean and(Boolean left, Boolean right) {
-        return left && Boolean.TRUE.equals(right);
+        return Boolean.TRUE.equals(left) && Boolean.TRUE.equals(right);
     }
 
     /**
@@ -15971,7 +15971,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean or(Boolean left, Boolean right) {
-        return left || Boolean.TRUE.equals(right);
+        return Boolean.TRUE.equals(left) || Boolean.TRUE.equals(right);
     }
 
     /**
@@ -15983,7 +15983,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.8.3
      */
     public static Boolean implies(Boolean left, Boolean right) {
-        return !left || Boolean.TRUE.equals(right);
+        return left == null || !left || Boolean.TRUE.equals(right);
     }
 
     /**
@@ -15995,7 +15995,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static Boolean xor(Boolean left, Boolean right) {
-        return left ^ Boolean.TRUE.equals(right);
+        return Boolean.TRUE.equals(left) ^ Boolean.TRUE.equals(right);
     }
 
 //    public static Boolean negate(Boolean left) {

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -285,8 +285,10 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertTrue(DefaultGroovyMethods.or(true, false))
         assertTrue(DefaultGroovyMethods.or(false, true))
         assertFalse(DefaultGroovyMethods.or(false, false))
+        assertFalse(DefaultGroovyMethods.or(null, false))
         assertFalse(DefaultGroovyMethods.or(false, null))
         assertTrue(DefaultGroovyMethods.or(true, null))
+        assertTrue(DefaultGroovyMethods.or(null, true))
     }
 
     public void testBooleanAnd() {
@@ -294,8 +296,10 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertFalse(DefaultGroovyMethods.and(true, false))
         assertFalse(DefaultGroovyMethods.and(false, true))
         assertFalse(DefaultGroovyMethods.and(false, false))
+        assertFalse(DefaultGroovyMethods.and(null, false))
         assertFalse(DefaultGroovyMethods.and(false, null))
         assertFalse(DefaultGroovyMethods.and(true, null))
+        assertFalse(DefaultGroovyMethods.and(null, true))
     }
 
     public void testBooleanXor() {
@@ -303,8 +307,10 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertTrue(DefaultGroovyMethods.xor(true, false))
         assertTrue(DefaultGroovyMethods.xor(false, true))
         assertFalse(DefaultGroovyMethods.xor(false, false))
+        assertFalse(DefaultGroovyMethods.xor(null, false))
         assertFalse(DefaultGroovyMethods.xor(false, null))
         assertTrue(DefaultGroovyMethods.xor(true, null))
+        assertTrue(DefaultGroovyMethods.xor(null, true))
     }
 
     public void testBooleanImplication() {
@@ -312,7 +318,9 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertFalse(DefaultGroovyMethods.implies(true, false))
         assertTrue(DefaultGroovyMethods.implies(false, true))
         assertTrue(DefaultGroovyMethods.implies(false, false))
+        assertTrue(DefaultGroovyMethods.implies(null, false))
         assertTrue(DefaultGroovyMethods.implies(false, null))
         assertFalse(DefaultGroovyMethods.implies(true, null))
+        assertTrue(DefaultGroovyMethods.implies(null, true))
     }
 }


### PR DESCRIPTION
* updated DefaultGroovyMethods.java boolean operations to allow for the
  left parameter to be null instead of throwing a NullPointerException.
  I noticed null was considered false for the right parameter, so i
  followed the same strategy.
* adding missing tests for boolean operations