### PR TITLE
Fix for GROOVY-9396

### DIFF
--- a/src/main/java/org/apache/groovy/ast/tools/AnnotatedNodeUtils.java
+++ b/src/main/java/org/apache/groovy/ast/tools/AnnotatedNodeUtils.java
@@ -36,7 +36,11 @@ public class AnnotatedNodeUtils {
     }
 
     public static <T extends AnnotatedNode> T markAsGenerated(ClassNode containingClass, T nodeToMark) {
-        boolean shouldAnnotate = containingClass.getModule() != null && containingClass.getModule().getContext() != null;
+        return markAsGenerated(containingClass, nodeToMark, false);
+    }
+
+    public static <T extends AnnotatedNode> T markAsGenerated(ClassNode containingClass, T nodeToMark, boolean skipChecks) {
+        boolean shouldAnnotate = skipChecks || (containingClass.getModule() != null && containingClass.getModule().getContext() != null);
         if (shouldAnnotate && !hasAnnotation(nodeToMark, GENERATED_TYPE)) {
             nodeToMark.addAnnotation(new AnnotationNode(GENERATED_TYPE));
         }

--- a/src/main/java/org/codehaus/groovy/classgen/asm/ClosureWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/ClosureWriter.java
@@ -51,6 +51,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.groovy.ast.tools.AnnotatedNodeUtils.markAsGenerated;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
@@ -284,13 +285,15 @@ public class ClosureWriter {
 
             // let's add a getter & setter
             Expression fieldExp = new FieldExpression(paramField);
-            answer.addMethod(
+            markAsGenerated(answer,
+                answer.addMethod(
                     "get" + methodName,
                     ACC_PUBLIC,
                     realType.getPlainNodeReference(),
                     Parameter.EMPTY_ARRAY,
                     ClassNode.EMPTY_ARRAY,
-                    new ReturnStatement(fieldExp));
+                    new ReturnStatement(fieldExp)),
+                true);
         }
     }
 

--- a/src/test/groovy/generated/ClosureGeneratedTest.groovy
+++ b/src/test/groovy/generated/ClosureGeneratedTest.groovy
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.generated
+
+import org.junit.Test
+
+class ClosureGeneratedTest extends AbstractGeneratedAstTestCase {
+    final Class<?> classUnderTest = parseClass('''class ClassUnderTest {
+           Closure<String> c(String arg) {
+               def closureVar = {
+                   arg
+               }
+               closureVar
+           }
+       }''')
+
+    @Test
+    void test_captured_argument_is_annotated() {
+        def objectUnderTest = classUnderTest.newInstance()
+        Closure<String> cls = classUnderTest.getMethod('c', String)
+            .invoke(objectUnderTest, 'var')
+        assertMethodIsAnnotated(cls.class, 'getArg')
+    }
+}


### PR DESCRIPTION
Please review the changes to `org.apache.groovy.ast.tools.AnnotatedNodeUtils` as the check prevented the `@Generated` annotation from being added to the target method.

If accepted, this PR should be cherry-picked to 2_X and 3_X branches