### PR TITLE
Changing SH_COMMENT to allow multiple shell directives

### DIFF
--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -948,7 +948,7 @@ SL_COMMENT
 // Script-header comments.
 // The very first characters of the file may be "#!".  If so, ignore the first line.
 SH_COMMENT
-    :   '#!' { require(0 == this.tokenIndex, "Shebang comment should appear at the first line", -2, true); } ~[\r\n\uFFFF]* -> skip
+    : '#!' { require(0 == this.tokenIndex, "Shebang comment should appear at the first line", -2, true); } ~[\r\n\uFFFF]* LineTerminator ('#!' ~[\r\n\uFFFF]* LineTerminator)* -> skip
     ;
 
 // Unexpected characters will be handled by groovy parser later.

--- a/src/main/antlr2/org/codehaus/groovy/antlr/groovy.g
+++ b/src/main/antlr2/org/codehaus/groovy/antlr/groovy.g
@@ -3554,8 +3554,16 @@ options {
             // This will fix the issue GROOVY-766 (infinite loop).
             ~('\n'|'\r'|'\uffff')
         )*
+        ONE_NL[true]
+        ("#!"
+          (
+              options {  greedy = true;  }:
+              // '\uffff' means the EOF character.
+              // This will fix the issue GROOVY-766 (infinite loop).
+              ~('\n'|'\r'|'\uffff')
+          )* ONE_NL[true]
+        )*
         { if (!whitespaceIncluded)  $setType(Token.SKIP); }
-        //ONE_NL  //Never a significant newline, but might as well separate it.
     ;
 
 // multiple-line comments

--- a/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
+++ b/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
@@ -44,6 +44,10 @@ final class GroovyParserTest extends GroovyTestCase {
         doTestAttachedComments()
     }
 
+    void "test groovy core - Shebang Comments"() {
+        doTest('core/Comments_03.groovy', [ExpressionStatement])
+    }
+
     // java.lang.ClassFormatError: Illegal method name "test IO stream/reader closed by the parser properly" when using Java9
     void "test IO reader closed by the parser properly"() {
         def f = File.createTempFile("Script${System.nanoTime()}", ".groovy")

--- a/subprojects/parser-antlr4/src/test/resources/core/Comments_03.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/core/Comments_03.groovy
@@ -1,0 +1,30 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i groovy -p groovy
+#! other directives
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+/**
+ * Created by Daniel.Sun on 2016/08/16.
+ */
+
+// this is a line comment
+
+println /* method name */ 1 /* one */ /* followed by plus */ + /* plus */ 2 /* two */
++3


### PR DESCRIPTION
Hello, this is intended to fix [GROOVY-9310](https://issues.apache.org/jira/browse/GROOVY-9310)