### PR TITLE
GroovyLexer: Eliminate duplication in JavaLetter[OrDigit]InGString

### DIFF
--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -887,37 +887,19 @@ IdentifierInGString
     ;
 
 fragment
-JavaLetterInGString
-    :   [a-zA-Z_] // these are the "java letters" below 0x7F, except for $
-    |   // covers all characters above 0x7F which are not a surrogate
-        ~[\u0000-\u007F\uD800-\uDBFF]
-        {Character.isJavaIdentifierStart(_input.LA(-1))}?
-    |   // covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
-        [\uD800-\uDBFF] [\uDC00-\uDFFF]
-        {Character.isJavaIdentifierStart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1)))}?
-    ;
-
-fragment
-JavaLetterOrDigitInGString
-    :   [a-zA-Z0-9_] // these are the "java letters or digits" below 0x7F, except for $
-    |   // covers all characters above 0x7F which are not a surrogate
-        ~[\u0000-\u007F\uD800-\uDBFF]
-        {Character.isJavaIdentifierPart(_input.LA(-1))}?
-    |   // covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
-        [\uD800-\uDBFF] [\uDC00-\uDFFF]
-        {Character.isJavaIdentifierPart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1)))}?
-    ;
-
-
-fragment
 JavaLetter
     :   [a-zA-Z$_] // these are the "java letters" below 0x7F
     |   // covers all characters above 0x7F which are not a surrogate
         ~[\u0000-\u007F\uD800-\uDBFF]
-        {Character.isJavaIdentifierStart(_input.LA(-1))}?
+        { Character.isJavaIdentifierStart(_input.LA(-1)) }?
     |   // covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
         [\uD800-\uDBFF] [\uDC00-\uDFFF]
-        {Character.isJavaIdentifierStart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1)))}?
+        { Character.isJavaIdentifierStart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1))) }?
+    ;
+
+fragment
+JavaLetterInGString
+    :   JavaLetter { _input.LA(-1) != '$' }?
     ;
 
 fragment
@@ -925,10 +907,15 @@ JavaLetterOrDigit
     :   [a-zA-Z0-9$_] // these are the "java letters or digits" below 0x7F
     |   // covers all characters above 0x7F which are not a surrogate
         ~[\u0000-\u007F\uD800-\uDBFF]
-        {Character.isJavaIdentifierPart(_input.LA(-1))}?
+        { Character.isJavaIdentifierPart(_input.LA(-1)) }?
     |   // covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
         [\uD800-\uDBFF] [\uDC00-\uDFFF]
-        {Character.isJavaIdentifierPart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1)))}?
+        { Character.isJavaIdentifierPart(Character.toCodePoint((char)_input.LA(-2), (char)_input.LA(-1))) }?
+    ;
+
+fragment
+JavaLetterOrDigitInGString
+    :   JavaLetterOrDigit  { _input.LA(-1) != '$' }?
     ;
 
 //
@@ -941,9 +928,8 @@ ELLIPSIS : '...';
 //
 // Whitespace, line escape and comments
 //
-WS  :  ([ \t\u000C]+ | LineEscape+)     -> skip
+WS  : ([ \t\u000C]+ | LineEscape+) -> skip
     ;
-
 
 // Inside (...) and [...] but not {...}, ignore newlines.
 NL  : LineTerminator   { this.ignoreTokenInsideParens(); }


### PR DESCRIPTION
Define them in terms of JavaLetter[OrDigit] with semantic predicate

NOTE: I want to propose a change to JavaLetter, JavaLetterOrDigit, JavaLetterInGString and JavaLetterOrDigitInGString.  But first, I wanted to reduce the duplication.