### PR TITLE
 Fixed the Reference of the metaclass in ClassInfo.java to use a Weak…

### DIFF
--- a/src/main/java/org/codehaus/groovy/reflection/ClassInfo.java
+++ b/src/main/java/org/codehaus/groovy/reflection/ClassInfo.java
@@ -244,7 +244,7 @@ public class ClassInfo implements Finalizable {
         strongMetaClass = null;
         ManagedReference<MetaClass> newRef = null;
         if (answer != null) {
-            newRef = new ManagedReference<MetaClass> (softBundle,answer);
+            newRef = new ManagedReference<MetaClass> (weakBundle,answer);
         }
         replaceWeakMetaClassRef(newRef);
     }


### PR DESCRIPTION
…Reference now, so the Reference is cleaned up nearly immediately

after freeing the last strong reference of the metaclass.

Prior it was used a SoftReference which prevents the ClassLoader, the ClassInfo and the Metaclass instances from beeing garbage-collected
until the JVM runs nearly into an OutOfMemoryException (PermGen). This leads to a JVM which is always near the maximum of memory usage.