### PR TITLE
GROOVY-7954 Fix equality check in special case

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
+++ b/src/main/java/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
@@ -600,7 +600,7 @@ public class DefaultTypeTransformation {
         }
 
         if (equalityCheckOnly) {
-            return -1; // anything other than 0
+            return left.equals(right) ? 0 : -1;
         }
         String message = MessageFormat.format("Cannot compare {0} with value ''{1}'' and {2} with value ''{3}''",
                 left.getClass().getName(), left, right.getClass().getName(), right);

--- a/src/test/groovy/runtime/typehandling/EqualityTest.groovy
+++ b/src/test/groovy/runtime/typehandling/EqualityTest.groovy
@@ -1,0 +1,12 @@
+package groovy.runtime.typehandling
+
+class EqualityTest extends GroovyTestCase {
+
+    void testEquality() {
+        def classA = new EqualityTestClassA(1, "Test")
+        def classB = new EqualityTestClassB(1, "Test")
+
+        assert classA == classB
+        assert classA.equals(classB)
+    }
+}

--- a/src/test/groovy/runtime/typehandling/EqualityTestAbstractClass.java
+++ b/src/test/groovy/runtime/typehandling/EqualityTestAbstractClass.java
@@ -1,0 +1,57 @@
+package groovy.runtime.typehandling;
+
+public class EqualityTestAbstractClass implements EqualityTestInterface {
+
+    private final int id;
+    private final String value;
+
+    public EqualityTestAbstractClass(int id, String value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public int compareTo(EqualityTestInterface other) {
+        if (other == null) {
+            return 1;
+        }
+        if (getValue() == null) {
+            if (other.getValue() == null) {
+                return 0;
+            }
+            return -1;
+        }
+        if (other.getValue() == null) {
+            return 1;
+        }
+        return getValue().compareTo(other.getValue());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other instanceof EqualityTestInterface) {
+            EqualityTestInterface castedOther = (EqualityTestInterface) other;
+            return getId() == castedOther.getId();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return getId();
+    }
+
+}

--- a/src/test/groovy/runtime/typehandling/EqualityTestClassA.java
+++ b/src/test/groovy/runtime/typehandling/EqualityTestClassA.java
@@ -1,0 +1,9 @@
+package groovy.runtime.typehandling;
+
+public class EqualityTestClassA extends EqualityTestAbstractClass {
+
+    public EqualityTestClassA(int id, String value) {
+        super(id, value);
+    }
+
+}

--- a/src/test/groovy/runtime/typehandling/EqualityTestClassB.java
+++ b/src/test/groovy/runtime/typehandling/EqualityTestClassB.java
@@ -1,0 +1,9 @@
+package groovy.runtime.typehandling;
+
+public class EqualityTestClassB extends EqualityTestAbstractClass {
+
+    public EqualityTestClassB(int id, String value) {
+        super(id, value);
+    }
+
+}

--- a/src/test/groovy/runtime/typehandling/EqualityTestInterface.java
+++ b/src/test/groovy/runtime/typehandling/EqualityTestInterface.java
@@ -1,0 +1,6 @@
+package groovy.runtime.typehandling;
+
+public interface EqualityTestInterface extends Comparable<EqualityTestInterface> {
+    int getId();
+    String getValue();
+}


### PR DESCRIPTION
Fix equality check with two instances A & B when:
- A and B implement the same interface but are not of the same class
- The common interface implements `Comparable`

`DefaultTypeTransformation.compareToWithEqualityCheck(...)` checks for
assignable classes and use `compareTo()` when assignable on the class
level, but it doesn't check it on the interface level.

As a result `compareTo()` is not called at the interface level and `-1`
is returned.  The fix performs an actual equality check instead of
returning -1.

I added a unit test, but I'm not completely sure of the right structure
for unit tests so let me know if I should do it differently.