### PR TITLE
Groovy 8562 wrong closure delegation for property access and compile static

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/sc/transformers/VariableExpressionTransformer.java
+++ b/src/main/java/org/codehaus/groovy/transform/sc/transformers/VariableExpressionTransformer.java
@@ -34,11 +34,11 @@ import org.codehaus.groovy.transform.stc.StaticTypesMarker;
 public class VariableExpressionTransformer {
 
     public Expression transformVariableExpression(VariableExpression expr) {
-        Expression trn = tryTransformPrivateFieldAccess(expr);
+        Expression trn = tryTransformDelegateToProperty(expr);
         if (trn != null) {
             return trn;
         }
-        trn = tryTransformDelegateToProperty(expr);
+        trn = tryTransformPrivateFieldAccess(expr);
         if (trn != null) {
             return trn;
         }

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -606,9 +606,9 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                     // IMPLICIT_RECEIVER is handled elsewhere
                     // however other access needs to be fixed for private access
                     if (vexp.getNodeMetaData(StaticTypesMarker.IMPLICIT_RECEIVER) == null) {
-                        boolean lhsOfEnclosingAssignment = isLHSOfEnclosingAssignment(vexp);
                         ClassNode owner = (ClassNode) vexp.getNodeMetaData(StaticCompilationMetadataKeys.PROPERTY_OWNER);
                         if (owner != null) {
+                            boolean lhsOfEnclosingAssignment = isLHSOfEnclosingAssignment(vexp);
                             fieldNode = owner.getField(vexp.getName());
                             vexp.setAccessedVariable(fieldNode);
                             checkOrMarkPrivateAccess(vexp, fieldNode, lhsOfEnclosingAssignment);

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -782,11 +782,9 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             // if left expression is a closure shared variable, a second pass should be done
             if (leftExpression instanceof VariableExpression) {
                 VariableExpression leftVar = (VariableExpression) leftExpression;
-                // TODO is the || part required?
-                if (leftVar.isClosureSharedVariable() || leftVar.getNodeMetaData(StaticTypesMarker.IMPLICIT_RECEIVER) != null) {
+                if (leftVar.isClosureSharedVariable()) {
                     // if left expression is a closure shared variable, we should check it twice
                     // see GROOVY-5874
-                    // also if it is delegated
                     typeCheckingContext.secondPassExpressions.add(new SecondPassExpression<Void>(expression));
                 }
             }

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -596,6 +596,15 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         } else if (accessedVariable instanceof FieldNode) {
             FieldNode fieldNode = (FieldNode) accessedVariable;
 
+            TypeCheckingContext.EnclosingClosure enclosingClosure = typeCheckingContext.getEnclosingClosure();
+            if (enclosingClosure != null) {
+                // when vexp has the same name as a property of the owner,
+                // the IMPLICIT_RECEIVER must be set in case it's the delegate
+                if (tryVariableExpressionAsProperty(vexp, vexp.getName())) {
+
+                }
+            }
+
             ClassNode parameterizedType = GenericsUtils.findParameterizedType(fieldNode.getDeclaringClass(), typeCheckingContext.getEnclosingClassNode());
             if (null != parameterizedType) {
                 ClassNode originalType = fieldNode.getOriginType();

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -782,9 +782,11 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             // if left expression is a closure shared variable, a second pass should be done
             if (leftExpression instanceof VariableExpression) {
                 VariableExpression leftVar = (VariableExpression) leftExpression;
-                if (leftVar.isClosureSharedVariable()) {
+                // TODO is the || part required?
+                if (leftVar.isClosureSharedVariable() || leftVar.getNodeMetaData(StaticTypesMarker.IMPLICIT_RECEIVER) != null) {
                     // if left expression is a closure shared variable, we should check it twice
                     // see GROOVY-5874
+                    // also if it is delegated
                     typeCheckingContext.secondPassExpressions.add(new SecondPassExpression<Void>(expression));
                 }
             }

--- a/src/spec/test/typing/TypeCheckingExtensionSpecTest.groovy
+++ b/src/spec/test/typing/TypeCheckingExtensionSpecTest.groovy
@@ -481,6 +481,46 @@ assert new AClass().test() == "delegate"
 '''
     }
 
+
+    void testDelegateResolution2() {
+
+        assertScript '''import groovy.transform.CompileStatic
+class DelegateTest {
+
+  @CompileStatic
+  private static class Person {
+    String name
+    int age
+
+    Person copyWithName(String newName) {
+      return new Person().with {
+        name = newName
+        age = this.age
+        it
+      }
+    }
+  }
+
+  void delegate() {
+    def oldTim = new Person().with {
+      name = 'Tim Old'
+      age = 20
+      it
+    }
+    def newTim = new Person().with {
+      name = 'Tim New'
+      age = 20
+      it
+    }
+    def copiedTim = oldTim.copyWithName('Tim New')
+    assert oldTim.name == 'Tim Old'
+    assert copiedTim.name == newTim.name
+    assert copiedTim.age == newTim.age
+  }
+}
+new DelegateTest().delegate()
+'''
+    }
     private static class SpecSupport {
         static int getLongueur(String self) { self.length() }
         static int longueur(String self) { self.length() }

--- a/src/spec/test/typing/TypeCheckingExtensionSpecTest.groovy
+++ b/src/spec/test/typing/TypeCheckingExtensionSpecTest.groovy
@@ -18,6 +18,7 @@
  */
 package typing
 
+import groovy.$Temp
 import groovy.test.GroovyAssert
 import groovy.transform.TypeChecked
 import groovy.xml.MarkupBuilder
@@ -544,47 +545,48 @@ assert expected == result
         doDelegateResolutionForPropertyWriteTest("Closure.OWNER_FIRST", "owner")
     }
 
+    void testDelegateResolutionToPropertyWhenWritingInsideWith() {
+        // Failing example provided by Jan Hackel (@jhunovis) in groovy slack
+        // https://groovy-community.slack.com/files/U9CM8G6AJ/FAR1PJT1U/behavior_of__with__and___compilestatic.groovy
 
-    // TODO unignore this
-//    void testDelegateResolution2() {
-//
-//        assertScript '''import groovy.transform.CompileStatic
-//class DelegateTest {
-//
-//  @CompileStatic
-//  private static class Person {
-//    String name
-//    int age
-//
-//    Person copyWithName(String newName) {
-//      return new Person().with {
-//        name = newName
-//        age = this.age
-//        it
-//      }
-//    }
-//  }
-//
-//  void delegate() {
-//    def oldTim = new Person().with {
-//      name = 'Tim Old'
-//      age = 20
-//      it
-//    }
-//    def newTim = new Person().with {
-//      name = 'Tim New'
-//      age = 20
-//      it
-//    }
-//    def copiedTim = oldTim.copyWithName('Tim New')
-//    assert oldTim.name == 'Tim Old'
-//    assert copiedTim.name == newTim.name
-//    assert copiedTim.age == newTim.age
-//  }
-//}
-//new DelegateTest().delegate()
-//'''
-//    }
+        assertScript '''import groovy.transform.CompileStatic
+class DelegateTest {
+
+  @CompileStatic
+  private static class Person {
+    String name
+    int age
+
+    Person copyWithName(String newName) {
+      return new Person().with {
+        name = newName
+        age = this.age
+        it
+      }
+    }
+  }
+
+  void delegate() {
+    def oldTim = new Person().with {
+      name = 'Tim Old'
+      age = 20
+      it
+    }
+    def newTim = new Person().with {
+      name = 'Tim New'
+      age = 20
+      it
+    }
+    def copiedTim = oldTim.copyWithName('Tim New')
+    assert oldTim.name == 'Tim Old'
+    assert copiedTim.name == newTim.name
+    assert copiedTim.age == newTim.age
+  }
+}
+new DelegateTest().delegate()
+'''
+    }
+
     private static class SpecSupport {
         static int getLongueur(String self) { self.length() }
         static int longueur(String self) { self.length() }

--- a/src/spec/test/typing/TypeCheckingExtensionSpecTest.groovy
+++ b/src/spec/test/typing/TypeCheckingExtensionSpecTest.groovy
@@ -449,6 +449,38 @@ runner.run()
     }
 
 
+    void testDelegateResolution() {
+
+        assertScript '''import groovy.transform.CompileStatic
+class ADelegate {
+    def x = "delegate"
+}
+
+@CompileStatic // @CompileStatic, @CompileDynamic, @TypeChecked
+class AClass {
+    public <T> T closureExecuter(
+            ADelegate d,
+            @DelegatesTo(value = ADelegate, strategy = Closure.DELEGATE_ONLY) Closure<T> c) {
+        c.resolveStrategy = Closure.DELEGATE_ONLY
+        c.delegate = d
+        return c()
+    }
+
+    def x = "owner"
+    
+    def test() {
+        def theDelegate = new ADelegate()
+        def res = closureExecuter(theDelegate) {
+            return x
+        }
+        
+        return res
+    }
+}
+assert new AClass().test() == "delegate"
+'''
+    }
+
     private static class SpecSupport {
         static int getLongueur(String self) { self.length() }
         static int longueur(String self) { self.length() }


### PR DESCRIPTION
Roundup:

The StaticTypeCheckingVisitor would not look consider FieldNode to potentially delegate to a different Field. I think this could only occur for name collisions, i.e. the owner has a field with the same name as the delegate.
Calling tryVariableExpressionAsProperty solved this, however this broke other tests. To solve this I cheked IMPLICIT_RECEIVER, if unset and PROPERTY_OWNER is present, checkOrMarkPrivateAccess must be called to ensure the accessors are generated.

The VariableExpressionTransformer ignored delegation metadata when a private field accessor was present. I inversed that logic to give delegation metadata precedence over private field accessors.

Build passes https://travis-ci.org/MeneDev/groovy/builds/382561549