### PR TITLE
support JAVA_HOME including spaces

### DIFF
--- a/src/bin/startGroovy.bat
+++ b/src/bin/startGroovy.bat
@@ -266,7 +266,7 @@ if not "%TOOLS_JAR%" == "" set GROOVY_OPTS=%GROOVY_OPTS% -Dtools.jar="%TOOLS_JAR
 set GROOVY_OPTS=%GROOVY_OPTS% -Dgroovy.starter.conf="%STARTER_CONF%"
 set GROOVY_OPTS=%GROOVY_OPTS% -Dscript.name="%GROOVY_SCRIPT_NAME%"
 
-for /f "tokens=3" %%g in ('%JAVA_EXE% -version 2^>^&1 ^| findstr /i "version"') do (
+for /f "tokens=3" %%g in ('call "%JAVA_EXE%" -version 2^>^&1 ^| findstr /i "version"') do (
   SET JAVA_VERSION=%%g
 )
 for /f "useback tokens=*" %%a in ('%JAVA_VERSION%') do set JAVA_VERSION=%%~a


### PR DESCRIPTION
Since Groovy 2.5.2, JAXB modules are added automatically based on detected Java version.
But in my environment, NoClassDefFoundError for JAXB is still thrown.

```console
$ where java
C:\Program Files\Java\jdk-10.0.2\bin\java.exe

$ groovy --version
Groovy Version: 2.5.2 JVM: 10.0.2 Vendor: "Oracle Corporation" OS: Windows 10

$ type hello.groovy
println "hello, Groovy 2.5.2"

$ groovy hello.groovy
Caught: java.lang.NoClassDefFoundError: Unable to load class org.apache.groovy.jaxb.extensions.JaxbExtensions due to missing dependency javax/xml/bind/JAXBContext
java.lang.NoClassDefFoundError: Unable to load class org.apache.groovy.jaxb.extensions.JaxbExtensions due to missing dependency javax/xml/bind/JAXBContext
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

Java version detection in startGroovy.bat seems not to be able to handle JAVA_HOME containing spaces.

ref: version detection in startGroovy.bat
https://github.com/apache/groovy/blob/223366702a13ef369f216af2ba443670f42f02a1/src/bin/startGroovy.bat#L269-L272

Removing redirection from first line like `for /f "tokens=3" %%g in ('%JAVA_EXE% -version ^| findstr /i "version"') do (`, following error is shown.

```console
$ .\groovy.bat hello.groovy
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

---
Before this PR, `JAVA_VERSION` is empty.
```console
# enable DEBUG to show echos
$ set DEBUG=1

$ groovy -v

...
> for /F "tokens=3" %g in ('C:\Program Files\Java\jdk-10.0.2\bin\java.exe -version 2>&1 | findstr /i "version"') do (SET JAVA_VERSION=%g )

> for /F "useback tokens=*" %a in ('') do set JAVA_VERSION=%~a
...
```

After, `JAVA_VERSION` set correctly.
```console
$ groovy -v

...
> for /F "tokens=3" %g in ('call "C:\Program Files\Java\jdk-10.0.2\bin\java.exe" -version 2>&1 | findstr /i "version"') do (SET JAVA_VERSION=%g )

> (SET JAVA_VERSION="10.0.2" )

> for /F "useback tokens=*" %a in ('"10.0.2"') do set JAVA_VERSION=%~a
...
```