### PR TITLE
enable Log4J tests bye ensuring indy is really enabled by default. 

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/WriterController.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/WriterController.java
@@ -79,17 +79,10 @@ public class WriterController {
 
     public void init(final AsmClassGenerator asmClassGenerator, final GeneratorContext gcon, final ClassVisitor cv, final ClassNode cn) {
         CompilerConfiguration config = cn.getCompileUnit().getConfig();
+        boolean invokedynamic = config.isIndyEnabled();
         Map<String,Boolean> optOptions = config.getOptimizationOptions();
-        boolean invokedynamic = false;
-        if (optOptions.isEmpty()) {
-            // IGNORE
-        } else if (Boolean.FALSE.equals(optOptions.get("all"))) {
+        if (!invokedynamic && Boolean.FALSE.equals(optOptions.get("all"))) {
             this.optimizeForInt = false;
-            // set other optimizations options to false here
-        } else {
-            if (config.isIndyEnabled()) invokedynamic = true;
-            if (Boolean.FALSE.equals(optOptions.get("int"))) this.optimizeForInt = false;
-            if (invokedynamic) this.optimizeForInt = false;
             // set other optimizations options to false here
         }
         this.classNode = cn;

--- a/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -1066,7 +1066,7 @@ public class CompilerConfiguration {
      */
     public boolean isIndyEnabled() {
         Boolean indyEnabled = getOptimizationOptions().get(INVOKEDYNAMIC);
-        return Optional.ofNullable(indyEnabled).orElse(Boolean.TRUE);
+        return indyEnabled != Boolean.FALSE;
     }
 
     /**

--- a/src/test/groovy/util/logging/Log4j2Test.groovy
+++ b/src/test/groovy/util/logging/Log4j2Test.groovy
@@ -206,7 +206,6 @@ class Log4j2Test extends GroovyTestCase {
         }
     }
 
-    @NotYetImplemented
     void testLogInfo() {
         Class clazz = new GroovyClassLoader().parseClass('''
             @groovy.util.logging.Log4j2
@@ -242,7 +241,6 @@ class Log4j2Test extends GroovyTestCase {
         assert events[ind].message == "trace called"
     }
 
-    @NotYetImplemented
     void testLogFromStaticMethods() {
         Class clazz = new GroovyClassLoader().parseClass("""
             @groovy.util.logging.Log4j2
@@ -261,7 +259,6 @@ class Log4j2Test extends GroovyTestCase {
         assert events[0].message == "(static) info called"
     }
 
-    @NotYetImplemented
     void testLogInfoForNamedLogger() {
         Class clazz = new GroovyClassLoader().parseClass('''
             @groovy.util.logging.Log4j2('logger')
@@ -323,7 +320,6 @@ class Log4j2Test extends GroovyTestCase {
         assert appender.isLogGuarded == true
     }
 
-    @NotYetImplemented
     void testDefaultCategory() {
         Class clazz = new GroovyClassLoader().parseClass("""
                 @groovy.util.logging.Log4j2
@@ -338,7 +334,6 @@ class Log4j2Test extends GroovyTestCase {
         assert appender.getEvents().size() == 1
     }
 
-    @NotYetImplemented
     void testCustomCategory() {
         PatternLayout layout = createLayout('%m', Charset.forName('UTF-8'))
         Log4j2InterceptingAppender appenderForCustomCategory = new Log4j2InterceptingAppender('Appender4CustomCategory', null, layout)


### PR DESCRIPTION
Warning these tests will still fail in a mixed indy/old callsite mode.