### PR TITLE
GROOVY-8549: Compile Static causes getAt to fail

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -7818,6 +7818,13 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Support subscript operator for list access.
+     */
+    public static <T> T getAt(List<T> self, Number idx) {
+        return getAt(self, idx.intValue());
+    }
+
+    /**
      * Support the subscript operator for an Iterator. The iterator
      * will be partially exhausted up until the idx entry after returning
      * if a +ve or 0 idx is used, or fully exhausted if a -ve idx is used
@@ -7912,6 +7919,13 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
             }
             self.add(idx, value);
         }
+    }
+
+    /**
+     * Support subscript operator for list modification.
+     */
+    public static <T> void putAt(List<T> self, Number idx, T value) {
+        putAt(self, idx.intValue(), value);
     }
 
     /**

--- a/src/test/groovy/bugs/Groovy8549Bug.groovy
+++ b/src/test/groovy/bugs/Groovy8549Bug.groovy
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import gls.CompilableTestSupport
+
+class Groovy8549Bug extends CompilableTestSupport {
+    void testNumberWithVarSlotLoader() {
+        assertScript """
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            def method() {
+                def list = [0, 1, 2, 3]
+                for (idx in 1..2) {
+                    list[idx-1]++
+                }
+                list
+            }
+
+            assert method() == [1, 2, 2, 3]
+        """
+    }
+}


### PR DESCRIPTION
I started fixing this in STCSW first with something like below but then putAt also needs fixing.
In the meantime, the added DGM methods provide sufficient info for the static compiler to behave correctly.

```
Index: src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java	(revision ba5eb9b2f19ca0cc8927359ce414c4e1974b7016)
+++ src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java	(date 1537092045389)
@@ -663,6 +663,10 @@
         ClassNode classNode = controller.getClassNode();
         ClassNode rType = typeChooser.resolveType(receiver, classNode);
         ClassNode aType = typeChooser.resolveType(arguments, classNode);
+        if ("getAt".equals(message) && (rType.implementsInterface(LIST_TYPE) || LIST_TYPE.equals(rType)) &&
+                isOrExtends(aType, Number_TYPE))) {
+            aType = int_TYPE;
+        }
         if (trySubscript(receiver, message, arguments, rType, aType, safe)) {
             return;
         }

```