### PR TITLE
GROOVY-8966 Exclusive NumberRange is converted to inclusive when used by List.getAt(range)

### DIFF
--- a/src/main/java/groovy/lang/IntRange.java
+++ b/src/main/java/groovy/lang/IntRange.java
@@ -223,6 +223,10 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
         if (inclusive == null) {
             throw new IllegalStateException("Should not call subListBorders on a non-inclusive aware IntRange");
         }
+        return subListBorders(from, to, inclusive, size);
+    }
+
+    static RangeInfo subListBorders(int from, int to, boolean inclusive, int size) {
         int tempFrom = from;
         if (tempFrom < 0) {
             tempFrom += size;

--- a/src/main/java/groovy/lang/NumberRange.java
+++ b/src/main/java/groovy/lang/NumberRange.java
@@ -20,6 +20,7 @@ package groovy.lang;
 
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.runtime.IteratorClosureAdapter;
+import org.codehaus.groovy.runtime.RangeInfo;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -175,6 +176,20 @@ public class NumberRange extends AbstractList<Comparable> implements Range<Compa
         this.to = (Comparable) tempTo;
         this.stepSize = stepSize == null ? 1 : stepSize;
         this.inclusive = inclusive;
+    }
+
+    /**
+     * A method for determining from and to information when using this IntRange to index an aggregate object of the specified size.
+     * Normally only used internally within Groovy but useful if adding range indexing support for your own aggregates.
+     *
+     * @param size the size of the aggregate being indexed
+     * @return the calculated range information (with 1 added to the to value, ready for providing to subList
+     */
+    public RangeInfo subListBorders(int size) {
+        if (stepSize.intValue() != 1) {
+            throw new IllegalStateException("Step must be 1 when used by subList!");
+        }
+        return IntRange.subListBorders(((Number) from).intValue(), ((Number) to).intValue(), inclusive, size);
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
@@ -20,6 +20,7 @@ package org.codehaus.groovy.runtime;
 
 import groovy.lang.EmptyRange;
 import groovy.lang.IntRange;
+import groovy.lang.NumberRange;
 import groovy.lang.Range;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
@@ -76,7 +77,10 @@ public class DefaultGroovyMethodsSupport {
     // helper method for getAt and putAt
     protected static RangeInfo subListBorders(int size, Range range) {
         if (range instanceof IntRange) {
-            return ((IntRange)range).subListBorders(size);
+            return ((IntRange) range).subListBorders(size);
+        }
+        if (range instanceof NumberRange) {
+            return ((NumberRange) range).subListBorders(size);
         }
         int from = normaliseIndex(DefaultTypeTransformation.intUnbox(range.getFrom()), size);
         int to = normaliseIndex(DefaultTypeTransformation.intUnbox(range.getTo()), size);

--- a/src/test/groovy/bugs/groovy8966/Groovy8966.groovy
+++ b/src/test/groovy/bugs/groovy8966/Groovy8966.groovy
@@ -1,0 +1,18 @@
+package groovy.bugs.groovy8966
+
+import groovy.test.GroovyTestCase
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+@CompileStatic
+final class Groovy8966 extends GroovyTestCase {
+    @Test
+    void test() {
+        assertScript '''
+            def array = [0, 1, 2]
+            int a = 2 
+            long b = 3
+            assert array[a..<b] == [2]
+        '''
+    }
+}


### PR DESCRIPTION
Previously, when a exclusive NumberRange constructed from non-int type (e.g. long)
is used in List.getAt(), it will be incorrectly converted to inclusive. This commit
fixes this issue by introducing a subListBorders() method to NumberRange, which is
similar to IntRange.