### PR TITLE
eclipse: mark antlr source folders as optional

### DIFF
--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -126,4 +126,9 @@ allprojects {
 
 eclipse.classpath.file.whenMerged {
     entries.removeAll { entry -> entry.path == '/groovy-groovydoc' }
+
+    entries.findAll { entry -> entry.path =~ '^target/generated/sources/antlr' }.each { entry ->
+        entry.entryAttributes['ignore_optional_problems'] = 'true'
+        entry.entryAttributes['optional'] = 'true'
+    }
 }

--- a/src/main/groovy/org/codehaus/groovy/tools/GrapeMain.groovy
+++ b/src/main/groovy/org/codehaus/groovy/tools/GrapeMain.groovy
@@ -32,11 +32,11 @@ import picocli.CommandLine.Unmatched
 @SuppressWarnings('Println')
 @Command(name = 'grape', description = 'Allows for the inspection and management of the local grape cache.',
         subcommands = [
-                Install,
-                Uninstall,
-                ListCommand,
-                Resolve,
-                picocli.CommandLine.HelpCommand])
+                GrapeMain.Install,
+                GrapeMain.Uninstall,
+                GrapeMain.ListCommand,
+                GrapeMain.Resolve,
+                CommandLine.HelpCommand])
 class GrapeMain implements Runnable {
     @Option(names = ['-D', '--define'], description = 'define a system property', paramLabel = '<name=value>')
     private final Map<String, String> properties = new LinkedHashMap<String, String>()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18193802/58829673-10247680-860e-11e9-8b4b-7d49271aa17b.png)

Generate the grammar source folders with:
>gradlew antlr2classes generateGrammarSource eclipse

GrapeMain makes references to inner classes from type annotation.  Eclipse respects the static scoping of type annotations, so qualifiers are required.  GROOVY-8063 has more details.

This fixes 99% of the build errors in Eclipse IDE.