### PR TITLE
Implement `CurlyLevelCountingGroovyLexer` based on parrot lexer

### DIFF
--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -143,9 +143,14 @@ options {
         }
     });
 
+    protected void enterParenCallback(String text) {}
+    protected void exitParenCallback(String text) {}
+
     private final Deque<Paren> parenStack = new ArrayDeque<>(32);
     private void enterParen() {
-        parenStack.push(new Paren(getText(), this.lastTokenType, getLine(), getCharPositionInLine()));
+        String text = getText();
+        enterParenCallback(text);
+        parenStack.push(new Paren(text, this.lastTokenType, getLine(), getCharPositionInLine()));
     }
     private void exitParen() {
         Paren paren = parenStack.peek();
@@ -155,6 +160,7 @@ options {
         require(text.equals(PAREN_MAP.get(paren.getText())),
                 "'" + paren.getText() + "'" + new PositionInfo(paren.getLine(), paren.getColumn()) + " can not match '" + text + "'", -1);
 
+        exitParenCallback(text);
         parenStack.pop();
     }
     private boolean isInsideParens() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/Interpreter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/Interpreter.groovy
@@ -37,17 +37,13 @@ class Interpreter implements Evaluator
     private final GroovyShell shell
 
     Interpreter(final ClassLoader classLoader, final Binding binding) {
-        this(classLoader, binding, null)
+        this(classLoader, binding, CompilerConfiguration.DEFAULT)
     }
 
     Interpreter(final ClassLoader classLoader, final Binding binding, CompilerConfiguration configuration) {
         assert classLoader
         assert binding
-        if (configuration != null) {
-            shell = new GroovyShell(classLoader, binding, configuration)
-        } else {
-            shell = new GroovyShell(classLoader, binding)
-        }
+        shell = new GroovyShell(classLoader, binding, configuration)
     }
 
     Binding getContext() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/util/CurlyLevelCountingGroovyLexer.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/util/CurlyLevelCountingGroovyLexer.groovy
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.groovysh.util
+
+import groovy.transform.CompileStatic
+import org.antlr.v4.runtime.CommonTokenStream
+import org.apache.groovy.parser.antlr4.GroovyLangLexer
+
+/**
+ * patching GroovyLangLexer to get access to Paren level
+ */
+@CompileStatic
+class CurlyLevelCountingGroovyLexer extends GroovyLangLexer {
+    static CurlyLevelCountingGroovyLexer createGroovyLexer(String text) {
+        return new CurlyLevelCountingGroovyLexer(new StringReader(text))
+    }
+
+    CurlyLevelCountingGroovyLexer(Reader reader) throws IOException {
+        super(reader)
+    }
+
+    private int curlyLevel
+
+    int getCurlyLevel() {
+        return curlyLevel
+    }
+
+    int countCurlyLevel() {
+        CommonTokenStream tokenStream = new CommonTokenStream(this)
+        try {
+            tokenStream.fill()
+        } catch (e) {
+        }
+
+        return curlyLevel
+    }
+
+    @Override
+    protected void enterParenCallback(String text) {
+        if ("{" == text) {
+            curlyLevel++
+        }
+    }
+
+    @Override
+    protected void exitParenCallback(String text) {
+        if ("}" == text) {
+            curlyLevel--
+        }
+    }
+}

--- a/subprojects/groovy-groovysh/src/test/groovy/org/apache/groovy/groovysh/util/CurlyLevelCountingGroovyLexerTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/apache/groovy/groovysh/util/CurlyLevelCountingGroovyLexerTest.groovy
@@ -1,0 +1,61 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.groovysh.util
+
+import groovy.test.GroovyTestCase
+
+/**
+ * Unit tests for the {@link CurlyLevelCountingGroovyLexer} class.
+ */
+class CurlyLevelCountingGroovyLexerTest extends GroovyTestCase {
+   void testLexerEmpty() {
+       CurlyLevelCountingGroovyLexer it = CurlyLevelCountingGroovyLexer.createGroovyLexer('')
+       assert 0 == it.curlyLevel
+       assert 0 == it.countCurlyLevel()
+       assert 0 == it.curlyLevel
+   }
+
+    void testLexerText() {
+        CurlyLevelCountingGroovyLexer it = CurlyLevelCountingGroovyLexer.createGroovyLexer('foo bar baz')
+        assert 0 == it.curlyLevel
+        assert 0 == it.countCurlyLevel()
+        assert 0 == it.curlyLevel
+    }
+
+    void testLexerCurly() {
+        CurlyLevelCountingGroovyLexer it = CurlyLevelCountingGroovyLexer.createGroovyLexer('Foo{')
+        assert 0 == it.curlyLevel
+        assert 1 == it.countCurlyLevel()
+        assert 1 == it.curlyLevel
+    }
+
+    void testLexerCurlyMore() {
+        CurlyLevelCountingGroovyLexer it = CurlyLevelCountingGroovyLexer.createGroovyLexer('Foo{Baz{Bar{')
+        assert 0 == it.curlyLevel
+        assert 3 == it.countCurlyLevel()
+        assert 3 == it.curlyLevel
+    }
+
+    void testLexerCurlyMany() {
+        CurlyLevelCountingGroovyLexer it = CurlyLevelCountingGroovyLexer.createGroovyLexer('Foo{Bar{}}{')
+        assert 0 == it.curlyLevel
+        assert 1 == it.countCurlyLevel()
+        assert 1 == it.curlyLevel
+    }
+}


### PR DESCRIPTION
As antlr2 parser will be removed in the future, we should not rely on its API.