### PR TITLE
Override getText() in DeclarationExpression to provide type info

### DIFF
--- a/src/test/org/codehaus/groovy/ast/expr/DeclarationExpressionTest.groovy
+++ b/src/test/org/codehaus/groovy/ast/expr/DeclarationExpressionTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.codehaus.groovy.ast.expr
+
+import org.junit.Test
+
+final class DeclarationExpressionTest {
+
+    @Test
+    void getTextForBasicDeclaration() {
+        def ast = macro {
+            String greeting = 'hello'
+        }
+
+        assert ast.text == 'String greeting = hello'
+    }
+
+    @Test
+    void getTextForDynamicDeclaration() {
+        def ast = macro {
+            def greeting = 'hello'
+        }
+
+        assert ast.text == 'def greeting = hello'
+    }
+
+    @Test
+    void getTextForMultipleDeclaration() {
+        def ast = macro {
+            def (one, two) = ['1', '2']
+        }
+
+        assert ast.text == 'def (one, two) = [1, 2]'
+    }
+
+    @Test
+    void getTextForMultipleMixedDeclaration() {
+        def ast = macro {
+            def (String one, two) = ['1', '2']
+        }
+
+        assert ast.text == 'def (String one, two) = [1, 2]'
+    }
+
+    @Test
+    void getTextForMultipleTypedDeclaration() {
+        def ast = macro {
+            def (String one, CharSequence two) = ['1', '2']
+        }
+
+        assert ast.text == 'def (String one, CharSequence two) = [1, 2]'
+    }
+}

--- a/subprojects/groovy-console/src/test/groovy/groovy/console/ui/ScriptToTreeNodeAdapterTest.groovy
+++ b/subprojects/groovy-console/src/test/groovy/groovy/console/ui/ScriptToTreeNodeAdapterTest.groovy
@@ -30,17 +30,17 @@ import javax.swing.tree.TreeNode
  *
  * The assertions in this test case often assert against the toString() representation of
  * an object. Normally, this is bad form. However, the class under test is meant to display
- * toString() forms in a user interface. So in this case it is appropriate. 
+ * toString() forms in a user interface. So in this case it is appropriate.
  */
 class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
 
      private final classLoader = new GroovyClassLoader()
-     
+
      private createAdapter(showScriptFreeForm, showScriptClass, showClosureClasses) {
         def nodeMaker = new SwingTreeNodeMaker()
         new ScriptToTreeNodeAdapter(classLoader, showScriptFreeForm, showScriptClass, showClosureClasses, nodeMaker)
      }
-     
+
     /**
      * Asserts that a given script produces the expected tree like
      * structure.
@@ -49,7 +49,7 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
          ScriptToTreeNodeAdapter adapter = createAdapter(true, true, true)
          assertTreeStructure(script, specification, adapter)
      }
-     
+
      private assertTreeStructure(String script, List<Closure> specification, ScriptToTreeNodeAdapter adapter) {
          assertTreeStructure(script, CompilePhase.SEMANTIC_ANALYSIS, specification, adapter)
      }
@@ -128,7 +128,6 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
     }
 
     void testHelloWorld() {
-
         assertTreeStructure(
                 '"Hello World"',
                 [
@@ -139,7 +138,6 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
     }
 
     void testSimpleClass() {
-
         assertTreeStructure(
                 ' class Foo { public aField } ',
                 [
@@ -151,7 +149,6 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
     }
 
     void testMethodWithParameter() {
-
         assertTreeStructure(
                 ' def foo(String bar) { println bar } ',
                 [
@@ -164,7 +161,6 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
     }
 
     void testMethodWithParameterAndInitialValue() {
-
         assertTreeStructure(
                 ' def foo(String bar = "some_value") { println bar } ',
                 [
@@ -178,13 +174,12 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
     }
 
     void testClosureParameters() {
-
         assertTreeStructure(
                 ' def x = { parm1 ->  println parm1 } ',
                 [
                         eq('BlockStatement - (1)'),
                         startsWith('ExpressionStatement'),
-                        startsWith('Declaration - (x ='),
+                        startsWith('Declaration - def x ='),
                         startsWith('ClosureExpression'),
                         startsWith('Parameter - parm1'),
                 ]
@@ -192,13 +187,12 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
     }
 
     void testClosureParametersWithInitialValue() {
-
         assertTreeStructure(
                 ' def x = { parm1 = "some_value" ->  println parm1 } ',
                 [
                         eq('BlockStatement - (1)'),
                         startsWith('ExpressionStatement'),
-                        startsWith('Declaration - (x ='),
+                        startsWith('Declaration - def x ='),
                         eq('ClosureExpression'),
                         startsWith('Parameter - parm1'),
                         startsWith('Constant - some_value : java.lang.String'),
@@ -232,7 +226,6 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
     }
 
     void testDynamicVariable() {
-
         assertTreeStructure(
                 " foo = 'bar' ",
                 [
@@ -265,7 +258,7 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
                 [
                         startsWith('BlockStatement'),
                         startsWith('ExpressionStatement'),
-                        eq('Declaration - ((x, y) = [1, 2])'),
+                        eq('Declaration - def (x, y) = [1, 2]'),
                         eq('ArgumentList - (x, y)'),
                 ]
         )
@@ -412,7 +405,7 @@ class ScriptToTreeNodeAdapterTest extends GroovyTestCase {
                     adapter
                 )
         }
-        
+
         // since script class is being loaded, it should go through
         assertTreeStructure(
                 'def foo(String bar) {}',


### PR DESCRIPTION
Instead of returning "(var = value)" from getText(), a declaration will return "def var = value" or "Type var = value" or "def (var1, Type var2) = [value1, value2]".