### PR TITLE
Fixes GROOVY-8537 GroovyCollections.combinations(Iterable) exhibits incorrect (asymmetric) behavior.

### DIFF
--- a/src/main/groovy/groovy/util/GroovyCollections.java
+++ b/src/main/groovy/groovy/util/GroovyCollections.java
@@ -118,6 +118,9 @@ public class GroovyCollections {
                 }
                 collectedCombos = newCombos;
             }
+
+            if (collectedCombos.isEmpty()) 
+                break;
         }
         return collectedCombos;
     }

--- a/src/test/groovy/util/GroovyCollectionsTest.groovy
+++ b/src/test/groovy/util/GroovyCollectionsTest.groovy
@@ -50,6 +50,11 @@ public class GroovyCollectionsTest extends GroovyTestCase {
         // collection versions should match Collection
         assert GroovyCollections.combinations(input) as Set == expected
         assert combinations(input) as Set == expected
+
+        // an empty iterable should result in no combination
+        assert combinations([[]] + input).isEmpty()
+        assert combinations(input + [[]]).isEmpty()
+        assert combinations(input + [[]] + input).isEmpty()
     }
 
     void testTranspose() {


### PR DESCRIPTION
The patch ensures no combination is returned if any of the input iterables to
GroovyCollections.combinations() is empty.

https://issues.apache.org/jira/browse/GROOVY-8537