### PR TITLE
GROOVY-9174: try junit-platform-launcher as compile-time-only dependency

### DIFF
--- a/subprojects/groovy-test-junit5/build.gradle
+++ b/subprojects/groovy-test-junit5/build.gradle
@@ -24,12 +24,13 @@ ext {
 
 dependencies {
     implementation rootProject
-    compile "org.junit.platform:junit-platform-launcher:$junit5PlatformVersion"
-    runtime "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
-    testRuntime "org.junit.platform:junit-platform-engine:$junit5PlatformVersion"
-    testRuntime "org.junit.platform:junit-platform-runner:$junit5PlatformVersion"
+    runtimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
+    compileOnly "org.junit.platform:junit-platform-launcher:$junit5PlatformVersion"
+
     testImplementation project(':groovy-test')
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
+    testRuntimeOnly "org.junit.platform:junit-platform-engine:$junit5PlatformVersion"
+    testRuntimeOnly "org.junit.platform:junit-platform-runner:$junit5PlatformVersion"
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
I'm not sure of the impact of this change.  But it does manage to build successfully.  Here is a bit of reference material: https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_dependency_management_overview

Additionally or alternatively, the `groovy-all-X.Y.Z.pom` could include `groovy-test-junit5` as a runtime dependency so it is not part of the compile classpath of a project.  The "all" pom is created in the `upload.gradle` script.