### PR TITLE
GROOVY-9370: check for non-synthetic propertyMissing

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -675,7 +675,8 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                 if (val != null) vexp.putNodeMetaData(key, val);
             }
             vexp.removeNodeMetaData(INFERRED_TYPE);
-            storeType(vexp, getType(pexp));
+            ClassNode type = pexp.getNodeMetaData(INFERRED_TYPE);
+            storeType(vexp, Optional.ofNullable(type).orElseGet(pexp::getType));
             return true;
         }
         return false;
@@ -1618,7 +1619,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                 }
                 if (mopMethod == null) mopMethod = testClass.getMethod("propertyMissing", new Parameter[]{new Parameter(STRING_TYPE, "propertyName")});
 
-                if (mopMethod != null) {
+                if (mopMethod != null && !mopMethod.isSynthetic()) {
                     pexp.putNodeMetaData(DYNAMIC_RESOLUTION, Boolean.TRUE);
                     pexp.removeNodeMetaData(DECLARATION_INFERRED_TYPE);
                     pexp.removeNodeMetaData(INFERRED_TYPE);

--- a/src/test/groovy/bugs/Groovy9370.groovy
+++ b/src/test/groovy/bugs/Groovy9370.groovy
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+@CompileStatic
+final class Groovy9370 {
+
+    @Test
+    void testClosureForSAMWithinAIC() {
+        assertScript '''
+            class Main {
+                static final Pogo pogo = new Pogo()
+
+                @groovy.transform.CompileStatic
+                static main(args) {
+                    def face = new Face() {
+                        @Override
+                        def meth() {
+                            pogo.thing1 { ->
+                                pogo.thing2() // STC error; AIC's propertyMissing is taking precedence
+                            }
+                        }
+                    }
+                    assert face.meth() == 'works'
+                }
+            }
+
+            @FunctionalInterface
+            interface Face {
+                def meth()
+            }
+
+            class Pogo {
+                def thing1(Face face) {
+                    face.meth()
+                }
+
+                def thing2() {
+                    'works'
+                }
+            }
+        '''
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9370

Not sure if anon. inner class should not add GroovyObject methods, but this check should at least get Groovy 2.5/3.0 into better territory.