### PR TITLE
GROOVY-8525: Binary compatibility issue for GroovyClassLoader between…

### DIFF
--- a/src/main/groovy/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/groovy/lang/GroovyClassLoader.java
@@ -90,13 +90,13 @@ public class GroovyClassLoader extends URLClassLoader {
     /**
      * this cache contains the loaded classes or PARSING, if the class is currently parsed
      */
-    protected final EvictableCache<String, Class> classCache = new UnlimitedConcurrentCache<String, Class>();
+    protected final Map<String, Class> classCache = new UnlimitedConcurrentCache<String, Class>();
 
     /**
      * This cache contains mappings of file name to class. It is used
      * to bypass compilation.
      */
-    protected final EvictableCache<String, Class> sourceCache = new StampedCommonCache<String, Class>();
+    protected final Map<String, Class> sourceCache = new StampedCommonCache<String, Class>();
 
     private final CompilerConfiguration config;
     private String sourceEncoding;
@@ -1017,7 +1017,7 @@ public class GroovyClassLoader extends URLClassLoader {
      * @see #removeClassCacheEntry(String)
      */
     public void clearCache() {
-        Map<String, Class> clearedClasses = classCache.clear();
+        Map<String, Class> clearedClasses = ((EvictableCache<String, Class>)classCache).clearAll();
 
         sourceCache.clear();
 

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/CommonCache.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/CommonCache.java
@@ -108,7 +108,7 @@ public class CommonCache<K, V> implements EvictableCache<K, V>, ValueConvertable
      * {@inheritDoc}
      */
     @Override
-    public V get(K key) {
+    public V get(Object key) {
         return map.get(key);
     }
 
@@ -150,6 +150,11 @@ public class CommonCache<K, V> implements EvictableCache<K, V>, ValueConvertable
         return map.values();
     }
 
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return map.entrySet();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -158,11 +163,16 @@ public class CommonCache<K, V> implements EvictableCache<K, V>, ValueConvertable
         return map.keySet();
     }
 
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
-    public boolean containsKey(K key) {
+    public boolean containsKey(Object key) {
         return map.containsKey(key);
     }
 
@@ -174,22 +184,36 @@ public class CommonCache<K, V> implements EvictableCache<K, V>, ValueConvertable
         return map.size();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public V remove(K key) {
-        return map.remove(key);
+    public boolean isEmpty() {
+        return size() == 0;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Map<K, V> clear() {
+    public V remove(Object key) {
+        return map.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        map.putAll(m);
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<K, V> clearAll() {
         Map<K, V> result = new LinkedHashMap<K, V>(map);
         map.clear();
-
         return result;
     }
 

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/ConcurrentCommonCache.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/ConcurrentCommonCache.java
@@ -93,7 +93,7 @@ public class ConcurrentCommonCache<K, V> implements EvictableCache<K, V>, ValueC
      * {@inheritDoc}
      */
     @Override
-    public V get(final K key) {
+    public V get(final Object key) {
         return doWithReadLock(c -> c.get(key));
     }
 
@@ -153,6 +153,11 @@ public class ConcurrentCommonCache<K, V> implements EvictableCache<K, V>, ValueC
         return doWithReadLock(c -> c.values());
     }
 
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return doWithReadLock(c -> c.entrySet());
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -165,8 +170,13 @@ public class ConcurrentCommonCache<K, V> implements EvictableCache<K, V>, ValueC
      * {@inheritDoc}
      */
     @Override
-    public boolean containsKey(final K key) {
+    public boolean containsKey(final Object key) {
         return doWithReadLock(c -> c.containsKey(key));
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return doWithReadLock(c -> c.containsValue(value));
     }
 
     /**
@@ -177,20 +187,38 @@ public class ConcurrentCommonCache<K, V> implements EvictableCache<K, V>, ValueC
         return doWithReadLock(c -> c.size());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public V remove(final K key) {
-        return doWithWriteLock(c -> c.remove(key));
+    public boolean isEmpty() {
+        return size() == 0;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Map<K, V> clear() {
-        return doWithWriteLock(c -> c.clear());
+    public V remove(final Object key) {
+        return doWithWriteLock(c -> c.remove(key));
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        doWithWriteLock(c -> {
+            c.putAll(m);
+            return null;
+        });
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return keys();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<K, V> clearAll() {
+        return doWithWriteLock(c -> c.clearAll());
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/EvictableCache.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/EvictableCache.java
@@ -29,19 +29,27 @@ import java.util.Set;
  *
  * @since 2.5.0
  */
-public interface EvictableCache<K, V> extends MemoizeCache<K, V> {
+public interface EvictableCache<K, V> extends MemoizeCache<K, V>, Map<K, V>/* */ {
     /**
      * Remove the cached value by the key
-     * @param key
+     * @param key of the cached value
      * @return returns the removed value
      */
-    V remove(K key);
+    V remove(Object key);
 
     /**
      * Clear the cache
      * @return returns the content of the cleared map
      */
-    Map<K, V> clear();
+    Map<K, V> clearAll();
+
+    /**
+     * Clear the cache
+     * @see #clearAll()
+     */
+    default void clear() {
+        clearAll();
+    }
 
     /**
      * Get all cached values
@@ -60,7 +68,7 @@ public interface EvictableCache<K, V> extends MemoizeCache<K, V> {
      * @param key key whose presence in this cache is to be tested.
      * @return true if the cache contains a mapping for the specified key
      */
-    boolean containsKey(K key);
+    boolean containsKey(Object key);
 
     /**
      * Get the size of the cache

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/LRUCache.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/LRUCache.java
@@ -28,9 +28,6 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * A cache backed by a ConcurrentLinkedHashMap
- *
- * @author Vaclav Pech
- * @author <a href="mailto:realbluesun@hotmail.com">Daniel.Sun</a>
  */
 @ThreadSafe
 public final class LRUCache<K, V> implements MemoizeCache<K, V> {

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/LRUProtectionStorage.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/LRUProtectionStorage.java
@@ -26,8 +26,6 @@ import java.util.Map;
  * If the maximum size has been reached all newly added elements will cause the oldest element to be removed from the storage
  * in order not to exceed the maximum capacity.
  * The touch method can be used to renew an element and move it to the from the LRU queue.
- *
- * @author Vaclav Pech
  */
 final class LRUProtectionStorage extends LinkedHashMap<Object, Object> implements ProtectionStorage {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/Memoize.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/Memoize.java
@@ -30,8 +30,6 @@ import static java.util.Arrays.copyOf;
 /**
  * Implements memoize for Closures.
  * It is supposed to be used by the Closure class itself to implement the memoize() family of methods.
- *
- * @author Vaclav Pech
  */
 public abstract class Memoize {
 

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/MemoizeCache.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/MemoizeCache.java
@@ -22,8 +22,6 @@ package org.codehaus.groovy.runtime.memoize;
  * Represents a memoize cache with its essential methods
  * @param <K> type of the keys
  * @param <V> type of the values
- *
- * @author Vaclav Pech
  */
 public interface MemoizeCache<K, V> {
 

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/NullProtectionStorage.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/NullProtectionStorage.java
@@ -22,8 +22,6 @@ package org.codehaus.groovy.runtime.memoize;
  * A NullObject pattern implementation for ProtectionStorage
  * Doesn't protect any resources.
  * Used when the user doesn't mind to eventually have the whole memoize cache emptied by gc.
- *
- * @author Vaclav Pech
  */
 public final class NullProtectionStorage implements ProtectionStorage{
 

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/ProtectionStorage.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/ProtectionStorage.java
@@ -21,8 +21,6 @@ package org.codehaus.groovy.runtime.memoize;
 /**
  * Protects stored resources from eviction from memory following the LRU (Last Recently Used) strategy.
  * The touch method can be used to renew an element and move it to the from the LRU queue.
- *
- * @author Vaclav Pech
  */
 interface ProtectionStorage<K, V> {
     void touch(K key, V value);

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/StampedCommonCache.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/StampedCommonCache.java
@@ -31,7 +31,6 @@ import java.util.concurrent.locks.StampedLock;
  * but it is not reentrant, in other words, <b>it may cause deadlock</b> if {@link #getAndPut(K, ValueProvider)} OR {@link #getAndPut(K, ValueProvider, boolean)} is called recursively:
  * readlock -> upgrade to writelock -> readlock(fails to get and wait forever)
  *
- *
  * @param <K> type of the keys
  * @param <V> type of the values
  * @since 3.0.0
@@ -95,7 +94,7 @@ public class StampedCommonCache<K, V> implements EvictableCache<K, V>, ValueConv
      * {@inheritDoc}
      */
     @Override
-    public V get(final K key) {
+    public V get(final Object key) {
         return doWithReadLock(c -> c.get(key));
     }
 
@@ -175,6 +174,11 @@ public class StampedCommonCache<K, V> implements EvictableCache<K, V>, ValueConv
         return doWithReadLock(c -> c.values());
     }
 
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return doWithReadLock(c -> c.entrySet());
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -187,8 +191,13 @@ public class StampedCommonCache<K, V> implements EvictableCache<K, V>, ValueConv
      * {@inheritDoc}
      */
     @Override
-    public boolean containsKey(final K key) {
+    public boolean containsKey(final Object key) {
         return doWithReadLock(c -> c.containsKey(key));
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return doWithReadLock(c -> c.containsValue(value));
     }
 
     /**
@@ -199,20 +208,38 @@ public class StampedCommonCache<K, V> implements EvictableCache<K, V>, ValueConv
         return doWithReadLock(c -> c.size());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public V remove(final K key) {
-        return doWithWriteLock(c -> c.remove(key));
+    public boolean isEmpty() {
+        return size() == 0;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Map<K, V> clear() {
-        return doWithWriteLock(c -> c.clear());
+    public V remove(final Object key) {
+        return doWithWriteLock(c -> c.remove(key));
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        doWithWriteLock(c -> {
+            c.putAll(m);
+            return null;
+        });
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return keys();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<K, V> clearAll() {
+        return doWithWriteLock(c -> c.clearAll());
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/UnlimitedConcurrentCache.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/UnlimitedConcurrentCache.java
@@ -29,8 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A cache backed by a ConcurrentHashMap
- *
- * @author Vaclav Pech
  */
 @ThreadSafe
 public final class UnlimitedConcurrentCache<K, V> implements EvictableCache<K, V>, Serializable {
@@ -67,8 +65,18 @@ public final class UnlimitedConcurrentCache<K, V> implements EvictableCache<K, V
      * @return returns the removed value
      */
     @Override
-    public V remove(K key) {
+    public V remove(Object key) {
         return map.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        map.putAll(m);
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return map.keySet();
     }
 
     /**
@@ -77,7 +85,7 @@ public final class UnlimitedConcurrentCache<K, V> implements EvictableCache<K, V
      * @return returns the content of the cleared map
      */
     @Override
-    public Map<K, V> clear() {
+    public Map<K, V> clearAll() {
         Map<K, V> result = new LinkedHashMap<K, V>(map.size());
 
         for (Map.Entry<K, V> entry : map.entrySet()) {
@@ -104,6 +112,11 @@ public final class UnlimitedConcurrentCache<K, V> implements EvictableCache<K, V
         return map.values();
     }
 
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return map.entrySet();
+    }
+
     /**
      * Get all keys associated to cached values
      *
@@ -121,8 +134,13 @@ public final class UnlimitedConcurrentCache<K, V> implements EvictableCache<K, V
      * @return true if the cache contains a mapping for the specified key
      */
     @Override
-    public boolean containsKey(K key) {
+    public boolean containsKey(Object key) {
         return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
     }
 
     /**
@@ -133,6 +151,11 @@ public final class UnlimitedConcurrentCache<K, V> implements EvictableCache<K, V
     @Override
     public int size() {
         return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
     }
 
     /**
@@ -154,7 +177,7 @@ public final class UnlimitedConcurrentCache<K, V> implements EvictableCache<K, V
      * @return the value, or null, if it does not exist.
      */
     @Override
-    public V get(K key) {
+    public V get(Object key) {
         return map.get(key);
     }
 

--- a/src/test/org/codehaus/groovy/runtime/memoize/CacheCleanupTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/memoize/CacheCleanupTest.groovy
@@ -22,9 +22,6 @@ import java.lang.ref.SoftReference
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.TimeUnit
 
-/**
- * @author Vaclav Pech
- */
 public class CacheCleanupTest extends GroovyTestCase {
     private static final Object ANCHOR = "I'm never gonna go"
     
@@ -34,14 +31,14 @@ public class CacheCleanupTest extends GroovyTestCase {
     }
 
     private def checkCache(MemoizeCache cache) {
-        assert cache.map.size() == 0
+        assert cache.@map.size() == 0
         cache.put('key1', new SoftReference(ANCHOR))
         cache.put('key2', new SoftReference(ANCHOR))
-        assert cache.map.size() == 2
+        assert cache.@map.size() == 2
         cache.put('key3', new SoftReference(null))  //Simulating evicted objects
         cache.put('key4', new SoftReference(null))
         cache.cleanUpNullReferences()
-        assert cache.map.size() == 2
+        assert cache.@map.size() == 2
     }
 
     public void testUnlimitedCacheConcurrently() {
@@ -51,10 +48,10 @@ public class CacheCleanupTest extends GroovyTestCase {
     }
 
     private def checkCacheConcurrently(MemoizeCache cache) {
-        assert cache.map.size() == 0
+        assert cache.@map.size() == 0
         cache.put('key1', new SoftReference(ANCHOR))
         cache.put('key2', new SoftReference(ANCHOR))
-        assert cache.map.size() == 2
+        assert cache.@map.size() == 2
         for (i in (3..1000)) {
             cache.put("key${i}", new SoftReference(null))  //Simulating evicted objects
             cache.get('key1')  //touch the non-null cache entries to keep them hot to prevent a potential LRU algorithm from evicting them
@@ -72,6 +69,6 @@ public class CacheCleanupTest extends GroovyTestCase {
         barrier.await(30, TimeUnit.SECONDS)  //start threads
         barrier.await(30, TimeUnit.SECONDS)  //wait for threads to finish
 
-        assert cache.map.size() == 2
+        assert cache.@map.size() == 2
     }
 }

--- a/src/test/org/codehaus/groovy/runtime/memoize/CommonCacheTest.java
+++ b/src/test/org/codehaus/groovy/runtime/memoize/CommonCacheTest.java
@@ -156,7 +156,7 @@ public class CommonCacheTest {
                         )
                 );
 
-        Assert.assertArrayEquals(new String[] {"Daniel", "Male", "Shanghai"}, sc.clear().values().toArray(new String[0]));
+        Assert.assertArrayEquals(new String[] {"Daniel", "Male", "Shanghai"}, sc.clearAll().values().toArray(new String[0]));
     }
 
     @Test

--- a/src/test/org/codehaus/groovy/runtime/memoize/ConcurrentCommonCacheTest.java
+++ b/src/test/org/codehaus/groovy/runtime/memoize/ConcurrentCommonCacheTest.java
@@ -157,7 +157,7 @@ public class ConcurrentCommonCacheTest {
                         )
                 );
 
-        Assert.assertArrayEquals(new String[] {"Daniel", "Male", "Shanghai"}, sc.clear().values().toArray(new String[0]));
+        Assert.assertArrayEquals(new String[] {"Daniel", "Male", "Shanghai"}, sc.clearAll().values().toArray(new String[0]));
     }
 
     @Test

--- a/src/test/org/codehaus/groovy/runtime/memoize/StampedCommonCacheTest.java
+++ b/src/test/org/codehaus/groovy/runtime/memoize/StampedCommonCacheTest.java
@@ -157,7 +157,7 @@ public class StampedCommonCacheTest {
                         )
                 );
 
-        Assert.assertArrayEquals(new String[] {"Daniel", "Male", "Shanghai"}, sc.clear().values().toArray(new String[0]));
+        Assert.assertArrayEquals(new String[] {"Daniel", "Male", "Shanghai"}, sc.clearAll().values().toArray(new String[0]));
     }
 
     @Test

--- a/src/test/org/codehaus/groovy/runtime/memoize/UnlimitedConcurrentCacheTest.java
+++ b/src/test/org/codehaus/groovy/runtime/memoize/UnlimitedConcurrentCacheTest.java
@@ -155,7 +155,7 @@ public class UnlimitedConcurrentCacheTest {
                         )
                 );
 
-        Assert.assertEquals(new TreeSet<>(Arrays.asList("Daniel", "Male", "Shanghai")), new TreeSet<>(sc.clear().values()));
+        Assert.assertEquals(new TreeSet<>(Arrays.asList("Daniel", "Male", "Shanghai")), new TreeSet<>(sc.clearAll().values()));
     }
 
     @Test


### PR DESCRIPTION
… 2.4 vs later branches (alternative to PR#678)

What I haven't yet checked is whether we need to make some of the delegated method calls just throw UnsupportedOperationException in order to keep the claims like @Threadsafe.