### PR TITLE
GROOVY-8282: Error while popping argument from operand stack tracker …

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/trait/TraitReceiverTransformer.java
+++ b/src/main/java/org/codehaus/groovy/transform/trait/TraitReceiverTransformer.java
@@ -42,6 +42,7 @@ import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.expr.PropertyExpression;
 import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
 import org.codehaus.groovy.ast.expr.TernaryExpression;
+import org.codehaus.groovy.ast.expr.TupleExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.syntax.SyntaxException;
@@ -58,7 +59,6 @@ import java.util.List;
  * In a nutshell, code like the following method definition in a trait:<p></p> <code>void foo() { this.bar() }</code> is
  * transformed into: <code>void foo() { TraitHelper$bar(this) }</code>
  *
- * @author Cedric Champeau
  * @since 2.3.0
  */
 class TraitReceiverTransformer extends ClassCodeExpressionTransformer {
@@ -438,8 +438,8 @@ class TraitReceiverTransformer extends ClassCodeExpressionTransformer {
     private ArgumentListExpression createArgumentList(final Expression origCallArgs) {
         ArgumentListExpression newArgs = new ArgumentListExpression();
         newArgs.addExpression(new VariableExpression(weaved));
-        if (origCallArgs instanceof ArgumentListExpression) {
-            List<Expression> expressions = ((ArgumentListExpression) origCallArgs).getExpressions();
+        if (origCallArgs instanceof TupleExpression) {
+            List<Expression> expressions = ((TupleExpression) origCallArgs).getExpressions();
             for (Expression expression : expressions) {
                 newArgs.addExpression(transform(expression));
             }

--- a/src/test/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
@@ -2474,4 +2474,22 @@ assert c.b() == 2
         '''
     }
 
+    //GROOVY-8282
+    void testBareNamedArgumentPrivateMethodCall() {
+        assertScript '''
+            trait BugReproduction {
+                def foo() {
+                    bar(a: 1)
+                }
+                private String bar(Map args) {
+                    args.collect{ k, v -> "$k$v" }.join()
+                }
+            }
+
+            class Main implements BugReproduction {}
+
+            assert new Main().foo() == 'a1'
+        '''
+    }
+
 }


### PR DESCRIPTION
…in class ...$Trait$Helper

Bare named argument parameters are captured in a TupleExpression rather than an ArgumentListExpression.
While it would be nice to retrofit APP to have the correct type, that would impact many more places.