### PR TITLE
Add Java13 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ install: true
 
 matrix:
   include:
+    - env: BC='legacy' FEATURE='13' TARGET_JAVA_HOME="/home/travis/openjdk$FEATURE" LICENSE='GPL'
+      jdk: openjdk11
+
     - env: BC='legacy'
       jdk: openjdk12
 
@@ -37,6 +40,9 @@ matrix:
 
     - env: BC='legacy'
       jdk: oraclejdk8
+
+    - env: BC='indy' FEATURE='13' TARGET_JAVA_HOME="/home/travis/openjdk$FEATURE" LICENSE='GPL'
+      jdk: openjdk11
 
     - env: BC='indy'
       jdk: openjdk12
@@ -58,7 +64,9 @@ before_script:
 
 script:
   - ./gradlew -version
-  - if [ "$BC" == "legacy" ]; then travis_wait 60 ./gradlew test; else travis_wait 60 ./gradlew testWithIndy; fi
+  - if [ "$TARGET_JAVA_HOME" != "" ]; then wget https://github.com/sormuras/bach/raw/master/install-jdk.sh -P /tmp/ && chmod 755 /tmp/install-jdk.sh; fi
+  - if [ "$TARGET_JAVA_HOME" != "" ]; then /tmp/install-jdk.sh --target "$TARGET_JAVA_HOME" --workspace "/home/travis/.cache/install-jdk" --feature "$FEATURE" --license "$LICENSE" --cacerts; fi
+  - if [ "$BC" == "legacy" ]; then travis_wait 60 ./gradlew test -Ptarget.java.home=$TARGET_JAVA_HOME; else travis_wait 60 ./gradlew testWithIndy -Ptarget.java.home=$TARGET_JAVA_HOME; fi
 
 # As recommended in:
 # https://docs.travis-ci.com/user/languages/java/#Caching

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ ext.modules = {
     subprojects.findAll{ !['performance', 'binary-compatibility'].contains(it.name) }
 }
 ext.isReleaseVersion = !groovyVersion.toLowerCase().endsWith("snapshot")
+ext.targetJavaHome = rootProject.hasProperty('target.java.home') ? rootProject.property('target.java.home') : ''
 
 apply from: 'gradle/bad-practices.gradle'
 //apply from: 'gradle/indy.gradle'

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -36,6 +36,9 @@ allprojects {
         }
         systemProperties 'apple.awt.UIElement': 'true', 'javadocAssertion.src.dir': './src/main'
 
+        if (rootProject.targetJavaHome) {
+            executable = "${rootProject.targetJavaHome}/bin/java"
+        }
         forkEvery = 50
         maxParallelForks = isRunningOnCI() ? 1 : Runtime.runtime.availableProcessors()
         scanForTestClasses = true

--- a/src/main/java/org/codehaus/groovy/runtime/StringGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/StringGroovyMethods.java
@@ -21,12 +21,14 @@ package org.codehaus.groovy.runtime;
 import groovy.lang.Closure;
 import groovy.lang.EmptyRange;
 import groovy.lang.GString;
+import groovy.lang.GroovyRuntimeException;
 import groovy.lang.IntRange;
 import groovy.lang.Range;
 import groovy.transform.stc.ClosureParams;
 import groovy.transform.stc.FromString;
 import groovy.transform.stc.PickFirstResolver;
 import org.apache.groovy.io.StringBuilderWriter;
+import org.apache.groovy.lang.annotation.Incubating;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 import org.codehaus.groovy.util.CharSequenceReader;
 
@@ -34,6 +36,9 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -2597,6 +2602,29 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
             if (runningCount == 0) break;
         }
         return stripIndent(self, runningCount == -1 ? 0 : runningCount);
+    }
+
+    /**
+     * Same logic to {@link #stripIndent(CharSequence)} if {@code forceGroovyBehavior} is {@code true},
+     * otherwise Java13's {@code stripIndent} will be invoked
+     *
+     * @param self The CharSequence to strip the leading spaces from
+     * @param forceGroovyBehavior force groovy behavior to avoid conflicts with Java13's stripIndent
+     * @since 3.0.0
+     */
+    @Incubating
+    public static String stripIndent(CharSequence self, boolean forceGroovyBehavior) {
+        if (!forceGroovyBehavior) {
+            try {
+                MethodHandle mh = MethodHandles.lookup().findVirtual(self.getClass(), "stripIndent", MethodType.methodType(String.class));
+                return (String) mh.bindTo(self).invokeWithArguments();
+            } catch (NoSuchMethodException | IllegalAccessException ignored) {
+            } catch (Throwable t) {
+                throw new GroovyRuntimeException(t);
+            }
+        }
+
+        return stripIndent(self);
     }
 
     /**

--- a/src/test/groovy/lang/ScriptSourcePositionInAstTest.groovy
+++ b/src/test/groovy/lang/ScriptSourcePositionInAstTest.groovy
@@ -49,7 +49,7 @@ class ScriptSourcePositionInAstTest extends GroovyTestCase {
         assert positionsForScript("""\
             println 'hello'
             println 'bye'
-        """.stripIndent()) == [[1, 1], [2, 14]]
+        """.stripIndent(true)) == [[1, 1], [2, 14]]
     }
 
     void testScriptWithClasses() {
@@ -58,6 +58,6 @@ class ScriptSourcePositionInAstTest extends GroovyTestCase {
             println 'hello'
             println 'bye'
             class Baz{}
-        """.stripIndent()) == [[2, 1], [3, 14]]
+        """.stripIndent(true)) == [[2, 1], [3, 14]]
     }
 }

--- a/src/test/groovy/lang/StripMarginTest.groovy
+++ b/src/test/groovy/lang/StripMarginTest.groovy
@@ -57,7 +57,7 @@ class StripMarginTest extends GroovyTestCase {
             def method() {
                 return 'bar'
             }
-        """.stripIndent()
+        """.stripIndent(true)
 
         def expected = """
     return 'foo'
@@ -79,7 +79,7 @@ def method() {
             def method() {
                 return 'bar'
             }
-        """.stripIndent()
+        """.stripIndent(true)
         
         def expected = """\
     return 'foo'


### PR DESCRIPTION
1) As we do not have enough time to migrate gradle from 5.6.4 to 6.x, we decide to build Groovy with Java 11 and run tests with Java 13. BTW, volunteers to help Apache Groovy polish the Gradle build scripts are always welcome.
2) Java 13 introduces some new API, e.g. `String::stripIndent`, which has conflicts with GDK's existing method. As a workaround, we add a incubating variant of `stripIndent` in GDK.