### PR TITLE
GROOVY-9469: Preserve exception in global AST transformation creation

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -345,9 +345,10 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
                         + entry.getValue().toExternalForm() + " is not an ASTTransformation.", null));
                 }
             } catch (Exception e) {
+                Throwable effectiveException = e instanceof InvocationTargetException ? e.getCause() : e;
                 compilationUnit.getErrorCollector().addError(new SimpleMessage(
                     "Could not instantiate global transform class " + entry.getKey() + " specified at "
-                    + entry.getValue().toExternalForm() + "  because of exception " + e.toString(), null));
+                    + entry.getValue().toExternalForm() + "  because of exception " + effectiveException.toString(), null));
             }
         }
     }


### PR DESCRIPTION
InvocationTargetException is not very meaningful. It worked in Groovy 2.5.

https://issues.apache.org/jira/browse/GROOVY-9469

Related issue in Spock: https://github.com/spockframework/spock/issues/1067