### PR TITLE
GROOVY-8623: Show Groovy version in about help

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/ObjectBrowser.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/ObjectBrowser.groovy
@@ -152,7 +152,8 @@ class ObjectBrowser {
     void showAbout(EventObject evt) {
          def pane = swing.optionPane()
          // work around GROOVY-1048
-         pane.setMessage('An interactive GUI to explore object capabilities.')
+         def version = GroovySystem.version
+         pane.setMessage('An interactive GUI to explore object capabilities.\nVersion' + version)
          def dialog = pane.createDialog(frame, 'About Groovy Object Browser')
          dialog.show()
     }


### PR DESCRIPTION
Show current version of the Groovy in Groovy Object Browser in about->help
Jira: https://issues.apache.org/jira/browse/GROOVY-8623

How it looks like:
![obraz](https://user-images.githubusercontent.com/7474972/42387453-96f0e828-8142-11e8-85d1-1b6704b78577.png)

