### PR TITLE
Fix assertion error for sample code

### DIFF
--- a/src/spec/test/ClosuresSpecTest.groovy
+++ b/src/spec/test/ClosuresSpecTest.groovy
@@ -311,7 +311,7 @@ class ClosuresSpecTest extends GroovyTestCase {
                     String name
                 }
                 def p = new Person(name:'Igor')
-                def cl = { name.toUpperCase() }                 // <1>
+                def cl = { delegate.name.toUpperCase() }        // <1>
                 cl.delegate = p                                 // <2>
                 assert cl() == 'IGOR'                           // <3>
                 // end::delegation_strategy_intro[]


### PR DESCRIPTION
The original sample code in [3.2.4. Delegation strategy](http://www.groovy-lang.org/closures.html#_delegation_strategy_2) assert failed:
```groovy
class Person {
    String name
}
def p = new Person(name:'Igor')
def cl = { name.toUpperCase() }                 
cl.delegate = p                                 
assert cl() == 'IGOR'   
```

My sample code:
```groovy
class Person {
    String name
}

class GroovyClosure {
    static void main(args) {
        def p = new Person(name: 'Igor')
        def cl = { name.toUpperCase() }          // 1
        cl.delegate = p
        assert cl() == 'IGOR'
    }
}
```

And the running result is like this:
```
Exception in thread "main" Assertion failed: 

assert cl() == 'IGOR'
       |    |
       |    false
       GROOVYCLOSURE

	at org.codehaus.groovy.runtime.InvokerHelper.assertFailed(InvokerHelper.java:404)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.assertFailed(ScriptBytecodeAdapter.java:650)
	at GroovyClosure.main(GroovyClosure.groovy:10)
```

The assertion will not fail if adding a `delegate` property in closure `cl`:
```groovy
def cl = { delegate.name.toUpperCase() }
```
