### PR TITLE
GROOVY-9218: Reduce the memory usage of `MethodIndex` instances

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -3981,7 +3981,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         }
     };
 
-    class MethodIndex extends Index {
+    static class MethodIndex extends Index {
         public MethodIndex(boolean b) {
             super(false);
         }


### PR DESCRIPTION
A static inner class does not keep an implicit reference to its enclosing instance. This prevents a common cause of memory leaks and uses less memory per instance of the class.