### PR TITLE
GROOVY-9368: handle in-memory stubs system property in compilation unit

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -47,16 +47,16 @@ import static org.apache.groovy.util.SystemUtil.getSystemPropertySafe;
  */
 public class CompilerConfiguration {
 
-    /** This (<code>"indy"</code>) is the Optimization Option value for enabling <code>invokedynamic</code> compilation. */
+    /** Optimization Option for enabling <code>invokedynamic</code> compilation. */
     public static final String INVOKEDYNAMIC = "indy";
 
-    /** This (<code>"groovydoc"</code>) is the Optimization Option value for enabling attaching groovydoc as AST node metadata. */
+    /** Optimization Option for enabling attaching groovydoc as AST node metadata. */
     public static final String GROOVYDOC = "groovydoc";
 
-    /** This (<code>"runtimeGroovydoc"</code>) is the Optimization Option value for enabling attaching {@link groovy.lang.Groovydoc} annotation. */
+    /** Optimization Option for enabling attaching {@link groovy.lang.Groovydoc} annotation. */
     public static final String RUNTIME_GROOVYDOC = "runtimeGroovydoc";
 
-    /** This (<code>"memStub"</code>) is the Joint Compilation Option value for enabling generating stubs in memory. */
+    /** Joint Compilation Option for enabling generating stubs in memory. */
     public static final String MEM_STUB = "memStub";
 
     /** This (<code>"1.4"</code>) is the value for targetBytecode to compile for a JDK 1.4. */
@@ -437,12 +437,6 @@ public class CompilerConfiguration {
         handleOptimizationOption(optimizationOptions, INVOKEDYNAMIC, "groovy.target.indy");
         handleOptimizationOption(optimizationOptions, GROOVYDOC, "groovy.attach.groovydoc");
         handleOptimizationOption(optimizationOptions, RUNTIME_GROOVYDOC, "groovy.attach.runtime.groovydoc");
-
-        if (Optional.ofNullable(getSystemPropertySafe("groovy.generate.stub.in.memory"))
-                .map(Boolean::valueOf).orElse(DEFAULT != null && DEFAULT.isMemStubEnabled()).booleanValue()) {
-            jointCompilationOptions = new HashMap<>();
-            jointCompilationOptions.put(MEM_STUB, Boolean.TRUE);
-        }
     }
 
     private void handleOptimizationOption(final Map<String, Boolean> options, final String optionName, final String sysOptionName) {
@@ -1091,13 +1085,5 @@ public class CompilerConfiguration {
     public boolean isRuntimeGroovydocEnabled() {
         Boolean runtimeGroovydocEnabled = getOptimizationOptions().get(RUNTIME_GROOVYDOC);
         return Optional.ofNullable(runtimeGroovydocEnabled).orElse(Boolean.FALSE).booleanValue();
-    }
-
-    /**
-     * Checks if in-memory stub creation is enabled.
-     */
-    public boolean isMemStubEnabled() {
-        return Optional.ofNullable(getJointCompilationOptions()).map(opts -> opts.get(MEM_STUB))
-                .map(Object::toString).map(Boolean::valueOf).orElse(Boolean.FALSE).booleanValue();
     }
 }

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -217,7 +217,7 @@ public class FileSystemCompiler {
         File tmpDir = null;
         // if there are any joint compilation options set stubDir if not set
         try {
-            if ((configuration.getJointCompilationOptions() != null)
+            if (configuration.getJointCompilationOptions() != null
                     && !configuration.getJointCompilationOptions().containsKey("stubDir")) {
                 tmpDir = DefaultGroovyStaticMethods.createTempDir(null, "groovy-generated-", "-java-source");
                 configuration.getJointCompilationOptions().put("stubDir", tmpDir);

--- a/src/test/org/codehaus/groovy/control/CompilerConfigurationTest.java
+++ b/src/test/org/codehaus/groovy/control/CompilerConfigurationTest.java
@@ -73,6 +73,7 @@ public final class CompilerConfigurationTest {
     public void testSetViaSystemProperties() {
         System.setProperty("groovy.warnings", "PaRaNoiA");
         System.setProperty("groovy.output.verbose", "trUE");
+        System.setProperty("groovy.generate.stub.in.memory", "true");
         System.setProperty("groovy.recompile.minimumInterval", "867892345");
 
         assertEquals("PaRaNoiA", System.getProperty("groovy.warnings"));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9368

Prevent enabling joint compilation merely by setting "groovy.generate.stub.in.memory" property.  Prevent overwriting "groovy.generate.stub.in.memory" setting when compiler config is created by `FileSystemCompiler`.