### PR TITLE
GROOVY-8520 fixes

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -199,7 +199,7 @@ allprojects {
                             return component.module in [
                                     'antlr', 'antlr-runtime', 'antlr4', 'antlr4-runtime', 'antlr4-annotations',
                                     'asm', 'asm-commons', 'asm-tree', 'asm-util',
-                                    'commons-cli']
+                                    'commons-cli', 'picocli']
                         }
                         return false
                     }
@@ -209,16 +209,21 @@ allprojects {
             }
             jarjarToolClasspath = rootProject.configurations.tools
             untouchedFiles = [
-                    'org/codehaus/groovy/cli/GroovyPosixParser*.class',
+                    'groovy/cli/commons/CliBuilder*.class',
+                    'groovy/cli/commons/OptionAccessor*.class',
+                    'groovy/cli/picocli/CliBuilder*.class',
+                    'groovy/cli/picocli/OptionAccessor*.class',
                     'groovy/util/CliBuilder*.class',
                     'groovy/util/OptionAccessor*.class',
+                    'org/codehaus/groovy/cli/GroovyPosixParser*.class',
                     'org/codehaus/groovy/tools/shell/util/HelpFormatter*.class'
             ]
             patterns = [
                     'antlr.**'                 : 'groovyjarjarantlr.@1', // antlr2
                     'org.antlr.**'             : 'groovyjarjarantlr4.@1', // antlr4
                     'org.objectweb.**'         : 'groovyjarjarasm.@1',
-                    'org.apache.commons.cli.**': 'groovyjarjarcommonscli.@1'
+                    'org.apache.commons.cli.**': 'groovyjarjarcommonscli.@1',
+                    'picocli.**'               : 'groovyjarjarpicocli.@1'
             ]
             excludesPerLibrary = [
                     '*': ['META-INF/maven/**', 'META-INF/*', 'META-INF/services/javax.annotation.processing.Processor', 'module-info.class']

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -116,12 +116,7 @@ public class FileSystemCompiler {
      */
     public static void commandLineCompile(String[] args, boolean lookupUnnamedFiles) throws Exception {
         CompilationOptions options = new CompilationOptions();
-        CommandLine parser = new CommandLine(options);
-        parser.getCommandSpec().parser()
-                .unmatchedArgumentsAllowed(true)
-                .unmatchedOptionsArePositionalParams(true)
-                .expandAtFiles(false)
-                .toggleBooleanFlags(false);
+        CommandLine parser = configureParser(options);
         ParseResult parseResult = parser.parseArgs(args);
         if (CommandLine.printHelpIfRequested(parseResult)) {
             return;
@@ -142,6 +137,17 @@ public class FileSystemCompiler {
         if (!fileNameErrors) {
             doCompilation(configuration, null, filenames, lookupUnnamedFiles);
         }
+    }
+
+    public static CommandLine configureParser(CompilationOptions options) {
+        CommandLine parser = new CommandLine(options);
+        parser.getCommandSpec().mixinStandardHelpOptions(true); // programmatically so these options appear last in usage help
+        parser.getCommandSpec().parser()
+                .unmatchedArgumentsAllowed(true)
+                .unmatchedOptionsArePositionalParams(true)
+                .expandAtFiles(false)
+                .toggleBooleanFlags(false);
+        return parser;
     }
 
     /**
@@ -267,8 +273,10 @@ public class FileSystemCompiler {
         }
     }
 
-    @Command(name = "groovyc", customSynopsis = "groovyc [options] <source-files>",
-            mixinStandardHelpOptions = true, versionProvider = VersionProvider.class)
+    @Command(name = "groovyc",
+            customSynopsis = "groovyc [options] <source-files>",
+            sortOptions = false,
+            versionProvider = VersionProvider.class)
     public static class CompilationOptions {
         // IMPLEMENTATION NOTE:
         // classpath must be the first argument, so that the `startGroovy(.bat)` script

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -20,6 +20,8 @@ package org.codehaus.groovy.tools;
 
 import groovy.lang.GroovyResourceLoader;
 import groovy.lang.GroovySystem;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
 import picocli.CommandLine;
 import picocli.CommandLine.*;
 import org.codehaus.groovy.control.CompilationUnit;
@@ -29,10 +31,7 @@ import org.codehaus.groovy.runtime.DefaultGroovyStaticMethods;
 import org.codehaus.groovy.runtime.StringGroovyMethods;
 import org.codehaus.groovy.tools.javac.JavaAwareCompilationUnit;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -73,9 +72,36 @@ public class FileSystemCompiler {
         unit.compile();
     }
 
+    /** @deprecated use {@link #displayHelp(PrintWriter)} instead */
+    @Deprecated
+    public static void displayHelp(final Options options) {
+        final HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp(80, "groovyc [options] <source-files>", "options:", options, "");
+    }
+
+    /** Prints the usage help message for {@link CompilationOptions} to stderr.
+     * @see #displayHelp(PrintWriter)
+     * @since 2.5 */
+    public static void displayHelp() {
+        displayHelp(new PrintWriter(System.err, true));
+    }
+
+    /** Prints the usage help message for the {@link CompilationOptions} to the specified PrintWriter. */
+    public static void displayHelp(final PrintWriter writer) {
+        configureParser(new CompilationOptions()).usage(writer);
+    }
+
+    /** Prints version information to stderr.
+     * @see #displayVersion(PrintWriter)
+     * @since 2.5 */
     public static void displayVersion() {
+        displayVersion(new PrintWriter(System.err, true));
+    }
+
+    /** Prints version information to the specified PrintWriter. */
+    public static void displayVersion(final PrintWriter writer) {
         for (String line : new VersionProvider().getVersion()) {
-            System.err.println(line);
+            writer.println(line);
         }
     }
 
@@ -394,11 +420,6 @@ public class FileSystemCompiler {
             }
             return flags.toArray(new String[0]);
         }
-    }
-
-    @SuppressWarnings({"AccessStaticViaInstance"})
-    public static CommandLine createCompilationOptions() {
-        return new CommandLine(new CompilationOptions());
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -73,6 +73,12 @@ public class FileSystemCompiler {
         unit.compile();
     }
 
+    public static void displayVersion() {
+        for (String line : new VersionProvider().getVersion()) {
+            System.err.println(line);
+        }
+    }
+
     public static int checkFiles(String[] filenames) {
         int errors = 0;
 

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -20,12 +20,8 @@ package org.codehaus.groovy.tools;
 
 import groovy.lang.GroovyResourceLoader;
 import groovy.lang.GroovySystem;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
+import picocli.CommandLine;
+import picocli.CommandLine.*;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.ConfigurationException;
@@ -77,18 +73,6 @@ public class FileSystemCompiler {
         unit.compile();
     }
 
-    public static void displayHelp(final Options options) {
-        final HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp(80, "groovyc [options] <source-files>", "options:", options, "");
-    }
-
-    public static void displayVersion() {
-        String version = GroovySystem.getVersion();
-        System.err.println("Groovy compiler version " + version);
-        System.err.println("Copyright 2003-2018 The Apache Software Foundation. http://groovy-lang.org/");
-        System.err.println("");
-    }
-
     public static int checkFiles(String[] filenames) {
         int errors = 0;
 
@@ -125,32 +109,25 @@ public class FileSystemCompiler {
      * the VM to exit and the lookup for .groovy files can be controlled
      */
     public static void commandLineCompile(String[] args, boolean lookupUnnamedFiles) throws Exception {
-        Options options = createCompilationOptions();
-
-        CommandLineParser cliParser = new DefaultParser();
-
-        CommandLine cli;
-        cli = cliParser.parse(options, args);
-
-        if (cli.hasOption('h')) {
-            displayHelp(options);
+        CompilationOptions options = new CompilationOptions();
+        CommandLine parser = new CommandLine(options);
+        parser.getCommandSpec().parser()
+                .unmatchedArgumentsAllowed(true)
+                .unmatchedOptionsArePositionalParams(true)
+                .expandAtFiles(false)
+                .toggleBooleanFlags(false);
+        ParseResult parseResult = parser.parseArgs(args);
+        if (CommandLine.printHelpIfRequested(parseResult)) {
             return;
         }
-
-        if (cli.hasOption('v')) {
-            displayVersion();
-            return;
-        }
-
-        displayStackTraceOnError = cli.hasOption('e');
-
-        CompilerConfiguration configuration = generateCompilerConfigurationFromOptions(cli);
+        displayStackTraceOnError = options.printStack;
+        CompilerConfiguration configuration = options.toCompilerConfiguration();
 
         // Load the file name list
-        String[] filenames = generateFileNamesFromOptions(cli);
+        String[] filenames = options.generateFileNames();
         boolean fileNameErrors = filenames == null;
         if (!fileNameErrors && (filenames.length == 0)) {
-            displayHelp(options);
+            parser.usage(System.err);
             return;
         }
 
@@ -234,9 +211,11 @@ public class FileSystemCompiler {
         }
     }
 
-    public static String[] generateFileNamesFromOptions(CommandLine cli) {
-        String[] filenames = cli.getArgs();
-        List<String> fileList = new ArrayList<String>(filenames.length);
+    private static String[] generateFileNamesFromOptions(List<String> filenames) {
+        if (filenames == null) {
+            return new String[0];
+        }
+        List<String> fileList = new ArrayList<String>(filenames.size());
         boolean errors = false;
         for (String filename : filenames) {
             if (filename.startsWith("@")) {
@@ -271,94 +250,137 @@ public class FileSystemCompiler {
         }
     }
 
-    public static CompilerConfiguration generateCompilerConfigurationFromOptions(CommandLine cli) throws IOException {
-        // Setup the configuration data
-        CompilerConfiguration configuration = new CompilerConfiguration();
-
-        if (cli.hasOption("classpath")) {
-            configuration.setClasspath(cli.getOptionValue("classpath"));
+    static class VersionProvider implements IVersionProvider {
+        @Override
+        public String[] getVersion() {
+            return new String[] {
+                    "Groovy compiler version " + GroovySystem.getVersion(),
+                    "Copyright 2003-2018 The Apache Software Foundation. http://groovy-lang.org/",
+                    "",
+            };
         }
+    }
 
-        if (cli.hasOption('d')) {
-            configuration.setTargetDirectory(cli.getOptionValue('d'));
-        }
+    @Command(name = "groovyc", customSynopsis = "groovyc [options] <source-files>",
+            mixinStandardHelpOptions = true, versionProvider = VersionProvider.class)
+    public static class CompilationOptions {
+        @Option(names = {"-cp", "-classpath", "--classpath"}, paramLabel = "<path>", description = "Specify where to find the class files")
+        private String classpath;
 
-        configuration.setParameters(cli.hasOption("pa"));
+        @Option(names = {"-sourcepath", "--sourcepath"}, paramLabel = "<path>", description = "Specify where to find the source files")
+        private File sourcepath;
 
-        if (cli.hasOption("encoding")) {
-            configuration.setSourceEncoding(cli.getOptionValue("encoding"));
-        }
+        @Option(names = {"--temp"}, paramLabel = "<temp>", description = "Specify temporary directory")
+        private File temp;
 
-        if (cli.hasOption("basescript")) {
-            configuration.setScriptBaseClass(cli.getOptionValue("basescript"));
-        }
+        @Option(names = {"--encoding"}, description = "Specify the encoding of the user class files")
+        private String encoding;
 
-        // joint compilation parameters
-        if (cli.hasOption('j')) {
-            Map<String, Object> compilerOptions = new HashMap<String, Object>();
+        @Option(names = "-d", paramLabel = "<dir>", description = "Specify where to place generated class files")
+        private File targetDir;
 
-            String[] namedValues = cli.getOptionValues("J");
-            compilerOptions.put("namedValues", namedValues);
+        @Option(names = {"-e", "--exception"}, description = "Print stack trace on error")
+        private boolean printStack;
 
-            String[] flags = cli.getOptionValues("F");
-            if (flags != null && cli.hasOption("pa")){
-                flags = Arrays.copyOf(flags, flags.length + 1);
-                flags[flags.length - 1] = "parameters";
+        @Option(names = {"-pa", "--parameters"}, description = "Generate metadata for reflection on method parameter names (jdk8+ only)")
+        private boolean parameterMetadata;
+
+        @Option(names = {"-j", "--jointCompilation"}, description = "Attach javac compiler to compile .java files")
+        private boolean jointCompilation;
+
+        @Option(names = {"-b", "--basescript"}, paramLabel = "<class>", description = "Base class name for scripts (must derive from Script)")
+        private String scriptBaseClass;
+
+        @Option(names = "-J", paramLabel = "<property=value>", description = "Name-value pairs to pass to javac")
+        private Map<String, String> javacOptionsMap;
+
+        @Option(names = "-F", paramLabel = "<flag>", description = "Passed to javac for joint compilation")
+        private List<String> flags;
+
+        @Option(names = {"--indy"}, description = "Enables compilation using invokedynamic")
+        private boolean indy;
+
+        @Option(names = {"--configscript"}, paramLabel = "<script>", description = "A script for tweaking the configuration options")
+        private String configScript;
+
+        @Parameters(description = "The groovy source files to compile, or @-files containing a list of source files to compile",
+                    paramLabel = "<source-files>")
+        private List<String> files;
+
+        public CompilerConfiguration toCompilerConfiguration() throws IOException {
+            // Setup the configuration data
+            CompilerConfiguration configuration = new CompilerConfiguration();
+
+            if (classpath != null) {
+                configuration.setClasspath(classpath);
             }
-            compilerOptions.put("flags", flags);
 
-            configuration.setJointCompilationOptions(compilerOptions);
-        }
-
-        if (cli.hasOption("indy")) {
-            configuration.getOptimizationOptions().put("int", false);
-            configuration.getOptimizationOptions().put("indy", true);
-        }
-
-        String configScripts = System.getProperty("groovy.starter.configscripts", null);
-        if (cli.hasOption("configscript") || (configScripts != null && !configScripts.isEmpty())) {
-            List<String> scripts = new ArrayList<String>();
-            if (cli.hasOption("configscript")) {
-                scripts.add(cli.getOptionValue("configscript"));
+            if (targetDir != null && targetDir.getName().length() > 0) {
+                configuration.setTargetDirectory(targetDir);
             }
-            if (configScripts != null) {
-                scripts.addAll(StringGroovyMethods.tokenize((CharSequence) configScripts, ','));
+
+            configuration.setParameters(parameterMetadata);
+            configuration.setSourceEncoding(encoding);
+            configuration.setScriptBaseClass(scriptBaseClass);
+
+            // joint compilation parameters
+            if (jointCompilation) {
+                Map<String, Object> compilerOptions = new HashMap<String, Object>();
+                compilerOptions.put("namedValues", javacOptionsList());
+                compilerOptions.put("flags", flagsWithParameterMetaData());
+                configuration.setJointCompilationOptions(compilerOptions);
             }
-            processConfigScripts(scripts, configuration);
+
+            if (indy) {
+                configuration.getOptimizationOptions().put("int", false);
+                configuration.getOptimizationOptions().put("indy", true);
+            }
+
+            String configScripts = System.getProperty("groovy.starter.configscripts", null);
+            if (configScript != null || (configScripts != null && !configScripts.isEmpty())) {
+                List<String> scripts = new ArrayList<String>();
+                if (configScript != null) {
+                    scripts.add(configScript);
+                }
+                if (configScripts != null) {
+                    scripts.addAll(StringGroovyMethods.tokenize((CharSequence) configScripts, ','));
+                }
+                processConfigScripts(scripts, configuration);
+            }
+
+            return configuration;
         }
 
-        return configuration;
+        public String[] generateFileNames() {
+            return generateFileNamesFromOptions(files);
+        }
+
+        String[] javacOptionsList() {
+            if (javacOptionsMap == null) {
+                return null;
+            }
+            List<String> result = new ArrayList<String>();
+            for (Map.Entry<String, String> entry : javacOptionsMap.entrySet()) {
+                result.add(entry.getKey());
+                result.add(entry.getValue());
+            }
+            return result.toArray(new String[0]);
+        }
+
+        String[] flagsWithParameterMetaData() {
+            if (flags == null) {
+                return null;
+            }
+            if (parameterMetadata) {
+                flags.add("parameters");
+            }
+            return flags.toArray(new String[0]);
+        }
     }
 
     @SuppressWarnings({"AccessStaticViaInstance"})
-    public static Options createCompilationOptions() {
-        Options options = new Options();
-        options.addOption(Option.builder("classpath").hasArg().argName("path").desc("Specify where to find the class files - must be first argument").build());
-        options.addOption(Option.builder("cp").longOpt("classpath").hasArg().argName("path").desc("Aliases for '-classpath'").build());
-        options.addOption(Option.builder().longOpt("sourcepath").hasArg().argName("path").desc("Specify where to find the source files").build());
-        options.addOption(Option.builder().longOpt("temp").hasArg().argName("temp").desc("Specify temporary directory").build());
-        options.addOption(Option.builder().longOpt("encoding").hasArg().argName("encoding").desc("Specify the encoding of the user class files").build());
-        options.addOption(Option.builder("d").hasArg().desc("Specify where to place generated class files").build());
-        options.addOption(Option.builder("h").longOpt("help").desc("Print a synopsis of standard options").build());
-        options.addOption(Option.builder("v").longOpt("version").desc("Print the version").build());
-        options.addOption(Option.builder("e").longOpt("exception").desc("Print stack trace on error").build());
-        options.addOption(Option.builder("pa").longOpt("parameters").desc("Generate metadata for reflection on method parameter names (jdk8+ only)").build());
-        options.addOption(Option.builder("j").longOpt("jointCompilation").desc("Attach javac compiler to compile .java files").build());
-        options.addOption(Option.builder("b").longOpt("basescript").hasArg().argName("class").desc("Base class name for scripts (must derive from Script)").build());
-        options.addOption(
-                Option.builder("J").argName("property=value")
-                        .valueSeparator()
-                        .numberOfArgs(2)
-                        .desc("Name-value pairs to pass to javac")
-                        .build());
-        options.addOption(
-                Option.builder("F").argName("flag")
-                        .hasArg()
-                        .desc("Passed to javac for joint compilation")
-                        .build());
-        options.addOption(Option.builder().longOpt("indy").desc("Enables compilation using invokedynamic").build());
-        options.addOption(Option.builder().longOpt("configscript").hasArg().desc("A script for tweaking the configuration options").build());
-        return options;
+    public static CommandLine createCompilationOptions() {
+        return new CommandLine(new CompilationOptions());
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -270,7 +270,11 @@ public class FileSystemCompiler {
     @Command(name = "groovyc", customSynopsis = "groovyc [options] <source-files>",
             mixinStandardHelpOptions = true, versionProvider = VersionProvider.class)
     public static class CompilationOptions {
-        @Option(names = {"-cp", "-classpath", "--classpath"}, paramLabel = "<path>", description = "Specify where to find the class files")
+        // IMPLEMENTATION NOTE:
+        // classpath must be the first argument, so that the `startGroovy(.bat)` script
+        // can extract it and the JVM can be started with the classpath already correctly set.
+        // This saves us from having to fork a new JVM process with the classpath set from the processed arguments.
+        @Option(names = {"-cp", "-classpath", "--classpath"}, paramLabel = "<path>", description = "Specify where to find the class files - must be first argument")
         private String classpath;
 
         @Option(names = {"-sourcepath", "--sourcepath"}, paramLabel = "<path>", description = "Specify where to find the source files")

--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
@@ -20,10 +20,6 @@ package org.codehaus.groovy.ant;
 
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyResourceLoader;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Options;
 import org.apache.groovy.io.StringBuilderWriter;
 import org.apache.tools.ant.AntClassLoader;
 import org.apache.tools.ant.BuildException;
@@ -45,6 +41,7 @@ import org.codehaus.groovy.tools.ErrorReporter;
 import org.codehaus.groovy.tools.FileSystemCompiler;
 import org.codehaus.groovy.tools.RootLoader;
 import org.codehaus.groovy.tools.javac.JavaAwareCompilationUnit;
+import picocli.CommandLine;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -1184,14 +1181,15 @@ public class Groovyc extends MatchingTask {
     private void runCompiler(String[] commandLine) {
         // hand crank it so we can add our own compiler configuration
         try {
-            Options options = FileSystemCompiler.createCompilationOptions();
-
-            CommandLineParser cliParser = new DefaultParser();
-
-            CommandLine cli;
-            cli = cliParser.parse(options, commandLine);
-
-            configuration = FileSystemCompiler.generateCompilerConfigurationFromOptions(cli);
+            FileSystemCompiler.CompilationOptions options = new FileSystemCompiler.CompilationOptions();
+            CommandLine parser = new CommandLine(options);
+            parser.getCommandSpec().parser()
+                    .unmatchedArgumentsAllowed(true)
+                    .unmatchedOptionsArePositionalParams(true)
+                    .expandAtFiles(false)
+                    .toggleBooleanFlags(false);
+            parser.parseArgs(commandLine);
+            configuration = options.toCompilerConfiguration();
             configuration.setScriptExtensions(getScriptExtensions());
             String tmpExtension = getScriptExtension();
             if (tmpExtension.startsWith("*."))
@@ -1199,7 +1197,7 @@ public class Groovyc extends MatchingTask {
             configuration.setDefaultScriptExtension(tmpExtension);
 
             // Load the file name list
-            String[] filenames = FileSystemCompiler.generateFileNamesFromOptions(cli);
+            String[] filenames = options.generateFileNames();
             boolean fileNameErrors = filenames == null;
 
             fileNameErrors = fileNameErrors || !FileSystemCompiler.validateFiles(filenames);

--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
@@ -1182,12 +1182,7 @@ public class Groovyc extends MatchingTask {
         // hand crank it so we can add our own compiler configuration
         try {
             FileSystemCompiler.CompilationOptions options = new FileSystemCompiler.CompilationOptions();
-            CommandLine parser = new CommandLine(options);
-            parser.getCommandSpec().parser()
-                    .unmatchedArgumentsAllowed(true)
-                    .unmatchedOptionsArePositionalParams(true)
-                    .expandAtFiles(false)
-                    .toggleBooleanFlags(false);
+            CommandLine parser = FileSystemCompiler.configureParser(options);
             parser.parseArgs(commandLine);
             configuration = options.toCompilerConfiguration();
             configuration.setScriptExtensions(getScriptExtensions());

--- a/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
+++ b/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
@@ -378,6 +378,7 @@ class CliBuilder {
      * <code>true</code> if the parser should recognize long options with both
      * a single hyphen and a double hyphen prefix. The default is <code>false</code>,
      * so only long options with a double hypen prefix (<code>--option</code>) are recognized.
+     * @since 2.5
      */
     boolean acceptLongOptionsWithSingleHyphen = false
 

--- a/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
+++ b/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
@@ -455,6 +455,28 @@ class CliBuilder {
     private CommandSpec commandSpec = CommandSpec.create()
 
     /**
+     * This setter exists for backwards compatibility with previous versions of CliBuilder:
+     * In this version of CliBuilder, the <code>parser</code> property is read-only.
+     * This methods prints a message to the standard error stream and ignores the specified value.
+     * @param ignored the new value is ignored
+     * @since 2.5
+     */
+    @Deprecated void setParser(Object ignored) {
+        System.err.println('The program attempted to replace the CliBuilder parser. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the posix property, or use groovy.cli.commons.CliBuilder instead.')
+    }
+
+    /**
+     * This setter exists for backwards compatibility with previous versions of CliBuilder:
+     * This version of CliBuilder does not have a <code>formatter</code> property.
+     * This methods prints a message to the standard error stream and ignores the specified value.
+     * @param ignored the new value is ignored
+     * @since 2.5
+     */
+    @Deprecated void setFormatter(Object ignored) {
+        System.err.println('The program attempted to set a formatter on CliBuilder. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the usageMessage property, or use groovy.cli.commons.CliBuilder instead.')
+    }
+
+    /**
      * Sets the {@link #usage usage} property on this <code>CliBuilder</code> and the
      * <code>customSynopsis</code> on the {@link #usageMessage} used by the underlying library.
      * @param usage the custom synopsis of the usage help message

--- a/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
+++ b/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
@@ -804,6 +804,7 @@ class CliBuilder {
         if (attr.type)           { builder.type(attr.type) } // cannot set type to null
         if (attr.auxiliaryTypes) { builder.auxiliaryTypes(attr.auxiliaryTypes) } // cannot set aux types to null
         builder.arity(arity)
+        builder.description(unparsed.description())
         builder.paramLabel("<$attr.label>")
         builder.getter(attr.getter)
         builder.setter(attr.setter)

--- a/subprojects/groovy-cli-picocli/src/spec/test/builder/CliBuilderTest.groovy
+++ b/subprojects/groovy-cli-picocli/src/spec/test/builder/CliBuilderTest.groovy
@@ -446,6 +446,61 @@ Footer 2
         assert options.Xs == [ 'x':'y', 'i':'j' ]                                     // <6>
         assert options.Zs == [ (DAYS as TimeUnit):2, (HOURS as TimeUnit):23 ]         // <7>
         // end::MapOption[]
+    }
 
+    public void testGroovyDocAntExample() {
+        def cli = new CliBuilder(usage:'ant [options] [targets]',
+                header:'Options:')
+        cli.help('print this message')
+        cli.logfile(type:File, argName:'file', 'use given file for log')
+        cli.D(type:Map, argName:'property=value', 'use value for given property')
+        cli.lib(argName:'path', valueSeparator:',', args: '3',
+                'comma-separated list of 3 paths to search for jars and classes')
+
+        // suppress ANSI escape codes to make this test pass on all environments
+        System.setProperty("picocli.ansi", "false")
+        StringWriter sw = new StringWriter()
+        cli.writer = new PrintWriter(sw)
+
+        cli.usage()
+
+        String expected = '''\
+Usage: ant [options] [targets]
+Options:
+  -D= <property=value>   use value for given property
+      -help              print this message
+      -lib=<path>,<path>,<path>
+                         comma-separated list of 3 paths to search for jars and
+                           classes
+      -logfile=<file>    use given file for log
+'''
+        assertEquals(expected.normalize(), sw.toString().normalize())
+    }
+
+    public void testGroovyDocCurlExample() {
+        // suppress ANSI escape codes to make this test pass on all environments
+        System.setProperty("picocli.ansi", "false")
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(baos, true))
+
+        def cli = new CliBuilder(name:'curl')
+        cli._(longOpt:'basic', 'Use HTTP Basic Authentication')
+        cli.d(longOpt:'data', args:1, argName:'data', 'HTTP POST data')
+        cli.G(longOpt:'get', 'Send the -d data with a HTTP GET')
+        cli.q('If used as the first parameter disables .curlrc')
+        cli._(longOpt:'url', type:URL, argName:'URL', 'Set URL to work with')
+
+        cli.usageMessage.sortOptions(false)
+        cli.usage()
+
+        String expected = '''\
+Usage: curl [-Gq] [--basic] [--url=<URL>] [-d=<data>]
+      --basic         Use HTTP Basic Authentication
+  -d, --data=<data>   HTTP POST data
+  -G, --get           Send the -d data with a HTTP GET
+  -q                  If used as the first parameter disables .curlrc
+      --url=<URL>     Set URL to work with
+'''
+        assertEquals(expected.normalize(), baos.toString().normalize())
     }
 }

--- a/subprojects/groovy-cli-picocli/src/spec/test/builder/CliBuilderTest.groovy
+++ b/subprojects/groovy-cli-picocli/src/spec/test/builder/CliBuilderTest.groovy
@@ -40,7 +40,7 @@ class CliBuilderTest extends GroovyTestCase {
     interface GreeterI {
         @Option(shortName='h', description='display usage') Boolean help()        // <1>
         @Option(shortName='a', description='greeting audience') String audience() // <2>
-        @Unparsed List remaining()                                                // <3>
+        @Unparsed(description = "positional parameters") List remaining()         // <3>
     }
     // end::annotationInterfaceSpec[]
 
@@ -56,14 +56,14 @@ class CliBuilderTest extends GroovyTestCase {
         }
         String getAudience() { audience }
 
-        @Unparsed
+        @Unparsed(description = "positional parameters")
         List remaining                      // <3>
     }
     // end::annotationClassSpec[]
 
     void testAnnotationsInterface() {
         // tag::annotationInterface[]
-        def cli = new CliBuilder(usage: 'groovy Greeter [option]')  // <1>
+        def cli = new CliBuilder(name: 'groovy Greeter')  // <1>
         def argz = '--audience Groovologist'.split()
         def options = cli.parseFromSpec(GreeterI, argz)             // <2>
         assert options.audience() == 'Groovologist'                 // <3>
@@ -73,6 +73,22 @@ class CliBuilderTest extends GroovyTestCase {
         assert options.help()
         assert options.remaining() == ['Some', 'Other', 'Args']     // <5>
         // end::annotationInterface[]
+
+        options = cli.parseFromSpec(GreeterI, ['-h', 'Some', 'Other', 'Args'] as String[])
+        assert options.help()
+        assert options.remaining() == ['Some', 'Other', 'Args']
+        StringWriter sw = new StringWriter()
+        cli.writer = new PrintWriter(sw)
+        cli.usage()
+
+        String expected = '''\
+Usage: groovy Greeter [-h] [-a=<audience>] [<remaining>...]
+      [<remaining>...]   positional parameters
+  -a, --audience=<audience>
+                         greeting audience
+  -h, --help             display usage
+'''
+        assert expected.normalize() == sw.toString().normalize()
     }
 
     void testAnnotationsClass() {

--- a/subprojects/groovy-cli-picocli/src/test/groovy/groovy/cli/picocli/CliBuilderTest.groovy
+++ b/subprojects/groovy-cli-picocli/src/test/groovy/groovy/cli/picocli/CliBuilderTest.groovy
@@ -23,6 +23,11 @@ import groovy.cli.Unparsed
 import groovy.cli.picocli.CliBuilder
 import groovy.transform.ToString
 import groovy.transform.TypeChecked
+import org.apache.commons.cli.BasicParser
+import org.apache.commons.cli.DefaultParser
+import org.apache.commons.cli.GnuParser
+import org.apache.commons.cli.HelpFormatter
+import org.codehaus.groovy.cli.GroovyPosixParser
 import picocli.CommandLine.DuplicateOptionAnnotationsException
 
 import java.math.RoundingMode
@@ -121,6 +126,68 @@ class CliBuilderTest extends GroovyTestCase {
         groovy.util.GroovyTestCase.assertEquals(['1', '2'], options.as)
         groovy.util.GroovyTestCase.assertEquals('1', options.arg)
         groovy.util.GroovyTestCase.assertEquals(['1', '2'], options.args)
+    }
+
+    void testCliBuilderIgnoresAttemptsToModifyParserProperty_inConstructor() {
+        PrintStream orig = System.err
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(baos))
+        try {
+            [new DefaultParser(), new GroovyPosixParser(), new GnuParser(), new BasicParser()].each { parser ->
+                assert baos.size() == 0
+                new CliBuilder(parser: parser)
+                assert 'The program attempted to replace the CliBuilder parser. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the posix property, or use groovy.cli.commons.CliBuilder instead.' == baos.toString().trim()
+                baos.reset()
+            }
+        } finally {
+            System.setErr(orig)
+        }
+    }
+
+    void testCliBuilderIgnoresAttemptsToModifyParserProperty_inSetter() {
+        PrintStream orig = System.err
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(baos))
+        try {
+            [new DefaultParser(), new GroovyPosixParser(), new GnuParser(), new BasicParser()].each { parser ->
+                def cli = new CliBuilder()
+                assert baos.size() == 0
+                cli.parser = parser
+                assert 'The program attempted to replace the CliBuilder parser. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the posix property, or use groovy.cli.commons.CliBuilder instead.' == baos.toString().trim()
+                baos.reset()
+            }
+        } finally {
+            System.setErr(orig)
+        }
+    }
+
+    void testCliBuilderIgnoresAttemptsToModifyFormatterProperty_inConstructor() {
+        PrintStream orig = System.err
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(baos))
+        try {
+            assert baos.size() == 0
+            def cli = new CliBuilder(formatter: new HelpFormatter())
+            assert 'The program attempted to set a formatter on CliBuilder. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the usageMessage property, or use groovy.cli.commons.CliBuilder instead.' == baos.toString().trim()
+            baos.reset()
+        } finally {
+            System.setErr(orig)
+        }
+    }
+
+    void testCliBuilderIgnoresAttemptsToSetFormatterProperty_inSetter() {
+        PrintStream orig = System.err
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(baos))
+        try {
+            def cli = new CliBuilder()
+            assert baos.size() == 0
+            cli.formatter = new HelpFormatter()
+            assert 'The program attempted to set a formatter on CliBuilder. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the usageMessage property, or use groovy.cli.commons.CliBuilder instead.' == baos.toString().trim()
+            baos.reset()
+        } finally {
+            System.setErr(orig)
+        }
     }
 
     void testFailedParsePrintsUsage() {


### PR DESCRIPTION
* add CliBuilder.setParser and setFormatter methods that ignore the specified values and print a warning to stderr to easy the transition for existing applications
* bugfix: @Unparsed annotation description attribute was ignored
* add @since tag to acceptLongOptionsWithSingleHyphen property