### PR TITLE
GROOVY-8632: Groovy 2.5.0 fails to compile Google Java Client sample code

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
@@ -103,7 +103,22 @@ public abstract class AsmDecompiler {
 
         @Override
         public void visitInnerClass(String name, String outerName, String innerName, int access) {
-            result.innerClassModifiers.put(innerName, access);
+            // Class files generated for static nested classes have an INNERCLASS reference to self.
+            // The top level class access modifiers do not include the static modifier but the
+            // INNERCLASS self reference does so we capture those modifiers here.
+            //
+            // Must compare against the fully qualified name because there may be other INNERCLASS
+            // references to same named nested classes from other classes.
+            //
+            // Example:
+            //
+            //    public final class org/foo/Groovy8632$Builder extends org/foo/Groovy8632Abstract$Builder  {
+            //        public final static INNERCLASS org/foo/Groovy8632$Builder org/foo/Groovy8632 Builder
+            //        public static abstract INNERCLASS org/foo/Groovy8632Abstract$Builder org/foo/Groovy8632Abstract Builder
+            //
+            if (fromInternalName(name).equals(result.className)) {
+                result.innerClassModifiers = access;
+            }
         }
 
         @Override

--- a/src/main/java/org/codehaus/groovy/ast/decompiled/ClassStub.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/ClassStub.java
@@ -35,7 +35,7 @@ public class ClassStub extends MemberStub {
     final String[] interfaceNames;
     List<MethodStub> methods;
     List<FieldStub> fields;
-    final Map<String, Integer> innerClassModifiers = new HashMap<String, Integer>();
+    int innerClassModifiers;
 
     public ClassStub(String className, int accessModifiers, String signature, String superName, String[] interfaceNames) {
         this.className = className;

--- a/src/main/java/org/codehaus/groovy/ast/decompiled/DecompiledClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/DecompiledClassNode.java
@@ -44,34 +44,17 @@ public class DecompiledClassNode extends ClassNode {
     private boolean membersInitialized = false;
 
     public DecompiledClassNode(ClassStub data, AsmReferenceResolver resolver) {
-        super(data.className, getFullModifiers(data, resolver), null, null, MixinNode.EMPTY_ARRAY);
+        super(data.className, getFullModifiers(data), null, null, MixinNode.EMPTY_ARRAY);
         classData = data;
         this.resolver = resolver;
         isPrimaryNode = false;
     }
 
     /**
-     * Static inner classes don't have "static" part in their own modifiers. Their containing classes have to be inspected
-     * whether they have an inner class with the same name that's static. '$' separator convention is used to search
-     * for parent classes.
+     * Handle the case of static nested classes so the static modifier can be included.
      */
-    private static int getFullModifiers(ClassStub data, AsmReferenceResolver resolver) {
-        String className = data.className;
-        int bound = className.length();
-        while (bound > 0) {
-            int idx = className.lastIndexOf('$', bound);
-            if (idx > 0) {
-                ClassNode outerClass = resolver.resolveClassNullable(className.substring(0, idx));
-                if (outerClass instanceof DecompiledClassNode) {
-                    Integer outerModifiers = ((DecompiledClassNode) outerClass).classData.innerClassModifiers.get(className.substring(idx + 1));
-                    if (outerModifiers != null) {
-                        return data.accessModifiers | outerModifiers;
-                    }
-                }
-            }
-            bound = idx - 1;
-        }
-        return data.accessModifiers;
+    private static int getFullModifiers(ClassStub data) {
+        return data.accessModifiers | data.innerClassModifiers;
     }
 
     public long getCompilationTimeStamp() {

--- a/src/test/org/codehaus/groovy/ast/decompiled/AsmDecompilerTest.groovy
+++ b/src/test/org/codehaus/groovy/ast/decompiled/AsmDecompilerTest.groovy
@@ -21,6 +21,7 @@ import junit.framework.TestCase
 import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.decompiled.support.*
 import org.codehaus.groovy.ast.expr.*
 import org.codehaus.groovy.control.ClassNodeResolver
 import org.codehaus.groovy.control.CompilationUnit
@@ -284,8 +285,36 @@ class AsmDecompilerTest extends TestCase {
         assert (decompile(SomeInnerclass.name).modifiers & Opcodes.ACC_STATIC) != 0
     }
 
+    void "test static inner classes with same name"() {
+        ClassNode cn = decompile(Groovy8632Abstract.Builder.name)
+        assert (cn.modifiers & Opcodes.ACC_STATIC) != 0
+        assert (cn.modifiers & Opcodes.ACC_ABSTRACT) != 0
+
+        cn = decompile(Groovy8632.Builder.name)
+        assert (cn.modifiers & Opcodes.ACC_STATIC) != 0
+        assert (cn.modifiers & Opcodes.ACC_ABSTRACT) == 0
+
+        cn = decompile(Groovy8632Groovy.Builder.name)
+        assert (cn.modifiers & Opcodes.ACC_STATIC) != 0
+        assert (cn.modifiers & Opcodes.ACC_ABSTRACT) == 0
+    }
+
     void "test static inner with dollar"() {
         assert (decompile(AsmDecompilerTestData.Inner$WithDollar.name).modifiers & Opcodes.ACC_STATIC) != 0
+    }
+
+    void "test inner classes with same name"() {
+        ClassNode cn = decompile(Groovy8632Abstract.InnerBuilder.name)
+        assert (cn.modifiers & Opcodes.ACC_STATIC) == 0
+        assert (cn.modifiers & Opcodes.ACC_ABSTRACT) != 0
+
+        cn = decompile(Groovy8632.InnerBuilder.name)
+        assert (cn.modifiers & Opcodes.ACC_STATIC) == 0
+        assert (cn.modifiers & Opcodes.ACC_ABSTRACT) == 0
+
+        cn = decompile(Groovy8632Groovy.InnerBuilder.name)
+        assert (cn.modifiers & Opcodes.ACC_STATIC) == 0
+        assert (cn.modifiers & Opcodes.ACC_ABSTRACT) == 0
     }
 
     void "test non-parameterized generics"() {

--- a/src/test/org/codehaus/groovy/ast/decompiled/support/Groovy8632.java
+++ b/src/test/org/codehaus/groovy/ast/decompiled/support/Groovy8632.java
@@ -1,0 +1,7 @@
+package org.codehaus.groovy.ast.decompiled.support;
+
+public class Groovy8632 extends Groovy8632Abstract {
+    Groovy8632(Builder builder) { super(builder); }
+    public static final class Builder extends Groovy8632Abstract.Builder {}
+    public class InnerBuilder extends Groovy8632Abstract.InnerBuilder {}
+}

--- a/src/test/org/codehaus/groovy/ast/decompiled/support/Groovy8632Abstract.java
+++ b/src/test/org/codehaus/groovy/ast/decompiled/support/Groovy8632Abstract.java
@@ -1,0 +1,7 @@
+package org.codehaus.groovy.ast.decompiled.support;
+
+public abstract class Groovy8632Abstract {
+    Groovy8632Abstract(Builder builder) {}
+    public abstract static class Builder {}
+    public abstract class InnerBuilder {}
+}

--- a/src/test/org/codehaus/groovy/ast/decompiled/support/Groovy8632Groovy.groovy
+++ b/src/test/org/codehaus/groovy/ast/decompiled/support/Groovy8632Groovy.groovy
@@ -1,0 +1,6 @@
+package org.codehaus.groovy.ast.decompiled.support
+
+class Groovy8632Groovy {
+    static class Builder extends Groovy8632Abstract.Builder {}
+    class InnerBuilder extends Groovy8632Abstract.InnerBuilder {}
+}


### PR DESCRIPTION
Class files can contain INNERCLASS references to other
classes inner classes whose name may be the same name as a
contained inner class. By storing modifiers in a map keyed
by short class name there is a possibility for the wrong
modifiers to be stored.

Since generated class files for inner classes contain an INNERCLASS
self reference, the logic can be simplified to look for a matching
name and storing those access modifiers. This eliminates the need
to search the outer class for the INNERCLASS reference.