### PR TITLE
 GROOVY-9168: emit more specific error for use of uninitialized this

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/InnerClassVisitor.java
+++ b/src/main/java/org/codehaus/groovy/classgen/InnerClassVisitor.java
@@ -48,9 +48,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.codehaus.groovy.ast.tools.GeneralUtils.classX;
-import static org.codehaus.groovy.ast.tools.GenericsUtils.nonGeneric;
-
 public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcodes {
 
     private ClassNode classNode;
@@ -74,7 +71,7 @@ public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcode
         InnerClassNode innerClass = null;
         if (!node.isEnum() && !node.isInterface() && node instanceof InnerClassNode) {
             innerClass = (InnerClassNode) node;
-            if (!isStatic(innerClass) && innerClass.getVariableScope() == null) {
+            if (innerClass.getVariableScope() == null && (innerClass.getModifiers() & ACC_STATIC) == 0) {
                 innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, node.getOuterClass().getPlainNodeReference(), null);
             }
         }
@@ -197,9 +194,7 @@ public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcode
             // "this" reference is saved in a field named "this$0"
             FieldNode thisField = innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, enclosingType, null);
             addFieldInit(thisParameter, thisField, block);
-        }/* else {
-            innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, nonGeneric(ClassHelper.CLASS_Type), classX(outerClass));
-        }*/
+        }
 
         // for each shared variable, add a Reference field
         for (Iterator<Variable> it = scope.getReferencedLocalVariablesIterator(); it.hasNext();) {

--- a/src/main/java/org/codehaus/groovy/classgen/InnerClassVisitor.java
+++ b/src/main/java/org/codehaus/groovy/classgen/InnerClassVisitor.java
@@ -53,13 +53,11 @@ import static org.codehaus.groovy.ast.tools.GenericsUtils.nonGeneric;
 
 public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcodes {
 
-    private final SourceUnit sourceUnit;
     private ClassNode classNode;
-    private FieldNode thisField;
-    private MethodNode currentMethod;
     private FieldNode currentField;
-    private boolean processingObjInitStatements;
-    private boolean inClosure;
+    private MethodNode currentMethod;
+    private final SourceUnit sourceUnit;
+    private boolean inClosure, processingObjInitStatements;
 
     public InnerClassVisitor(CompilationUnit cu, SourceUnit su) {
         sourceUnit = su;
@@ -73,12 +71,11 @@ public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcode
     @Override
     public void visitClass(ClassNode node) {
         classNode = node;
-        thisField = null;
         InnerClassNode innerClass = null;
         if (!node.isEnum() && !node.isInterface() && node instanceof InnerClassNode) {
             innerClass = (InnerClassNode) node;
             if (!isStatic(innerClass) && innerClass.getVariableScope() == null) {
-                thisField = innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, node.getOuterClass().getPlainNodeReference(), null);
+                innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, node.getOuterClass().getPlainNodeReference(), null);
             }
         }
 
@@ -159,45 +156,24 @@ public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcode
 
         VariableScope scope = innerClass.getVariableScope();
         if (scope == null) return;
-
-        int additionalParamCount = scope.getReferencedLocalVariablesCount();
-        boolean[] precedesSuperOrThisCall = new boolean[1];
-        if (currentMethod instanceof ConstructorNode) {
-            ConstructorNode ctor = (ConstructorNode) currentMethod;
-            GroovyCodeVisitor visitor = new CodeVisitorSupport() {
-                @Override
-                public void visitConstructorCallExpression(ConstructorCallExpression cce) {
-                    if (cce == call) {
-                        precedesSuperOrThisCall[0] = true;
-                    } else {
-                        super.visitConstructorCallExpression(cce);
-                    }
-                }
-            };
-            if (ctor.firstStatementIsSpecialConstructorCall()) currentMethod.getFirstStatement().visit(visitor);
-            Arrays.stream(ctor.getParameters()).filter(Parameter::hasInitialExpression).forEach(p -> p.getInitialExpression().visit(visitor));
-        }
-        if (!precedesSuperOrThisCall[0]) additionalParamCount += 1;
+        boolean isStatic = !inClosure && isStatic(innerClass, scope, call);
 
         // expressions = constructor call arguments
         List<Expression> expressions = ((TupleExpression) call.getArguments()).getExpressions();
         // block = init code for the constructor we produce
         BlockStatement block = new BlockStatement();
         // parameters = parameters of the constructor
+        int additionalParamCount = (isStatic ? 0 : 1) + scope.getReferencedLocalVariablesCount();
         List<Parameter> parameters = new ArrayList<>(expressions.size() + additionalParamCount);
         // superCallArguments = arguments for the super call == the constructor call arguments
         List<Expression> superCallArguments = new ArrayList<>(expressions.size());
 
-        // first we add a super() call for all expressions given in the
-        // constructor call expression
-        int pCount = additionalParamCount;
-        for (Expression expr : expressions) {
-            pCount++;
-            // add one parameter for each expression in the
-            // constructor call
-            Parameter param = new Parameter(ClassHelper.OBJECT_TYPE, "p" + pCount);
+        // first we add a super() call for all expressions given in the constructor call expression
+        for (int i = 0, n = expressions.size(); i < n; i += 1) {
+            // add one parameter for each expression in the constructor call
+            Parameter param = new Parameter(ClassHelper.OBJECT_TYPE, "p" + additionalParamCount + i);
             parameters.add(param);
-            // add to super call
+            // add the corresponsing argument to the super constructor call
             superCallArguments.add(new VariableExpression(param));
         }
 
@@ -209,45 +185,40 @@ public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcode
 
         block.addStatement(new ExpressionStatement(cce));
 
-        pCount = 0;
-        boolean isStatic = isStaticThis(innerClass, scope);
-        ClassNode outerClassType;
-        if (!isStatic && inClosure) {
-            outerClassType = ClassHelper.CLOSURE_TYPE.getPlainNodeReference();
-        } else {
-            outerClassType = getClassNode(outerClass, isStatic).getPlainNodeReference();
-        }
-        if (!precedesSuperOrThisCall[0]) {
+        int pCount = 0;
+        if (!isStatic) {
             // need to pass "this" to access unknown methods/properties
             expressions.add(pCount, VariableExpression.THIS_EXPRESSION);
 
-            Parameter thisParameter = new Parameter(outerClassType, "p" + pCount);
-            parameters.add(pCount, thisParameter);
+            ClassNode enclosingType = (inClosure ? ClassHelper.CLOSURE_TYPE : outerClass).getPlainNodeReference();
+            Parameter thisParameter = new Parameter(enclosingType, "p" + pCount);
+            parameters.add(pCount++, thisParameter);
 
             // "this" reference is saved in a field named "this$0"
-            thisField = innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, outerClassType, null);
+            FieldNode thisField = innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, enclosingType, null);
             addFieldInit(thisParameter, thisField, block);
         }/* else {
-            thisField = innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, nonGeneric(ClassHelper.CLASS_Type), classX(outerClassType));
+            innerClass.addField("this$0", ACC_FINAL | ACC_SYNTHETIC, nonGeneric(ClassHelper.CLASS_Type), classX(outerClass));
         }*/
 
         // for each shared variable, add a Reference field
         for (Iterator<Variable> it = scope.getReferencedLocalVariablesIterator(); it.hasNext();) {
-            pCount++;
             Variable var = it.next();
+
             VariableExpression ve = new VariableExpression(var);
             ve.setClosureSharedVariable(true);
             ve.setUseReferenceDirectly(true);
             expressions.add(pCount, ve);
 
-            ClassNode rawReferenceType = ClassHelper.REFERENCE_TYPE.getPlainNodeReference();
-            Parameter p = new Parameter(rawReferenceType, "p" + pCount);
-            parameters.add(pCount, p);
+            ClassNode referenceType = ClassHelper.REFERENCE_TYPE.getPlainNodeReference();
+            Parameter p = new Parameter(referenceType, "p" + pCount);
             p.setOriginType(var.getOriginType());
+            parameters.add(pCount++, p);
+
             VariableExpression initial = new VariableExpression(p);
             initial.setSynthetic(true);
             initial.setUseReferenceDirectly(true);
-            FieldNode pField = innerClass.addFieldFirst(ve.getName(), ACC_PUBLIC | ACC_SYNTHETIC, rawReferenceType, initial);
+            FieldNode pField = innerClass.addFieldFirst(ve.getName(), ACC_PUBLIC | ACC_SYNTHETIC, referenceType, initial);
             pField.setHolder(true);
             pField.setOriginType(ClassHelper.getWrapper(var.getOriginType()));
         }
@@ -255,17 +226,35 @@ public class InnerClassVisitor extends InnerClassVisitorHelper implements Opcode
         innerClass.addConstructor(ACC_SYNTHETIC, parameters.toArray(Parameter.EMPTY_ARRAY), ClassNode.EMPTY_ARRAY, block);
     }
 
-    private boolean isStaticThis(InnerClassNode innerClass, VariableScope scope) {
-        if (inClosure) return false;
-        boolean ret = innerClass.isStaticClass();
-        if (innerClass.getEnclosingMethod() != null) {
-            ret = ret || innerClass.getEnclosingMethod().isStatic();
-        } else if (currentField != null) {
-            ret = ret || currentField.isStatic();
-        } else if (currentMethod != null && "<clinit>".equals(currentMethod.getName())) {
-            ret = true;
+    private boolean isStatic(InnerClassNode innerClass, VariableScope scope, ConstructorCallExpression call) {
+        boolean isStatic = innerClass.isStaticClass();
+        if (!isStatic) {
+            if (currentMethod != null) {
+                if (currentMethod instanceof ConstructorNode) {
+                    boolean[] precedesSuperOrThisCall = new boolean[1];
+                    ConstructorNode ctor = (ConstructorNode) currentMethod;
+                    GroovyCodeVisitor visitor = new CodeVisitorSupport() {
+                        @Override
+                        public void visitConstructorCallExpression(ConstructorCallExpression cce) {
+                            if (cce == call) {
+                                precedesSuperOrThisCall[0] = true;
+                            } else {
+                                super.visitConstructorCallExpression(cce);
+                            }
+                        }
+                    };
+                    if (ctor.firstStatementIsSpecialConstructorCall()) currentMethod.getFirstStatement().visit(visitor);
+                    Arrays.stream(ctor.getParameters()).filter(Parameter::hasInitialExpression).forEach(p -> p.getInitialExpression().visit(visitor));
+
+                    isStatic = precedesSuperOrThisCall[0];
+                } else {
+                    isStatic = currentMethod.isStatic();
+                }
+            } else if (currentField != null) {
+                isStatic = currentField.isStatic();
+            }
         }
-        return ret;
+        return isStatic;
     }
 
     // this is the counterpart of addThisReference(). To non-static inner classes, outer this should be

--- a/src/main/java/org/codehaus/groovy/classgen/VerifierCodeVisitor.java
+++ b/src/main/java/org/codehaus/groovy/classgen/VerifierCodeVisitor.java
@@ -29,19 +29,18 @@ import org.codehaus.groovy.ast.expr.MapEntryExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.ast.stmt.ForStatement;
 import org.codehaus.groovy.syntax.RuntimeParserException;
-import org.objectweb.asm.Opcodes;
 
 /**
  * Performs various checks on code inside methods and constructors
  * including checking for valid field, variables names etc. that
  * would otherwise lead to invalid code.
  */
-public class VerifierCodeVisitor extends CodeVisitorSupport implements Opcodes {
+public class VerifierCodeVisitor extends CodeVisitorSupport {
 
-    private final Verifier verifier;
+    private final ClassNode classNode;
 
-    VerifierCodeVisitor(Verifier verifier) {
-        this.verifier = verifier;
+    public VerifierCodeVisitor(ClassNode classNode) {
+        this.classNode = classNode;
     }
 
     public void visitForLoop(ForStatement expression) {
@@ -72,7 +71,7 @@ public class VerifierCodeVisitor extends CodeVisitorSupport implements Opcodes {
 
     public void visitConstructorCallExpression(ConstructorCallExpression call) {
         ClassNode callType = call.getType();
-        if (callType.isEnum() && !callType.equals(verifier.getClassNode())) {
+        if (callType.isEnum() && !callType.equals(classNode)) {
             throw new RuntimeParserException("Enum constructor calls are only allowed inside the enum class", call);
         }
     }

--- a/src/main/java/org/codehaus/groovy/control/StaticVerifier.java
+++ b/src/main/java/org/codehaus/groovy/control/StaticVerifier.java
@@ -24,31 +24,29 @@ import org.codehaus.groovy.ast.DynamicVariable;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
-import org.codehaus.groovy.ast.Variable;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.ConstructorCallExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
 
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 /**
- * Checks for non-static access in static contexts.
+ * Checks for dynamic variables in static contexts.
  */
 public class StaticVerifier extends ClassCodeVisitorSupport {
     private boolean inClosure, inSpecialConstructorCall;
-    private MethodNode currentMethod;
-    private SourceUnit source;
+    private MethodNode methodNode;
+    private SourceUnit sourceUnit;
 
     @Override
     protected SourceUnit getSourceUnit() {
-        return source;
+        return sourceUnit;
     }
 
     public void visitClass(ClassNode node, SourceUnit unit) {
-        source = unit;
+        sourceUnit = unit;
         visitClass(node);
     }
 
@@ -70,8 +68,8 @@ public class StaticVerifier extends ClassCodeVisitorSupport {
 
     @Override
     public void visitConstructorOrMethod(MethodNode node, boolean isConstructor) {
-        MethodNode oldCurrentMethod = currentMethod;
-        currentMethod = node;
+        MethodNode oldMethodNode = methodNode;
+        methodNode = node;
         super.visitConstructorOrMethod(node, isConstructor);
         if (isConstructor) {
             for (Parameter param : node.getParameters()) {
@@ -84,40 +82,22 @@ public class StaticVerifier extends ClassCodeVisitorSupport {
                 }
             }
         }
-        currentMethod = oldCurrentMethod;
+        methodNode = oldMethodNode;
     }
 
     @Override
     public void visitVariableExpression(VariableExpression ve) {
-        Variable variable = ve.getAccessedVariable();
-        if (variable instanceof DynamicVariable) {
-            if (inSpecialConstructorCall || (!inClosure && ve.isInStaticContext())) {
-                if (currentMethod != null && currentMethod.isStatic()) {
-                    FieldNode fieldNode = getDeclaredOrInheritedField(currentMethod.getDeclaringClass(), ve.getName());
-                    if (fieldNode != null && fieldNode.isStatic()) return;
-                }
-                addVariableError(ve);
+        if (ve.getAccessedVariable() instanceof DynamicVariable
+                && (inSpecialConstructorCall || (!inClosure && ve.isInStaticContext()))) {
+            if (methodNode != null && methodNode.isStatic()) {
+                FieldNode fieldNode = getDeclaredOrInheritedField(methodNode.getDeclaringClass(), ve.getName());
+                if (fieldNode != null && fieldNode.isStatic()) return;
             }
-        } else if (inSpecialConstructorCall) {
-            if (ve.isThisExpression() || ve.isSuperExpression()) {
-                addError("Cannot reference '" + ve.getName() + "' before supertype constructor has been called. Possible causes:\n" +
-                        "You attempted to access an instance field, method or property.\n" +
-                        "You attempted to construct a non-static inner class.",
-                        ve);
-            } else if (!inClosure && !Modifier.isStatic(variable.getModifiers())
-                    && Arrays.stream(currentMethod.getParameters()).noneMatch(p -> p.getName().equals(ve.getName()))) {
-                addVariableError(ve); // only params and static or outer members may be accessed from special ctor call
-            }
+            addError("Apparent variable '" + ve.getName() + "' was found in a static scope but doesn't refer to a local variable, static field or class. Possible causes:\n" +
+                    "You attempted to reference a variable in the binding or an instance variable from a static context.\n" +
+                    "You misspelled a classname or statically imported field. Please check the spelling.\n" +
+                    "You attempted to use a method '" + ve.getName() + "' but left out brackets in a place not allowed by the grammar.", ve);
         }
-    }
-
-    private void addVariableError(VariableExpression ve) {
-        addError("Apparent variable '" + ve.getName() + "' was found in a static scope but doesn't refer" +
-                " to a local variable, static field or class. Possible causes:\n" +
-                "You attempted to reference a variable in the binding or an instance variable from a static context.\n" +
-                "You misspelled a classname or statically imported field. Please check the spelling.\n" +
-                "You attempted to use a method '" + ve.getName() +
-                "' but left out brackets in a place not allowed by the grammar.", ve);
     }
 
     private static FieldNode getDeclaredOrInheritedField(ClassNode cn, String fieldName) {

--- a/src/main/java/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/java/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -47,6 +47,7 @@ import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.classgen.FinalVariableAnalyzer;
 import org.codehaus.groovy.classgen.Verifier;
+import org.codehaus.groovy.classgen.VerifierCodeVisitor;
 import org.codehaus.groovy.control.ResolveVisitor;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.tools.Utilities;
@@ -55,6 +56,7 @@ import org.objectweb.asm.Opcodes;
 
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -181,8 +183,11 @@ public class JavaStubGenerator {
                 }
 
                 @Override
-                protected FinalVariableAnalyzer.VariableNotFinalCallback getFinalVariablesCallback() {
-                    return null;
+                public void visitConstructor(ConstructorNode node) {
+                    Statement stmt = node.getCode();
+                    if (stmt != null) {
+                        stmt.visit(new VerifierCodeVisitor(getClassNode()));
+                    }
                 }
 
                 @Override
@@ -242,6 +247,11 @@ public class JavaStubGenerator {
                 @Override
                 protected void addDefaultConstructor(ClassNode node) {
                     // not required for stub generation
+                }
+
+                @Override
+                protected FinalVariableAnalyzer.VariableNotFinalCallback getFinalVariablesCallback() {
+                    return null;
                 }
             };
             int origNumConstructors = classNode.getDeclaredConstructors().size();
@@ -581,7 +591,7 @@ public class JavaStubGenerator {
             for (ClassNode stub:stubExceptions) {
                 if (stub.isDerivedFrom(superExc)) continue outer;
             }
-            // not found 
+            // not found
             return false;
         }
 

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -351,7 +351,7 @@ final class InnerClassTest {
         '''
     }
 
-    @Test @NotYetImplemented
+    @Test
     void testUsageOfOuterFieldOverridden() {
         assertScript '''
             interface Run {
@@ -359,23 +359,23 @@ final class InnerClassTest {
             }
             class Foo {
                 private x = 1
+
                 def foo() {
                     def runner = new Run() {
-                        def run() { return x }
+                        def run() { return x } // <-- dynamic variable
                     }
                     runner.run()
                 }
-                void setX(y) { x = y }
+
+                void setX(val) { x = val }
             }
             class Bar extends Foo {
-                def x = "string"
+                def x = 'string' // hides 'foo.@x' and overrides 'foo.setX(val)'
             }
             def bar = new Bar()
-            assert bar.foo() == 1
-            bar.x(2)
-            assert bar.foo() == 2
-            bar.x = "new string"
-            assert bar.foo() == 2
+            assert bar.foo() == 'string'
+            bar.x = 'new string'
+            assert bar.foo() == 'new string'
         '''
     }
 
@@ -1010,38 +1010,8 @@ final class InnerClassTest {
         '''
     }
 
-    @Test @NotYetImplemented // GROOVY-7609
-    void testReferenceToUninitializedThis4() {
-        assertScript '''
-            class Login {
-                Login() {
-                    def navBar = new LoginNavigationBar()
-                }
-
-                class LoginNavigationBar {
-                    ExploreDestinationsDropdown exploreDestinationsDropdown
-
-                    LoginNavigationBar() {
-                        exploreDestinationsDropdown = new ExploreDestinationsDropdown()
-                    }
-
-                    class ExploreDestinationsDropdown /*extends NavigationBarDropdown<ExploreDestinationsDropdown>*/ {
-                        ExploreDestinationsDropdown() {
-                            //super(Login.this.sw, 0)
-                            Login.this.sw
-                        }
-                    }
-                }
-
-                static main(args) {
-                    new Login()
-                }
-            }
-        '''
-    }
-
     @Test // GROOVY-9168
-    void testReferenceToUninitializedThis5() {
+    void testReferenceToUninitializedThis4() {
         def err = shouldFail '''
             class Outer {
               class Inner {
@@ -1059,7 +1029,7 @@ final class InnerClassTest {
     }
 
     @Test // GROOVY-9168
-    void testReferenceToUninitializedThis6() {
+    void testReferenceToUninitializedThis5() {
         def err = shouldFail '''
             class Outer {
               class Inner {
@@ -1074,7 +1044,7 @@ final class InnerClassTest {
     }
 
     @Test // GROOVY-9168
-    void testReferenceToUninitializedThis7() {
+    void testReferenceToUninitializedThis6() {
         assertScript '''
             import groovy.transform.ASTTest
             import java.util.concurrent.Callable

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -847,9 +847,9 @@ final class InnerClassTest {
         '''
     }
 
-    @Test @NotYetImplemented // GROOVY-6809
+    @Test // GROOVY-6809
     void testReferenceToUninitializedThis() {
-        assertScript '''
+        def err = shouldFail '''
             class Test {
                 static main(args) {
                     def a = new A()
@@ -860,19 +860,16 @@ final class InnerClassTest {
                         def b = new B()
                     }
 
-                    void sayA() {
-                        println 'saying A'
-                    }
-
                     class B extends A {
                         B() {
-                            super(A.this) // does not exist
-                            sayA()
+                            super(A.this)
                         }
                     }
                 }
             }
         '''
+
+        assert err =~ / Could not find matching constructor for: Test.A\(Test.A\)/
     }
 
     @Test // GROOVY-6809
@@ -942,9 +939,27 @@ final class InnerClassTest {
         '''
     }
 
-    @Test @NotYetImplemented // GROOVY-9168
+    @Test // GROOVY-9168
     void testReferenceToUninitializedThis5() {
-        assertScript '''
+        def err = shouldFail '''
+            class Outer {
+              class Inner {
+              }
+              Outer(Inner inner) {
+              }
+              Outer() {
+                  this(new Inner())
+              }
+            }
+            new Outer()
+        '''
+
+        assert err =~ / Cannot reference 'this' before supertype constructor has been called. /
+    }
+
+    @Test // GROOVY-9168
+    void testReferenceToUninitializedThis6() {
+        def err = shouldFail '''
             class Outer {
               class Inner {
               }
@@ -953,10 +968,12 @@ final class InnerClassTest {
             }
             new Outer()
         '''
+
+        assert err =~ / Cannot reference 'this' before supertype constructor has been called. /
     }
 
     @Test // GROOVY-9168
-    void testReferenceToUninitializedThis6() {
+    void testReferenceToUninitializedThis7() {
         assertScript '''
             import groovy.transform.ASTTest
             import java.util.concurrent.Callable
@@ -985,7 +1002,7 @@ final class InnerClassTest {
     }
 
     @Test @NotYetImplemented // GROOVY-9168
-    void testReferenceToUninitializedThis7() {
+    void testReferenceToUninitializedThis8() {
         assertScript '''
             class A {
                 //                  AIC in this position can use static properties:
@@ -1003,7 +1020,7 @@ final class InnerClassTest {
     }
 
     @Test @NotYetImplemented // GROOVY-9168
-    void testReferenceToUninitializedThis8() {
+    void testReferenceToUninitializedThis9() {
         assertScript '''
             class A {
                 //                  AIC in this position can use static methods:

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -18,12 +18,18 @@
  */
 package gls.innerClass
 
-import gls.CompilableTestSupport
+import groovy.transform.NotYetImplemented
+import org.codehaus.groovy.control.CompilationFailedException
+import org.junit.Test
 
-class InnerClassTest extends CompilableTestSupport {
+import static groovy.test.GroovyAssert.assertScript
+import static groovy.test.GroovyAssert.shouldFail
 
+final class InnerClassTest {
+
+    @Test
     void testTimerAIC() {
-        assertScript """
+        assertScript '''
             import java.util.concurrent.CountDownLatch
             import java.util.concurrent.TimeUnit
 
@@ -37,11 +43,12 @@ class InnerClassTest extends CompilableTestSupport {
             }, 0)
 
             assert called.await(10, TimeUnit.SECONDS)
-        """
+        '''
     }
 
+    @Test
     void testAICReferenceInClosure() {
-        assertScript """
+        assertScript '''
             def y = [true]
             def o = new Object() {
               def foo() {
@@ -52,21 +59,23 @@ class InnerClassTest extends CompilableTestSupport {
               }
             }
             o.foo()
-        """
+        '''
     }
 
+    @Test
     void testExtendsObjectAndAccessAFinalVariableInScope() {
-        assertScript """
+        assertScript '''
             final String objName = "My name is Guillaume"
 
             assert new Object() {
                 String toString() { objName }
             }.toString() == objName
-        """
+        '''
     }
 
+    @Test
     void testExtendsObjectAndReferenceAMethodParameterWithinAGString() {
-        assertScript """
+        assertScript '''
             Object makeObj0(String name) {
                 new Object() {
                     String toString() { "My name is \${name}" }
@@ -74,11 +83,12 @@ class InnerClassTest extends CompilableTestSupport {
             }
 
             assert makeObj0("Guillaume").toString() == "My name is Guillaume"
-        """
+        '''
     }
 
+    @Test
     void testExtendsObjectAndReferenceAGStringPropertyDependingOnAMethodParameter() {
-        assertScript """
+        assertScript '''
             Object makeObj1(String name) {
                  new Object() {
                     String objName = "My name is \${name}"
@@ -88,11 +98,12 @@ class InnerClassTest extends CompilableTestSupport {
             }
 
             assert makeObj1("Guillaume").toString() == "My name is Guillaume"
-        """
+        '''
     }
 
+    @Test
     void testUsageOfInitializerBlockWithinAnAIC() {
-        assertScript """
+        assertScript '''
             Object makeObj2(String name) {
                  new Object() {
                     String objName
@@ -108,11 +119,12 @@ class InnerClassTest extends CompilableTestSupport {
             }
 
             assert makeObj2("Guillaume").toString() == "My name is Guillaume"
-        """
+        '''
     }
 
+    @Test
     void testStaticInnerClass() {
-        assertScript """
+        assertScript '''
             import java.lang.reflect.Modifier
 
             class A {
@@ -123,41 +135,58 @@ class InnerClassTest extends CompilableTestSupport {
 
             def mods = A.B.modifiers
             assert Modifier.isPublic(mods)
-        """
+        '''
+    }
 
-        assertScript """
+    @Test
+    void testStaticInnerClass2() {
+        assertScript '''
             class A {
                 static class B{}
             }
             assert A.declaredClasses.length==1
             assert A.declaredClasses[0]==A.B
-        """
+        '''
     }
 
-    void testNonStaticInnerClass_FAILS() {
-        if (notYetImplemented()) return
+    @Test
+    void testNonStaticInnerClass() {
+        assertScript '''
+            class A {
+                class B {
+                    final String foo = 'foo'
+                }
+            }
+            def b = new A.B(new A())
+            assert b.foo == 'foo'
+        '''
+    }
 
-        shouldNotCompile """
+    @Test @NotYetImplemented
+    void testNonStaticInnerClass2() {
+        shouldFail CompilationFailedException, '''
             class A {
                 class B {}
             }
-            def x = new A.B()
-        """
+            def x = new A.B() // requires reference to A
+        '''
     }
 
+    @Test
     void testAnonymousInnerClass() {
-        assertScript """
+        assertScript '''
             class Foo {}
 
             def x = new Foo(){
                 def bar() { 1 }
             }
             assert x.bar() == 1
-        """
+        '''
     }
 
+    @Test
     void testLocalVariable() {
-        assertScript """
+        assertScript '''
             class Foo {}
             final val = 2
             def x = new Foo() {
@@ -165,20 +194,22 @@ class InnerClassTest extends CompilableTestSupport {
             }
             assert x.bar() == val
             assert x.bar() == 2
-        """
+        '''
     }
 
+    @Test
     void testConstructor() {
-        shouldNotCompile """
+        shouldFail CompilationFailedException, '''
             class Foo {}
             def x = new Foo() {
                 Foo() {}
             }
-        """
+        '''
     }
 
+    @Test
     void testUsageOfOuterField() {
-        assertScript """
+        assertScript '''
             interface Run {
                 def run()
             }
@@ -198,9 +229,12 @@ class InnerClassTest extends CompilableTestSupport {
             assert foo.foo() == 1
             foo.x(2)
             assert foo.foo() == 2
-        """
+        '''
+    }
 
-        assertScript """
+    @Test
+    void testUsageOfOuterField2() {
+        assertScript '''
             interface Run {
                 def run()
             }
@@ -219,9 +253,12 @@ class InnerClassTest extends CompilableTestSupport {
             assert Foo.foo() == 1
             Foo.x(2)
             assert Foo.foo() == 2
-        """
+        '''
+    }
 
-        assertScript """
+    @Test
+    void testUsageOfOuterField3() {
+        assertScript '''
             interface X {
                 def m()
             }
@@ -240,9 +277,11 @@ class InnerClassTest extends CompilableTestSupport {
             }
             def a = new A()
             assert "pm" == a.foo()
-        """
+        '''
+    }
 
-        //GROOVY-6141
+    @Test // GROOVY-6141
+    void testUsageOfOuterField4() {
         assertScript '''
             class A {
                 def x = 1
@@ -271,22 +310,21 @@ class InnerClassTest extends CompilableTestSupport {
         '''
     }
 
-    void testUsageOfOuterFieldOverridden_FAILS() {
-        if (notYetImplemented()) return
-
-        assertScript """
+    @Test @NotYetImplemented
+    void testUsageOfOuterFieldOverridden() {
+        assertScript '''
             interface Run {
                 def run()
             }
             class Foo {
                 private x = 1
                 def foo() {
-                    def runner = new Run(){
+                    def runner = new Run() {
                         def run() { return x }
                     }
                     runner.run()
                 }
-                void setX(y) { x=y }
+                void setX(y) { x = y }
             }
             class Bar extends Foo {
                 def x = "string"
@@ -297,14 +335,12 @@ class InnerClassTest extends CompilableTestSupport {
             assert bar.foo() == 2
             bar.x = "new string"
             assert bar.foo() == 2
-        """
-
-        //TODO: static part
-
+        '''
     }
 
+    @Test
     void testUsageOfOuterMethod() {
-        assertScript """
+        assertScript '''
             interface Run {
                 def run()
             }
@@ -319,9 +355,12 @@ class InnerClassTest extends CompilableTestSupport {
             }
             def foo = new Foo()
             assert foo.foo() == 1
-        """
+        '''
+    }
 
-        assertScript """
+    @Test
+    void testUsageOfOuterMethod2() {
+        assertScript '''
             interface Run {
                 def run()
             }
@@ -337,11 +376,12 @@ class InnerClassTest extends CompilableTestSupport {
             }
             def foo = new Foo()
             assert foo.foo() == 1
-        """
+        '''
     }
 
+    @Test
     void testUsageOfOuterMethodoverridden() {
-        assertScript """
+        assertScript '''
             interface Run {
                 def run()
             }
@@ -359,9 +399,12 @@ class InnerClassTest extends CompilableTestSupport {
             }
             def bar = new Bar()
             assert bar.foo() == 1
-        """
+        '''
+    }
 
-        assertScript """
+    @Test
+    void testUsageOfOuterMethodoverridden2() {
+        assertScript '''
             interface Run {
                 def run()
             }
@@ -380,9 +423,10 @@ class InnerClassTest extends CompilableTestSupport {
             }
             def bar = new Bar()
             assert bar.foo() == 1
-        """
+        '''
     }
 
+    @Test
     void testClassOutputOrdering() {
         // this does actually not do much, but before this
         // change the inner class was tried to be executed
@@ -391,16 +435,17 @@ class InnerClassTest extends CompilableTestSupport {
         // not. So if Foo$Bar is returned, asserScript will
         // fail. If Foo is returned, asserScript will not
         // fail.
-        assertScript """
+        assertScript '''
             class Foo {
                 static class Bar{}
                 static main(args){}
             }
-        """
+        '''
     }
 
+    @Test
     void testInnerClassDotThisUsage() {
-        assertScript """
+        assertScript '''
             class A{
                 int x = 0;
                 class B{
@@ -419,9 +464,12 @@ class InnerClassTest extends CompilableTestSupport {
             c.foo()
             assert a.x == 1
             assert b.y == 4
-        """
+        '''
+    }
 
-        assertScript """
+    @Test
+    void testInnerClassDotThisUsage2() {
+        assertScript '''
             interface X {
                 def m()
             }
@@ -439,40 +487,45 @@ class InnerClassTest extends CompilableTestSupport {
             class B extends A {}
             def b = new B()
             assert b.foo() instanceof B
-        """
+        '''
     }
 
+    @Test
     void testImplicitThisPassingWithNamedArguments() {
         def oc = new MyOuterClass4028()
         assert oc.foo().propMap.size() == 2
     }
 
+    @Test
     void testThis0() {
-        assertScript """
-class A {
-   static def field = 10
-   void main (a) {
-     new C ().r ()
-   }
+        assertScript '''
+            class A {
+                static def field = 10
+                void main (a) {
+                    new C ().r ()
+                }
 
-   class C {
-      def r () {
-        4.times {
-          new B(it).u (it)
-        }
-      }
-   }
+                class C {
+                    def r () {
+                        4.times {
+                            new B(it).u (it)
+                        }
+                    }
+                }
 
-   class B {
-     def s
-     B (s) { this.s = s}
-     def u (i) { println i + s + field }
-   }}"""
+                class B {
+                    def s
+                    B (s) { this.s = s}
+                    def u (i) { println i + s + field }
+                }
+            }
+        '''
     }
 
+    @Test
     void testReferencedVariableInAIC() {
-        assertScript """
-            interface X{}
+        assertScript '''
+            interface X {}
 
             final double delta = 0.1
             (0 ..< 1).collect { n ->
@@ -482,9 +535,13 @@ class A {
                     }
                 }
             }
-        """
-        assertScript """
-            interface X{}
+        '''
+    }
+
+    @Test
+    void testReferencedVariableInAIC2() {
+        assertScript '''
+            interface X {}
 
             final double delta1 = 0.1
             final double delta2 = 0.1
@@ -495,10 +552,10 @@ class A {
                     }
                 }
             }
-        """
+        '''
     }
 
-    // GROOVY-5989
+    @Test // GROOVY-5989
     void testReferenceToOuterClassNestedInterface() {
         assertScript '''
             interface Koo { class Inner { } }
@@ -511,39 +568,20 @@ class A {
         '''
     }
 
-    // GROOVY-5679, GROOVY-5681
+    @Test // GROOVY-5679, GROOVY-5681
     void testEnclosingMethodIsSet() {
         assertScript '''
             import groovy.transform.ASTTest
-            import org.codehaus.groovy.ast.InnerClassNode
-            import org.codehaus.groovy.ast.expr.ConstructorCallExpression
+            import org.codehaus.groovy.ast.expr.*
             import static org.codehaus.groovy.classgen.Verifier.*
             import static org.codehaus.groovy.control.CompilePhase.*
 
             class A {
-                int x
-
-                /*@ASTTest(phase=SEMANTIC_ANALYSIS, value={
-                    def cce = lookup('inner')[0].expression
-                    def icn = cce.type
-                    assert icn instanceof InnerClassNode
-                    assert icn.enclosingMethod == node
-                })
-                A() { inner: new Runnable() { void run() {} } }
-
-                @ASTTest(phase=SEMANTIC_ANALYSIS, value={
-                    def cce = lookup('inner')[0].expression
-                    def icn = cce.type
-                    assert icn instanceof InnerClassNode
-                    assert icn.enclosingMethod == node
-                })
-                void foo() { inner: new Runnable() { void run() {} } }*/
-
                 @ASTTest(phase=CLASS_GENERATION, value={
                     def initialExpression = node.parameters[0].getNodeMetaData(INITIAL_EXPRESSION)
                     assert initialExpression instanceof ConstructorCallExpression
                     def icn = initialExpression.type
-                    assert icn instanceof InnerClassNode
+                    assert icn instanceof org.codehaus.groovy.ast.InnerClassNode
                     assert icn.enclosingMethod != null
                     assert icn.enclosingMethod.name == 'bar'
                     assert icn.enclosingMethod.parameters.length == 0 // ensure the enclosing method is bar(), not bar(Object)
@@ -551,6 +589,7 @@ class A {
                 void bar(action = new Runnable() { void run() { x = 123 }}) {
                     action.run()
                 }
+                int x
             }
             def a = new A()
             a.bar()
@@ -558,7 +597,7 @@ class A {
         '''
     }
 
-    // GROOVY-5681, GROOVY-9151
+    @Test // GROOVY-5681, GROOVY-9151
     void testEnclosingMethodIsSet2() {
         assertScript '''
             import groovy.transform.ASTTest
@@ -584,7 +623,7 @@ class A {
         '''
     }
 
-    // GROOVY-5681, GROOVY-9151
+    @Test // GROOVY-5681, GROOVY-9151
     void testEnclosingMethodIsSet3() {
         assertScript '''
             import groovy.transform.ASTTest
@@ -624,7 +663,7 @@ class A {
         '''
     }
 
-    // GROOVY-4896, GROOVY-6810
+    @Test // GROOVY-6810
     void testThisReferenceForAICInOpenBlock() {
         assertScript '''
             import java.security.AccessController
@@ -656,7 +695,10 @@ class A {
             def t = new Test()
             injectVariables(t, ['p': 'q'])
         '''
+    }
 
+    @Test // GROOVY-4896
+    void testThisReferenceForAICInOpenBlock2() {
         assertScript '''
             def doSomethingUsingLocal(){
                 logExceptions {
@@ -720,7 +762,7 @@ class A {
         '''
     }
 
-    // GROOVY-5582
+    @Test // GROOVY-5582
     void testAICextendingAbstractInnerClass() {
         assertScript '''
             class Outer {
@@ -739,7 +781,7 @@ class A {
         '''
     }
 
-    // GROOVY-6831
+    @Test // GROOVY-6831
     void testNestedPropertyHandling() {
         assertScript '''
             class Outer {
@@ -762,7 +804,7 @@ class A {
         '''
     }
 
-    // GROOVY-7312
+    @Test // GROOVY-7312
     void testInnerClassOfInterfaceIsStatic() {
         assertScript '''
             import java.lang.reflect.Modifier
@@ -774,7 +816,7 @@ class A {
         '''
     }
 
-    // GROOVY-7312
+    @Test // GROOVY-7312
     void testInnerClassOfInterfaceIsStatic2() {
         assertScript '''
             import java.lang.reflect.Modifier
@@ -792,7 +834,7 @@ class A {
         '''
     }
 
-    // GROOVY-8914
+    @Test // GROOVY-8914
     void testNestedClassInheritingFromNestedClass() {
         // control
         assert new Outer8914.Nested()
@@ -805,8 +847,8 @@ class A {
         '''
     }
 
-    // GROOVY-6809
-    void _FIXME_testReferenceToUninitializedThis() {
+    @Test @NotYetImplemented // GROOVY-6809
+    void testReferenceToUninitializedThis() {
         assertScript '''
             class Test {
                 static main(args) {
@@ -833,7 +875,7 @@ class A {
         '''
     }
 
-    // GROOVY-6809
+    @Test // GROOVY-6809
     void testReferenceToUninitializedThis2() {
         assertScript '''
             class A {
@@ -853,7 +895,7 @@ class A {
         '''
     }
 
-    // GROOVY-6809
+    @Test // GROOVY-6809
     void testReferenceToUninitializedThis3() {
         assertScript '''
             class A {
@@ -870,8 +912,8 @@ class A {
         '''
     }
 
-    // GROOVY-7609
-    void _FIXME_testReferenceToUninitializedThis4() {
+    @Test @NotYetImplemented // GROOVY-7609
+    void testReferenceToUninitializedThis4() {
         assertScript '''
             class Login {
                 Login() {
@@ -900,8 +942,8 @@ class A {
         '''
     }
 
-    // GROOVY-9168
-    void _FIXME_testReferenceToUninitializedThis5() {
+    @Test @NotYetImplemented // GROOVY-9168
+    void testReferenceToUninitializedThis5() {
         assertScript '''
             class Outer {
               class Inner {
@@ -913,7 +955,7 @@ class A {
         '''
     }
 
-    // GROOVY-9168
+    @Test // GROOVY-9168
     void testReferenceToUninitializedThis6() {
         assertScript '''
             import groovy.transform.ASTTest
@@ -942,8 +984,8 @@ class A {
         '''
     }
 
-    // GROOVY-9168
-    void _FIXME_testReferenceToUninitializedThis7() {
+    @Test @NotYetImplemented // GROOVY-9168
+    void testReferenceToUninitializedThis7() {
         assertScript '''
             class A {
                 //                  AIC in this position can use static properties:
@@ -960,8 +1002,8 @@ class A {
         '''
     }
 
-    // GROOVY-9168
-    void _FIXME_testReferenceToUninitializedThis8() {
+    @Test @NotYetImplemented // GROOVY-9168
+    void testReferenceToUninitializedThis8() {
         assertScript '''
             class A {
                 //                  AIC in this position can use static methods:
@@ -979,6 +1021,8 @@ class A {
         '''
     }
 }
+
+//------------------------------------------------------------------------------
 
 class Parent8914 {
     static class Nested {}

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -310,6 +310,47 @@ final class InnerClassTest {
         '''
     }
 
+    @Test // GROOVY-9189
+    void testUsageOfOuterField5() {
+        assertScript '''
+            interface Run {
+                def run()
+            }
+            class Foo {
+                private static x = 1
+
+                static foo(def runner = new Run() {
+                    def run() { return x }
+                }) {
+                    runner.run()
+                }
+
+                static x(y) { x = y }
+            }
+            assert Foo.foo() == 1
+            Foo.x(2)
+            assert Foo.foo() == 2
+        '''
+    }
+
+    @Test @NotYetImplemented // GROOVY-9168
+    void testUsageOfOuterField6() {
+        assertScript '''
+            class A {
+                //                  AIC in this position can use static properties:
+                A(Runnable action = new Runnable() { void run() { answer = 42 }}) {
+                    this.action = action
+                }
+                Runnable   action
+                static int answer
+            }
+
+            def a = new A()
+            a.action.run();
+            assert a.answer == 42
+        '''
+    }
+
     @Test @NotYetImplemented
     void testUsageOfOuterFieldOverridden() {
         assertScript '''
@@ -345,7 +386,8 @@ final class InnerClassTest {
                 def run()
             }
             class Foo {
-                private x(){1}
+                private x() { return 1 }
+
                 def foo() {
                     def runner = new Run(){
                         def run() { return x() }
@@ -365,7 +407,7 @@ final class InnerClassTest {
                 def run()
             }
             class Foo {
-                private static x() {1}
+                private static x() { return 1 }
 
                 def foo() {
                     def runner = new Run() {
@@ -380,22 +422,81 @@ final class InnerClassTest {
     }
 
     @Test
-    void testUsageOfOuterMethodoverridden() {
+    void testUsageOfOuterMethod3() {
         assertScript '''
             interface Run {
                 def run()
             }
             class Foo {
-                private x(){1}
+                private static x() { return 1 }
+
+                def foo(def runner = new Run() {
+                    def run() { return x() }
+                }) {
+                    runner.run()
+                }
+            }
+            def foo = new Foo()
+            assert foo.foo() == 1
+        '''
+    }
+
+    @Test // GROOVY-9189
+    void testUsageOfOuterMethod4() {
+        assertScript '''
+            interface Run {
+                def run()
+            }
+            class Foo {
+                private static x() { return 1 }
+
+                static def foo(def runner = new Run() {
+                    def run() { return x() }
+                }) {
+                    runner.run()
+                }
+            }
+            def foo = new Foo()
+            assert foo.foo() == 1
+        '''
+    }
+
+    @Test @NotYetImplemented // GROOVY-9168
+    void testUsageOfOuterMethod5() {
+        assertScript '''
+            class A {
+                //                  AIC in this position can use static methods:
+                A(Runnable action = new Runnable() { void run() { setAnswer(42) }}) {
+                    this.action = action
+                }
+                Runnable action
+                static int answer
+            }
+
+            def a = new A()
+            a.action.run();
+            assert a.answer == 42
+        '''
+    }
+
+    @Test
+    void testUsageOfOuterMethodOverridden() {
+        assertScript '''
+            interface Run {
+                def run()
+            }
+            class Foo {
+                private x() { return 1 }
+
                 def foo() {
-                    def runner = new Run(){
+                    def runner = new Run() {
                         def run() { return x() }
                     }
                     runner.run()
                 }
             }
-            class Bar extends Foo{
-                def x() { 2 }
+            class Bar extends Foo {
+                def x() { return 2 }
             }
             def bar = new Bar()
             assert bar.foo() == 1
@@ -403,13 +504,13 @@ final class InnerClassTest {
     }
 
     @Test
-    void testUsageOfOuterMethodoverridden2() {
+    void testUsageOfOuterMethodOverridden2() {
         assertScript '''
             interface Run {
                 def run()
             }
             class Foo {
-                private static x() { 1 }
+                private static x() { return 1 }
 
                 static foo() {
                     def runner = new Run() {
@@ -419,7 +520,7 @@ final class InnerClassTest {
                 }
             }
             class Bar extends Foo {
-                static x() { 2 }
+                static x() { return 2 }
             }
             def bar = new Bar()
             assert bar.foo() == 1
@@ -763,7 +864,7 @@ final class InnerClassTest {
     }
 
     @Test // GROOVY-5582
-    void testAICextendingAbstractInnerClass() {
+    void testAICExtendingAbstractInnerClass() {
         assertScript '''
             class Outer {
                 int outer() { 1 }
@@ -998,43 +1099,6 @@ final class InnerClassTest {
 
             def a = new A()
             assert a.action.call() == 42
-        '''
-    }
-
-    @Test @NotYetImplemented // GROOVY-9168
-    void testReferenceToUninitializedThis8() {
-        assertScript '''
-            class A {
-                //                  AIC in this position can use static properties:
-                A(Runnable action = new Runnable() { void run() { answer = 42 }}) {
-                    this.action = action
-                }
-                Runnable   action
-                static int answer
-            }
-
-            def a = new A()
-            a.action.run();
-            assert a.answer == 42
-        '''
-    }
-
-    @Test @NotYetImplemented // GROOVY-9168
-    void testReferenceToUninitializedThis9() {
-        assertScript '''
-            class A {
-                //                  AIC in this position can use static methods:
-                A(Runnable action = new Runnable() { void run() { setAnswer(42) }}) {
-                    this.action = action
-                }
-                Runnable action
-                protected static int answer
-                static void setAnswer(int value) { answer = value }
-            }
-
-            def a = new A()
-            a.action.run();
-            assert a.answer == 42
         '''
     }
 }

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -333,7 +333,7 @@ final class InnerClassTest {
         '''
     }
 
-    @Test @NotYetImplemented // GROOVY-9168
+    @Test // GROOVY-9168
     void testUsageOfOuterField6() {
         assertScript '''
             class A {
@@ -461,7 +461,7 @@ final class InnerClassTest {
         '''
     }
 
-    @Test @NotYetImplemented // GROOVY-9168
+    @Test // GROOVY-9168
     void testUsageOfOuterMethod5() {
         assertScript '''
             class A {

--- a/src/test/groovy/bugs/ConstructorParameterBug.groovy
+++ b/src/test/groovy/bugs/ConstructorParameterBug.groovy
@@ -54,6 +54,6 @@ final class ConstructorParameterBug {
                 }
             }
         '''
-        assert err =~ / Cannot reference 'this' before supertype constructor has been called. /
+        assert err =~ / Cannot reference 'baz' before supertype constructor has been called. /
     }
 }

--- a/src/test/groovy/bugs/ConstructorParameterBug.groovy
+++ b/src/test/groovy/bugs/ConstructorParameterBug.groovy
@@ -54,6 +54,6 @@ final class ConstructorParameterBug {
                 }
             }
         '''
-        assert err.message.contains("Can't access instance method 'baz' for a constructor parameter default value")
+        assert err =~ / Cannot reference 'this' before supertype constructor has been called. /
     }
 }

--- a/src/test/groovy/bugs/ConstructorParameterBug.groovy
+++ b/src/test/groovy/bugs/ConstructorParameterBug.groovy
@@ -18,37 +18,42 @@
  */
 package groovy.bugs
 
-import gls.CompilableTestSupport
+import org.junit.Test
 
-class ConstructorParameterBug extends CompilableTestSupport {
+import static groovy.test.GroovyAssert.assertScript
+import static groovy.test.GroovyAssert.shouldFail
 
+final class ConstructorParameterBug {
+
+    @Test
     void testParamWithDefaultCallingStaticMethod() {
         assertScript '''
-        class StaticDefault {
-            def name
-            StaticDefault(name = baz()) {
-                this.name = name
+            class StaticDefault {
+                def name
+                StaticDefault(name = baz()) {
+                    this.name = name
+                }
+                private static baz() {
+                    'baz'
+                }
             }
-            private static baz() {
-                'baz'
-            }
-        }
-        assert 'baz' == new StaticDefault().name
+            assert 'baz' == new StaticDefault().name
         '''
     }
 
+    @Test
     void testParamWithDefaultCallingInstanceMethod() {
-        def msg = shouldFail '''
-        class InstanceDefault {
-            def name
-            InstanceDefault(name = baz()) {
-                this.name = name
+        def err = shouldFail '''
+            class InstanceDefault {
+                def name
+                InstanceDefault(name = baz()) {
+                    this.name = name
+                }
+                private baz() {
+                    'baz'
+                }
             }
-            private baz() {
-                'baz'
-            }
-        }
         '''
-        assert msg.contains("Can't access instance method 'baz' for a constructor parameter default value")
+        assert err.message.contains("Can't access instance method 'baz' for a constructor parameter default value")
     }
 }

--- a/src/test/groovy/bugs/ConstructorThisCallBug.groovy
+++ b/src/test/groovy/bugs/ConstructorThisCallBug.groovy
@@ -18,21 +18,28 @@
  */
 package groovy.bugs
 
-class ConstructorThisCallBug extends GroovyTestCase {
-    // GROOVY-7014
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+import static groovy.test.GroovyAssert.shouldFail
+
+final class ConstructorThisCallBug {
+
+    @Test // GROOVY-7014
     void testThisCallingInstanceMethod() {
-        def msg = shouldFail '''
+        def err = shouldFail '''
             class Base {
                 String getData() { return "ABCD" }
                 Base() { this(getData()) }
                 Base(String arg) {}
             }
         '''
-        assert msg.contains("Can't access instance method 'getData' before the class is constructed")
+        assert err.message.contains("Can't access instance method 'getData' before the class is constructed")
     }
 
+    @Test
     void testNestedClassThisCallingInstanceMethod() {
-        def msg = shouldFail '''
+        def err = shouldFail '''
             class Base {
                 static class Nested {
                     String getData() { return "ABCD" }
@@ -41,9 +48,10 @@ class ConstructorThisCallBug extends GroovyTestCase {
                 }
             }
         '''
-        assert msg.contains("Can't access instance method 'getData' before the class is constructed")
+        assert err.message.contains("Can't access instance method 'getData' before the class is constructed")
     }
 
+    @Test
     void testThisCallingStaticMethod() {
         assertScript '''
             class Base {
@@ -57,6 +65,7 @@ class ConstructorThisCallBug extends GroovyTestCase {
         '''
     }
 
+    @Test
     void testNestedThisCallingStaticMethod() {
         assertScript '''
             class Base {
@@ -72,6 +81,7 @@ class ConstructorThisCallBug extends GroovyTestCase {
         '''
     }
 
+    @Test
     void testInnerClassSuperCallingInstanceMethod() {
         assertScript '''
             class Parent {
@@ -94,6 +104,7 @@ class ConstructorThisCallBug extends GroovyTestCase {
         '''
     }
 
+    @Test
     void testInnerClassSuperCallingStaticProperty() {
         assertScript '''
             class Parent {
@@ -115,7 +126,7 @@ class ConstructorThisCallBug extends GroovyTestCase {
         '''
     }
 
-    // GROOVY-994
+    @Test // GROOVY-994
     void testCallA() {
         assert new ConstructorCallA("foo").toString() == 'foo'
         assert new ConstructorCallA(9).toString() == '81'

--- a/src/test/groovy/bugs/ConstructorThisCallBug.groovy
+++ b/src/test/groovy/bugs/ConstructorThisCallBug.groovy
@@ -25,32 +25,6 @@ import static groovy.test.GroovyAssert.shouldFail
 
 final class ConstructorThisCallBug {
 
-    @Test // GROOVY-7014
-    void testThisCallingInstanceMethod() {
-        def err = shouldFail '''
-            class Base {
-                String getData() { return "ABCD" }
-                Base() { this(getData()) }
-                Base(String arg) {}
-            }
-        '''
-        assert err =~ / Cannot reference 'this' before supertype constructor has been called. /
-    }
-
-    @Test
-    void testNestedClassThisCallingInstanceMethod() {
-        def err = shouldFail '''
-            class Base {
-                static class Nested {
-                    String getData() { return "ABCD" }
-                    Nested() { this(getData()) }
-                    Nested(String arg) {}
-                }
-            }
-        '''
-        assert err =~ / Cannot reference 'this' before supertype constructor has been called. /
-    }
-
     @Test
     void testThisCallingStaticMethod() {
         assertScript '''
@@ -66,7 +40,7 @@ final class ConstructorThisCallBug {
     }
 
     @Test
-    void testNestedThisCallingStaticMethod() {
+    void testNestedClassThisCallingStaticMethod() {
         assertScript '''
             class Base {
                 static class Nested {
@@ -82,30 +56,7 @@ final class ConstructorThisCallBug {
     }
 
     @Test
-    void testInnerClassSuperCallingInstanceMethod() {
-        assertScript '''
-            class Parent {
-                String str
-                Parent(String s) { str = s }
-            }
-            class Outer {
-                static String a
-
-                private class Inner extends Parent {
-                   Inner() { super(myA()) }
-                }
-
-                String test() { new Inner().str }
-                String myA() { a }
-            }
-            def o = new Outer()
-            Outer.a = 'ok'
-            assert o.test() == 'ok'
-        '''
-    }
-
-    @Test
-    void testInnerClassSuperCallingStaticProperty() {
+    void testNestedClassSuperCallingStaticMethod() {
         assertScript '''
             class Parent {
                 String str
@@ -125,6 +76,60 @@ final class ConstructorThisCallBug {
             assert o.test() == 'ok'
         '''
     }
+
+    //
+
+    @Test // GROOVY-7014
+    void testThisCallingInstanceMethod() {
+        def err = shouldFail '''
+            class Base {
+                String getData() { return "ABCD" }
+                Base() { this(getData()) }
+                Base(String arg) {}
+            }
+        '''
+        assert err =~ / Cannot reference 'getData' before supertype constructor has been called. /
+    }
+
+    @Test
+    void testNestedClassThisCallingInstanceMethod() {
+        def err = shouldFail '''
+            class Base {
+                static class Nested {
+                    String getData() { return "ABCD" }
+                    Nested() { this(getData()) }
+                    Nested(String arg) {}
+                }
+            }
+        '''
+        assert err =~ / Cannot reference 'getData' before supertype constructor has been called. /
+    }
+
+    @Test
+    void testNestedClassSuperCallingInstanceMethod() {
+        def err = shouldFail '''
+            class Parent {
+                String str
+                Parent(String s) { str = s }
+            }
+            class Outer {
+                static String a
+
+                private class Inner extends Parent {
+                   Inner() { super(myA()) }
+                }
+
+                String test() { new Inner().str }
+                String myA() { a }
+            }
+            def o = new Outer()
+            Outer.a = 'ok'
+            assert o.test() == 'ok'
+        '''
+        assert err =~ / Cannot reference 'myA' before supertype constructor has been called. /
+    }
+
+    //
 
     @Test // GROOVY-994
     void testCallA() {

--- a/src/test/groovy/bugs/ConstructorThisCallBug.groovy
+++ b/src/test/groovy/bugs/ConstructorThisCallBug.groovy
@@ -34,7 +34,7 @@ final class ConstructorThisCallBug {
                 Base(String arg) {}
             }
         '''
-        assert err.message.contains("Can't access instance method 'getData' before the class is constructed")
+        assert err =~ / Cannot reference 'this' before supertype constructor has been called. /
     }
 
     @Test
@@ -48,7 +48,7 @@ final class ConstructorThisCallBug {
                 }
             }
         '''
-        assert err.message.contains("Can't access instance method 'getData' before the class is constructed")
+        assert err =~ / Cannot reference 'this' before supertype constructor has been called. /
     }
 
     @Test

--- a/src/test/groovy/bugs/Groovy5259.groovy
+++ b/src/test/groovy/bugs/Groovy5259.groovy
@@ -18,9 +18,15 @@
  */
 package groovy.bugs
 
-class Groovy5259Bug extends GroovyTestCase {
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+import static groovy.test.GroovyAssert.shouldFail
+
+final class Groovy5259 {
+
+    @Test
     void testInnerClassAccessingOuterClassConstant() {
-        // using a script because the bug is a compiler error
         assertScript '''
             class InnerAccessOuter {
                 static final String OUTER_CONSTANT = 'Constant Value'
@@ -41,13 +47,11 @@ class Groovy5259Bug extends GroovyTestCase {
             }
             new InnerAccessOuter().testInnerClassAccessOuter()
         '''
-
     }
 
+    @Test
     void testInnerClassWithWrongCallToSuperAccessingOuterClassConstant() {
-        // using a script because the bug is a compiler error
-        shouldFail {
-            assertScript '''
+        shouldFail '''
             class InnerAccessOuter {
                 protected static final String OUTER_CONSTANT = 'Constant Value'
 
@@ -69,11 +73,10 @@ class Groovy5259Bug extends GroovyTestCase {
             }
             new InnerAccessOuter().testInnerClassAccessOuter()
         '''
-        }
     }
 
+    @Test
     void testInnerClassWithSuperClassAccessingOuterClassConstant() {
-        // using a script because the bug is a compiler error
         assertScript '''
             class Base {
                 Base(String str) {}
@@ -96,11 +99,10 @@ class Groovy5259Bug extends GroovyTestCase {
             }
             new InnerAccessOuter().testInnerClassAccessOuter()
         '''
-
     }
 
+    @Test
     void testInnerClassWithSuperClassAccessingSuperOuterClassConstant() {
-        // using a script because the bug is a compiler error
         assertScript '''
             class Base {
                 Base(String str) {}
@@ -125,6 +127,5 @@ class Groovy5259Bug extends GroovyTestCase {
             }
             new InnerAccessOuter().testInnerClassAccessOuter()
         '''
-
     }
 }

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
@@ -1196,7 +1196,7 @@ println someInt
 '''
     }
 
-    void _FIXME_testAccessOuterClassMethodFromInnerClassConstructor() {
+    void testAccessOuterClassMethodFromInnerClassConstructor() {
         assertScript '''
             class Parent {
                 String str

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
@@ -1196,85 +1196,85 @@ println someInt
 '''
     }
 
-    void testAccessOuterClassMethodFromInnerClassConstructor() {
+    void _FIXME_testAccessOuterClassMethodFromInnerClassConstructor() {
         assertScript '''
-    class Parent {
-        String str
-        Parent(String s) { str = s }
-    }
-    class Outer {
-        String a
+            class Parent {
+                String str
+                Parent(String s) { str = s }
+            }
+            class Outer {
+                String a
 
-        private class Inner extends Parent {
-           Inner() { super(getA()) }
-        }
+                private class Inner extends Parent {
+                   Inner() { super(getA()) }
+                }
 
-        String test() { new Inner().str }
-    }
-    def o = new Outer(a:'ok')
-    assert o.test() == 'ok'
-    '''
+                String test() { new Inner().str }
+            }
+            def o = new Outer(a:'ok')
+            assert o.test() == 'ok'
+        '''
     }
 
     void testAccessOuterClassMethodFromInnerClassConstructorUsingExplicitOuterThis() {
         assertScript '''
-    class Parent {
-        String str
-        Parent(String s) { str = s }
-    }
-    class Outer {
-        String a
+            class Parent {
+                String str
+                Parent(String s) { str = s }
+            }
+            class Outer {
+                String a
 
-        private class Inner extends Parent {
-           Inner() { super(Outer.this.getA()) }
-        }
+                private class Inner extends Parent {
+                   Inner() { super(Outer.this.getA()) }
+                }
 
-        String test() { new Inner().str }
-    }
-    def o = new Outer(a:'ok')
-    assert o.test() == 'ok'
-    '''
+                String test() { new Inner().str }
+            }
+            def o = new Outer(a:'ok')
+            assert o.test() == 'ok'
+        '''
     }
 
     void testAccessOuterClassMethodFromInnerClassConstructorUsingExplicitOuterThisAndProperty() {
         assertScript '''
-    class Parent {
-        String str
-        Parent(String s) { str = s }
-    }
-    class Outer {
-        String a
+            class Parent {
+                String str
+                Parent(String s) { str = s }
+            }
+            class Outer {
+                String a
 
-        private class Inner extends Parent {
-           Inner() { super(Outer.this.a) }
-        }
+                private class Inner extends Parent {
+                   Inner() { super(Outer.this.a) }
+                }
 
-        String test() { new Inner().str }
-    }
-    def o = new Outer(a:'ok')
-    assert o.test() == 'ok'
-    '''
+                String test() { new Inner().str }
+            }
+            def o = new Outer(a:'ok')
+            assert o.test() == 'ok'
+        '''
     }
 
     void testAccessOuterClassStaticMethodFromInnerClassConstructor() {
         assertScript '''
-    class Parent {
-        String str
-        Parent(String s) { str = s }
-    }
-    class Outer {
-        static String a
+            class Parent {
+                String str
+                Parent(String s) { str = s }
+            }
+            class Outer {
+                static String a
 
-        private class Inner extends Parent {
-           Inner() { super(getA()) }
-        }
+                private class Inner extends Parent {
+                   Inner() { super(getA()) }
+                }
 
-        String test() { new Inner().str }
-    }
-    def o = new Outer()
-    Outer.a = 'ok'
-    assert o.test() == 'ok'
-    '''
+                String test() { new Inner().str }
+            }
+            def o = new Outer()
+            Outer.a = 'ok'
+            assert o.test() == 'ok'
+        '''
     }
 
     void testStaticMethodFromInnerClassConstructor() {


### PR DESCRIPTION
Improved error message for cases like:
```groovy
class Outer {
  class Inner {}
  Outer(Inner inner) {}
  Outer() { this(new Inner()) } // uninitialized this passed to inner class constructor
}
```
Simplified `StaticVerifier` and handle `this.@foo` and `this.&foo` in addition to `this.foo` and implicit-this `foo()`.  Special constructor call args and parameter defaults have unified handling.

One test case was disabled.  It is not possible to distinguish this case from other error cases.  And you can add `Outer.this.` qualifier to reference the property (next test case in the unit test source).
```groovy
    void _FIXME_testAccessOuterClassMethodFromInnerClassConstructor() {
        assertScript '''
            class Parent {
                String str
                Parent(String s) { str = s }
            }
            class Outer {
                String a

                private class Inner extends Parent {
                   Inner() { super(getA()) } // Is this a reference to instance property or outer property?
                }

                String test() { new Inner().str }
            }
            def o = new Outer(a:'ok')
            assert o.test() == 'ok'
        '''
    }
```

