### PR TITLE
Fix ArrayIndexOutOfBoundsException in CallSiteWriter.getCreateArraySignature()

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/CallSiteWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/CallSiteWriter.java
@@ -70,6 +70,11 @@ public class CallSiteWriter {
     
     private static String [] sig = new String [255];
     private static String getCreateArraySignature(int numberOfArguments) {
+        if (numberOfArguments >= 255) {
+            throw new IllegalArgumentException(String.format(
+                      "The max number of arguments is 255, actual got %s",
+                      numberOfArguments);
+        }
         if (sig[numberOfArguments] == null) {
             StringBuilder sb = new StringBuilder("(");
             for (int i = 0; i != numberOfArguments; ++i) {


### PR DESCRIPTION
It would throw `ArrayIndexOutOfBoundsException` if the `numberOfArguments` exceed 255,
but there is no check for array index and it's hard to get the root cause to users.

We should throw a more readable exception here.