### PR TITLE
Avoid `gradlew assemble` before running tests on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ language: groovy
 # https://docs.travis-ci.com/user/reference/overview/
 sudo: required
 dist: trusty
+install: true
 
 matrix:
   include:
@@ -45,3 +46,4 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+


### PR DESCRIPTION
Avoid `gradlew assemble` in test builds can save us a lot of time.