### PR TITLE
GROOVY-9075: The exception message should be more clear when a Groovy…

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -114,6 +114,7 @@ import java.util.concurrent.ConcurrentMap;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.inSamePackage;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.isDefaultVisibility;
 import static org.codehaus.groovy.reflection.ReflectionCache.isAssignableFrom;
+import static org.codehaus.groovy.runtime.MetaClassHelper.checkMetaClassProperty;
 
 /**
  * Allows methods to be dynamically added to existing classes at runtime
@@ -144,6 +145,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     private static final MetaMethod[] EMPTY = MetaMethod.EMPTY_ARRAY;
     private static final MetaMethod AMBIGUOUS_LISTENER_METHOD = new DummyMetaMethod();
     private static final boolean PERMISSIVE_PROPERTY_ACCESS = SystemUtil.getBooleanSafe("groovy.permissive.property.access");
+    private static final String META_CLASS_PROPERTY_NAME = "metaClass";
 
     protected final Class theClass;
     protected final CachedClass theCachedClass;
@@ -2720,6 +2722,8 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
      */
     public void setProperty(Class sender, Object object, String name, Object newValue, boolean useSuper, boolean fromInsideClass) {
         checkInitalised();
+
+        if (META_CLASS_PROPERTY_NAME.equals(name)) checkMetaClassProperty(this, newValue);
 
         //----------------------------------------------------------------------
         // handling of static

--- a/src/main/java/org/codehaus/groovy/runtime/MetaClassHelper.java
+++ b/src/main/java/org/codehaus/groovy/runtime/MetaClassHelper.java
@@ -97,6 +97,8 @@ public class MetaClassHelper {
         return accessible;
     }
 
+
+
     private static Boolean checkCompatiblePackages(Class at, Constructor constructor) {
         if (at.getPackage() == null && constructor.getDeclaringClass().getPackage() == null) {
             return Boolean.TRUE;
@@ -1015,5 +1017,22 @@ public class MetaClassHelper {
             return prop;
         }
         return BeanUtils.decapitalize(prop);
+    }
+
+    // GROOVY-9075
+    public static void checkMetaClassProperty(MetaClass oldValue, Object newValue) {
+        if (null == newValue) return;
+
+        if (!(newValue instanceof MetaClass)) {
+            throw new IllegalArgumentException("the new metaClass[" + newValue.getClass() + "] is not an instance of " + MetaClass.class);
+        }
+
+        MetaClass newMetaClass = (MetaClass) newValue;
+        if (!newMetaClass.getTheClass().isAssignableFrom(oldValue.getTheClass())) {
+            throw new IllegalArgumentException(
+                    "the new metaClass[" + newMetaClass.getTheClass() + "]"
+                            + " is not compatible with the old metaClass[" + oldValue.getTheClass() + "]"
+            );
+        }
     }
 }

--- a/src/test/groovy/bugs/Groovy9075Bug.groovy
+++ b/src/test/groovy/bugs/Groovy9075Bug.groovy
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+class Groovy9075Bug extends GroovyTestCase {
+    void testSetMetaClassWithDifferentType() {
+        def errMsg = shouldFail '''
+            import groovy.transform.CompileStatic
+            
+            class C1 {
+                int x
+            }
+            class C2 {
+                int x
+            }
+            
+            def c1 = new C1()
+            def c2 = new C2()
+            c1.metaClass = c2.metaClass  //eg: org.springframework.beans.BeanUtils.copyProperties
+                                         // or c1.setMetaClass(c2.getMetaClass())
+    
+            c1.x += 1  // crash here with unclear exception, but c1.setX() works
+        '''
+
+        assert 'the new metaClass[class C2] is not compatible with the old metaClass[class C1]' == errMsg
+    }
+
+    void testSetInvalidMetaClass() {
+        def errMsg = shouldFail '''
+            import groovy.transform.CompileStatic
+            
+            class C1 {
+                int x
+            }
+
+            def c1 = new C1()
+            c1.metaClass = 'hello'
+        '''
+
+        assert 'the new metaClass[class java.lang.String] is not an instance of interface groovy.lang.MetaClass' == errMsg
+    }
+}


### PR DESCRIPTION
…Object's metaClass is wrong