### PR TITLE
Console, GroovyMain and Groovysh (via its Main) use context class loader

### DIFF
--- a/src/main/groovy/groovy/ui/GroovyMain.java
+++ b/src/main/groovy/groovy/ui/GroovyMain.java
@@ -479,7 +479,7 @@ public class GroovyMain {
      * Process the input files.
      */
     private void processFiles() throws CompilationFailedException, IOException, URISyntaxException {
-        GroovyShell groovy = new GroovyShell(conf);
+        GroovyShell groovy = new GroovyShell(Thread.currentThread().getContextClassLoader(), conf);
         setupContextClassLoader(groovy);
 
         Script s = groovy.parse(getScriptSource(isScriptFile, script));
@@ -587,7 +587,7 @@ public class GroovyMain {
      * Process the standard, single script with args.
      */
     private void processOnce() throws CompilationFailedException, IOException, URISyntaxException {
-        GroovyShell groovy = new GroovyShell(conf);
+        GroovyShell groovy = new GroovyShell(Thread.currentThread().getContextClassLoader(), conf);
         setupContextClassLoader(groovy);
         groovy.run(getScriptSource(isScriptFile, script), args);
     }

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
@@ -244,7 +244,7 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
         //when starting via main set the look and feel to system
         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
 
-        def baseConfig = new CompilerConfiguration()
+        def baseConfig = new CompilerConfiguration(System.getProperties())
         String starterConfigScripts = System.getProperty("groovy.starter.configscripts", null)
         if (options.configscript || (starterConfigScripts != null && !starterConfigScripts.isEmpty())) {
             List<String> configScripts = new ArrayList<String>()
@@ -263,7 +263,7 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
             enableIndy(baseConfig)
         }
 
-        def console = new Console(Console.class.classLoader?.getRootLoader(), new Binding(), baseConfig)
+        def console = new Console(Thread.currentThread().contextClassLoader, new Binding(), baseConfig)
         console.useScriptClassLoaderForScriptExecution = true
         console.run()
         def remaining = options.arguments()
@@ -312,23 +312,11 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
         }
     }
 
-    Console() {
-        this(new Binding())
-    }
-
-    Console(Binding binding) {
+    Console(Binding binding = new Binding()) {
         this(null, binding)
     }
 
-    Console(ClassLoader parent) {
-        this(parent, new Binding())
-    }
-
-    Console(ClassLoader parent, Binding binding) {
-        this(parent, binding, new CompilerConfiguration())
-    }
-
-    Console(ClassLoader parent, Binding binding, CompilerConfiguration baseConfig) {
+    Console(ClassLoader parent, Binding binding = new Binding(), CompilerConfiguration baseConfig = new CompilerConfiguration(System.getProperties())) {
         this.baseConfig = baseConfig
         this.maxOutputChars = loadMaxOutputChars()
         indy = indy || isIndyEnabled(baseConfig)

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Main.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Main.groovy
@@ -65,10 +65,6 @@ class Main {
         groovysh = new Groovysh(io, configuration)
     }
 
-    Groovysh getGroovysh() {
-        return groovysh
-    }
-
     /**
      * create a Main instance, configures it according to CLI arguments, and starts the shell.
      * @param main must have a Groovysh member that has an IO member.
@@ -151,7 +147,7 @@ class Main {
         if (options.e) {
             evalString = options.getOptionValue('e')
         }
-        def configuration = new CompilerConfiguration()
+        def configuration = new CompilerConfiguration(System.getProperties())
         configuration.setParameters((boolean) options.hasOption("pa"))
 
         List<String> filenames = options.arguments()


### PR DESCRIPTION
- All: pass system properties to new CompilerConfiguration instances
- Console: use default parameters to reduce constructor variants

(Clone of 93bebbe140846117cf16127360217dac1d13f5fc)

See also https://github.com/apache/groovy/pull/942