### PR TITLE
Make some groovy classes compile static

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/inspect/TextNode.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/inspect/TextNode.groovy
@@ -23,6 +23,9 @@
  */
 package groovy.inspect
 
+import groovy.transform.CompileStatic
+
+@CompileStatic
 class TextNode {
     Object userObject
     List<List<String>> properties

--- a/subprojects/groovy-console/src/main/groovy/groovy/inspect/TextTreeNodeMaker.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/inspect/TextTreeNodeMaker.groovy
@@ -24,7 +24,9 @@
 package groovy.inspect
 
 import groovy.inspect.swingui.AstBrowserNodeMaker
+import groovy.transform.CompileStatic
 
+@CompileStatic
 class TextTreeNodeMaker implements AstBrowserNodeMaker<TextNode> {
     TextNode makeNode(Object userObject) {
         new TextNode(userObject)

--- a/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/AstBrowser.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/AstBrowser.groovy
@@ -20,6 +20,7 @@ package groovy.inspect.swingui
 
 import groovy.lang.GroovyClassLoader.ClassCollector
 import groovy.swing.SwingBuilder
+import groovy.transform.CompileStatic
 import org.apache.groovy.io.StringBuilderWriter
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.control.CompilationUnit
@@ -553,6 +554,7 @@ class AstBrowserUiPreferences {
 /**
  * An adapter for the CompilePhase enum that can be entered into a Swing combobox.
  */
+@CompileStatic
 enum CompilePhaseAdapter {
     INITIALIZATION(Phases.INITIALIZATION, 'Initialization'),
     PARSING(Phases.PARSING, 'Parsing'),
@@ -567,7 +569,7 @@ enum CompilePhaseAdapter {
     final int phaseId
     final String string
 
-    def CompilePhaseAdapter(phaseId, string) {
+    def CompilePhaseAdapter(int phaseId, String string) {
         this.phaseId = phaseId
         this.string = string
     }
@@ -580,6 +582,7 @@ enum CompilePhaseAdapter {
 /**
  * This class is a TreeNode and you can store additional properties on it.
  */
+@CompileStatic
 class TreeNodeWithProperties extends DefaultMutableTreeNode {
 
     List<List<String>> properties
@@ -611,6 +614,7 @@ class TreeNodeWithProperties extends DefaultMutableTreeNode {
 /**
  * This interface is used to create tree nodes of various types 
  */
+@CompileStatic
 interface AstBrowserNodeMaker<T> {
     T makeNode(Object userObject)
 
@@ -620,6 +624,7 @@ interface AstBrowserNodeMaker<T> {
 /**
  * Creates tree nodes for swing UI  
  */
+@CompileStatic
 class SwingTreeNodeMaker implements AstBrowserNodeMaker<DefaultMutableTreeNode> {
     DefaultMutableTreeNode makeNode(Object userObject) {
         new DefaultMutableTreeNode(userObject)
@@ -647,6 +652,7 @@ class BytecodeCollector extends ClassCollector {
 
 }
 
+@CompileStatic
 class GeneratedBytecodeAwareGroovyClassLoader extends GroovyClassLoader {
 
     private final Map<String, byte[]> bytecode = new HashMap<String, byte[]>()

--- a/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/ButtonOrDefaultRenderer.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/ButtonOrDefaultRenderer.groovy
@@ -19,6 +19,8 @@
  */
 package groovy.inspect.swingui
 
+import groovy.transform.CompileStatic
+
 import javax.swing.*
 import javax.swing.table.DefaultTableCellRenderer
 import java.awt.*
@@ -28,6 +30,7 @@ import java.awt.*
  * or call the default in the case of a non component object.
  * This hack allows to render a button shape in a table cell.
  */
+@CompileStatic
 class ButtonOrDefaultRenderer extends DefaultTableCellRenderer {
     Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
         if (value instanceof JComponent) {

--- a/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/ButtonOrTextEditor.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/ButtonOrTextEditor.groovy
@@ -19,6 +19,8 @@
  */
 package groovy.inspect.swingui
 
+import groovy.transform.CompileStatic
+
 import javax.swing.*
 import javax.swing.table.TableCellEditor
 import java.awt.*
@@ -30,6 +32,7 @@ import java.awt.event.FocusListener
  * a text field if the value exists, or null otherwise (non editable cell).
  * This hack allows to interact with buttons in a cell.
  */
+@CompileStatic
 class ButtonOrTextEditor extends AbstractCellEditor implements TableCellEditor {
     /** The Swing component being edited. */
     protected JComponent editorComponent
@@ -38,7 +41,7 @@ class ButtonOrTextEditor extends AbstractCellEditor implements TableCellEditor {
     Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
         if (value instanceof JButton) {
             editorComponent = value
-            editorComponent.addActionListener({ fireEditingStopped() } as ActionListener)
+            ((JButton) editorComponent).addActionListener({ fireEditingStopped() } as ActionListener)
         } else if (value instanceof JTextArea) {
             editorComponent = value
         } else if (value) {

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
@@ -23,6 +23,7 @@ import groovy.cli.picocli.OptionAccessor
 import groovy.inspect.swingui.AstBrowser
 import groovy.inspect.swingui.ObjectBrowser
 import groovy.swing.SwingBuilder
+import groovy.transform.CompileStatic
 import groovy.transform.ThreadInterrupt
 import groovy.ui.text.FindReplaceUtility
 import org.apache.groovy.io.StringBuilderWriter
@@ -1547,8 +1548,9 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
     public void focusLost(FocusEvent e) { }
 }
 
+@CompileStatic
 class GroovyFileFilter extends FileFilter {
-    private static final GROOVY_SOURCE_EXTENSIONS = ['*.groovy', '*.gvy', '*.gy', '*.gsh', '*.story', '*.gpp', '*.grunit']
+    private static final java.util.List GROOVY_SOURCE_EXTENSIONS = ['*.groovy', '*.gvy', '*.gy', '*.gsh', '*.story', '*.gpp', '*.grunit']
     private static final GROOVY_SOURCE_EXT_DESC = GROOVY_SOURCE_EXTENSIONS.join(',')
 
     public boolean accept(File f) {
@@ -1562,7 +1564,7 @@ class GroovyFileFilter extends FileFilter {
         "Groovy Source Files ($GROOVY_SOURCE_EXT_DESC)"
     }
     
-    static String getExtension(f) {
+    static String getExtension(File f) {
         def ext = null;
         def s = f.getName()
         def i = s.lastIndexOf('.')

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/ConsoleApplet.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/ConsoleApplet.groovy
@@ -18,11 +18,14 @@
  */
 package groovy.ui
 
+import groovy.transform.CompileStatic
+
 import javax.swing.*
 
 /**
  * ConsoleApplet
  */
+@CompileStatic
 class ConsoleApplet extends JApplet {
 
     Console console

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/HistoryRecord.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/HistoryRecord.groovy
@@ -18,7 +18,9 @@
  */
 package groovy.ui
 
+import groovy.transform.CompileStatic
 
+@CompileStatic
 class HistoryRecord {
     String allText
     int selectionStart

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/OutputTransforms.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/OutputTransforms.groovy
@@ -18,17 +18,19 @@
  */
 package groovy.ui
 
+import groovy.transform.CompileStatic
 import org.codehaus.groovy.runtime.InvokerHelper
 
 import javax.swing.*
 import java.awt.*
 import java.awt.image.BufferedImage
 
+@CompileStatic
 class OutputTransforms {
 
-    @Lazy static localTransforms = loadOutputTransforms()
+    @Lazy static java.util.List<Closure> localTransforms = loadOutputTransforms()
 
-    static loadOutputTransforms() {
+    static java.util.List<Closure> loadOutputTransforms() {
         def transforms = []
 
         //
@@ -82,10 +84,10 @@ class OutputTransforms {
         // final case, non-nulls just get inspected as strings
         transforms << { it -> if (it != null) "${InvokerHelper.inspect(it)}" }
 
-        return transforms
+        return (java.util.List<Closure>) transforms
     }
 
-    static transformResult(base, transforms = localTransforms) {
+    static transformResult(base, java.util.List<Closure> transforms = localTransforms) {
         for (Closure c : transforms) {
             def result = c(base as Object)
             if (result != null)  {
@@ -94,5 +96,4 @@ class OutputTransforms {
         }
         return base
     }
-
 }

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/text/AutoIndentAction.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/text/AutoIndentAction.groovy
@@ -18,16 +18,19 @@
  */
 package groovy.ui.text
 
+import groovy.transform.CompileStatic
+
 import javax.swing.*
 import javax.swing.text.AttributeSet
 import javax.swing.text.SimpleAttributeSet
 import java.awt.event.ActionEvent
 
+@CompileStatic
 class AutoIndentAction extends AbstractAction {
     AttributeSet simpleAttributeSet = new SimpleAttributeSet()
 
-    public void actionPerformed(ActionEvent evt) {
-        def inputArea = evt.source
+    void actionPerformed(ActionEvent evt) {
+        JTextPane inputArea = (JTextPane) evt.source
         def rootElement = inputArea.document.defaultRootElement
         def cursorPos = inputArea.getCaretPosition()
         int rowNum = rootElement.getElementIndex(cursorPos)


### PR DESCRIPTION
In order to reduce the size of class files and improve the performance of groovy console, the PR tries to make as many groovy classes as possible compile static.