### PR TITLE
GROOVY-8422: Incorrect properties copy in Sql.newInstance

### DIFF
--- a/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
@@ -589,14 +589,16 @@ public class Sql {
         Connection connection;
         LOG.fine("url = " + url);
         if (props != null) {
-            Properties propsCopy = new Properties(props);
-            connection = DriverManager.getConnection(url.toString(), propsCopy);
-            if (propsCopy.containsKey("password")) {
+            connection = DriverManager.getConnection(url.toString(), props);
+            if (!props.containsKey("password")) {
+                LOG.fine("props = " + props);
+            } else {
                 // don't log the password
-                propsCopy = new Properties(propsCopy);
+                Properties propsCopy = new Properties();
+                propsCopy.putAll(props);
                 propsCopy.setProperty("password", "***");
+                LOG.fine("props = " + propsCopy);
             }
-            LOG.fine("props = " + propsCopy);
         } else if (sqlArgs.containsKey("user")) {
             Object user = sqlArgs.remove("user");
             LOG.fine("user = " + user);

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
@@ -47,6 +47,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -590,14 +591,16 @@ public class Sql {
         LOG.fine("url = " + url);
         if (props != null) {
             connection = DriverManager.getConnection(url.toString(), props);
-            if (!props.containsKey("password")) {
-                LOG.fine("props = " + props);
-            } else {
-                // don't log the password
-                Properties propsCopy = new Properties();
-                propsCopy.putAll(props);
-                propsCopy.setProperty("password", "***");
-                LOG.fine("props = " + propsCopy);
+            if (LOG.isLoggable(Level.FINE)) {
+                if (!props.containsKey("password")) {
+                    LOG.fine("props = " + props);
+                } else {
+                    // don't log the password
+                    Properties propsCopy = new Properties();
+                    propsCopy.putAll(props);
+                    propsCopy.setProperty("password", "***");
+                    LOG.fine("props = " + propsCopy);
+                }
             }
         } else if (sqlArgs.containsKey("user")) {
             Object user = sqlArgs.remove("user");


### PR DESCRIPTION
The provided Properties should be passed to the DriverManager as-is.
A copy is only needed when changes are made to the provided Properties
in order to mask sensitive information for logging purposes.