### PR TITLE
GROOVY-8872: Populate parameter names from byte code when available

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
@@ -158,6 +158,12 @@ public abstract class AsmDecompiler {
                             }
                         };
                     }
+
+                    @Override
+                    public void visitParameter(String name, int access) {
+                        if (stub.parameterNames == null) stub.parameterNames = new ArrayList<String>();
+                        stub.parameterNames.add(name);
+                    }
                 };
             }
             return null;

--- a/src/main/java/org/codehaus/groovy/ast/decompiled/ClassStub.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/ClassStub.java
@@ -65,6 +65,7 @@ class MethodStub extends MemberStub {
     final String signature;
     final String[] exceptions;
     Map<Integer, List<AnnotationStub>> parameterAnnotations;
+    List<String> parameterNames;
     Object annotationDefault;
 
     public MethodStub(String methodName, int accessModifiers, String desc, String signature, String[] exceptions) {

--- a/src/main/java/org/codehaus/groovy/ast/decompiled/MemberSignatureParser.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/MemberSignatureParser.java
@@ -97,8 +97,16 @@ class MemberSignatureParser {
         }
 
         Parameter[] parameters = new Parameter[parameterTypes.length];
+        List<String> parameterNames = method.parameterNames;
         for (int i = 0; i < parameterTypes.length; i++) {
-            parameters[i] = new Parameter(parameterTypes[i], "param" + i);
+            String parameterName = "param" + i;
+            if (parameterNames != null && i < parameterNames.size()) {
+                String decompiledName = parameterNames.get(i);
+                if (decompiledName != null) {
+                    parameterName = decompiledName;
+                }
+            }
+            parameters[i] = new Parameter(parameterTypes[i], parameterName);
         }
 
         if (method.parameterAnnotations != null) {


### PR DESCRIPTION
I'm not sure how to create a test for this. I verified the change works locally in the example project I linked and uploaded in the jira issue.

I think adding or modifying a test in AsmDecompilerTest would be the best thing, but I'm not sure how to inform Groovy to compile the Java source with parameters.