### PR TITLE
GROOVY-8558: Add DGM `whichJar` to get the url of the jar containing the specified class

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -108,7 +108,9 @@ import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.net.URL;
 import java.security.AccessController;
+import java.security.CodeSource;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
 import java.util.AbstractCollection;
@@ -595,6 +597,22 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      */
     public static void mixin(Class self, Class[] categoryClass) {
         mixin(getMetaClass(self), Arrays.asList(categoryClass));
+    }
+
+    /**
+     * Gets the url of the jar containing the specified class
+     *
+     * @param self the class
+     * @return the url of the jar, {@code null} if the specified class is from JDK
+     */
+    public static URL whichJar(Class self) {
+        CodeSource codeSource = self.getProtectionDomain().getCodeSource();
+
+        if (null == codeSource) {
+            return null;
+        }
+
+        return codeSource.getLocation();
     }
 
     /**

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -308,4 +308,8 @@ class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertFalse(DefaultGroovyMethods.implies(true, null))
     }
 
+    void testWhichJar() {
+        assert DefaultGroovyMethods.whichJar(org.objectweb.asm.Opcodes).getFile().matches(/(.+\/)?asm[-].+\.jar/)
+        assert null == DefaultGroovyMethods.whichJar(String)
+    }
 }


### PR DESCRIPTION
… class