### PR TITLE
Documentation: fix style-guide range example

### DIFF
--- a/src/spec/doc/style-guide.adoc
+++ b/src/spec/doc/style-guide.adoc
@@ -494,9 +494,9 @@ def map = [CA: 'California', MI: 'Michigan']
 
 // ranges can be inclusive and exclusive
 def range = 10..20 // inclusive
-assert range.size() == 21
+assert range.size() == 11
 // use brackets if you need to call a method on a range definition
-assert (10..<20).size() == 20 // exclusive
+assert (10..<20).size() == 10 // exclusive
 
 def pattern = ~/fo*/
 


### PR DESCRIPTION
e674d77 added more information about ranges
but included erroneous code for `range.size()`.

The style guide does not seem to have tests associated like some of the other
docs. If you want me to create a test, please give me some guidance.

I don't think code sample from e674d77 was tested. It was probably just
an ad hoc example written on the fly.