### PR TITLE
BigDecimalMath.MAX_DIVISION_SCALE is hard-coded to 10 digits

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/typehandling/BigDecimalMath.java
+++ b/src/main/java/org/codehaus/groovy/runtime/typehandling/BigDecimalMath.java
@@ -30,11 +30,11 @@ public final class BigDecimalMath extends NumberMath {
 
     // This is an arbitrary value, picked as a reasonable choice for a precision
     // for typical user math when a non-terminating result would otherwise occur.
-    public static final int DIVISION_EXTRA_PRECISION = 10;
+    public static final int DIVISION_EXTRA_PRECISION = 32;
 
     //This is an arbitrary value, picked as a reasonable choice for a rounding point
     //for typical user math.
-    public static final int DIVISION_MIN_SCALE = 10;
+    public static final int DIVISION_MIN_SCALE = 32;
 
     public static final BigDecimalMath INSTANCE = new BigDecimalMath();
 

--- a/src/test/groovy/operator/BigDecimalOperatorsTest.groovy
+++ b/src/test/groovy/operator/BigDecimalOperatorsTest.groovy
@@ -90,10 +90,10 @@ class BigDecimalOperatorsTest extends GroovyTestCase {
         assert y == 10 , "y = " + y
 
         y = 34 / 3.000
-        assert y == 11.3333333333 , "y = " + y
+        assert y == 11.33333333333333333333333333333333 , "y = " + y
 
         y = 34.00000000000 / 3
-        assert y == 11.33333333333 , "y = " + y
+        assert y == 11.33333333333333333333333333333333 , "y = " + y
     }
     
     BigDecimal echoX ( BigDecimal x, BigDecimal y) {x}

--- a/src/test/org/codehaus/groovy/runtime/typehandling/NumberMathTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/typehandling/NumberMathTest.groovy
@@ -132,10 +132,10 @@ class NumberMathTest extends GroovyTestCase {
         assert BI1.intdiv(BI2) == 0
 
         assert I1 / I3 instanceof BigDecimal
-        assert I1 / I3 == new BigDecimal("0.3333333333")
+        assert I1 / I3 == new BigDecimal("0.33333333333333333333333333333333")
 
         assert I2 / I3 instanceof BigDecimal
-        assert I2 / I3 == new BigDecimal("0.6666666667")
+        assert I2 / I3 == new BigDecimal("0.66666666666666666666666666666667")
 
         assert I1 / BD2 instanceof BigDecimal
 


### PR DESCRIPTION
The "scale" for BigDecimal division is hard-coded to 10 (BigDecimalMath.MAX_DIVISION_SCALE), which is fewer than the roughly equivalent 16-17 digits for double (64-bit) division. It seems like the default scale should be at least as accurate as double division. Also it is probably desirable for this setting to be configurable in some way, maybe more than one. Maybe a global Java system property setting, and then some form of context related override (per-thread, per-script, etc.).

I use this fix for 2 years without side effects on a software for a big company. For comparison, Excel use a round with 15 digit after decimal