### PR TITLE
Fix inferring return type issues

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -3288,12 +3288,14 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                         if (typeCheckMethodsWithGenericsOrFail(chosenReceiver.getType(), args, mn.get(0), call)) {
                             returnType = adjustWithTraits(directMethodCallCandidate, chosenReceiver.getType(), args, returnType);
 
+                            /*
                             if (null != typeCheckingContext.getEnclosingReturnStatement() && !isNestedOrSandwichedMethodCall()) {
                                 ClassNode inferredType = infer(returnType, typeCheckingContext.getEnclosingMethod().getReturnType());
                                 if (null != inferredType) {
                                     returnType = inferredType;
                                 }
                             }
+                            */
 
                             storeType(call, returnType);
                             storeTargetMethod(call, directMethodCallCandidate);


### PR DESCRIPTION
When methods are mixed with other expressions in the return statement, `isNestedOrSandwichedMethodCall` fails to handle all cases and becomes the source of issues. As `isNestedOrSandwichedMethodCall` is a temporary solution, it's useless and can be removed now.