### PR TITLE
Console, GroovyMain and Groovysh (via its Main) use context class loader

### DIFF
--- a/src/main/java/groovy/ui/GroovyMain.java
+++ b/src/main/java/groovy/ui/GroovyMain.java
@@ -479,7 +479,7 @@ public class GroovyMain {
      * Process the input files.
      */
     private void processFiles() throws CompilationFailedException, IOException, URISyntaxException {
-        GroovyShell groovy = new GroovyShell(conf);
+        GroovyShell groovy = new GroovyShell(Thread.currentThread().getContextClassLoader(), conf);
         setupContextClassLoader(groovy);
 
         Script s = groovy.parse(getScriptSource(isScriptFile, script));
@@ -587,7 +587,7 @@ public class GroovyMain {
      * Process the standard, single script with args.
      */
     private void processOnce() throws CompilationFailedException, IOException, URISyntaxException {
-        GroovyShell groovy = new GroovyShell(conf);
+        GroovyShell groovy = new GroovyShell(Thread.currentThread().getContextClassLoader(), conf);
         setupContextClassLoader(groovy);
         groovy.run(getScriptSource(isScriptFile, script), args);
     }

--- a/subprojects/groovy-console/src/main/groovy/groovy/console/ui/Console.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/console/ui/Console.groovy
@@ -20,12 +20,12 @@ package groovy.console.ui
 
 import groovy.cli.picocli.CliBuilder
 import groovy.cli.picocli.OptionAccessor
-import groovy.swing.SwingBuilder
-import groovy.transform.CompileStatic
-import groovy.transform.ThreadInterrupt
 import groovy.console.ui.text.FindReplaceUtility
 import groovy.console.ui.text.GroovyFilter
 import groovy.console.ui.text.SmartDocumentFilter
+import groovy.swing.SwingBuilder
+import groovy.transform.CompileStatic
+import groovy.transform.ThreadInterrupt
 import groovy.ui.GroovyMain
 import org.apache.groovy.io.StringBuilderWriter
 import org.apache.groovy.parser.antlr4.GroovyLangLexer
@@ -71,6 +71,7 @@ import javax.swing.text.SimpleAttributeSet
 import javax.swing.text.Style
 import javax.swing.text.StyleConstants
 import javax.swing.text.html.HTML
+
 import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Dimension
@@ -267,7 +268,7 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
         //when starting via main set the look and feel to system
         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
 
-        def baseConfig = new CompilerConfiguration()
+        def baseConfig = new CompilerConfiguration(System.getProperties())
         String starterConfigScripts = System.getProperty("groovy.starter.configscripts", null)
         if (options.configscript || (starterConfigScripts != null && !starterConfigScripts.isEmpty())) {
             List<String> configScripts = new ArrayList<String>()
@@ -286,7 +287,7 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
             enableIndy(baseConfig)
         }
 
-        def console = new Console(Console.class.classLoader?.getRootLoader(), new Binding(), baseConfig)
+        def console = new Console(Thread.currentThread().contextClassLoader, new Binding(), baseConfig)
         console.useScriptClassLoaderForScriptExecution = true
         console.run()
         def remaining = options.arguments()
@@ -335,23 +336,11 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
         }
     }
 
-    Console() {
-        this(new Binding())
-    }
-
-    Console(Binding binding) {
+    Console(Binding binding = new Binding()) {
         this(null, binding)
     }
 
-    Console(ClassLoader parent) {
-        this(parent, new Binding())
-    }
-
-    Console(ClassLoader parent, Binding binding) {
-        this(parent, binding, new CompilerConfiguration())
-    }
-
-    Console(ClassLoader parent, Binding binding, CompilerConfiguration baseConfig) {
+    Console(ClassLoader parent, Binding binding = new Binding(), CompilerConfiguration baseConfig = new CompilerConfiguration(System.getProperties())) {
         this.baseConfig = baseConfig
         this.maxOutputChars = loadMaxOutputChars()
         indy = indy || isIndyEnabled(baseConfig)

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
@@ -72,6 +72,7 @@ import javax.swing.text.SimpleAttributeSet
 import javax.swing.text.Style
 import javax.swing.text.StyleConstants
 import javax.swing.text.html.HTML
+
 import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Dimension
@@ -266,7 +267,7 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
         //when starting via main set the look and feel to system
         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
 
-        def baseConfig = new CompilerConfiguration()
+        def baseConfig = new CompilerConfiguration(System.getProperties())
         String starterConfigScripts = System.getProperty("groovy.starter.configscripts", null)
         if (options.configscript || (starterConfigScripts != null && !starterConfigScripts.isEmpty())) {
             List<String> configScripts = new ArrayList<String>()
@@ -285,7 +286,7 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
             enableIndy(baseConfig)
         }
 
-        def console = new Console(Console.class.classLoader?.getRootLoader(), new Binding(), baseConfig)
+        def console = new Console(Thread.currentThread().contextClassLoader, new Binding(), baseConfig)
         console.useScriptClassLoaderForScriptExecution = true
         console.run()
         def remaining = options.arguments()
@@ -334,23 +335,11 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
         }
     }
 
-    Console() {
-        this(new Binding())
-    }
-
-    Console(Binding binding) {
+    Console(Binding binding = new Binding()) {
         this(null, binding)
     }
 
-    Console(ClassLoader parent) {
-        this(parent, new Binding())
-    }
-
-    Console(ClassLoader parent, Binding binding) {
-        this(parent, binding, new CompilerConfiguration())
-    }
-
-    Console(ClassLoader parent, Binding binding, CompilerConfiguration baseConfig) {
+    Console(ClassLoader parent, Binding binding = new Binding(), CompilerConfiguration baseConfig = new CompilerConfiguration(System.getProperties())) {
         this.baseConfig = baseConfig
         this.maxOutputChars = loadMaxOutputChars()
         indy = indy || isIndyEnabled(baseConfig)

--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/Main.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/Main.groovy
@@ -24,11 +24,11 @@ import jline.TerminalFactory
 import jline.UnixTerminal
 import jline.UnsupportedTerminal
 import jline.WindowsTerminal
+import org.apache.groovy.groovysh.util.NoExitSecurityManager
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.tools.shell.IO
 import org.codehaus.groovy.tools.shell.util.Logger
 import org.codehaus.groovy.tools.shell.util.MessageSource
-import org.apache.groovy.groovysh.util.NoExitSecurityManager
 import org.fusesource.jansi.Ansi
 import org.fusesource.jansi.AnsiConsole
 
@@ -64,10 +64,6 @@ class Main {
     Main(IO io, CompilerConfiguration configuration) {
         Logger.io = io
         groovysh = new Groovysh(io, configuration)
-    }
-
-    Groovysh getGroovysh() {
-        return groovysh
     }
 
     /**
@@ -152,7 +148,7 @@ class Main {
         if (options.e) {
             evalString = options.getOptionValue('e')
         }
-        def configuration = new CompilerConfiguration()
+        def configuration = new CompilerConfiguration(System.getProperties())
         configuration.setParameters((boolean) options.hasOption("pa"))
 
         List<String> filenames = options.arguments()

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Main.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Main.groovy
@@ -66,10 +66,6 @@ class Main {
         groovysh = new Groovysh(io, configuration)
     }
 
-    Groovysh getGroovysh() {
-        return groovysh
-    }
-
     /**
      * create a Main instance, configures it according to CLI arguments, and starts the shell.
      * @param main must have a Groovysh member that has an IO member.
@@ -152,7 +148,7 @@ class Main {
         if (options.e) {
             evalString = options.getOptionValue('e')
         }
-        def configuration = new CompilerConfiguration()
+        def configuration = new CompilerConfiguration(System.getProperties())
         configuration.setParameters((boolean) options.hasOption("pa"))
 
         List<String> filenames = options.arguments()


### PR DESCRIPTION
- All: pass system properties to new CompilerConfiguration instances
- Console: use default parameters to reduce constructor variants

As discussed with @paulk-asert; support for starting Colsole, et al. using GroovyStarter.  This would allow separate classpath similar to how compiler has transform classpath (for tooling) and standard classpath (for user code).

See also https://github.com/groovy/groovy-eclipse/issues/890


**NOTE**: I don't have any unit tests created yet.  Essentially I would load Console using GroovyStarter, as I have tested separately.