### PR TITLE
GROOVY-8628: Groovydoc fails to parse Java static nested classes with…

### DIFF
--- a/src/main/antlr2/org/codehaus/groovy/antlr/java/java.g
+++ b/src/main/antlr2/org/codehaus/groovy/antlr/java/java.g
@@ -370,10 +370,10 @@ classTypeSpec[boolean addImagNode]  {Token first = LT(1);}
 
 // A non-built in type name, with possible type parameters
 classOrInterfaceType[boolean addImagNode]  {Token first = LT(1);}
-	:	IDENT^ (typeArguments|typeArgumentsDiamond)?
+	:	IDENT^ (typeArgumentsOrDiamond)?
 		(options{greedy=true;}: // match as many as possible
 			DOT^
-			IDENT (typeArguments)?
+			IDENT (typeArgumentsOrDiamond)?
 		)*
 		{
 			if ( addImagNode ) {
@@ -402,10 +402,9 @@ wildcardType
 		(("extends" | "super")=> typeArgumentBounds)?
 	;
 
-typeArgumentsDiamond
-{Token first = LT(1);}
+typeArgumentsOrDiamond
     :   LT! GT!
-    {#typeArgumentsDiamond = #(create(TYPE_ARGUMENTS, "TYPE_ARGUMENTS",first,LT(1)), #typeArgumentsDiamond);}
+    |   typeArguments
     ;
 
 // Type arguments to a class or interface type

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -333,6 +333,18 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertTrue("stringList not found in: \"" + doc + "\"", doc.contains("stringList"));
     }
 
+    public void testJavaStaticNestedClassWithDiamondOperator() throws Exception {
+        List<String> srcList = new ArrayList<String>();
+        String base = "org/codehaus/groovy/tools/groovydoc/testfiles/JavaStaticNestedClassWithDiamond";
+        srcList.add(base + ".java");
+        xmlTool.add(srcList);
+        MockOutputTool output = new MockOutputTool();
+        xmlTool.renderToOutput(output, MOCK_DIR);
+        String doc = output.getText(MOCK_DIR + "/" + base + ".html");
+        assertNotNull("No GroovyDoc found for " + base, doc);
+        assertTrue("expectedObject not found in: \"" + doc + "\"", doc.contains("expectedObject"));
+    }
+
     public void testVisibilityPublic() throws Exception {
         Properties props = new Properties();
         props.put("publicScope", "true");

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -341,8 +341,11 @@ public class GroovyDocToolTest extends GroovyTestCase {
         MockOutputTool output = new MockOutputTool();
         xmlTool.renderToOutput(output, MOCK_DIR);
         String doc = output.getText(MOCK_DIR + "/" + base + ".html");
-        assertNotNull("No GroovyDoc found for " + base, doc);
-        assertTrue("expectedObject not found in: \"" + doc + "\"", doc.contains("expectedObject"));
+        assertNotNull("No GroovyDoc found for outer class " + base, doc);
+        assertTrue("Outer class expectedObject not found in: \"" + doc + "\"", doc.contains("expectedObject"));
+        String docNested = output.getText(MOCK_DIR + "/" + base + ".Nested.html");
+        assertNotNull("No GroovyDoc found for nested class " + base, docNested);
+        assertTrue("Nested class comment not found in: \"" + docNested + "\"", docNested.contains("static nested class comment"));
     }
 
     public void testVisibilityPublic() throws Exception {

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaStaticNestedClassWithDiamond.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaStaticNestedClassWithDiamond.java
@@ -18,12 +18,17 @@
  */
 package org.codehaus.groovy.tools.groovydoc.testfiles;
 
-public abstract class JavaStaticNestedClassWithDiamond<E> {
+public class JavaStaticNestedClassWithDiamond<E> {
 
     JavaStaticNestedClassWithDiamond() {
     }
 
-    static class Nested<E> extends JavaStaticNestedClassWithDiamond<E> {
+    /**
+     * static nested class comment
+     *
+     * @param <E>
+     */
+    public static class Nested<E> extends JavaStaticNestedClassWithDiamond<E> {
         Nested() {
         }
     }

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaStaticNestedClassWithDiamond.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaStaticNestedClassWithDiamond.java
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.groovydoc.testfiles;
+
+public abstract class JavaStaticNestedClassWithDiamond<E> {
+
+    JavaStaticNestedClassWithDiamond() {
+    }
+
+    static class Nested<E> extends JavaStaticNestedClassWithDiamond<E> {
+        Nested() {
+        }
+    }
+
+    public JavaStaticNestedClassWithDiamond<Object> expectedObject = new JavaStaticNestedClassWithDiamond.Nested<>();
+
+}


### PR DESCRIPTION
… diamond operator

java.g grammar file:
* Added support for Java static nested class with diamond operator,
  e.g. new Class.Nested<>()
* Simplified classOrInterfaceType with typeArgumentsOrDiamond

groovydoc test:
* Added groovydoc tool test for Java static nested class with diamond
  operator