### PR TITLE
GROOVY-8913: Parrot Parser: partially-parenthesized binary expression…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
             maven { url 'http://maven.aliyun.com/nexus/content/groups/public' }
         }
         jcenter()
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven{
             name 'Bintray Javadoc Hotfix repo'
             url 'http://dl.bintray.com/melix/gradle-javadoc-hotfix-plugin'
@@ -95,6 +96,7 @@ allprojects {
             maven { url 'http://maven.aliyun.com/nexus/content/groups/public' }
         }
         jcenter()
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven { url 'http://dl.bintray.com/melix/thirdparty-apache' } // openbeans
     }
 
@@ -162,7 +164,7 @@ ext {
     xmlunitVersion = '1.6'
     xstreamVersion = '1.4.11.1'
     spockVersion = '1.2-groovy-2.4-SNAPSHOT' // supports 3.0
-    antlr4Version = '4.7.2'
+    antlr4Version = '4.7.3-SNAPSHOT'
     spotbugsannotationsVersion = '3.1.9'
 }
 

--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -779,7 +779,7 @@ postfixExpression
 expression
     // qualified names, array expressions, method invocation, post inc/dec, type casting (level 1)
     // The cast expression must be put before pathExpression to resovle the ambiguities between type casting and call on parentheses expression, e.g. (int)(1 / 2)
-    :   castParExpression expression                                                        #castExprAlt
+    :   castParExpression castOperandExpression                                             #castExprAlt
     |   postfixExpression                                                                   #postfixExprAlt
 
     // ~(BNOT)/!(LNOT) (level 1)
@@ -871,6 +871,17 @@ expression
                            ) nls
                      enhancedStatementExpression                                            #assignmentExprAlt
     ;
+
+castOperandExpression
+options { baseContext = expression; }
+    :   castParExpression castOperandExpression                                             #castExprAlt
+    |   postfixExpression                                                                   #postfixExprAlt
+    // ~(BNOT)/!(LNOT) (level 1)
+    |   (BITNOT | NOT) nls castOperandExpression                                            #unaryNotExprAlt
+    // ++(prefix)/--(prefix)/+(unary)/-(unary) (level 3)
+    |   op=(INC | DEC | ADD | SUB) castOperandExpression                                    #unaryAddExprAlt
+    ;
+
 
 /*
 enhancedExpression

--- a/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
+++ b/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
@@ -438,5 +438,6 @@ class GroovyParserTest extends GroovyTestCase {
         doTest('bugs/BUG-GROOVY-8511.groovy')
         doRunAndTestAntlr4('bugs/BUG-GROOVY-8613.groovy')
         doTest('bugs/BUG-GROOVY-8641.groovy')
+        doTest('bugs/BUG-GROOVY-8913.groovy')
     }
 }

--- a/subprojects/parser-antlr4/src/test/resources/bugs/BUG-GROOVY-8913.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/bugs/BUG-GROOVY-8913.groovy
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+def x = (a.b) + c()
+
+def x = 1
+def y = 2
+(boolean) !(-x + (+y--))
+
+assertEquals((short)-1, IH.unaryMinus((short)1));
+
+(Number) (Long) m()


### PR DESCRIPTION
… parsed as cast and unary plus (apply changes suggested by @sharwell)