### PR TITLE
GROOVY-8604: Cache the parameterized type for better performance

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -37,7 +37,6 @@ import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.ResolveVisitor;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.runtime.memoize.EvictableCache;
-import org.codehaus.groovy.runtime.memoize.MemoizeCache;
 import org.codehaus.groovy.runtime.memoize.StampedCommonCache;
 import org.codehaus.groovy.syntax.ParserException;
 import org.codehaus.groovy.syntax.Reduction;
@@ -666,14 +665,9 @@ public class GenericsUtils {
      * If no cached item found, cache and return the result of {@link #findParameterizedType(ClassNode, ClassNode)}
      */
     public static ClassNode findParameterizedTypeFromCache(final ClassNode genericsClass, final ClassNode actualType) {
-        final ParameterizedInfoCacheKey parameterizedInfoCacheKey = new ParameterizedInfoCacheKey(genericsClass, actualType);
+        final ParameterizedTypeCacheKey parameterizedInfoCacheKey = new ParameterizedTypeCacheKey(genericsClass, actualType);
 
-        return PARAMETERIZED_INFO_CACHE.getAndPut(parameterizedInfoCacheKey, new MemoizeCache.ValueProvider<ParameterizedInfoCacheKey, ClassNode>() {
-            @Override
-            public ClassNode provide(ParameterizedInfoCacheKey key) {
-                return findParameterizedType(key.getGenericsClass(), key.getActualType());
-            }
-        });
+        return PARAMETERIZED_TYPE_CACHE.getAndPut(parameterizedInfoCacheKey, key -> findParameterizedType(key.getGenericsClass(), key.getActualType()));
     }
 
     /**
@@ -740,12 +734,12 @@ public class GenericsUtils {
         return superClassNodeList;
     }
 
-    private static final EvictableCache<ParameterizedInfoCacheKey, ClassNode> PARAMETERIZED_INFO_CACHE = new StampedCommonCache<>(128);
-    private static class ParameterizedInfoCacheKey {
+    private static final EvictableCache<ParameterizedTypeCacheKey, ClassNode> PARAMETERIZED_TYPE_CACHE = new StampedCommonCache<>(128);
+    private static class ParameterizedTypeCacheKey {
         private ClassNode genericsClass;
         private ClassNode actualType;
 
-        public ParameterizedInfoCacheKey(ClassNode genericsClass, ClassNode actualType) {
+        public ParameterizedTypeCacheKey(ClassNode genericsClass, ClassNode actualType) {
             this.genericsClass = genericsClass;
             this.actualType = actualType;
         }
@@ -771,7 +765,7 @@ public class GenericsUtils {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            ParameterizedInfoCacheKey cacheKey = (ParameterizedInfoCacheKey) o;
+            ParameterizedTypeCacheKey cacheKey = (ParameterizedTypeCacheKey) o;
 
             return genericsClass == cacheKey.genericsClass &&
                     actualType == cacheKey.actualType;

--- a/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -665,9 +665,7 @@ public class GenericsUtils {
      * If no cached item found, cache and return the result of {@link #findParameterizedType(ClassNode, ClassNode)}
      */
     public static ClassNode findParameterizedTypeFromCache(final ClassNode genericsClass, final ClassNode actualType) {
-        final ParameterizedTypeCacheKey parameterizedInfoCacheKey = new ParameterizedTypeCacheKey(genericsClass, actualType);
-
-        return PARAMETERIZED_TYPE_CACHE.getAndPut(parameterizedInfoCacheKey, key -> findParameterizedType(key.getGenericsClass(), key.getActualType()));
+        return PARAMETERIZED_TYPE_CACHE.getAndPut(new ParameterizedTypeCacheKey(genericsClass, actualType), key -> findParameterizedType(key.getGenericsClass(), key.getActualType()));
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1196,7 +1196,7 @@ public abstract class StaticTypeCheckingSupport {
     }
 
     private static Parameter[] makeRawTypes(Parameter[] params, ClassNode declaringClassForDistance, ClassNode actualReceiverForDistance) {
-        Map<String, GenericsType> placeholderInfo = GenericsUtils.extractPlaceholders(GenericsUtils.findParameterizedType(declaringClassForDistance, actualReceiverForDistance));
+        Map<String, GenericsType> placeholderInfo = GenericsUtils.extractPlaceholders(GenericsUtils.findParameterizedTypeFromCache(declaringClassForDistance, actualReceiverForDistance));
 
         Parameter[] newParam = new Parameter[params.length];
         for (int i = 0; i < params.length; i++) {

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -599,7 +599,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         } else if (accessedVariable instanceof FieldNode) {
             FieldNode fieldNode = (FieldNode) accessedVariable;
 
-            ClassNode parameterizedType = GenericsUtils.findParameterizedType(fieldNode.getDeclaringClass(), typeCheckingContext.getEnclosingClassNode());
+            ClassNode parameterizedType = GenericsUtils.findParameterizedTypeFromCache(fieldNode.getDeclaringClass(), typeCheckingContext.getEnclosingClassNode());
             if (null != parameterizedType) {
                 ClassNode originalType = fieldNode.getOriginType();
                 ClassNode actualType = findActualTypeByPlaceholderName(originalType.getUnresolvedName(), GenericsUtils.extractPlaceholders(parameterizedType));


### PR DESCRIPTION
Finding the parameterized type is expensive, so it's better to cache it.