### PR TITLE
GROOVY-8664 : Switch from findbugs to spotbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ buildscript {
 plugins {
     id 'com.gradle.build-scan' version '1.13.4'
     id 'me.champeau.buildscan-recipes' version '0.2.3'
+    id 'com.github.spotbugs' version '1.6.2'
 }
 
 buildScan {
@@ -194,8 +195,6 @@ dependencies {
         transitive = false
     }
     compile files("${buildDir}/generated-classes")
-
-    compileOnly "com.google.code.findbugs:jsr305:$jsr305Version"
 
     runtime("org.codehaus.gpars:gpars:$gparsVersion") {
         exclude(group: 'org.codehaus.groovy', module: 'groovy-all')
@@ -468,6 +467,10 @@ if (!JavaVersion.current().java8Compatible) {
     *********************************************************************************************
 '''
 }
+
+// Workaround to be able to access SpotBugsTask from external gradle script.
+// More info: https://discuss.gradle.org/t/buildscript-dependencies-in-external-script/23243
+project.extensions.extraProperties.set('SpotBugsTask', com.github.spotbugs.SpotBugsTask)
 
 apply from: 'gradle/test.gradle'
 apply from: 'gradle/groovydoc.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,8 @@ ext {
 }
 
 dependencies {
+	compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.3'
+	
     compile "antlr:antlr:$antlrVersion"
     compile "org.ow2.asm:asm:$asmVersion"
     compile "org.ow2.asm:asm-analysis:$asmVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ ext {
 }
 
 dependencies {
-	compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.3'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.3'
 	
     compile "antlr:antlr:$antlrVersion"
     compile "org.ow2.asm:asm:$asmVersion"

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -24,7 +24,6 @@ allprojects {
     //apply plugin: "com.github.hierynomus.license"
     apply plugin: 'checkstyle'
     apply plugin: 'codenarc'
-    apply plugin: 'findbugs'
     configurations.codenarc {
         // because we will rely on the version we build
         // because version ranges are evil
@@ -127,19 +126,24 @@ allprojects {
         }
     }
 
-    findbugs {
-        // continue build despite findbug warnings
-        ignoreFailures = true
-        sourceSets = [sourceSets.main]
-    }
-    tasks.withType(FindBugs) {
-        effort = 'max'
-        reports {
-            xml.enabled = false
-            html.enabled = true
-        }
-        maxHeapSize = '2g'
-    }
+	spotbugs {
+    	toolVersion = '3.1.1'
+    	// continue build despite findbug warnings
+    	ignoreFailures = true
+    	//defining source set is needless
+    	//just run ./gradlew spotbugsMain then it will parse src/main/java. 
+    	//To parse test cases, you need to use ./gradlew spotbugsTest.
+	}
+
+	// To generate an HTML report instead of XML
+	tasks.withType(SpotBugsTask) {
+	    effort = 'max'
+    	reports {
+        	xml.enabled = false
+        	html.enabled = true
+    	}
+    	maxHeapSize '2g'
+	} 
 }
 
 subprojects { sp ->

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -136,15 +136,15 @@ allprojects {
     	//To parse test cases, you need to use ./gradlew spotbugsTest.
 	}
 
-	// To generate an HTML report instead of XML
-	tasks.withType(SpotBugsTask) {
-	    effort = 'max'
-    	reports {
-        	xml.enabled = false
-        	html.enabled = true
-    	}
-    	maxHeapSize '2g'
-	} 
+    // To generate an HTML report instead of XML
+    tasks.withType(SpotBugsTask) {
+        effort = 'max'
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
+        maxHeapSize '2g'
+    } 
 }
 
 subprojects { sp ->

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -127,14 +127,14 @@ allprojects {
         }
     }
 
-	spotbugs {
-    	toolVersion = '3.1.1'
-    	// continue build despite findbug warnings
-    	ignoreFailures = true
-    	//defining source set is needless
-    	//just run ./gradlew spotbugsMain then it will parse src/main/java. 
-    	//To parse test cases, you need to use ./gradlew spotbugsTest.
-	}
+    spotbugs {
+        toolVersion = '3.1.1'
+        // continue build despite findbug warnings
+        ignoreFailures = true
+        //defining source set is needless
+        //just run ./gradlew spotbugsMain then it will parse src/main/java. 
+        //To parse test cases, you need to use ./gradlew spotbugsTest.
+    }
 
     // To generate an HTML report instead of XML
     tasks.withType(SpotBugsTask) {

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -24,6 +24,7 @@ allprojects {
     //apply plugin: "com.github.hierynomus.license"
     apply plugin: 'checkstyle'
     apply plugin: 'codenarc'
+    apply plugin: 'com.github.spotbugs'
     configurations.codenarc {
         // because we will rely on the version we build
         // because version ranges are evil


### PR DESCRIPTION
**Description** : Findbugs hasn't been updated in a few years. The community has since forked it and created Spotbugs.

**Changes** : Updated build to use spotbugs plugin

Screenshot below of SpotBugs Test report
<img width="953" alt="screen **shot** 2018-07-02 at 11 14 25 pm" src="https://user-images.githubusercontent.com/10268220/42178609-adcbf41c-7e4e-11e8-894c-f030abf538f7.png">
