### PR TITLE
GROOVY-8520 fixes (attempt 2)

### DIFF
--- a/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
+++ b/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
@@ -378,6 +378,7 @@ class CliBuilder {
      * <code>true</code> if the parser should recognize long options with both
      * a single hyphen and a double hyphen prefix. The default is <code>false</code>,
      * so only long options with a double hypen prefix (<code>--option</code>) are recognized.
+     * @since 2.5
      */
     boolean acceptLongOptionsWithSingleHyphen = false
 

--- a/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
+++ b/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
@@ -455,6 +455,28 @@ class CliBuilder {
     private CommandSpec commandSpec = CommandSpec.create()
 
     /**
+     * This setter exists for backwards compatibility with previous versions of CliBuilder:
+     * In this version of CliBuilder, the <code>parser</code> property is read-only.
+     * This methods prints a message to the standard error stream and ignores the specified value.
+     * @param ignored the new value is ignored
+     * @since 2.5
+     */
+    @Deprecated void setParser(Object ignored) {
+        System.err.println('The program attempted to replace the CliBuilder parser. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the posix property, or use groovy.cli.commons.CliBuilder instead.')
+    }
+
+    /**
+     * This setter exists for backwards compatibility with previous versions of CliBuilder:
+     * This version of CliBuilder does not have a <code>formatter</code> property.
+     * This methods prints a message to the standard error stream and ignores the specified value.
+     * @param ignored the new value is ignored
+     * @since 2.5
+     */
+    @Deprecated void setFormatter(Object ignored) {
+        System.err.println('The program attempted to set a formatter on CliBuilder. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the usageMessage property, or use groovy.cli.commons.CliBuilder instead.')
+    }
+
+    /**
      * Sets the {@link #usage usage} property on this <code>CliBuilder</code> and the
      * <code>customSynopsis</code> on the {@link #usageMessage} used by the underlying library.
      * @param usage the custom synopsis of the usage help message

--- a/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
+++ b/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
@@ -804,6 +804,7 @@ class CliBuilder {
         if (attr.type)           { builder.type(attr.type) } // cannot set type to null
         if (attr.auxiliaryTypes) { builder.auxiliaryTypes(attr.auxiliaryTypes) } // cannot set aux types to null
         builder.arity(arity)
+        builder.description(unparsed.description())
         builder.paramLabel("<$attr.label>")
         builder.getter(attr.getter)
         builder.setter(attr.setter)

--- a/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
+++ b/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
@@ -535,9 +535,9 @@ class CliBuilder {
      * used by the underlying library.
      * @param poxis whether to allow clustered short options
      */
-    void setPosix(boolean posix) {
+    void setPosix(Boolean posix) {
         this.posix = posix
-        parser.posixClusteredShortOptionsAllowed(posix)
+        parser.posixClusteredShortOptionsAllowed(posix ?: false)
     }
 
     /**

--- a/subprojects/groovy-cli-picocli/src/spec/test/builder/CliBuilderTest.groovy
+++ b/subprojects/groovy-cli-picocli/src/spec/test/builder/CliBuilderTest.groovy
@@ -446,6 +446,61 @@ Footer 2
         assert options.Xs == [ 'x':'y', 'i':'j' ]                                     // <6>
         assert options.Zs == [ (DAYS as TimeUnit):2, (HOURS as TimeUnit):23 ]         // <7>
         // end::MapOption[]
+    }
 
+    public void testGroovyDocAntExample() {
+        def cli = new CliBuilder(usage:'ant [options] [targets]',
+                header:'Options:')
+        cli.help('print this message')
+        cli.logfile(type:File, argName:'file', 'use given file for log')
+        cli.D(type:Map, argName:'property=value', 'use value for given property')
+        cli.lib(argName:'path', valueSeparator:',', args: '3',
+                'comma-separated list of 3 paths to search for jars and classes')
+
+        // suppress ANSI escape codes to make this test pass on all environments
+        System.setProperty("picocli.ansi", "false")
+        StringWriter sw = new StringWriter()
+        cli.writer = new PrintWriter(sw)
+
+        cli.usage()
+
+        String expected = '''\
+Usage: ant [options] [targets]
+Options:
+  -D= <property=value>   use value for given property
+      -help              print this message
+      -lib=<path>,<path>,<path>
+                         comma-separated list of 3 paths to search for jars and
+                           classes
+      -logfile=<file>    use given file for log
+'''
+        assertEquals(expected.normalize(), sw.toString().normalize())
+    }
+
+    public void testGroovyDocCurlExample() {
+        // suppress ANSI escape codes to make this test pass on all environments
+        System.setProperty("picocli.ansi", "false")
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(baos, true))
+
+        def cli = new CliBuilder(name:'curl')
+        cli._(longOpt:'basic', 'Use HTTP Basic Authentication')
+        cli.d(longOpt:'data', args:1, argName:'data', 'HTTP POST data')
+        cli.G(longOpt:'get', 'Send the -d data with a HTTP GET')
+        cli.q('If used as the first parameter disables .curlrc')
+        cli._(longOpt:'url', type:URL, argName:'URL', 'Set URL to work with')
+
+        cli.usageMessage.sortOptions(false)
+        cli.usage()
+
+        String expected = '''\
+Usage: curl [-Gq] [--basic] [--url=<URL>] [-d=<data>]
+      --basic         Use HTTP Basic Authentication
+  -d, --data=<data>   HTTP POST data
+  -G, --get           Send the -d data with a HTTP GET
+  -q                  If used as the first parameter disables .curlrc
+      --url=<URL>     Set URL to work with
+'''
+        assertEquals(expected.normalize(), baos.toString().normalize())
     }
 }

--- a/subprojects/groovy-cli-picocli/src/spec/test/builder/CliBuilderTest.groovy
+++ b/subprojects/groovy-cli-picocli/src/spec/test/builder/CliBuilderTest.groovy
@@ -40,7 +40,7 @@ class CliBuilderTest extends GroovyTestCase {
     interface GreeterI {
         @Option(shortName='h', description='display usage') Boolean help()        // <1>
         @Option(shortName='a', description='greeting audience') String audience() // <2>
-        @Unparsed List remaining()                                                // <3>
+        @Unparsed(description = "positional parameters") List remaining()         // <3>
     }
     // end::annotationInterfaceSpec[]
 
@@ -56,14 +56,14 @@ class CliBuilderTest extends GroovyTestCase {
         }
         String getAudience() { audience }
 
-        @Unparsed
+        @Unparsed(description = "positional parameters")
         List remaining                      // <3>
     }
     // end::annotationClassSpec[]
 
     void testAnnotationsInterface() {
         // tag::annotationInterface[]
-        def cli = new CliBuilder(usage: 'groovy Greeter [option]')  // <1>
+        def cli = new CliBuilder(name: 'groovy Greeter')  // <1>
         def argz = '--audience Groovologist'.split()
         def options = cli.parseFromSpec(GreeterI, argz)             // <2>
         assert options.audience() == 'Groovologist'                 // <3>
@@ -73,6 +73,22 @@ class CliBuilderTest extends GroovyTestCase {
         assert options.help()
         assert options.remaining() == ['Some', 'Other', 'Args']     // <5>
         // end::annotationInterface[]
+
+        options = cli.parseFromSpec(GreeterI, ['-h', 'Some', 'Other', 'Args'] as String[])
+        assert options.help()
+        assert options.remaining() == ['Some', 'Other', 'Args']
+        StringWriter sw = new StringWriter()
+        cli.writer = new PrintWriter(sw)
+        cli.usage()
+
+        String expected = '''\
+Usage: groovy Greeter [-h] [-a=<audience>] [<remaining>...]
+      [<remaining>...]   positional parameters
+  -a, --audience=<audience>
+                         greeting audience
+  -h, --help             display usage
+'''
+        assert expected.normalize() == sw.toString().normalize()
     }
 
     void testAnnotationsClass() {

--- a/subprojects/groovy-cli-picocli/src/test/groovy/groovy/cli/picocli/CliBuilderTest.groovy
+++ b/subprojects/groovy-cli-picocli/src/test/groovy/groovy/cli/picocli/CliBuilderTest.groovy
@@ -23,6 +23,11 @@ import groovy.cli.Unparsed
 import groovy.cli.picocli.CliBuilder
 import groovy.transform.ToString
 import groovy.transform.TypeChecked
+import org.apache.commons.cli.BasicParser
+import org.apache.commons.cli.DefaultParser
+import org.apache.commons.cli.GnuParser
+import org.apache.commons.cli.HelpFormatter
+import org.codehaus.groovy.cli.GroovyPosixParser
 import picocli.CommandLine.DuplicateOptionAnnotationsException
 
 import java.math.RoundingMode
@@ -121,6 +126,68 @@ class CliBuilderTest extends GroovyTestCase {
         groovy.util.GroovyTestCase.assertEquals(['1', '2'], options.as)
         groovy.util.GroovyTestCase.assertEquals('1', options.arg)
         groovy.util.GroovyTestCase.assertEquals(['1', '2'], options.args)
+    }
+
+    void testCliBuilderIgnoresAttemptsToModifyParserProperty_inConstructor() {
+        PrintStream orig = System.err
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(baos))
+        try {
+            [new DefaultParser(), new GroovyPosixParser(), new GnuParser(), new BasicParser()].each { parser ->
+                assert baos.size() == 0
+                new CliBuilder(parser: parser)
+                assert 'The program attempted to replace the CliBuilder parser. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the posix property, or use groovy.cli.commons.CliBuilder instead.' == baos.toString().trim()
+                baos.reset()
+            }
+        } finally {
+            System.setErr(orig)
+        }
+    }
+
+    void testCliBuilderIgnoresAttemptsToModifyParserProperty_inSetter() {
+        PrintStream orig = System.err
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(baos))
+        try {
+            [new DefaultParser(), new GroovyPosixParser(), new GnuParser(), new BasicParser()].each { parser ->
+                def cli = new CliBuilder()
+                assert baos.size() == 0
+                cli.parser = parser
+                assert 'The program attempted to replace the CliBuilder parser. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the posix property, or use groovy.cli.commons.CliBuilder instead.' == baos.toString().trim()
+                baos.reset()
+            }
+        } finally {
+            System.setErr(orig)
+        }
+    }
+
+    void testCliBuilderIgnoresAttemptsToModifyFormatterProperty_inConstructor() {
+        PrintStream orig = System.err
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(baos))
+        try {
+            assert baos.size() == 0
+            def cli = new CliBuilder(formatter: new HelpFormatter())
+            assert 'The program attempted to set a formatter on CliBuilder. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the usageMessage property, or use groovy.cli.commons.CliBuilder instead.' == baos.toString().trim()
+            baos.reset()
+        } finally {
+            System.setErr(orig)
+        }
+    }
+
+    void testCliBuilderIgnoresAttemptsToSetFormatterProperty_inSetter() {
+        PrintStream orig = System.err
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(baos))
+        try {
+            def cli = new CliBuilder()
+            assert baos.size() == 0
+            cli.formatter = new HelpFormatter()
+            assert 'The program attempted to set a formatter on CliBuilder. This is no longer supported in groovy.cli.picocli.CliBuilder. Consider using the usageMessage property, or use groovy.cli.commons.CliBuilder instead.' == baos.toString().trim()
+            baos.reset()
+        } finally {
+            System.setErr(orig)
+        }
     }
 
     void testFailedParsePrintsUsage() {

--- a/subprojects/groovy-cli-picocli/src/test/groovy/groovy/cli/picocli/CliBuilderTest.groovy
+++ b/subprojects/groovy-cli-picocli/src/test/groovy/groovy/cli/picocli/CliBuilderTest.groovy
@@ -190,6 +190,38 @@ class CliBuilderTest extends GroovyTestCase {
         }
     }
 
+    void testPosixNullValueHandledCorrectly_inConstructor() {
+        def cli = new CliBuilder()
+        assert cli.posix == true
+        assert cli.parser.posixClusteredShortOptionsAllowed()
+
+        cli = new CliBuilder(posix: false)
+        assert cli.posix == false
+        assert !cli.parser.posixClusteredShortOptionsAllowed()
+
+        cli = new CliBuilder(posix: null)
+        assert cli.posix == null
+        assert !cli.parser.posixClusteredShortOptionsAllowed()
+    }
+
+    void testPosixNullValueHandledCorrectly_inSetter() {
+        def cli = new CliBuilder()
+        assert cli.posix == true
+        assert cli.parser.posixClusteredShortOptionsAllowed()
+
+        cli.posix = false
+        assert cli.posix == false
+        assert !cli.parser.posixClusteredShortOptionsAllowed()
+
+        cli = new CliBuilder()
+        assert cli.posix == true
+        assert cli.parser.posixClusteredShortOptionsAllowed()
+
+        cli.posix = null
+        assert cli.posix == null
+        assert !cli.parser.posixClusteredShortOptionsAllowed()
+    }
+
     void testFailedParsePrintsUsage() {
         def cli = new CliBuilder(writer: printWriter)
         cli.x(required: true, 'message')


### PR DESCRIPTION
* add CliBuilder.setParser and setFormatter methods that ignore the specified values and print a warning to stderr to easy the transition for existing applications
* bugfix: @Unparsed annotation description attribute was ignored
* add @since tag to acceptLongOptionsWithSingleHyphen property