### PR TITLE
GROOVY-9505: Bump ASM_API_VERSION to Opcodes.ASM8

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -122,7 +122,7 @@ public class CompilerConfiguration {
      */
     public static final String[] ALLOWED_JDKS = JDK_TO_BYTECODE_VERSION_MAP.keySet().toArray(new String[JDK_TO_BYTECODE_VERSION_MAP.size()]);
 
-    public static final int ASM_API_VERSION = Opcodes.ASM7;
+    public static final int ASM_API_VERSION = Opcodes.ASM8;
 
     /**
      * The default source encoding.


### PR DESCRIPTION
Related with issue:
https://issues.apache.org/jira/browse/GROOVY-9505
https://github.com/spockframework/spock/issues/1142#issuecomment-612855754