### PR TITLE
GROOVY-8509: SC error call to protected method from same package

### DIFF
--- a/src/main/java/org/apache/groovy/ast/tools/ClassNodeUtils.java
+++ b/src/main/java/org/apache/groovy/ast/tools/ClassNodeUtils.java
@@ -310,4 +310,20 @@ public class ClassNodeUtils {
         }
         return false;
     }
+
+    /**
+     * Determine if the given ClassNode values have the same package name.
+     *
+     * @param first a ClassNode
+     * @param second a ClassNode
+     * @return true if both given nodes have the same package name
+     * @throws NullPointerException if either of the given nodes are null
+     */
+    public static boolean samePackageName(ClassNode first, ClassNode second) {
+        String firstPackage = first.getPackageName();
+        String secondPackage = second.getPackageName();
+        return (firstPackage == secondPackage)
+                || (firstPackage != null && firstPackage.equals(secondPackage));
+    }
+
 }

--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.groovy.ast.tools.ClassNodeUtils.samePackageName;
 import static org.codehaus.groovy.ast.ClassHelper.CLOSURE_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.OBJECT_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.getWrapper;
@@ -343,6 +344,7 @@ public class StaticInvocationWriter extends InvocationWriter {
                     isThisOrSuper = ((VariableExpression) receiver).isThisExpression() || ((VariableExpression) receiver).isSuperExpression();
                 }
                 if (!implicitThis && !isThisOrSuper
+                        && !samePackageName(node, classNode)
                         && StaticTypeCheckingSupport.implementsInterfaceOrIsSubclassOf(node,target.getDeclaringClass())) {
                     ASTNode src = receiver==null?args:receiver;
                     controller.getSourceUnit().addError(

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -122,6 +122,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.groovy.ast.tools.ClassNodeUtils.samePackageName;
 import static org.codehaus.groovy.ast.ClassHelper.BigDecimal_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.BigInteger_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Boolean_TYPE;
@@ -4469,10 +4470,12 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             if (methodNode.isPrivate() && !enclosingClassNode.equals(declaringClass)) {
                 continue;
             }
-            if (methodNode.isProtected() && !enclosingClassNode.isDerivedFrom(declaringClass)) {
+            if (methodNode.isProtected()
+                    && !enclosingClassNode.isDerivedFrom(declaringClass)
+                    && !samePackageName(enclosingClassNode, declaringClass)) {
                 continue;
             }
-            if (methodNode.isPackageScope() && !getPackageName(enclosingClassNode).equals(getPackageName(declaringClass))) {
+            if (methodNode.isPackageScope() && !samePackageName(enclosingClassNode, declaringClass)) {
                 continue;
             }
 
@@ -4480,12 +4483,6 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         }
 
         return result;
-    }
-
-    private static String getPackageName(ClassNode cn) {
-        String name = cn.getPackageName();
-
-        return null == name ? "" : name;
     }
 
     /**

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/MethodCallsStaticCompilationTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/MethodCallsStaticCompilationTest.groovy
@@ -259,6 +259,24 @@ import groovy.transform.TypeCheckingMode//import org.codehaus.groovy.classgen.as
         '''
     }
 
+    //GROOVY-8509
+    void testProtectedCallFromClassInSamePackage() {
+        assertScript '''
+            package org.foo
+
+            class A {
+                protected A() {}
+                protected int m() { 123 }
+            }
+            class B {
+                int test() {
+                    new A().m()
+                }
+            }
+            assert new B().test() == 123
+        '''
+    }
+
     public static class Base {
         protected int foo() {
             123

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy7883Bug.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy7883Bug.groovy
@@ -53,24 +53,6 @@ class Groovy7883Bug extends GroovyTestCase {
         assert errMsg.contains('[Static type checking] - Cannot find matching method A#doIt()')
     }
 
-    void test3() {
-        def errMsg = shouldFail '''
-        @groovy.transform.CompileStatic
-        class A {
-            protected void doIt() {}
-        }
-        
-        @groovy.transform.CompileStatic
-        class B {
-            public void m() { new A().doIt() }
-        }
-        
-        new B().m()
-        '''
-
-        assert errMsg.contains('[Static type checking] - Cannot find matching method A#doIt()')
-    }
-
     void test4() {
         def errMsg = shouldFail '''
         @groovy.transform.CompileStatic

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
@@ -3973,7 +3973,7 @@ public class Sql {
      * @return the resulting list of rows
      * @throws SQLException if a database error occurs
      */
-    public List<GroovyRowResult> asList(String sql, ResultSet rs,
+    protected List<GroovyRowResult> asList(String sql, ResultSet rs,
                                            @ClosureParams(value=SimpleType.class, options="java.sql.ResultSetMetaData") Closure metaClosure) throws SQLException {
         return asList(sql, rs, 0, 0, metaClosure);
     }

--- a/subprojects/groovy-sql/src/test/groovy/groovy/sql/SqlSTCTest.groovy
+++ b/subprojects/groovy-sql/src/test/groovy/groovy/sql/SqlSTCTest.groovy
@@ -66,8 +66,16 @@ class SqlSTCTest extends GroovyShellTestCase {
 
     void testAsList() {
         shell.evaluate '''
-            def test(groovy.sql.Sql sql, java.sql.ResultSet rs) { 
-                sql.asList('SELECT * FROM FOO', rs) { println it.columnCount } 
+            class CustomSql extends groovy.sql.Sql {
+                CustomSql(groovy.sql.Sql sql) {
+                    super(sql)
+                }
+                def printColumnCount(String sql, java.sql.ResultSet rs) {
+                    this.asList(sql, rs) { println it.columnCount }
+                }
+            }
+            def test(groovy.sql.Sql sql, java.sql.ResultSet rs) {
+                new CustomSql(sql).printColumnCount('SELECT * FROM FOO', rs)
             }
         '''
     }


### PR DESCRIPTION
Because they were closely related, this PR also includes the following:

1. A change to the fix introduced by GROOVY-7883 (b1d1232770aa) to prevent filtering protected methods in the `StaticTypeCheckingVisitor` if caller is in the same package. From the same commit, removes the test `Groovy7883Bug#test3` because it should compile and the new test introduced for GROOVY-8509 in `MethodCallsStaticCompilation` takes it place.

1. A change to revert groovy.sql.Sql#asList (b1d1232770aa) back to `protected`. Fix for GROOVY-7883 enforced visibility for method calls in `TypedChecked` and `CompileStatic` modes. Test was originally put in place to verify the added ClosureParams, so changed test to access method via subclass so that the access modifier for the method can remain protected. I think the spirit of the test is preserved in this case without having to open access to the method under test.