### PR TITLE
ASM: remove push/pop for if/else blocks

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -814,12 +814,10 @@ public class AsmClassGenerator extends ClassGenerator {
 
     @Override
     public void visitBooleanExpression(final BooleanExpression expression) {
-        controller.getCompileStack().pushBooleanExpression();
         int mark = controller.getOperandStack().getStackLength();
-        Expression inner = expression.getExpression();
-        inner.visit(this);
+
+        expression.getExpression().visit(this);
         controller.getOperandStack().castToBool(mark, true);
-        controller.getCompileStack().pop();
     }
 
     @Override
@@ -839,7 +837,6 @@ public class AsmClassGenerator extends ClassGenerator {
     @Override
     public void visitConstructorCallExpression(final ConstructorCallExpression call) {
         onLineNumber(call, "visitConstructorCallExpression: \"" + call.getType().getName() + "\":");
-
         if (call.isSpecialCall()) {
             controller.getInvocationWriter().writeSpecialConstructorCall(call);
             return;

--- a/src/main/java/org/codehaus/groovy/classgen/asm/StatementWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/StatementWriter.java
@@ -36,7 +36,6 @@ import org.codehaus.groovy.ast.stmt.CaseStatement;
 import org.codehaus.groovy.ast.stmt.CatchStatement;
 import org.codehaus.groovy.ast.stmt.ContinueStatement;
 import org.codehaus.groovy.ast.stmt.DoWhileStatement;
-import org.codehaus.groovy.ast.stmt.EmptyStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.ForStatement;
 import org.codehaus.groovy.ast.stmt.IfStatement;
@@ -310,28 +309,19 @@ public class StatementWriter {
         controller.getAcg().onLineNumber(statement, "visitIfElse");
         writeStatementLabel(statement);
 
-        MethodVisitor mv = controller.getMethodVisitor();
-
         statement.getBooleanExpression().visit(controller.getAcg());
         Label l0 = controller.getOperandStack().jump(IFEQ);
-
-        // if-else is here handled as a special version
-        // of a boolean expression
-        controller.getCompileStack().pushBooleanExpression();
         statement.getIfBlock().visit(controller.getAcg());
-        controller.getCompileStack().pop();
 
-        if (statement.getElseBlock() instanceof EmptyStatement) {
+        MethodVisitor mv = controller.getMethodVisitor();
+        if (statement.getElseBlock().isEmpty()) {
             mv.visitLabel(l0);
         } else {
             Label l1 = new Label();
             mv.visitJumpInsn(GOTO, l1);
             mv.visitLabel(l0);
 
-            controller.getCompileStack().pushBooleanExpression();
             statement.getElseBlock().visit(controller.getAcg());
-            controller.getCompileStack().pop();
-
             mv.visitLabel(l1);
         }
     }


### PR DESCRIPTION
Calls to pushBooleanExpression() and pop() do not seem necessary.  Simplify AsmClassGenerator and StatementWriter a bit.