### PR TITLE
Request YourKit Java Profiler Open Source License

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -179,6 +179,10 @@ Please note that the following Gradle tasks generate both indy and non indy vari
 
 The official CI server runs {groovy-ci}[here] and is sponsored by http://www.jetbrains.com[JetBrains].
 
+== Java Profiler
+
+Groovy core team tunes performance through YourKit Java Profiler, which is sponsored by https://www.yourkit.com[YourKit].
+
 == License
 
 Groovy is licensed under the terms of the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0]


### PR DESCRIPTION
Here is the link to YourKit and search "Open source project license" in the page:
https://www.yourkit.com/purchase/

**Open source project license**
```
The license is granted to developers of non-commercial Open Source projects, with an established and active community. The license is free. However, we ask you to add a reference to YourKit website on the web pages of your Open Source project.
```