### PR TITLE
Documentation updated: added static methodMissing and propertyMissing variants description

### DIFF
--- a/src/spec/doc/core-metaprogramming.adoc
+++ b/src/spec/doc/core-metaprogramming.adoc
@@ -187,9 +187,25 @@ include::{projectdir}/src/spec/test/metaprogramming/MethodPropertyMissingTest.gr
 As with `methodMissing` it is best practice to dynamically register new properties at runtime to improve the overall lookup
 performance.
 
-[NOTE]
-`methodMissing` and `propertyMissing` methods that deal with static methods and properties can be added via
-the <<core-metaprogramming.adoc#metaprogramming_emc,ExpandoMetaClass>>.
+=== static methodMissing
+
+Static variant of `methodMissing` method can be added via the <<core-metaprogramming.adoc#metaprogramming_emc,ExpandoMetaClass>>
+or can be implemented at the class level with `$static_methodMissing` method.
+
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/metaprogramming/StaticPropertyMissingAndMethodMissingTest.groovy[tags=static_method_missing,indent=0]
+----
+
+=== static propertyMissing
+
+Static variant of `propertyMissing` method can be added via the <<core-metaprogramming.adoc#metaprogramming_emc,ExpandoMetaClass>>
+or can be implemented at the class level with `$static_propertyMissing` method.
+
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/metaprogramming/StaticPropertyMissingAndMethodMissingTest.groovy[tags=static_property_missing,indent=0]
+----
 
 === GroovyInterceptable
 The gapi:groovy.lang.GroovyInterceptable[] interface is marker interface that extends `GroovyObject` and is used to notify the Groovy runtime that all methods should be intercepted through the method dispatcher mechanism of the Groovy runtime.

--- a/src/spec/test/metaprogramming/StaticPropertyMissingAndMethodMissingTest.groovy
+++ b/src/spec/test/metaprogramming/StaticPropertyMissingAndMethodMissingTest.groovy
@@ -1,0 +1,33 @@
+package metaprogramming
+
+class StaticPropertyMissingAndMethodMissingTest extends GroovyTestCase {
+
+    void testStaticMethodMissing() {
+        assertScript '''
+            // tag::static_method_missing[]
+            class Foo {
+                static def $static_methodMissing(String name, Object args) {
+                    return "Missing static method name is $name"
+                }
+            }
+            
+            assert Foo.bar() == 'Missing static method name is bar'
+            // end::static_method_missing[]
+'''
+    }
+
+    void testStaticPropertyMissing() {
+
+        assertScript '''
+            // tag::static_property_missing[]
+            class Foo {
+                static def $static_propertyMissing(String name) {
+                    return "Missing static property name is $name"
+                }
+            }
+            
+            assert Foo.foobar == 'Missing static property name is foobar'
+            // end::static_property_missing[]
+'''
+    }
+}


### PR DESCRIPTION
This pull requests adds missing documentation for `$static_methodMissing` and `$static_propertyMissing` methods.