### PR TITLE
MissingPropertyExceptionTest.testNullMessage

### DIFF
--- a/src/main/groovy/groovy/lang/GroovyRuntimeException.java
+++ b/src/main/groovy/groovy/lang/GroovyRuntimeException.java
@@ -60,7 +60,12 @@ public class GroovyRuntimeException extends RuntimeException {
     }
 
     public String getMessage() {
-        return getMessageWithoutLocationText() + getLocationText();
+        String messageWithoutLocationText = getMessageWithoutLocationText();
+        String locationText = getLocationText();
+        if (messageWithoutLocationText == null && locationText.isEmpty()) {
+            return null; // not "null"
+        }
+        return messageWithoutLocationText + locationText;
     }
 
     public ASTNode getNode() {

--- a/src/main/groovy/groovy/lang/MissingPropertyException.java
+++ b/src/main/groovy/groovy/lang/MissingPropertyException.java
@@ -58,6 +58,9 @@ public class MissingPropertyException extends GroovyRuntimeException {
     }
 
     public String getMessageWithoutLocationText() {
+        if (property == null || type == null) {
+            return super.getMessageWithoutLocationText();
+        }
         final Throwable cause = getCause();
         if (cause == null) {
             if (super.getMessageWithoutLocationText() != null) {

--- a/src/test/groovy/lang/MissingPropertyExceptionTest.java
+++ b/src/test/groovy/lang/MissingPropertyExceptionTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.lang;
+
+import junit.framework.TestCase;
+
+/**
+ * Provides unit tests for the <code>MissingPropertyException</code> class.
+ */
+public class MissingPropertyExceptionTest extends TestCase {
+
+    public void testNullMessage() {
+        Throwable mpe = new MissingPropertyException(null);
+        assertNull(mpe.getMessage());
+        assertEquals("groovy.lang.MissingPropertyException", mpe.toString());
+    }
+
+}


### PR DESCRIPTION
Otherwise you get errors like

```
groovy.lang.MissingPropertyExceptionTest > testNullMessage FAILED
    java.lang.NullPointerException
        at groovy.lang.MissingPropertyException.getMessageWithoutLocationText(MissingPropertyException.java:66)
        at groovy.lang.GroovyRuntimeException.getMessage(GroovyRuntimeException.java:63)
        at java.lang.Throwable.getLocalizedMessage(Throwable.java:391)
        at java.lang.Throwable.toString(Throwable.java:480)
        at junit.framework.Assert.assertNull(Assert.java:268)
        at junit.framework.TestCase.assertNull(TestCase.java:438)
        at groovy.lang.MissingPropertyExceptionTest.testNullMessage(MissingPropertyExceptionTest.java:29)
```

it is unclear what null values for `property` and `type` would mean, but there is a constructor explicitly allowing that, and it is illegal for `getMessage`, `toString`, etc. to throw an undeclared NPE.

(A `MissingPropertyException` producing this error was originally observed as a build failure in a Jenkins project, though I do not have the details to know the root cause there.)