### PR TITLE
GROOVY-8707: SC: use makeSetProperty for compound assignment of property

### DIFF
--- a/src/test/groovy/transform/stc/STCAssignmentTest.groovy
+++ b/src/test/groovy/transform/stc/STCAssignmentTest.groovy
@@ -138,6 +138,21 @@ class STCAssignmentTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    void testPlusEqualsOnProperty() {
+        assertScript '''
+            class C {
+                int i
+
+                static main(args) {
+                    def c = new C()
+                    c.i = 5
+                    c.i += 10
+                    assert c.i == 15
+                }
+            }
+        '''
+    }
+
     // GROOVY-9385
     void testPlusEqualsOnPrivateField() {
         assertScript '''

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/AssignmentsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/AssignmentsStaticCompileTest.groovy
@@ -21,7 +21,14 @@ package org.codehaus.groovy.classgen.asm.sc
 import groovy.transform.stc.STCAssignmentTest
 
 /**
- * Unit tests for static type checking : assignments.
+ * Unit tests for static compilation : assignments.
  */
-class AssignmentsStaticCompileTest extends STCAssignmentTest implements StaticCompilationTestSupport {}
+final class AssignmentsStaticCompileTest extends STCAssignmentTest implements StaticCompilationTestSupport {
 
+    @Override // GROOVY-8707
+    void testPlusEqualsOnProperty() {
+        super.testPlusEqualsOnProperty()
+        String bytecode = astTrees['C'][1]
+        assert !bytecode.contains('ScriptBytecodeAdapter.setGroovyObjectProperty') : '"c.i += 10" should use setter, not dynamic property'
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-8707

StaticTypesBinaryExpressionMultiTypeDispatcher#evaluateEqual already does this for plain assignment

This replaces "invokestatic org.codehaus.groovy.runtime.ScriptBytecodeAdapter.setGroovyObjectProperty(java.lang.Object, java.lang.Class, groovy.lang.GroovyObject, java.lang.String)" with "invokevirtual ClassName.setPropName(int)".