### PR TITLE
GROOVY-8670: Make groovy-bsf an optional "module" for 2.5.1+, i.e. no…

### DIFF
--- a/gradle/upload.gradle
+++ b/gradle/upload.gradle
@@ -202,6 +202,7 @@ allprojects {
 }
 
 def optionalModules = [
+        'groovy-bsf',
         'groovy-cli-commons',
         'groovy-dateutil',
         'groovy-jaxb',


### PR DESCRIPTION
…t reference by groovy-all