### PR TITLE
GROOVY-9282: Allow protected override of package scoped methods

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -466,7 +466,7 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
             Parameter[] superParams = superMethod.getParameters();
             if (!hasEqualParameterTypes(params, superParams)) continue;
             if ((mn.isPrivate() && !superMethod.isPrivate())
-                    || (mn.isProtected() && !superMethod.isProtected() && !superMethod.isPrivate())
+                    || (mn.isProtected() && !superMethod.isProtected() && !superMethod.isPackageScope() && !superMethod.isPrivate())
                     || (!mn.isPrivate() && !mn.isProtected() && !mn.isPublic() && (superMethod.isPublic() || superMethod.isProtected()))) {
                 addWeakerAccessError(cn, mn, params, superMethod);
                 return;
@@ -704,20 +704,20 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
             checkGenericsUsage(ref, node);
         }
     }
-    
+
     private void checkGenericsUsage(ASTNode ref, Parameter[] params) {
         for (Parameter p : params) {
             checkGenericsUsage(ref, p.getType());
         }
     }
-    
+
     private void checkGenericsUsage(ASTNode ref, ClassNode node) {
         if (node.isArray()) {
             checkGenericsUsage(ref, node.getComponentType());
         } else if (!node.isRedirectNode() && node.isUsingGenerics()) {
-            addError(   
+            addError(
                     "A transform used a generics containing ClassNode "+ node + " " +
-                    "for "+getRefDescriptor(ref) + 
+                    "for "+getRefDescriptor(ref) +
                     "directly. You are not supposed to do this. " +
                     "Please create a new ClassNode referring to the old ClassNode " +
                     "and use the new ClassNode instead of the old one. Otherwise " +

--- a/src/test/gls/classes/methods/MethodOverridingAllowedTest.groovy
+++ b/src/test/gls/classes/methods/MethodOverridingAllowedTest.groovy
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package gls.classes.methods
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static groovy.test.GroovyAssert.assertScript
+
+@RunWith(Parameterized)
+class MethodOverridingAllowedTest {
+    String baseVisibility, childVisibility
+
+    MethodOverridingAllowedTest(String baseVisibility, String childVisibility) {
+        this.baseVisibility = baseVisibility
+        this.childVisibility = childVisibility
+    }
+
+    @Parameterized.Parameters(name = '{1} may override {0}')
+    static data() {
+        [
+            ['private', 'private'],
+            ['private', '@groovy.transform.PackageScope'],
+            ['private', 'protected'],
+            ['private', 'public'],
+            ['@groovy.transform.PackageScope', '@groovy.transform.PackageScope'],
+            ['@groovy.transform.PackageScope', 'protected'],
+            ['@groovy.transform.PackageScope', 'public'],
+            ['protected', 'protected'],
+            ['protected', 'public'],
+            ['public', 'public'],
+        ]*.toArray()
+    }
+
+    @Test
+    void 'stronger access may override weaker'() {
+        assertScript("""
+            class Base {
+                $baseVisibility myMethod() { true }
+            }
+            class Child extends Base {
+                $childVisibility myMethod() { true }
+            }
+            assert new Child() != null
+        """)
+    }
+}

--- a/src/test/gls/classes/methods/MethodOverridingDeniedTest.groovy
+++ b/src/test/gls/classes/methods/MethodOverridingDeniedTest.groovy
@@ -26,10 +26,10 @@ import org.junit.runners.Parameterized
 import static groovy.test.GroovyAssert.shouldFail
 
 @RunWith(Parameterized)
-class MethodOverridingTest {
+class MethodOverridingDeniedTest {
     String baseVisibility, childVisibility
 
-    MethodOverridingTest(String baseVisibility, String childVisibility) {
+    MethodOverridingDeniedTest(String baseVisibility, String childVisibility) {
         this.baseVisibility = baseVisibility
         this.childVisibility = childVisibility
     }


### PR DESCRIPTION
See [GROOVY-9282](https://issues.apache.org/jira/browse/GROOVY-9282) for the Jira issue.

When overriding a method as `protected` with a super method being package-private (no modifier in Java or `@PackageScope` in Groovy), compilation fails with an error similar to this:

```
...
exampleMethod(java.lang.Object -> java.lang.Object) in com.example.Child cannot override exampleMethod in com.example.Base; attempting to assign weaker access privileges; was package-private
...
```

This edge case seems to be missed at [GROOVY-8651](https://issues.apache.org/jira/browse/GROOVY-8651).

Groovy 2.5.7 and 2.5.8 are affected. I didn't check Groovy 3.x.

Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>