### PR TITLE
GROOVY-8382: Target Typing for empty collections should work for fiel…

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -195,6 +195,8 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
 
     protected TypeCheckingContext typeCheckingContext;
     protected DefaultTypeCheckingExtension extension;
+    protected FieldNode currentField;
+    protected PropertyNode currentProperty;
 
     public StaticTypeCheckingVisitor(SourceUnit source, ClassNode cn) {
         this.typeCheckingContext = new TypeCheckingContext(this);
@@ -1578,8 +1580,10 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         final boolean osc = typeCheckingContext.isInStaticContext;
         try {
             typeCheckingContext.isInStaticContext = node.isInStaticContext();
+            currentProperty = node;
             super.visitProperty(node);
         } finally {
+            currentProperty = null;
             typeCheckingContext.isInStaticContext = osc;
         }
     }
@@ -1589,6 +1593,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         final boolean osc = typeCheckingContext.isInStaticContext;
         try {
             typeCheckingContext.isInStaticContext = node.isInStaticContext();
+            currentField = node;
             super.visitField(node);
             Expression init = node.getInitialExpression();
             if (init != null) {
@@ -1605,6 +1610,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                 }
             }
         } finally {
+            currentField = null;
             typeCheckingContext.isInStaticContext = osc;
         }
     }
@@ -3468,12 +3474,17 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
     // currently just for empty literals, not for e.g. Collections.emptyList() at present
     /// it seems attractive to want to do this for more cases but perhaps not all cases
     private ClassNode checkForTargetType(final Expression expr, final ClassNode type) {
-        if (typeCheckingContext.getEnclosingBinaryExpression() != null && isEmptyCollection(expr)) {
-            int op = typeCheckingContext.getEnclosingBinaryExpression().getOperation().getType();
-            if (isAssignment(op)) {
-                VariableExpression target = (VariableExpression) typeCheckingContext.getEnclosingBinaryExpression().getLeftExpression();
-                return adjustForTargetType(target.getType(), type);
-            }
+        BinaryExpression enclosingBinaryExpression = typeCheckingContext.getEnclosingBinaryExpression();
+        if (enclosingBinaryExpression != null && enclosingBinaryExpression instanceof DeclarationExpression
+                && isEmptyCollection(expr) && isAssignment(enclosingBinaryExpression.getOperation().getType())) {
+            VariableExpression target = (VariableExpression) enclosingBinaryExpression.getLeftExpression();
+            return adjustForTargetType(target.getType(), type);
+        }
+        if (currentField != null) {
+            return adjustForTargetType(currentField.getType(), type);
+        }
+        if (currentProperty != null) {
+            return adjustForTargetType(currentProperty.getType(), type);
         }
         return type;
     }

--- a/src/test/groovy/transform/stc/BugsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/BugsSTCTest.groovy
@@ -745,7 +745,7 @@ Printer
         '''
     }
 
-    // GROOVY-8255
+    // GROOVY-8255 and GROOVY-8382
     void testTargetTypingEmptyCollectionLiterals() {
         assertScript '''
             class Foo {
@@ -772,6 +772,23 @@ Printer
                 }
             }
             assert new Foo().bar() == [[x:1], [y:2]]
+        '''
+        assertScript '''
+            import groovy.transform.*
+            @ToString(includeFields=true)
+            class Foo {
+                List<String> propWithGen = ['propWithGen'] ?: []
+                List propNoGen = ['propNoGen'] ?: []
+                private Map<String, Integer> fieldGen = [fieldGen:42] ?: [:]
+                def bar() {
+                    this.propNoGen = ['notDecl'] ?: [] // not applicable here
+                    List<String> localVar = ['localVar'] ?: []
+                    localVar
+                }
+            }
+            def foo = new Foo()
+            assert foo.bar() == ['localVar']
+            assert foo.toString() == 'Foo([propWithGen], [notDecl], [fieldGen:42])'
         '''
     }
 }


### PR DESCRIPTION
…d/property initialisers