### PR TITLE
Incorrect documentation layout

### DIFF
--- a/src/main/java/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
@@ -130,7 +130,7 @@ public class IndyInterface {
          * bootstrap method for method calls from Groovy compiled code with indy 
          * enabled. This method gets a flags parameter which uses the following 
          * encoding:<ul>
-         * <li>{@value #SAFE_NAVIGATION} is the flag value for safe navigation see {@link #SAFE_NAVIGATION}<li/>
+         * <li>{@value #SAFE_NAVIGATION} is the flag value for safe navigation see {@link #SAFE_NAVIGATION}</li>
          * <li>{@value #THIS_CALL} is the flag value for a call on this see {@link #THIS_CALL}</li>
          * </ul> 
          * @param caller - the caller


### PR DESCRIPTION
The layout for http://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/vmplugin/v7/IndyInterface.html#bootstrap(Lookup,%20java.lang.String,%20java.lang.invoke.MethodType,%20java.lang.String,%20int) is incorrect due to wrong usage of a tag.