### PR TITLE
fixed for NullPointerException in MissingMethodException

### DIFF
--- a/src/main/groovy/groovy/lang/MissingMethodException.java
+++ b/src/main/groovy/groovy/lang/MissingMethodException.java
@@ -54,16 +54,22 @@ public class MissingMethodException extends GroovyRuntimeException {
     }
 
     public String getMessage() {
-        return "No signature of method: "
-                + (isStatic ? "static " : "")
-                + type.getName()
-                + "."
-                + method
+         String s = "No signature of method: ";
+         if(isStatic) {
+             s += "static ";
+         }
+         if( type != null  ) {
+             s +=  type.getName() + ".";
+         }
+         s += method
                 + "() is applicable for argument types: ("
                 + InvokerHelper.toTypeString(arguments, 60)
                 + ") values: "
-                + InvokerHelper.toArrayString(arguments, 60, true)
-                + MethodRankHelper.getMethodSuggestionString(method, type, arguments);
+                + InvokerHelper.toArrayString(arguments, 60, true);
+         if( type != null  ) {
+             s += MethodRankHelper.getMethodSuggestionString(method, type, arguments) ;
+         }
+         return s;
     }
 
     /**


### PR DESCRIPTION
fixed for NullPointerException in MissingMethodException (when type is null)

```
Caused by: java.lang.NullPointerException
    at groovy.lang.MissingMethodException.getMessage (MissingMethodException.java:60)
    at java.lang.Throwable.getLocalizedMessage (Throwable.java:391)
    at java.lang.Throwable.toString (Throwable.java:480)
    at java.lang.String.valueOf (String.java:2994)
    at org.fusesource.jansi.FilterPrintStream.println (FilterPrintStream.java:238)
    at java.lang.Throwable$WrappedPrintStream.println (Throwable.java:748)
    at java.lang.Throwable.printStackTrace (Throwable.java:655)
    at java.lang.Throwable.printStackTrace (Throwable.java:643)
    at java_lang_Throwable$printStackTrace.call (Unknown Source)
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall (CallSiteArray.java:47)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call (AbstractCallSite.java:116)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call (AbstractCallSite.java:128)
```