### PR TITLE
Release 2.5.0 related fixes

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -62,6 +62,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -1099,7 +1100,8 @@ public abstract class StaticTypeCheckingSupport {
                 Person p = foo(b)
              */
 
-            Parameter[] params = makeRawTypes(safeNode.getParameters(), declaringClassForDistance, actualReceiverForDistance);
+            Map<GenericsType, GenericsType> declaringAndActualGenericsTypeMap = makeDeclaringAndActualGenericsTypeMap(declaringClassForDistance, actualReceiverForDistance);
+            Parameter[] params = makeRawTypes(safeNode.getParameters(), declaringAndActualGenericsTypeMap);
             int dist = measureParametersAndArgumentsDistance(params, safeArgs);
             if (dist >= 0) {
                 dist += getClassDistance(declaringClassForDistance, actualReceiverForDistance);
@@ -1189,20 +1191,62 @@ public abstract class StaticTypeCheckingSupport {
         return isExtensionMethodNode ? 0 : 1;
     }
 
+    private static ClassNode findActualTypeByGenericsPlaceholderName(String placeholderName, Map<GenericsType, GenericsType> genericsPlaceholderAndTypeMap) {
+        for (Map.Entry<GenericsType, GenericsType> entry : genericsPlaceholderAndTypeMap.entrySet()) {
+            GenericsType declaringGenericsType = entry.getKey();
+
+            if (placeholderName.equals(declaringGenericsType.getName())) {
+                return entry.getValue().getType();
+            }
+        }
+
+        return null;
+    }
+
     public static ClassNode findActualTypeByPlaceholderName(String placeholderName, Map<String, GenericsType> placeholderInfo) {
         GenericsType gt = placeholderInfo.get(placeholderName);
 
         return null == gt ? null : gt.getType().redirect();
     }
 
-    private static Parameter[] makeRawTypes(Parameter[] params, ClassNode declaringClassForDistance, ClassNode actualReceiverForDistance) {
-        Map<String, GenericsType> placeholderInfo = GenericsUtils.extractPlaceholders(GenericsUtils.findParameterizedTypeFromCache(declaringClassForDistance, actualReceiverForDistance));
+    /**
+     * map declaring generics type to actual generics type, e.g. GROOVY-7204:
+     * declaring generics types:      T,      S extends Serializable
+     * actual generics types   : String,      Long
+     *
+     * the result map is [
+     *  T: String,
+     *  S: Long
+     * ]
+     *
+     * The resolved types can not help us to choose methods correctly if the argument is a string:  T: Object, S: Serializable
+     * so we need actual types:  T: String, S: Long
+     */
+    private static Map<GenericsType, GenericsType> makeDeclaringAndActualGenericsTypeMap(ClassNode declaringClass, ClassNode actualReceiver) {
+        ClassNode parameterizedType = GenericsUtils.findParameterizedType(declaringClass, actualReceiver);
+
+        if (null == parameterizedType) {
+            return Collections.emptyMap();
+        }
+
+        GenericsType[] declaringGenericsTypes = declaringClass.getGenericsTypes();
+        GenericsType[] actualGenericsTypes = parameterizedType.getGenericsTypes();
+
+        Map<GenericsType, GenericsType> result = new LinkedHashMap<>();
+        for (int i = 0, n = declaringGenericsTypes.length; i < n; i++) {
+            result.put(declaringGenericsTypes[i], actualGenericsTypes[i]);
+        }
+
+        return result;
+    }
+
+    private static Parameter[] makeRawTypes(Parameter[] params, Map<GenericsType, GenericsType> genericsPlaceholderAndTypeMap) {
 
         Parameter[] newParam = new Parameter[params.length];
         for (int i = 0; i < params.length; i++) {
             Parameter oldP = params[i];
 
-            ClassNode actualType = findActualTypeByPlaceholderName(oldP.getType().getUnresolvedName(), placeholderInfo);
+            ClassNode actualType = findActualTypeByGenericsPlaceholderName(oldP.getType().getUnresolvedName(), genericsPlaceholderAndTypeMap);
             Parameter newP = new Parameter(makeRawType(null == actualType ? oldP.getType() : actualType), oldP.getName());
             newParam[i] = newP;
         }

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -611,10 +611,13 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                     if (vexp.getNodeMetaData(StaticTypesMarker.IMPLICIT_RECEIVER) == null) {
                         ClassNode owner = (ClassNode) vexp.getNodeMetaData(StaticCompilationMetadataKeys.PROPERTY_OWNER);
                         if (owner != null) {
-                            boolean lhsOfEnclosingAssignment = isLHSOfEnclosingAssignment(vexp);
-                            fieldNode = owner.getField(vexp.getName());
-                            vexp.setAccessedVariable(fieldNode);
-                            checkOrMarkPrivateAccess(vexp, fieldNode, lhsOfEnclosingAssignment);
+                            FieldNode veFieldNode = owner.getField(vexp.getName());
+                            if (veFieldNode != null) {
+                                fieldNode = veFieldNode;
+                                boolean lhsOfEnclosingAssignment = isLHSOfEnclosingAssignment(vexp);
+                                vexp.setAccessedVariable(fieldNode);
+                                checkOrMarkPrivateAccess(vexp, fieldNode, lhsOfEnclosingAssignment);
+                            }
                         }
                     }
                 }

--- a/src/spec/test/typing/TypeCheckingExtensionSpecTest.groovy
+++ b/src/spec/test/typing/TypeCheckingExtensionSpecTest.groovy
@@ -587,6 +587,25 @@ new DelegateTest().delegate()
 '''
     }
 
+    void testDelegateVariableFromDifferentOwningClass() {
+        assertScript '''
+        @groovy.transform.CompileStatic
+        class A {
+            static private int MAX_LINES = 2
+            static class B {
+                @Delegate
+                private Map<String, Object> delegate = [:]
+                void m(int c) {
+                    if (c > MAX_LINES) {
+                        return
+                    }
+                }
+            }
+        }
+        null
+        '''
+    }
+
     private static class SpecSupport {
         static int getLongueur(String self) { self.length() }
         static int longueur(String self) { self.length() }

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -76,7 +76,7 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         shouldFailWithMessages '''
             List<String> list = []
             list << 1
-        ''', '[Static type checking] - Cannot call <T> java.util.List <String>#leftShift(T) with arguments [int] '
+        ''', '[Static type checking] - Cannot find matching method java.util.List#leftShift(int)'
     }
 
     void testAddOnList2UsingLeftShift() {
@@ -88,6 +88,14 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         assertScript '''
             List<Integer> list = []
             list << 1
+        '''
+    }
+
+    void testAddOnListWithParameterizedTypeLeftShift() {
+        assertScript '''
+            class Trie<T> {}
+            List<Trie<String>> list = []
+            list << new Trie<String>()
         '''
     }
 


### PR DESCRIPTION
Some recent commits seem to cause problems with the Nextflow 2.5.0 snapshot builds on the CI server. One can lead to a NPE (commit 90486ae1075d14a62d14452abfea0c27485a67b5) because fieldNode can be reassigned `null` after the `instanceof` check. Another change (commit 57cfd2a3e4d985b3248569ea1d92b02c59627703) seems to have caused an issue with assigning parameterized types.