### PR TITLE
Remove deprecated StringGroovyMethods.capitalize call

### DIFF
--- a/src/main/org/codehaus/groovy/transform/SortableASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/SortableASTTransformation.java
@@ -161,8 +161,8 @@ public class SortableASTTransformation extends AbstractASTTransformation {
     }
 
     private static void createComparatorFor(ClassNode classNode, PropertyNode property, boolean reversed) {
-        String propName = property.getName();
-        String className = classNode.getName() + "$" + StringGroovyMethods.capitalize(propName) + "Comparator";
+        String propName = StringGroovyMethods.capitalize((CharSequence) property.getName());
+        String className = classNode.getName() + "$" + propName + "Comparator";
         ClassNode superClass = makeClassSafeWithGenerics(AbstractComparator.class, classNode);
         InnerClassNode cmpClass = new InnerClassNode(classNode, className, ACC_PRIVATE | ACC_STATIC, superClass);
         classNode.getModule().addClass(cmpClass);
@@ -176,7 +176,7 @@ public class SortableASTTransformation extends AbstractASTTransformation {
                 createCompareMethodBody(property, reversed)
         ));
 
-        String fieldName = "this$" + StringGroovyMethods.capitalize(propName) + "Comparator";
+        String fieldName = "this$" + propName + "Comparator";
         // private final Comparator this$<property>Comparator = new <type>$<property>Comparator();
         FieldNode cmpField = classNode.addField(
                 fieldName,
@@ -185,7 +185,7 @@ public class SortableASTTransformation extends AbstractASTTransformation {
                 ctorX(cmpClass));
 
         classNode.addMethod(new MethodNode(
-                "comparatorBy" + StringGroovyMethods.capitalize(propName),
+                "comparatorBy" + propName,
                 ACC_PUBLIC | ACC_STATIC,
                 COMPARATOR_TYPE,
                 Parameter.EMPTY_ARRAY,


### PR DESCRIPTION
I also noticed that propName was being capitalized three times in the createComparatorFor() method, so I only call it once at the beginning.

I followed the same style of passing in the CharSequence like it was defined in the deprecated method:
```groovy
@Deprecated
public static String capitalize(String self) {
    return capitalize((CharSequence) self);
}
````

If you would rather have something like the following, or something else let me know:
```groovy
CharSequence propName = property.getName();
String capitalizedPropName = StringGroovyMethods.capitalize(propName);

```