### PR TITLE
GROOVY-9327: handle STC for AIC in non-STC class but STC method

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/sc/StaticCompilationVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/sc/StaticCompilationVisitor.java
@@ -410,6 +410,12 @@ public class StaticCompilationVisitor extends StaticTypeCheckingVisitor {
     public void visitConstructorCallExpression(final ConstructorCallExpression call) {
         super.visitConstructorCallExpression(call);
 
+        if (call.isUsingAnonymousInnerClass() && call.getType().getNodeMetaData(StaticTypeCheckingVisitor.class) != null) {
+            ClassNode anonType = call.getType();
+            anonType.putNodeMetaData(STATIC_COMPILE_NODE, anonType.getEnclosingMethod().getNodeMetaData(STATIC_COMPILE_NODE));
+            anonType.putNodeMetaData(WriterControllerFactory.class, anonType.getOuterClass().getNodeMetaData(WriterControllerFactory.class));
+        }
+
         MethodNode target = call.getNodeMetaData(DIRECT_METHOD_CALL_TARGET);
         if (target == null && call.getLineNumber() > 0) {
             addError("Target constructor for constructor call expression hasn't been set", call);

--- a/src/test/groovy/bugs/Groovy9327.groovy
+++ b/src/test/groovy/bugs/Groovy9327.groovy
@@ -1,0 +1,60 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.shouldFail
+
+@CompileStatic
+final class Groovy9327 {
+
+    @Test
+    void testCheckedAIC() {
+        def err = shouldFail '''
+        @groovy.transform.TypeChecked
+        void test() {
+            def runner = new Runnable() {
+                @Override
+                void run() {
+                    unknownReference
+                }
+            }
+        }
+        '''
+        assert err.message.contains('The variable [unknownReference] is undeclared.')
+    }
+
+    @Test
+    void testCompiledAIC() {
+        def err = shouldFail '''
+        @groovy.transform.CompileStatic
+        void test() {
+            def runner = new Runnable() {
+                @Override
+                void run() {
+                    unknownReference
+                }
+            }
+        }
+        '''
+        assert err.message.contains('The variable [unknownReference] is undeclared.')
+    }
+}

--- a/src/test/groovy/transform/stc/AnonymousInnerClassSTCTest.groovy
+++ b/src/test/groovy/transform/stc/AnonymousInnerClassSTCTest.groovy
@@ -122,9 +122,10 @@ class AnonymousInnerClassSTCTest extends StaticTypeCheckingTestCase {
                   }
                 }
                 s.size()
-            }'''
+            }
+        '''
     }
-    
+
     void testAICInAICInStaticMethod() {
         assertScript '''
             class A {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9327

`visitClass` usually processes inner classes.  However, when specific methods are annotated for STC/SC, `visitClass` is not executed (see org.codehaus.groovy.transform.StaticTypesTransformation#visit).  In this case, `visitClass(anonType)` must be driven and the metadata that `visitClass` would normally set must be provided.