### PR TITLE
GROOVY-8579, GROOVY-8930, GROOVY-8944: check for static interface method on all direct calls

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -3492,10 +3492,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
 
                             storeType(call, returnType);
                             storeTargetMethod(call, directMethodCallCandidate);
-                            ClassNode declaringClass = directMethodCallCandidate.getDeclaringClass();
-                            if (declaringClass.isInterface() && directMethodCallCandidate.isStatic() && !(directMethodCallCandidate instanceof ExtensionMethodNode)) {
-                                typeCheckingContext.getEnclosingClassNode().putNodeMetaData(MINIMUM_BYTECODE_VERSION, Opcodes.V1_8);
-                            }
+
                             String data = chosenReceiver.getData();
                             if (data != null) {
                                 // the method which has been chosen is supposed to be a call on delegate or owner
@@ -3768,6 +3765,14 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
 
     protected void storeTargetMethod(final Expression call, final MethodNode directMethodCallCandidate) {
         call.putNodeMetaData(DIRECT_METHOD_CALL_TARGET, directMethodCallCandidate);
+
+        if (directMethodCallCandidate != null
+                && directMethodCallCandidate.isStatic()
+                && directMethodCallCandidate.getDeclaringClass().isInterface()
+                && !(directMethodCallCandidate instanceof ExtensionMethodNode)) {
+            typeCheckingContext.getEnclosingClassNode().putNodeMetaData(MINIMUM_BYTECODE_VERSION, Opcodes.V1_8);
+        }
+
         checkOrMarkPrivateAccess(call, directMethodCallCandidate);
         checkSuperCallFromClosure(call, directMethodCallCandidate);
         extension.onMethodSelection(call, directMethodCallCandidate);

--- a/subprojects/tests-vm8/src/test/groovy/groovy/bugs/vm8/Groovy8579.groovy
+++ b/subprojects/tests-vm8/src/test/groovy/groovy/bugs/vm8/Groovy8579.groovy
@@ -18,19 +18,35 @@
  */
 package groovy.bugs.vm8
 
-import groovy.test.GroovyTestCase
+import org.junit.Test
 
-class Groovy8579Bug extends GroovyTestCase {
-    void testCallToStaticInterfaceMethod() {
+import static groovy.test.GroovyAssert.assertScript
+
+final class Groovy8579 {
+
+    @Test
+    void testCallToStaticInterfaceMethod1() {
         assertScript '''
-            import groovy.transform.CompileStatic
-
-            @CompileStatic
-            Comparator myMethod() {
+            @groovy.transform.CompileStatic
+            Comparator test() {
                 Map.Entry.comparingByKey()
             }
 
-            assert myMethod() instanceof Comparator
+            assert test() instanceof Comparator
+        '''
+    }
+
+    @Test
+    void testCallToStaticInterfaceMethod2() {
+        assertScript '''
+            import static java.util.Map.Entry.comparingByKey
+
+            @groovy.transform.CompileStatic
+            Comparator test() {
+                comparingByKey()
+            }
+
+            assert test() instanceof Comparator
         '''
     }
 }


### PR DESCRIPTION
- calling a static interface method requires Java 1.8+ bytecode