### PR TITLE
GROOVY-8732: @CompileStatic refers to private field in parent class

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -89,6 +89,7 @@ import org.codehaus.groovy.ast.stmt.WhileStatement;
 import org.codehaus.groovy.ast.tools.GenericsUtils;
 import org.codehaus.groovy.ast.tools.WideningCategories;
 import org.codehaus.groovy.classgen.ReturnAdder;
+import org.codehaus.groovy.classgen.Verifier;
 import org.codehaus.groovy.classgen.asm.InvocationWriter;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.ErrorCollector;
@@ -487,12 +488,36 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
      * Given a field node, checks if we are accessing or setting a private field from an inner class.
      */
     private void checkOrMarkPrivateAccess(Expression source, FieldNode fn, boolean lhsOfAssignment) {
+        ClassNode enclosingClassNode = typeCheckingContext.getEnclosingClassNode();
+        ClassNode declaringClass = fn.getDeclaringClass();
         if (fn != null && Modifier.isPrivate(fn.getModifiers()) &&
-                (fn.getDeclaringClass() != typeCheckingContext.getEnclosingClassNode() || typeCheckingContext.getEnclosingClosure() != null) &&
-                fn.getDeclaringClass().getModule() == typeCheckingContext.getEnclosingClassNode().getModule()) {
+                (declaringClass != enclosingClassNode || typeCheckingContext.getEnclosingClosure() != null) &&
+                declaringClass.getModule() == enclosingClassNode.getModule()) {
+            if (!lhsOfAssignment && enclosingClassNode.isDerivedFrom(declaringClass)) {
+                // check for a public/protected getter since JavaBean getters haven't been recognised as properties
+                // at this point and we don't want private field access for that case which will be handled later
+                boolean isPrimBool = fn.getOriginType().equals(ClassHelper.boolean_TYPE);
+                String suffix = Verifier.capitalize(fn.getName());
+                MethodNode getterNode = findValidGetter(enclosingClassNode, "get" + suffix);
+                if (getterNode == null && isPrimBool) {
+                    getterNode = findValidGetter(enclosingClassNode, "is" + suffix);
+                }
+                if (getterNode != null) {
+                    source.setNodeMetaData(StaticTypesMarker.INFERRED_TYPE, getterNode.getReturnType());
+                    return;
+                }
+            }
             StaticTypesMarker marker = lhsOfAssignment ? StaticTypesMarker.PV_FIELDS_MUTATION : StaticTypesMarker.PV_FIELDS_ACCESS;
-            addPrivateFieldOrMethodAccess(source, fn.getDeclaringClass(), marker, fn);
+            addPrivateFieldOrMethodAccess(source, declaringClass, marker, fn);
         }
+    }
+
+    private MethodNode findValidGetter(ClassNode classNode, String name) {
+        MethodNode getterMethod = classNode.getGetterMethod(name);
+        if (getterMethod != null && (getterMethod.isPublic() || getterMethod.isProtected())) {
+            return getterMethod;
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Currently JavaBean style getters aren't recognised
before some preliminary provisions are made for the
case of accessing the private field in places where that
is allowed. The change is just not to proceed with those
provisions if the JavaBean getter is detected.