### PR TITLE
GROOVY-9217: Fix warning "An illegal reflective access operation has …

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -1922,7 +1922,8 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
             //----------------------------------------------------------------------
             // executing the getter method
             //----------------------------------------------------------------------
-            return method.doMethodInvoke(object, arguments);
+            MetaMethod transformedMetaMethod = CallSiteHelper.transformMetaMethod(this, method, MetaClassHelper.convertToTypeArray(arguments), MetaClassImpl.class);
+            return transformedMetaMethod.doMethodInvoke(object, arguments);
         }
 
         //----------------------------------------------------------------------
@@ -2826,7 +2827,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
 
         //----------------------------------------------------------------------
-        // executing the getter method
+        // executing the setter method
         //----------------------------------------------------------------------
         if (method != null) {
             if (arguments.length == 1) {
@@ -2840,7 +2841,9 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
                         method.getParameterTypes()[1].getTheClass());
                 arguments[1] = newValue;
             }
-            method.doMethodInvoke(object, arguments);
+
+            MetaMethod transformedMetaMethod = CallSiteHelper.transformMetaMethod(this, method, MetaClassHelper.convertToTypeArray(arguments), MetaClassImpl.class);
+            transformedMetaMethod.doMethodInvoke(object, arguments);
             return;
         }
 

--- a/src/test/groovy/bugs/Groovy9217Bug.groovy
+++ b/src/test/groovy/bugs/Groovy9217Bug.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+// TODO add JVM option `--illegal-access=deny` when all warnings fixed
+class Groovy9217Bug extends GroovyTestCase {
+    void testSetProperty() {
+        HttpURLConnection conn = new URL('http://www.bing.com').openConnection() as HttpURLConnection
+        conn.requestMethod = 'HEAD'
+        assert 'HEAD' == conn.requestMethod
+        conn.disconnect()
+    }
+}

--- a/src/test/groovy/bugs/groovy9081/Groovy9081.groovy
+++ b/src/test/groovy/bugs/groovy9081/Groovy9081.groovy
@@ -55,7 +55,7 @@ final class Groovy9081 {
         assert f.name
     }
 
-    @Test @Ignore
+    @Test
     void testGetPropertiesOfObjects() {
         assert null != ''.properties
     }


### PR DESCRIPTION
…occurred" when setting property