### PR TITLE
GROOVY-9389: check setter type(s) against field/property/accessor type

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -2010,6 +2010,15 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         }
         try {
             operand.visit(this);
+            SetterInfo setterInfo = removeSetterInfo(operand);
+            if (setterInfo != null) {
+                BinaryExpression rewrite = typeCheckingContext.getEnclosingBinaryExpression();
+                rewrite.setSourcePosition(origin);
+                if (ensureValidSetter(rewrite, operand, rewrite.getRightExpression(), setterInfo)) {
+                    return;
+                }
+            }
+
             ClassNode operandType = getType(operand);
             boolean isPostfix = (origin instanceof PostfixExpression);
             String name = (operator == PLUS_PLUS ? "next" : operator == MINUS_MINUS ? "previous" : null);

--- a/src/test/groovy/transform/stc/STCAssignmentTest.groovy
+++ b/src/test/groovy/transform/stc/STCAssignmentTest.groovy
@@ -732,6 +732,26 @@ class STCAssignmentTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-9389
+    void testPostfixOnNumber() {
+        assertScript '''
+            class Pogo {
+                Integer integer = 0
+                Integer getInteger() { return integer }
+                void setInteger(Integer i) { integer = i }
+            }
+            new Pogo().integer++
+        '''
+        shouldFailWithMessages '''
+            class Pogo {
+                Integer integer = 0
+                Integer getInteger() { return integer }
+                void setInteger(Character c) { integer = (c as int) }
+            }
+            new Pogo().integer++
+        ''', 'Cannot assign value of type java.lang.Integer to variable of type java.lang.Character'
+    }
+
     void testPostfixOnObject() {
         shouldFailWithMessages '''
             Object o = new Object()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9389

Need to check SetterInfo now that "x++" sees "x" as LHS.