### PR TITLE
GROOVY-9387: MissingMethodException: try one more metaClass.invokeMethod

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/callsite/PogoMetaClassSite.java
+++ b/src/main/java/org/codehaus/groovy/runtime/callsite/PogoMetaClassSite.java
@@ -63,8 +63,15 @@ public class PogoMetaClassSite extends MetaClassSite {
                     if (e instanceof MissingMethodExecutionFailed) {
                         throw (MissingMethodException) e.getCause();
                     } else if (receiver.getClass() == e.getType() && e.getMethod().equals(name)) {
-                        // in case there's nothing else, invoke the object's own invokeMethod()
-                        return receiver.invokeMethod(name, args);
+                        // in case there's nothing else, invoke the receiver's own invokeMethod()
+                        try {
+                            return receiver.invokeMethod(name, args);
+                        } catch (MissingMethodException mme) {
+                            if (mme instanceof MissingMethodExecutionFailed)
+                                throw (MissingMethodException) mme.getCause();
+                            // GROOVY-9387: in rare cases, this form still works
+                            return metaClass.invokeMethod(receiver, name, args);
+                        }
                     } else {
                         throw e;
                     }

--- a/src/test/groovy/bugs/Groovy9387.groovy
+++ b/src/test/groovy/bugs/Groovy9387.groovy
@@ -18,7 +18,6 @@
  */
 package groovy.bugs
 
-import groovy.test.NotYetImplemented
 import groovy.transform.CompileStatic
 import org.junit.Test
 
@@ -58,7 +57,7 @@ final class Groovy9387 {
         '''
     }
 
-    @Test @NotYetImplemented
+    @Test
     void testThisSetProperty() {
         assertScript SUPPORT_ADAPTER + '''
             class C extends BuilderSupportAdapter {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9387

This extra call could be made conditionally.  Or it could be called instead of "receiver.invokeMethod(name, args)".  Just not sure what to check to decide which way to go.