### PR TITLE
Add support for Path to groovy slurpers

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonSlurper.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonSlurper.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -332,6 +334,27 @@ public class JsonSlurper {
             default:
                 return new JsonParserCharArray();
         }
+    }
+
+    /**
+     * Parse a JSON data structure from content within a given Path.
+     *
+     * @param path {@link Path} containing JSON content
+     * @return a data structure of lists and maps
+     */
+    public Object parse(Path path) throws IOException {
+        return parse(Files.newInputStream(path));
+    }
+
+    /**
+     * Parse a JSON data structure from content within a given Path.
+     *
+     * @param path {@link Path} containing JSON content
+     * @param charset the charset for this File
+     * @return a data structure of lists and maps
+     */
+    public Object parse(Path path, String charset) throws IOException {
+        return parse(Files.newInputStream(path), charset);
     }
 
     /**

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -351,4 +351,37 @@ class JsonSlurperTest extends GroovyTestCase {
         shouldFail(exceptional) { parser.parseText('{"num": 6-}') }
     }
 
+
+    void testParsePath() {
+        def file = File.createTempFile('test','json')
+        file.deleteOnExit()
+        file.text = '''
+            {
+                "response": {
+                    "status": "ok",
+                    "code": 200,
+                    "chuncked": false,
+                    "content-type-supported": ["text/html", "text/plain"],
+                    "headers": {
+                        "If-Last-Modified": "2010"
+                    }
+                }
+            }
+        '''
+
+        and:
+        def result = new JsonSlurper().parse(file.toPath())
+        assert result == [
+                response: [
+                        status: "ok",
+                        code: 200,
+                        chuncked: false,
+                        "content-type-supported": ["text/html", "text/plain"],
+                        headers: [
+                                "If-Last-Modified": "2010"
+                        ]
+                ] ]
+
+    }
+
 }

--- a/subprojects/groovy-xml/src/main/java/groovy/xml/XmlSlurper.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/xml/XmlSlurper.java
@@ -45,9 +45,12 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
+
 
 /**
  * Parse XML into a document tree that may be traversed similar to XPath
@@ -266,6 +269,10 @@ public class XmlSlurper extends DefaultHandler {
      */
     public GPathResult parse(final String uri) throws IOException, SAXException {
         return parse(new InputSource(uri));
+    }
+
+    public GPathResult parse(final Path path) throws IOException, SAXException {
+       return parse(Files.newInputStream(path));
     }
 
     /**

--- a/subprojects/groovy-yaml/src/main/java/groovy/yaml/YamlSlurper.java
+++ b/subprojects/groovy-yaml/src/main/java/groovy/yaml/YamlSlurper.java
@@ -21,8 +21,13 @@ package groovy.yaml;
 import groovy.json.JsonSlurper;
 import org.apache.groovy.yaml.util.YamlConverter;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  *  Represents a YAML parser
@@ -54,5 +59,36 @@ public class YamlSlurper {
      */
     public Object parse(Reader reader) {
         return jsonSlurper.parse(new StringReader(YamlConverter.convertYamlToJson(reader)));
+    }
+
+    /**
+     * Parse the content of the specified reader into a tree of Nodes.
+     *
+     * @param stream the reader of yaml
+     * @return the root node of the parsed tree of Nodes
+     */
+    public Object parse(InputStream stream) {
+        return parse(new InputStreamReader(stream));
+    }
+
+    /**
+     * Parse the content of the specified file into a tree of Nodes.
+     *
+     * @param file the reader of yaml
+     * @return the root node of the parsed tree of Nodes
+     */
+    public Object parse(java.io.File file) throws IOException {
+        return parse(file.toPath());
+    }
+
+    /**
+     * Parse the content of the specified path into a tree of Nodes.
+     *
+     * @param path the reader of yaml
+     * @return the root node of the parsed tree of Nodes
+     */
+    public Object parse(Path path) throws IOException {
+        // note: convert to an input stream to allow the support of foreign file objects
+        return parse(Files.newInputStream(path));
     }
 }

--- a/subprojects/groovy-yaml/src/spec/test/groovy/yaml/YamlParserTest.groovy
+++ b/subprojects/groovy-yaml/src/spec/test/groovy/yaml/YamlParserTest.groovy
@@ -18,6 +18,7 @@
  */
 package groovy.yaml
 
+
 import groovy.test.GroovyTestCase
 
 class YamlParserTest extends GroovyTestCase {
@@ -77,5 +78,32 @@ before_script:
         assert 'http://example.org' == yaml.records.car.homepage
         assert 'speed' == yaml.records.car.record.type
         assert 'production pickup truck with speed of 271kph' == yaml.records.car.record.description
+    }
+
+
+    void testParsePath() {
+        def file = File.createTempFile('test','yml')
+        file.deleteOnExit()
+        file.text = '''
+language: groovy
+sudo: required
+dist: trusty
+
+matrix:
+  include:
+    - jdk: openjdk10
+    - jdk: oraclejdk9
+    - jdk: oraclejdk8
+'''
+
+        def ys = new YamlSlurper()
+        def yaml = ys.parse(file.toPath())
+
+        // check
+        assert 'groovy' == yaml.language
+        assert 'required' == yaml.sudo
+        assert 'trusty' == yaml.dist
+        assert ['openjdk10', 'oraclejdk9', 'oraclejdk8'] ==  yaml.matrix.include.jdk
+
     }
 }


### PR DESCRIPTION
This PR adds a `parse` method able to handle NIO `Path` object. 

This is convenient because it allows the handling of foreign file objects (such as S3) which currently cannot be parsed just converting plain `File` to a path using the built-in `File.toPath()` method.  