### PR TITLE
GROOVY-9341: fix "this" support for nested lambda expressions

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesLambdaWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesLambdaWriter.java
@@ -177,8 +177,7 @@ public class StaticTypesLambdaWriter extends LambdaWriter implements AbstractFun
         if (controller.isStaticMethod() || compileStack.isInSpecialConstructorCall() || !accessingInstanceMembers) {
             operandStack.pushConstant(ConstantExpression.NULL);
         } else {
-            mv.visitVarInsn(ALOAD, 0);
-            operandStack.push(controller.getClassNode());
+            loadThis();
         }
 
         operandStack.dup();

--- a/src/test/groovy/transform/stc/LambdaTest.groovy
+++ b/src/test/groovy/transform/stc/LambdaTest.groovy
@@ -1031,7 +1031,7 @@ final class LambdaTest {
         '''
     }
 
-    @Test @NotYetImplemented
+    @Test
     void testNestedLambdaAccessingInstanceFields() {
         assertScript '''
             @groovy.transform.CompileStatic
@@ -1097,7 +1097,7 @@ final class LambdaTest {
         '''
     }
 
-    @Test @NotYetImplemented
+    @Test
     void testAccessingThis2() {
         assertScript '''
             @groovy.transform.CompileStatic


### PR DESCRIPTION
ClosureWriter#loadThis() writes call to Closure#getThisObject() for nested closures or lambdas