### PR TITLE
Avoid unnecessary boxing and unbox of primitive values.

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -13069,7 +13069,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      */
     public static <T> List<List<T>> chop(Iterator<T> self, int... chopSizes) {
         List<List<T>> result = new ArrayList<List<T>>();
-        for (Integer nextSize : chopSizes) {
+        for (int nextSize : chopSizes) {
             int size = nextSize;
             List<T> next = new ArrayList<T>();
             while (size-- != 0 && self.hasNext()) {

--- a/src/main/java/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
+++ b/src/main/java/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
@@ -299,12 +299,12 @@ public class DefaultTypeTransformation {
                 return n.floatValue();
             }
             if (type == Double.class) {
-                Double answer = n.doubleValue();
+                double answer = n.doubleValue();
                 //throw a runtime exception if conversion would be out-of-range for the type.
                 if (!(n instanceof Double) && (answer == Double.NEGATIVE_INFINITY
                         || answer == Double.POSITIVE_INFINITY)) {
                     throw new GroovyRuntimeException("Automatic coercion of " + n.getClass().getName()
-                            + " value " + n + " to double failed.  Value is out of range.");
+                            + " value " + n + " to double failed. Value is out of range.");
                 }
                 return answer;
             }
@@ -345,12 +345,12 @@ public class DefaultTypeTransformation {
         } else if (type == float.class) {
             return floatUnbox(object);
         } else if (type == double.class) {
-            Double answer = doubleUnbox(object);
+            double answer = doubleUnbox(object);
             //throw a runtime exception if conversion would be out-of-range for the type.
             if (!(object instanceof Double) && (answer == Double.NEGATIVE_INFINITY
                     || answer == Double.POSITIVE_INFINITY)) {
                 throw new GroovyRuntimeException("Automatic coercion of " + object.getClass().getName()
-                        + " value " + object + " to double failed.  Value is out of range.");
+                        + " value " + object + " to double failed. Value is out of range.");
             }
             return answer;
         } //nothing else possible

--- a/src/main/java/org/codehaus/groovy/transform/FieldASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/FieldASTTransformation.java
@@ -273,7 +273,7 @@ public class FieldASTTransformation extends ClassCodeExpressionTransformer imple
 
     @Override
     public void visitMethod(MethodNode node) {
-        Boolean oldInsideScriptBody = insideScriptBody;
+        boolean oldInsideScriptBody = insideScriptBody;
         if (node.isScriptBody()) insideScriptBody = true;
         super.visitMethod(node);
         insideScriptBody = oldInsideScriptBody;


### PR DESCRIPTION
This improves readability because it makes it clear that the value can never be null.