### PR TITLE
 GROOVY-8475: unable to instantiate objects using the "new" keyword in groovysh

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -237,7 +237,7 @@ class Groovysh extends Shell {
         String variableBlocks = ''
         // To make groovysh behave more like an interpreter, we need to retrive all bound
         // vars at the end of script execution, and then update them into the groovysh Binding context.
-        Set<String> boundVars = ScriptVariableAnalyzer.getBoundVars(current.join(Parser.NEWLINE))
+        Set<String> boundVars = ScriptVariableAnalyzer.getBoundVars(current.join(Parser.NEWLINE), interp.classLoader)
         variableBlocks += "$COLLECTED_BOUND_VARS_MAP_VARNAME = new HashMap();"
         if (boundVars) {
             boundVars.each({ String varname ->

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzer.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzer.groovy
@@ -93,7 +93,16 @@ class ScriptVariableAnalyzer {
     static class VisitorClassLoader extends GroovyClassLoader {
         final GroovyClassVisitor visitor
 
+        /**
+         * @deprecated will be removed in 2.5.0, use {@link #VisitorClassLoader(GroovyClassVisitor, ClassLoader)}
+         */
+        @Deprecated
         VisitorClassLoader(final GroovyClassVisitor visitor) {
+            this.visitor = visitor
+        }
+
+        VisitorClassLoader(final GroovyClassVisitor visitor, ClassLoader parent) {
+            super(parent == null ?  Thread.currentThread().getContextClassLoader() : parent)
             this.visitor = visitor
         }
 
@@ -105,10 +114,18 @@ class ScriptVariableAnalyzer {
         }
     }
 
+    /**
+     * @deprecated will be removed in 2.5.0, use {@link #getBoundVars(java.lang.String, java.lang.ClassLoader)}
+     */
+    @Deprecated
     static Set<String> getBoundVars(final String scriptText) {
+        getBoundVars(scriptText, null);
+    }
+
+    static Set<String> getBoundVars(final String scriptText, ClassLoader parent) {
         assert scriptText != null
         GroovyClassVisitor visitor = new VariableVisitor()
-        VisitorClassLoader myCL = new VisitorClassLoader(visitor)
+        VisitorClassLoader myCL = new VisitorClassLoader(visitor, parent)
         // simply by parsing the script with our classloader
         // our visitor will be called and will visit all the variables
         myCL.parseClass(scriptText)

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -62,9 +62,13 @@ class GroovyshTest extends GroovyTestCase {
 
     void testClassDef() {
         Groovysh groovysh = createGroovysh()
-        groovysh.execute('class Foo {}')
+        groovysh.execute('class MyFooTestClass{ String foo }')
         assert mockOut.toString().length() > 0
         assert ' true\n' == mockOut.toString().normalize()[-6..-1]
+        groovysh.execute('m = new MyFooTestClass()')
+        assert mockOut.toString().length() > 0
+        // mostly assert no exception
+        assert mockOut.toString().normalize().contains('MyFooTestClass@')
     }
 
     void testmethodDef() {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -315,6 +315,17 @@ class GroovyshTest extends GroovyTestCase {
         } catch (ArithmeticException e) {}
     }
 
+    void testImports() {
+        Groovysh groovysh = new Groovysh(testio)
+        groovysh.execute('import java.rmi.Remote ')
+        assert mockOut.toString().length() > 0
+        assert 'java.rmi.Remote\n' == mockOut.toString().normalize()[-('java.rmi.Remote\n'.length())..-1]
+        groovysh.execute('Remote r')
+        assert mockOut.toString().length() > 0
+        // mostly assert no exception
+        assert 'null\n' == mockOut.toString().normalize()[-5..-1]
+    }
+
     static File createTemporaryGroovyScriptFile(content) {
         String testName = 'GroovyshTest' + System.currentTimeMillis()
         File groovyCode = new File(System.getProperty('java.io.tmpdir'), testName)


### PR DESCRIPTION
PR #100 was merged into 2_5_X and comments on GROOVY-7562 indicate it wasn't merged into 2_4_X due to binary compatibility concerns. I think this backport addresses those concerns and this PR is targeted only for the 2_4_X branch.