### PR TITLE
GROOVY-9151: fix variable expressions referring to replaced parameters

### DIFF
--- a/src/test/gls/invocation/DefaultParamTest.groovy
+++ b/src/test/gls/invocation/DefaultParamTest.groovy
@@ -139,8 +139,21 @@ final class DefaultParamTest extends GroovyTestCase {
     }
 
     // GROOVY-9151
-    void _FIXME_testConstructorWithAllParametersDefaulted() {
+    void testConstructorWithAllParametersDefaulted() {
         assertScript '''
+            class Greeting {
+                Greeting(Object o = 'world', String s = o) {
+                    this.text = "hello $s"
+                }
+                String text
+            }
+            assert new Greeting().text == 'hello world'
+        '''
+    }
+
+    // GROOVY-9151
+    void testConstructorWithAllParametersDefaulted2() {
+        def err = shouldFail '''
             class Greeting {
                 Greeting(Object o = 'world', String s = o.toString()) {
                     this.text = "hello $s"
@@ -149,6 +162,8 @@ final class DefaultParamTest extends GroovyTestCase {
             }
             assert new Greeting().text == 'hello world'
         '''
+
+        assert err =~ /The generated constructor "Greeting\(\)" references parameter 'o' which has been replaced by a default value expression./
     }
 
     // GROOVY-5632


### PR DESCRIPTION
`def meth(int x = 1, def y = { -> x * 2 }) {...}` would generate:
```groovy
    @Generated
    def meth() {
      Reference x = new Reference((int) 1)
      this.meth((int) 1, (Object) { -> x * 2 })
    }
```
and now:
```groovy
    @Generated
    def meth() {
      int x = 1 // with closureShare=true
      this.meth(x, (Object) { -> x * 2 })
    }
```

Generation of the local variable has been expanded to any reference found within the arguments.  This fixes the method case mentioned in GROOVY-9151.  The constructor case is not yet handled since local variable declarations cannot be added before a special constructor call (aka `this(...)`).

Anonymous inner setting of enclosing method was expanded to handle anon. inner appearing anywhere in the default expression.  Previous fix only handled anon. inner ctor call as the whole default value.