### PR TITLE
[GROOVY-9308] Added "final var" shortcut keywords "let" and "val"

### DIFF
--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -366,6 +366,8 @@ fragment DollarSlashyStringCharacter
 // Groovy keywords
 AS              : 'as';
 DEF             : 'def';
+VAL             : 'val';
+LET             : 'let';
 IN              : 'in';
 TRAIT           : 'trait';
 THREADSAFE      : 'threadsafe'; // reserved keyword

--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -131,6 +131,8 @@ modifier
           |   VOLATILE
           |   DEF
           |   VAR
+          |   VAL
+          |   LET
           )
     ;
 
@@ -170,6 +172,8 @@ variableModifier
     |   m=( FINAL
           | DEF
           | VAR
+          | VAL
+          | LET
           // Groovy supports declaring local variables as instance/class fields,
           // e.g. import groovy.transform.*; @Field static List awe = [1, 2, 3]
           // e.g. import groovy.transform.*; def a = { @Field public List awe = [1, 2, 3] }
@@ -1142,6 +1146,8 @@ identifier
     :   Identifier
     |   CapitalizedIdentifier
     |   VAR
+    |   VAL
+    |   LET
     |   IN
 //    |   DEF
     |   TRAIT
@@ -1200,6 +1206,8 @@ keywords
     |   THREADSAFE
     |   TRY
     |   VAR
+    |   VAL
+    |   LET
     |   VOLATILE
     |   WHILE
 

--- a/src/test/groovy/ModifiersTest.groovy
+++ b/src/test/groovy/ModifiersTest.groovy
@@ -22,90 +22,100 @@ import gls.CompilableTestSupport
 
 class ModifiersTest extends CompilableTestSupport {
 
-    public void testInterface() {
-        // control
-        shouldCompile("interface X {}")
-        // erroneous
-        shouldNotCompile("synchronized interface X {}")
-    }
+	public void testInterface() {
+		// control
+		shouldCompile("interface X {}")
+		// erroneous
+		shouldNotCompile("synchronized interface X {}")
+	}
 
-    public void testClass() {
-        // control
-        shouldCompile("public class X {}")
-        shouldCompile """
+	public void testClass() {
+		// control
+		shouldCompile("public class X {}")
+		shouldCompile """
             class X {
                 private class Y {}
             }
         """
-        // erroneous
-        shouldNotCompile("public private class X {}")
-        shouldNotCompile("synchronized class X {}")
-        shouldNotCompile("private class X {}")
-    }
+		// erroneous
+		shouldNotCompile("public private class X {}")
+		shouldNotCompile("synchronized class X {}")
+		shouldNotCompile("private class X {}")
+	}
 
-    public void testMethodsShouldOnlyHaveOneVisibility() {
-        // control
-        shouldCompile("class X { private method() {} }")
-        // erroneous
-        shouldNotCompile("class X { private public method() {} }")
-    }
+	public void testMethodsShouldOnlyHaveOneVisibility() {
+		// control
+		shouldCompile("class X { private method() {} }")
+		// erroneous
+		shouldNotCompile("class X { private public method() {} }")
+	}
 
-    public void testFinalMethodParametersShouldNotBeModified() {
-        // control
-        shouldCompile("class X { private method(x) { x = 1 } }")
-        // erroneous
-        shouldNotCompile("class X { private method(final x) { x = 1 } }")
-    }
+	public void testFinalMethodParametersShouldNotBeModified() {
+		// control
+		shouldCompile("class X { private method(x) { x = 1 } }")
+		// erroneous
+		shouldNotCompile("class X { private method(final x) { x = 1 } }")
+	}
 
-    public void testMethodsShouldNotBeVolatile() {
-        // control
-        shouldCompile("class X { def method() {} }")
-        // erroneous
-        shouldNotCompile("class X { volatile method() {} }")
-    }
+	public void testMethodsShouldNotBeVolatile() {
+		// control
+		shouldCompile("class X { def method() {} }")
+		// erroneous
+		shouldNotCompile("class X { volatile method() {} }")
+	}
 
-    public void testInterfaceMethodsShouldNotBeSynchronizedNativeStrictfp() {
-        // control
-        shouldCompile("interface X { def method() }")
-        // erroneous
-        shouldNotCompile("interface X { native method() }")
-        shouldNotCompile("interface X { synchronized method() }")
-        shouldNotCompile("interface X { strictfp method() }")
-    }
+	public void testInterfaceMethodsShouldNotBeSynchronizedNativeStrictfp() {
+		// control
+		shouldCompile("interface X { def method() }")
+		// erroneous
+		shouldNotCompile("interface X { native method() }")
+		shouldNotCompile("interface X { synchronized method() }")
+		shouldNotCompile("interface X { strictfp method() }")
+	}
 
-    public void testVariableInClass() {
-        // control
-        shouldCompile("class X { protected name }")
-        // erroneous
-        shouldNotCompile("class X { protected private name }")
-    }
+	public void testVariableInClass() {
+		// control
+		shouldCompile("class X { protected name }")
+		// erroneous
+		shouldNotCompile("class X { protected private name }")
+	}
 
-    public void testVariableInScript() {
-        // control
-        shouldCompile("def name")
-        shouldCompile("String name")
-        // erroneous
-        shouldNotCompile("abstract name")
-        shouldNotCompile("native name")
-        shouldNotCompile("private name")
-        shouldNotCompile("protected name")
-        shouldNotCompile("public name")
-        shouldNotCompile("static name")
-        shouldNotCompile("strictfp name")
-        shouldNotCompile("synchronized name")
-        shouldNotCompile("transient name")
-        shouldNotCompile("volatile name")
-        shouldNotCompile("private protected name")
-    }
+	public void testVariableInScript() {
+		// control
+		shouldCompile("def name")
+		shouldCompile("var name")
+		shouldCompile("val name")
+		shouldCompile("let name")
+		shouldCompile("String name")
+		shouldCompile("final name")
+		// erroneous
+		shouldNotCompile("final val name")
+		shouldNotCompile("final let name")
+		shouldNotCompile("abstract name")
+		shouldNotCompile("native name")
+		shouldNotCompile("private name")
+		shouldNotCompile("protected name")
+		shouldNotCompile("public name")
+		shouldNotCompile("static name")
+		shouldNotCompile("strictfp name")
+		shouldNotCompile("synchronized name")
+		shouldNotCompile("transient name")
+		shouldNotCompile("volatile name")
+		shouldNotCompile("private protected name")
+	}
 
-    public void testInvalidModifiersOnConstructor() {
-        // control
-        shouldCompile("class Foo { Foo() {}}")
-        // erroneous
-        shouldNotCompile("class Foo { static Foo() {}}")
-        shouldNotCompile("class Foo { final Foo() {}}")
-        shouldNotCompile("class Foo { abstract Foo() {}}")
-        shouldNotCompile("class Foo { native Foo() {}}")
-    }
+	public void testInvalidModifiersOnConstructor() {
+		// control
+		shouldCompile("class Foo { Foo() {}}")
+		// erroneous
+		shouldNotCompile("class Foo { static Foo() {}}")
+		shouldNotCompile("class Foo { final Foo() {}}")
+		shouldNotCompile("class Foo { abstract Foo() {}}")
+		shouldNotCompile("class Foo { native Foo() {}}")
+	}
 
+	public void testMethodsShouldNotAllowValOrLet() {
+		shouldNotCompile("class X { let method() {} }")
+		shouldNotCompile("class X { val method() {} }")
+	}
 }

--- a/subprojects/parser-antlr4/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/subprojects/parser-antlr4/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -190,6 +190,8 @@ import static org.apache.groovy.parser.antlr4.GroovyLangParser.CreatedNameContex
 import static org.apache.groovy.parser.antlr4.GroovyLangParser.CreatorContext;
 import static org.apache.groovy.parser.antlr4.GroovyLangParser.DEC;
 import static org.apache.groovy.parser.antlr4.GroovyLangParser.DEF;
+import static org.apache.groovy.parser.antlr4.GroovyLangParser.VAL;
+import static org.apache.groovy.parser.antlr4.GroovyLangParser.LET;
 import static org.apache.groovy.parser.antlr4.GroovyLangParser.DEFAULT;
 import static org.apache.groovy.parser.antlr4.GroovyLangParser.DimContext;
 import static org.apache.groovy.parser.antlr4.GroovyLangParser.DoWhileStmtAltContext;
@@ -1508,7 +1510,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     public MethodNode visitMethodDeclaration(MethodDeclarationContext ctx) {
         ModifierManager modifierManager = createModifierManager(ctx);
 
-        if (modifierManager.containsAny(VAR)) {
+        if (modifierManager.containsAny(VAR, VAL, LET)) {
             throw createParsingFailedException("var cannot be used for method declarations", ctx);
         }
 
@@ -4357,7 +4359,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
             return true;
         }
 
-        if (hasReturnType && (modifierManager.containsAny(DEF, VAR))) {
+        if (hasReturnType && (modifierManager.containsAny(DEF, VAR, VAL, LET))) {
             return true;
         }
 

--- a/subprojects/parser-antlr4/src/main/java/org/codehaus/groovy/ast/ModifierNode.java
+++ b/subprojects/parser-antlr4/src/main/java/org/codehaus/groovy/ast/ModifierNode.java
@@ -37,6 +37,8 @@ import static org.apache.groovy.parser.antlr4.GroovyParser.STRICTFP;
 import static org.apache.groovy.parser.antlr4.GroovyParser.SYNCHRONIZED;
 import static org.apache.groovy.parser.antlr4.GroovyParser.TRANSIENT;
 import static org.apache.groovy.parser.antlr4.GroovyParser.VAR;
+import static org.apache.groovy.parser.antlr4.GroovyParser.VAL;
+import static org.apache.groovy.parser.antlr4.GroovyParser.LET;
 import static org.apache.groovy.parser.antlr4.GroovyParser.VOLATILE;
 import static org.codehaus.groovy.runtime.DefaultGroovyMethods.asBoolean;
 
@@ -57,6 +59,8 @@ public class ModifierNode extends ASTNode {
             ANNOTATION_TYPE, 0,
             DEF, 0,
             VAR, 0,
+            VAL, Opcodes.ACC_FINAL, // -> final var
+            LET, Opcodes.ACC_FINAL, // -> final var
 
             NATIVE, Opcodes.ACC_NATIVE,
             SYNCHRONIZED, Opcodes.ACC_SYNCHRONIZED,
@@ -127,7 +131,12 @@ public class ModifierNode extends ASTNode {
     }
 
     public boolean isDef() {
-        return Objects.equals(DEF, this.type) || Objects.equals(VAR, this.type);
+        return Objects.equals(DEF, this.type) ||
+        		Objects.equals(VAR, this.type) ||
+        		
+        		// includes "final" modifier
+        		Objects.equals(VAL, this.type) ||
+        		Objects.equals(LET, this.type);
     }
 
     public Integer getType() {

--- a/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
+++ b/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
@@ -414,6 +414,14 @@ final class GroovyParserTest extends GroovyTestCase {
     void "test groovy core - var"() {
         doRunAndTestAntlr4('core/Var_01x.groovy');
     }
+	
+	void "test groovy core - val"() {
+		doRunAndTestAntlr4('core/Val_01x.groovy');
+	}
+	
+	void "test groovy core - let"() {
+		doRunAndTestAntlr4('core/Let_01x.groovy');
+	}
 
     void "test groovy core - String"() {
         doRunAndTestAntlr4('core/String_01x.groovy');

--- a/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/SyntaxErrorTest.groovy
+++ b/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/SyntaxErrorTest.groovy
@@ -355,6 +355,18 @@ final class SyntaxErrorTest extends GroovyTestCase {
         TestUtils.doRunAndShouldFail('fail/Var_01x.groovy')
         TestUtils.doRunAndShouldFail('fail/Var_02x.groovy')
     }
+	
+	void 'test groovy core - val'() {
+		TestUtils.doRunAndShouldFail('fail/Val_01x.groovy')
+		TestUtils.doRunAndShouldFail('fail/Val_02x.groovy')
+		TestUtils.doRunAndShouldFail('fail/Val_03x.groovy')
+	}
+	
+	void 'test groovy core - let'() {
+		TestUtils.doRunAndShouldFail('fail/Let_01x.groovy')
+		TestUtils.doRunAndShouldFail('fail/Let_02x.groovy')
+		TestUtils.doRunAndShouldFail('fail/Let_03x.groovy')
+	}
 
     void 'test groovy core - String'() {
         TestUtils.doRunAndShouldFail('fail/String_01x.groovy')

--- a/subprojects/parser-antlr4/src/test/resources/core/Let_01x.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/core/Let_01x.groovy
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+[1, 2, 3].each { let ->
+    assert 0 < let && let < 4
+}
+
+let name = "Daniel"
+assert "Daniel" == name
+
+let let = "let variable name"
+assert "let variable name" == let

--- a/subprojects/parser-antlr4/src/test/resources/core/Val_01x.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/core/Val_01x.groovy
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+[1, 2, 3].each { val ->
+    assert 0 < val && val < 4
+}
+
+val name = "Daniel"
+assert "Daniel" == name
+
+val val = "val variable name"
+assert "val variable name" == val

--- a/subprojects/parser-antlr4/src/test/resources/fail/Let_01x2.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/fail/Let_01x2.groovy
@@ -1,0 +1,20 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+class let {}

--- a/subprojects/parser-antlr4/src/test/resources/fail/Let_02x2.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/fail/Let_02x2.groovy
@@ -1,0 +1,20 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+let someMethod() {}

--- a/subprojects/parser-antlr4/src/test/resources/fail/Let_03x.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/fail/Let_03x.groovy
@@ -1,0 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+let name = "John"
+name = "Eden"

--- a/subprojects/parser-antlr4/src/test/resources/fail/Val_01x.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/fail/Val_01x.groovy
@@ -1,0 +1,20 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+class val {}

--- a/subprojects/parser-antlr4/src/test/resources/fail/Val_02x.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/fail/Val_02x.groovy
@@ -1,0 +1,20 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+val someMethod() {}

--- a/subprojects/parser-antlr4/src/test/resources/fail/Val_03x.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/fail/Val_03x.groovy
@@ -1,0 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+val name = "John"
+name = "Eden"


### PR DESCRIPTION
I implemented bot `let` and `val` in this repo: https://github.com/mojo2012/groovy
I also added tests (similar to the `var` and `def` keyword. But unfortunately I didn't manage to make `final val` or `final let` invalid. 
Maybe someone of you can point me in the right direction?

Anyway, I don't know if including both keywords is a good idea, but as both kotlin and scala went with the `val` keyword, I guess it's best to go for this as well.

Let me know if you are interested in this feature.