### PR TITLE
GROOVY-9245: exclude synthetic constructors from CachedClass

### DIFF
--- a/src/main/java/org/codehaus/groovy/reflection/CachedClass.java
+++ b/src/main/java/org/codehaus/groovy/reflection/CachedClass.java
@@ -72,6 +72,7 @@ public class CachedClass {
         public CachedConstructor[] initValue() {
             PrivilegedAction<CachedConstructor[]> action = () -> {
                 return Arrays.stream(getTheClass().getDeclaredConstructors())
+                    .filter(c -> !c.isSynthetic()) // GROOVY-9245: exclude inner class ctors
                     .filter(c -> checkCanSetAccessible(c, CachedClass.class))
                     .map(c -> new CachedConstructor(CachedClass.this, c))
                     .toArray(CachedConstructor[]::new);

--- a/src/test/groovy/bugs/Groovy9245.groovy
+++ b/src/test/groovy/bugs/Groovy9245.groovy
@@ -1,0 +1,70 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.tools.javac.JavaAwareCompilationUnit
+import org.junit.Test
+
+final class Groovy9245 {
+
+    @Test
+    void testConstructorSelection() {
+        def config = new CompilerConfiguration(
+            targetDirectory: File.createTempDir(),
+            jointCompilationOptions: [memStub: true]
+        )
+
+        def parentDir = File.createTempDir()
+        try {
+            def a = new File(parentDir, 'A.java')
+            a.write '''
+                public class A {
+                    private A() {
+                    }
+                    public A(String s) {
+                    }
+                    private static class B extends A {
+                    }
+                }
+            '''
+            def b = new File(parentDir, 'Main.groovy')
+            b.write '''
+                new A(null)
+                /*
+                groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method A#<init>.
+                Cannot resolve which method to invoke for [null] due to overlapping prototypes between:
+                    [class java.lang.String]
+                    [class A$1]
+                */
+            '''
+
+            def loader = new GroovyClassLoader(this.class.classLoader)
+            def cu = new JavaAwareCompilationUnit(config, loader)
+            cu.addSources(a, b)
+            cu.compile()
+
+            Class clazz = loader.loadClass('Main')
+            assert clazz.newInstance().run()
+        } finally {
+            parentDir.deleteDir()
+            config.targetDirectory.deleteDir()
+        }
+    }
+}

--- a/src/test/org/codehaus/groovy/transform/BuilderTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/BuilderTransformTest.groovy
@@ -774,7 +774,7 @@ class BuilderTransformTest extends CompilableTestSupport {
          '''
     }
 
-    void testInternalFieldsAreIncludedIfRequestedForInitializerStrategyStrategy_GROOVY6454() {
+    void testInternalFieldsAreIncludedIfRequestedForInitializerStrategy_GROOVY6454() {
         assertScript '''
             import groovy.transform.builder.*
 
@@ -806,5 +806,4 @@ class BuilderTransformTest extends CompilableTestSupport {
             assert new FooBuilder().name('Mary').build().name == 'John'
          '''
     }
-
 }


### PR DESCRIPTION
This has implications for AST transforms (like Builder) that create private methods to be called by other code that they create.  The builder InitializerStrategy makes private constructors and they won't be found by ScriptBytecodeAdapter if marked synthetic.  Maybe `@CompileStatic` can help resolve these constructors at compile time -- also, there is no `setMethodTarget` on `ConstructorCallExpression` to indicate the direct target.

If the risk is not acceptable, then different filter criteria could be used in `CachedClass` to specifically target constructors created for inner class instantiation.