### PR TITLE
GROOVY-9266: added closure annotations to DefaultGroovyMethods.metaClass

### DIFF
--- a/src/main/java/groovy/lang/ExpandoMetaClass.java
+++ b/src/main/java/groovy/lang/ExpandoMetaClass.java
@@ -18,6 +18,8 @@
  */
 package groovy.lang;
 
+import groovy.transform.stc.ClosureParams;
+import groovy.transform.stc.SimpleType;
 import org.codehaus.groovy.reflection.CachedClass;
 import org.codehaus.groovy.reflection.MixinInMetaClass;
 import org.codehaus.groovy.runtime.DefaultCachedMethodKey;
@@ -796,7 +798,8 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
         }
     }
 
-    public ExpandoMetaClass define(Closure closure) {
+    public ExpandoMetaClass define(@ClosureParams(value=SimpleType.class, options="java.lang.Object")
+            @DelegatesTo(value=DefiningClosure.class, strategy=Closure.DELEGATE_ONLY) Closure closure) {
         final DefiningClosure definer = new DefiningClosure();
         Object delegate = closure.getDelegate();
         closure.setDelegate(definer);

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -17753,7 +17753,8 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @throws GroovyRuntimeException if the metaclass can't be set for this class
      * @since 1.6.0
      */
-    public static MetaClass metaClass (Class self, Closure closure){
+    public static MetaClass metaClass(Class self, @ClosureParams(value=SimpleType.class, options="java.lang.Object")
+            @DelegatesTo(type="groovy.lang.ExpandoMetaClass.DefiningClosure", strategy=Closure.DELEGATE_ONLY) Closure closure) {
         MetaClassRegistry metaClassRegistry = GroovySystem.getMetaClassRegistry();
         MetaClass mc = metaClassRegistry.getMetaClass(self);
 
@@ -17800,7 +17801,8 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @throws GroovyRuntimeException if the metaclass can't be set for this object
      * @since 1.6.0
      */
-    public static MetaClass metaClass (Object self, Closure closure){
+    public static MetaClass metaClass(Object self, @ClosureParams(value=SimpleType.class, options="java.lang.Object")
+            @DelegatesTo(type="groovy.lang.ExpandoMetaClass.DefiningClosure", strategy=Closure.DELEGATE_ONLY) Closure closure) {
         MetaClass emc = hasPerInstanceMetaClass(self);
         if (emc == null) {
             final ExpandoMetaClass metaClass = new ExpandoMetaClass(self.getClass(), false, true);


### PR DESCRIPTION
and ExpandoMetaClass.define

The actual closure param is always a null, but I didn't know if that could be represented using `@ClosureParams` so I just set "java.lang.Object".