### PR TITLE
GROOVY-8855: Matcher.asBoolean() does not rely on matchers internal search index anymore

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/StringGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/StringGroovyMethods.java
@@ -104,7 +104,7 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
         }
 
         RegexSupport.setLastMatcher(matcher);
-        return matcher.find();
+        return matcher.find(0);
     }
 
     /**

--- a/src/test/groovy/RegularExpressionsTest.groovy
+++ b/src/test/groovy/RegularExpressionsTest.groovy
@@ -52,12 +52,12 @@ class RegularExpressionsTest extends GroovyTestCase {
 
         assert m instanceof Matcher
 
-        while (m) { i = i + 1 }
+        while (m.find()) { i = i + 1 }
         assert i == 2
 
         i = 0
         m = "cheesecheese" =~ "e+"
-        while (m) { i = i + 1 }
+        while (m.find()) { i = i + 1 }
         assert i == 4
 
         m.reset()

--- a/src/test/org/codehaus/groovy/runtime/StringGroovyMethodsTest.java
+++ b/src/test/org/codehaus/groovy/runtime/StringGroovyMethodsTest.java
@@ -22,11 +22,14 @@ import groovy.util.GroovyTestCase;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author James Strachan
  * @author Marc Guillemot
  * @author Brad Long
+ * @author Szymon Stepniak
  */
 public class StringGroovyMethodsTest extends GroovyTestCase {
 
@@ -60,6 +63,20 @@ public class StringGroovyMethodsTest extends GroovyTestCase {
         assertEquals(StringGroovyMethods.toBoolean("false"), Boolean.FALSE);
         assertEquals(StringGroovyMethods.toBoolean("n"), Boolean.FALSE);
         assertEquals(StringGroovyMethods.toBoolean("0"), Boolean.FALSE);
+    }
+
+    public void testMatcherAsBooleanMethod() {
+        Pattern pattern = Pattern.compile("[a-z]+");
+        String correctInput = "abcde";
+        String incorrectInput = "123";
+
+        Matcher correctMatcher = pattern.matcher(correctInput);
+        Matcher incorrectMatcher = pattern.matcher(incorrectInput);
+
+        assertEquals(StringGroovyMethods.asBoolean(correctMatcher), true);
+        assertEquals(StringGroovyMethods.asBoolean(correctMatcher), true);
+        assertEquals(StringGroovyMethods.asBoolean(incorrectMatcher), false);
+        assertEquals(StringGroovyMethods.asBoolean(incorrectMatcher), false);
     }
 
     public void testIsMethods() throws Exception {


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/GROOVY-8855