### PR TITLE
GROOVY-8815: preserve redirects for generics placeholders

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -466,8 +466,7 @@ public class GenericsUtils {
     }
 
     public static Map<String, ClassNode> addMethodGenerics(MethodNode current, Map<String, ClassNode> oldSpec) {
-        Map<String, ClassNode> ret = new HashMap<>(oldSpec);
-        // ret starts with the original type specs, now add gts for the current method if any
+        Map<String, ClassNode> newSpec = new HashMap<>(oldSpec);
         GenericsType[] gts = current.getGenericsTypes();
         if (gts != null) {
             for (GenericsType gt : gts) {
@@ -490,10 +489,10 @@ public class GenericsUtils {
                         type.setRedirect(redirect);
                     }
                 }
-                ret.put(name, type);
+                newSpec.put(name, type);
             }
         }
-        return ret;
+        return newSpec;
     }
 
     public static void extractSuperClassGenerics(ClassNode type, ClassNode target, Map<String, ClassNode> spec) {
@@ -663,12 +662,7 @@ public class GenericsUtils {
                 throw new GroovyBugError("Given generics type " + old + " must be a placeholder!");
             ClassNode fromSpec = genericsSpec.get(old.getName());
             if (fromSpec != null) {
-                if (fromSpec.isGenericsPlaceHolder()) {
-                    ClassNode[] upper = new ClassNode[]{fromSpec.redirect()};
-                    newTypes[i] = new GenericsType(fromSpec, upper, null);
-                } else {
-                    newTypes[i] = new GenericsType(fromSpec);
-                }
+                newTypes[i] = fromSpec.asGenericsType();
             } else {
                 ClassNode[] upper = old.getUpperBounds();
                 ClassNode[] newUpper = upper;

--- a/src/test/groovy/bugs/Groovy8815.groovy
+++ b/src/test/groovy/bugs/Groovy8815.groovy
@@ -1,0 +1,77 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.tools.javac.JavaAwareCompilationUnit
+import org.junit.Test
+
+final class Groovy8815 {
+
+    @Test
+    void testGenerics() {
+        def config = new CompilerConfiguration(
+            targetDirectory: File.createTempDir(),
+            jointCompilationOptions: [memStub: true]
+        )
+
+        def parentDir = File.createTempDir()
+        try {
+            def a = new File(parentDir, 'Event.groovy')
+            a.write '''
+                class Event<T> {
+                    Event(String id, T payload) {}
+                    Event<T> setReplyTo(Object replyTo) {}
+                }
+            '''
+            def b = new File(parentDir, 'Events.groovy')
+            b.write '''
+                import groovy.transform.CompileStatic
+                import java.util.function.Consumer
+                @CompileStatic
+                trait Events {
+                    def <E extends Event<?>> Registration<Object, Consumer<E>> on(Class key, Closure consumer) {}
+                }
+            '''
+            def c = new File(parentDir, 'Registration.java')
+            c.write '''
+                interface Registration<K, V> {
+                }
+            '''
+            def d = new File(parentDir, 'Service.groovy')
+            d.write '''
+                class Service implements Events {
+                }
+            '''
+
+            def loader = new GroovyClassLoader(this.class.classLoader)
+            def cu = new JavaAwareCompilationUnit(config, loader)
+            cu.addSources(a, b, c, d)
+            cu.compile()
+
+            def method = loader.loadClass('Service').getMethod('on', Class, Closure)
+
+            // should not contain unresolved type parameter 'T'
+            assert method.genericSignature == '<E:LEvent<*>;>(Ljava/lang/Class;Lgroovy/lang/Closure;)LRegistration<Ljava/lang/Object;Ljava/util/function/Consumer<TE;>;>;'
+        } finally {
+            parentDir.deleteDir()
+            config.targetDirectory.deleteDir()
+        }
+    }
+}


### PR DESCRIPTION
When resolving method with generics, placeholder may have bounds.  Ex:
```groovy
  def <T extends Type> void doSomething(Predicate<T> check) { ... }
```

If Type has generics, the resolved generics types must be retained:
```
  T -> Type<?> -> Type<X>
```