### PR TITLE
GROOVY-9059: use redirect in generics spec if redirect is placeholder

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/Verifier.java
@@ -1330,7 +1330,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         return null;
     }
 
-    public static long getTimestamp(Class clazz) {
+    public static long getTimestamp(Class<?> clazz) {
         if (clazz.getClassLoader() instanceof GroovyClassLoader.InnerLoader) {
             GroovyClassLoader.InnerLoader innerLoader = (GroovyClassLoader.InnerLoader) clazz.getClassLoader();
             return innerLoader.getTimeStamp();
@@ -1438,13 +1438,13 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         if ((overridingMethod.getModifiers() & ACC_BRIDGE) != 0) return null;
         if (oldMethod.isPrivate()) return null;
 
+        if (oldMethod.getGenericsTypes() != null)
+            genericsSpec = addMethodGenerics(oldMethod, genericsSpec);
+
         // parameters
         boolean normalEqualParameters = equalParametersNormal(overridingMethod, oldMethod);
         boolean genericEqualParameters = equalParametersWithGenerics(overridingMethod, oldMethod, genericsSpec);
         if (!normalEqualParameters && !genericEqualParameters) return null;
-
-        //correct to method level generics for the overriding method
-        genericsSpec = addMethodGenerics(overridingMethod, genericsSpec);
 
         // return type
         ClassNode mr = overridingMethod.getReturnType();

--- a/src/test/groovy/bugs/Groovy9059.groovy
+++ b/src/test/groovy/bugs/Groovy9059.groovy
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package groovy.bugs
+
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+@CompileStatic
+final class Groovy9059 {
+
+    @Test
+    void testTypeParameterWithExtends1() {
+        assertScript '''
+            interface Face<T> {
+                public <O extends T> O process(O o)
+            }
+
+            def impl = new Face<CharSequence>() {
+                @Override
+                public <Chars extends CharSequence> Chars process(Chars chars) { chars }
+            }
+        '''
+    }
+
+    @Test
+    void testTypeParameterWithExtends2() {
+        assertScript '''
+            interface Face<T> {
+                public <O extends T> O process(O o)
+            }
+
+            def impl = new Face<CharSequence>() {
+                @Override @SuppressWarnings('unchecked')
+                public CharSequence process(CharSequence chars) { chars }
+            }
+        '''
+    }
+
+    @Test
+    void testTypeParameterWithExtends3() {
+        assertScript '''
+            interface Face<T> {
+                public <O extends T> O process(O o)
+            }
+
+            def impl = new Face<String>() {
+                @Override @SuppressWarnings('unchecked')
+                public String process(String string) { string }
+            }
+        '''
+    }
+}

--- a/src/test/groovy/bugs/groovy6742/Groovy6742.groovy
+++ b/src/test/groovy/bugs/groovy6742/Groovy6742.groovy
@@ -1,32 +1,36 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * 	http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
-
-
-
 package groovy.bugs.groovy6742
 
-class Groovy6742Bug extends GroovyTestCase {
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+@CompileStatic
+final class Groovy6742 {
+
+    @Test
     void test1() {
         assertScript '''
             package groovy.bugs.groovy6742
-            
+
             @groovy.transform.TypeChecked
             class Issue1 {
                 public void issue(){
@@ -38,15 +42,16 @@ class Groovy6742Bug extends GroovyTestCase {
                     }
                 }
             }
-            
+
             assert true
         '''
     }
 
+    @Test
     void test2() {
         assertScript '''
             package groovy.bugs.groovy6742
-            
+
             @groovy.transform.TypeChecked
             class Issue2 {
                 public void issue() {
@@ -57,37 +62,36 @@ class Groovy6742Bug extends GroovyTestCase {
                         }
                     })
                 }
-            
+
                 public <I, O> void transform(Function<? super I, ? extends O> function) {
-            
                 }
             }
-            
+
             assert true
         '''
     }
 
+    @Test
     void test3() {
         assertScript '''
             package groovy.bugs.groovy6742
-            
+
             @groovy.transform.TypeChecked
             class Issue3 {
                 public static <F, T> FutureCallback<F> deferredCallback(DeferredResult<T> deferredResult, final Function<F, T> function) {
                     return new FutureCallback<F>() {
                         private F f = null
                         F f2 = null
-                        
+
                         @Override
                         void onSuccess(F result) {
                             deferredResult.setResult(function.apply(result))
                         }
-                    };
+                    }
                 }
             }
-            
+
             assert true
         '''
     }
-
 }


### PR DESCRIPTION
When resolving a type parameter like "X extends Y", instead of adding "X: X -> Object" to the generics spec, add "X: Y -> Object" to the spec and continue checking the spec if a returned type is a placeholder.