### PR TITLE
Documentation: add mandatory tag for the groovy-all artifact

### DIFF
--- a/src/spec/doc/core-getting-started.adoc
+++ b/src/spec/doc/core-getting-started.adoc
@@ -80,7 +80,7 @@ If you wish to embed Groovy in your application, you may just prefer to point to
 |<groupId>org.codehaus.groovy</groupId>
 <artifactId>groovy-all</artifactId>
 <version>{groovy-full-version}</version>
-<type>pom</type> <!-- required JUST since Groovy 2.5.0 -->
+<type>pom</type> <!-- required JUST since Groovy 2.5.0 +-->+
 |The core plus all the modules. Optional dependencies are marked as optional. You may need to include some of the optional dependencies to use some features of Groovy, e.g. AntBuilder, GroovyMBeans, etc.
 |===
 

--- a/src/spec/doc/core-getting-started.adoc
+++ b/src/spec/doc/core-getting-started.adoc
@@ -65,21 +65,21 @@ If you wish to embed Groovy in your application, you may just prefer to point to
 |Explanation
 
 |&#39;org.codehaus.groovy:groovy:{groovy-full-version}'
-|<groupId>org.codehaus.groovy</groupId>
-<artifactId>groovy</artifactId> 
+|<groupId>org.codehaus.groovy</groupId> +
+<artifactId>groovy</artifactId> +
 <version>{groovy-full-version}</version>
 |Just the core of groovy without the modules (see below).
 
 |&#39;org.codehaus.groovy:groovy-$module:{groovy-full-version}'
-|<groupId>org.codehaus.groovy</groupId>
-<artifactId>groovy-$module</artifactId>
+|<groupId>org.codehaus.groovy</groupId> +
+<artifactId>groovy-$module</artifactId> +
 <version>{groovy-full-version}</version>
 |"$module" stands for the different optional groovy modules "ant", "bsf", "console", "docgenerator", "groovydoc", "groovysh", "jmx", "json", "jsr223", "servlet", "sql", "swing", "test", "testng" and "xml". Example: <artifactId>groovy-sql</artifactId>
 
 |&#39;org.codehaus.groovy:groovy-all:{groovy-full-version}'
-|<groupId>org.codehaus.groovy</groupId>
-<artifactId>groovy-all</artifactId>
-<version>{groovy-full-version}</version>
+|<groupId>org.codehaus.groovy</groupId> +
+<artifactId>groovy-all</artifactId> +
+<version>{groovy-full-version}</version> +
 <type>pom</type> <!-- required JUST since Groovy 2.5.0 +-->+
 |The core plus all the modules. Optional dependencies are marked as optional. You may need to include some of the optional dependencies to use some features of Groovy, e.g. AntBuilder, GroovyMBeans, etc.
 |===

--- a/src/spec/doc/core-getting-started.adoc
+++ b/src/spec/doc/core-getting-started.adoc
@@ -80,6 +80,7 @@ If you wish to embed Groovy in your application, you may just prefer to point to
 |<groupId>org.codehaus.groovy</groupId>
 <artifactId>groovy-all</artifactId>
 <version>{groovy-full-version}</version>
+<type>pom</type> <!-- required JUST since Groovy 2.5.0 -->
 |The core plus all the modules. Optional dependencies are marked as optional. You may need to include some of the optional dependencies to use some features of Groovy, e.g. AntBuilder, GroovyMBeans, etc.
 |===
 


### PR DESCRIPTION
without `<type>pom</type>` tag maven breaks build with 

> Failure to find org.codehaus.groovy:groovy-all:jar:2.5.5 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced

 message.

The tag is already added to the http://groovy-lang.org/download.html but was forgotten here.