### PR TITLE
Make Interpreter changeable in Groovysh

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -98,13 +98,19 @@ class Groovysh extends Shell {
     }
 
     Groovysh(final ClassLoader classLoader, final Binding binding, final IO io, final Closure registrar, CompilerConfiguration configuration) {
+       this(classLoader, binding, io, registrar, configuration,  new Interpreter(classLoader, binding, configuration))
+    }
+    
+    Groovysh(final ClassLoader classLoader, final Binding binding, final IO io, final Closure registrar, CompilerConfiguration configuration, Interpreter interpreter) {
         super(io)
         assert classLoader
         assert binding
-        assert registrar
+        def actualRegistrar = registrar ?: createDefaultRegistrar(classLoader)
         parser = new Parser()
-        interp = new Interpreter(classLoader, binding, configuration)
-        registrar.call(this)
+        interp = interpreter
+        if (actualRegistrar != null) {
+          actualRegistrar.call(this)
+        }
         this.packageHelper = new PackageHelperImpl(classLoader)
     }
 
@@ -122,7 +128,7 @@ class Groovysh extends Shell {
     }
 
     Groovysh(final ClassLoader classLoader, final Binding binding, final IO io) {
-        this(classLoader, binding, io, createDefaultRegistrar(classLoader))
+        this(classLoader, binding, io, null)
     }
 
     Groovysh(final Binding binding, final IO io) {
@@ -134,8 +140,7 @@ class Groovysh extends Shell {
     }
 
     Groovysh(final IO io, CompilerConfiguration configuration) {
-        this(Thread.currentThread().contextClassLoader, new Binding(), io,
-                createDefaultRegistrar(Thread.currentThread().contextClassLoader), configuration)
+        this(Thread.currentThread().contextClassLoader, new Binding(), io, null, configuration)
     }
 
     Groovysh() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Interpreter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Interpreter.groovy
@@ -58,6 +58,10 @@ class Interpreter implements Evaluator
         return shell.classLoader
     }
 
+    GroovyShell getGroovyShell() {
+        return shell
+    }
+
     @Override
     def evaluate(final Collection<String> buffer) {
         assert buffer

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/CompletorTestSupport.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/CompletorTestSupport.groovy
@@ -54,12 +54,12 @@ abstract class CompletorTestSupport extends GroovyTestCase {
         idCompletorMocker = new MockFor(IdentifierCompletor)
 
         groovyshMocker = new MockFor(Groovysh)
+        groovyshMocker.demand.getClass(0..1) { Groovysh }
         groovyshMocker.demand.createDefaultRegistrar { { shell -> null } }
         groovyshMocker.demand.getIo(0..2) { testio }
         packageHelperMocker = new MockFor(PackageHelperImpl)
         def registry = new CommandRegistry()
         groovyshMocker.demand.getRegistry(0..1) { registry }
-        groovyshMocker.demand.getClass(0..1) { Groovysh }
         packageHelperMocker.demand.getContents(6) { ['java', 'test'] }
         groovyshMocker.demand.getIo(0..2) { testio }
         for (i in 1..19) {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ShellRunnerTestSupport.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ShellRunnerTestSupport.groovy
@@ -44,9 +44,9 @@ abstract class ShellRunnerTestSupport extends GroovyTestCase {
         // setup mock and stub with calls expected from InteractiveShellRunner Constructor
 
         shellMocker = new MockFor(Groovysh)
-        shellMocker.demand.createDefaultRegistrar(1) { {Shell shell -> null} }
         // when run with compileStatic
         shellMocker.demand.getClass(0..1) {Groovysh}
+        shellMocker.demand.createDefaultRegistrar(1) { {Shell shell -> null} }
         shellMocker.demand.getIo(2) { testio }
         shellMocker.demand.getRegistry(1) {new Object() {def commands() {[]} }}
         shellMocker.demand.getHistory(1) {new Serializable(){def size() {0}; def getMaxSize() {1}}}


### PR DESCRIPTION
Add Groovysh constructor that enables to inject own implementation of Interpreter. That might be useful in some extensions of the Groovysh (e.g. for better control of classnames of generated closure classes).