### PR TITLE
GROOVY-8954: VerifyError due to incorrect bytecode produced when a tr…

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/InvocationWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/InvocationWriter.java
@@ -151,10 +151,10 @@ public class InvocationWriter {
         int opcode = INVOKEVIRTUAL;
         if (target.isStatic()) {
             opcode = INVOKESTATIC;
-        } else if (target.isPrivate() || ((receiver instanceof VariableExpression && ((VariableExpression) receiver).isSuperExpression()))) {
-            opcode = INVOKESPECIAL;
         } else if (declaringClass.isInterface()) {
             opcode = INVOKEINTERFACE;
+        } else if (target.isPrivate() || ((receiver instanceof VariableExpression && ((VariableExpression) receiver).isSuperExpression()))) {
+            opcode = INVOKESPECIAL;
         }
 
         // handle receiver

--- a/src/test/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
@@ -2668,4 +2668,24 @@ assert c.b() == 2
             assert Counter.count == 11
         '''
     }
+
+    //GROOVY-8954
+    void testTraitWithPropertyAlsoFromInterfaceSC() {
+        assertScript '''
+            interface DomainProp {
+                boolean isNullable()
+            }
+
+            abstract class OrderedProp implements DomainProp { }
+
+            trait Nullable {
+                boolean nullable = true
+            }
+
+            @groovy.transform.CompileStatic
+            abstract class CustomProp extends OrderedProp implements Nullable { }
+
+            assert new CustomProp() {}
+        '''
+    }
 }


### PR DESCRIPTION
…ait super property call also comes from an interface