### PR TITLE
GROOVY-8457: use ClassHelper.make(Class) for resolved exception type

### DIFF
--- a/subprojects/groovy-test/src/main/java/org/apache/groovy/test/transform/NotYetImplementedASTTransformation.java
+++ b/subprojects/groovy-test/src/main/java/org/apache/groovy/test/transform/NotYetImplementedASTTransformation.java
@@ -33,6 +33,7 @@ import org.codehaus.groovy.transform.AbstractASTTransformation;
 import org.codehaus.groovy.transform.GroovyASTTransformation;
 
 import java.util.Arrays;
+import junit.framework.AssertionFailedError;
 
 import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.block;
@@ -52,7 +53,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.tryCatchS;
 public class NotYetImplementedASTTransformation extends AbstractASTTransformation {
 
     private static final ClassNode CATCH_TYPE = ClassHelper.make(Throwable.class);
-    private static final ClassNode THROW_TYPE = ClassHelper.make("junit.framework.AssertionFailedError"); // TODO: java.lang.AssertionError
+    private static final ClassNode THROW_TYPE = ClassHelper.make(AssertionFailedError.class); // TODO: java.lang.AssertionError
 
     public void visit(ASTNode[] nodes, SourceUnit source) {
         if (!(nodes.length == 2 && nodes[0] instanceof AnnotationNode && nodes[1] instanceof MethodNode)) {

--- a/subprojects/groovy-test/src/test/groovy/org/apache/groovy/test/transform/NotYetImplementedTransformTest.groovy
+++ b/subprojects/groovy-test/src/test/groovy/org/apache/groovy/test/transform/NotYetImplementedTransformTest.groovy
@@ -117,6 +117,27 @@ final class NotYetImplementedTransformTest {
         assert output.wasSuccessful() : '@Test method marked with @NotYetImplemented must NOT throw an AssertionFailedError'
     }
 
+    @Test // GROOVY-8457
+    void testNotYetImplementedJUnit4Failure_atCompileStatic()  {
+        def output = shell.evaluate('''
+            import groovy.transform.CompileStatic
+            import groovy.test.NotYetImplemented
+            import org.junit.Test
+            import org.junit.runner.JUnitCore
+
+            @CompileStatic
+            class MyTests {
+                @NotYetImplemented @Test void testThatFails()  {
+                    assert false
+                }
+            }
+
+            new JUnitCore().run(MyTests)
+        ''')
+
+        assert output.wasSuccessful() : '@Test method marked with @CompileStatic and @NotYetImplemented must NOT throw an AssertionFailedError'
+    }
+
     @Test
     void testNotYetImplementedJUnit4Success() {
         def output = shell.evaluate('''
@@ -136,5 +157,27 @@ final class NotYetImplementedTransformTest {
 
         assert output.failureCount == 1 : '@Test method marked with @NotYetImplemented must throw an AssertionFailedError'
         assert output.failures.first().exception instanceof AssertionFailedError : '@Test method marked with @NotYetImplemented must throw an AssertionFailedError'
+    }
+
+    @Test // GROOVY-8457
+    void testNotYetImplementedJUnit4Success_atCompileStatic()  {
+        def output = shell.evaluate('''
+            import groovy.transform.CompileStatic
+            import groovy.test.NotYetImplemented
+            import org.junit.Test
+            import org.junit.runner.JUnitCore
+
+            @CompileStatic
+            class MyTests {
+                @NotYetImplemented @Test void testThatFails()  {
+                    assert true
+                }
+            }
+
+            new JUnitCore().run(MyTests)
+        ''')
+
+        assert output.failureCount == 1 : '@Test method marked with @CompileStatic and @NotYetImplemented must throw an AssertionFailedError'
+        assert output.failures.first().exception instanceof AssertionFailedError : '@Test method marked with @CompileStatic and @NotYetImplemented must throw an AssertionFailedError'
     }
 }


### PR DESCRIPTION
General note: Any AST transform that uses `ClassHelper.make(String)` is likely to have problems interacting with `@CompileStatic` and possibly other parts of the compiler that expect resolved types after SEMANTIC_ANALYSIS.