### PR TITLE
Fix file descriptor leaks when using URL connections

### DIFF
--- a/src/main/groovy/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/groovy/lang/GroovyClassLoader.java
@@ -46,6 +46,7 @@ import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.runtime.memoize.EvictableCache;
 import org.codehaus.groovy.runtime.memoize.StampedCommonCache;
 import org.codehaus.groovy.runtime.memoize.UnlimitedConcurrentCache;
+import org.codehaus.groovy.util.URLStreams;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
@@ -812,7 +813,7 @@ public class GroovyClassLoader extends URLClassLoader {
                         // do nothing and fall back to the other version
                     }
                 }
-                return parseClass(new InputStreamReader(source.openStream(), sourceEncoding), name);
+                return parseClass(new InputStreamReader(URLStreams.openUncachedStream(source), sourceEncoding), name);
             }
         }
         return oldClass;

--- a/src/main/java/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
@@ -20,6 +20,7 @@ package org.codehaus.groovy.ast.decompiled;
 
 import groovy.lang.GroovyRuntimeException;
 import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.util.URLStreams;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -78,7 +79,7 @@ public abstract class AsmDecompiler {
         if (stub == null) {
             DecompilingVisitor visitor = new DecompilingVisitor();
 
-            try (InputStream stream = new BufferedInputStream(url.openStream())) {
+            try (InputStream stream = new BufferedInputStream(URLStreams.openUncachedStream(url))) {
                 new ClassReader(stream).accept(visitor, ClassReader.SKIP_FRAMES);
             }
             stub = visitor.result;

--- a/src/main/java/org/codehaus/groovy/control/SourceExtensionHandler.java
+++ b/src/main/java/org/codehaus/groovy/control/SourceExtensionHandler.java
@@ -19,6 +19,7 @@
 package org.codehaus.groovy.control;
 
 import groovy.lang.GroovyRuntimeException;
+import org.codehaus.groovy.util.URLStreams;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -45,7 +46,7 @@ public class SourceExtensionHandler {
                 BufferedReader svcIn = null;
                 URL service = globalServices.nextElement();
                 try {
-                    svcIn = new BufferedReader(new InputStreamReader(service.openStream()));
+                    svcIn = new BufferedReader(new InputStreamReader(URLStreams.openUncachedStream(service)));
                     String extension = svcIn.readLine();
                     while (extension != null) {
                         extension = extension.trim();

--- a/src/main/java/org/codehaus/groovy/control/io/URLReaderSource.java
+++ b/src/main/java/org/codehaus/groovy/control/io/URLReaderSource.java
@@ -20,6 +20,7 @@ package org.codehaus.groovy.control.io;
 
 import groovy.lang.GroovyRuntimeException;
 import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.util.URLStreams;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -50,7 +51,7 @@ public class URLReaderSource extends AbstractReaderSource {
     *  Returns a new Reader on the underlying source object.  
     */
     public Reader getReader() throws IOException {
-       return new InputStreamReader( url.openStream(), configuration.getSourceEncoding() );
+       return new InputStreamReader(URLStreams.openUncachedStream(url), configuration.getSourceEncoding() );
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/runtime/m12n/ExtensionModuleScanner.java
+++ b/src/main/java/org/codehaus/groovy/runtime/m12n/ExtensionModuleScanner.java
@@ -19,6 +19,7 @@
 package org.codehaus.groovy.runtime.m12n;
 
 import groovy.lang.GroovyRuntimeException;
+import org.codehaus.groovy.util.URLStreams;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,7 +71,7 @@ public class ExtensionModuleScanner {
         Properties properties = new Properties();
         InputStream inStream = null;
         try {
-            inStream = metadata.openStream();
+            inStream = URLStreams.openUncachedStream(metadata);
             properties.load(inStream);
         } catch (IOException e) {
             throw new GroovyRuntimeException("Unable to load module META-INF descriptor", e);

--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -34,6 +34,7 @@ import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.messages.SimpleMessage;
 import org.codehaus.groovy.control.messages.WarningMessage;
+import org.codehaus.groovy.util.URLStreams;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -221,7 +222,7 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
                 String className;
                 BufferedReader svcIn = null;
                 try {
-                    svcIn = new BufferedReader(new InputStreamReader(service.openStream(), "UTF-8"));
+                    svcIn = new BufferedReader(new InputStreamReader(URLStreams.openUncachedStream(service), "UTF-8"));
                     try {
                         className = svcIn.readLine();
                     } catch (IOException ioe) {

--- a/src/main/java/org/codehaus/groovy/util/ReleaseInfo.java
+++ b/src/main/java/org/codehaus/groovy/util/ReleaseInfo.java
@@ -53,7 +53,7 @@ public class ReleaseInfo {
         if (url != null) {
             InputStream is = null;
             try {
-                is = url.openStream();
+                is = URLStreams.openUncachedStream(url);
                 if (is != null) {
                     RELEASE_INFO.load(is);
                 }

--- a/src/main/java/org/codehaus/groovy/util/URLStreams.java
+++ b/src/main/java/org/codehaus/groovy/util/URLStreams.java
@@ -1,0 +1,26 @@
+package org.codehaus.groovy.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class URLStreams {
+    private URLStreams() {
+
+    }
+
+    /**
+     * Opens an {@link InputStream} reading from the given URL without
+     * caching the stream. This prevents file descriptor leaks when reading
+     * from file system URLs.
+     *
+     * @param url the URL to connect to
+     * @return an input stream reading from the URL connection
+     */
+    public static InputStream openUncachedStream(URL url) throws IOException {
+        URLConnection urlConnection = url.openConnection();
+        urlConnection.setUseCaches(false);
+        return urlConnection.getInputStream();
+    }
+}


### PR DESCRIPTION
The JVM keeps a cache of URL connections, which keeps
the underlying files open for the lifetime of the VM
unless the `setUseCaches(false)` method is used.

This change makes it possible to reuse the Groovy compiler,
e.g. embedded in the Gradle daemon without preventing files
from being deleted on Windows.