### PR TITLE
FIX GROOVY-9412

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/GenericsType.java
+++ b/src/main/java/org/codehaus/groovy/ast/GenericsType.java
@@ -291,7 +291,9 @@ public class GenericsType extends ASTNode {
     private boolean checkGenerics(final ClassNode classNode) {
         ClassNode lowerBound = getLowerBound();
         if (lowerBound != null) {
-            return compareGenericsWithBound(classNode, lowerBound);
+            if (!lowerBound.redirect().isUsingGenerics()) {
+                return compareGenericsWithBound(classNode, lowerBound);
+            }
         }
         ClassNode[] upperBounds = getUpperBounds();
         if (upperBounds != null) {

--- a/src/test/groovy/bugs/Groovy9412Bug.groovy
+++ b/src/test/groovy/bugs/Groovy9412Bug.groovy
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import groovy.test.GroovyTestCase;
+class Groovy9412Bug extends GroovyTestCase {
+    void testProtectedFieldInClosureInEnum(){
+        assertScript '''
+    import groovy.transform.TypeChecked
+
+        @TypeChecked
+        class MyClass {
+
+            interface Foo {}
+
+            enum Bar implements Foo {
+                AA
+            }
+
+            void F() {
+                List<Foo> g = []
+                g.add(Bar.AA)
+            }
+        }
+
+    assert new MyClass()
+    '''
+
+    }
+}


### PR DESCRIPTION
The bug is [https://issues.apache.org/jira/browse/GROOVY-9412](https://issues.apache.org/jira/browse/GROOVY-9412)

An IF statement is needed when checking the generic types of lower bounds, otherwise, it is problematic to check the inference of generic types.

Please ignore [wrong pull request](https://github.com/apache/groovy/pull/1176), I'm terribly sorry for this wrong pr.