### PR TITLE
GROOVY-9543: Groovydoc generics improvements

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/apache/groovy/antlr/GroovydocVisitor.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/apache/groovy/antlr/GroovydocVisitor.java
@@ -36,6 +36,7 @@ import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.groovydoc.GroovyClassDoc;
 import org.codehaus.groovy.groovydoc.GroovyMethodDoc;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codehaus.groovy.tools.groovydoc.LinkArgument;
 import org.codehaus.groovy.tools.groovydoc.SimpleGroovyAnnotationRef;
 import org.codehaus.groovy.tools.groovydoc.SimpleGroovyClassDoc;
@@ -205,19 +206,9 @@ public class GroovydocVisitor extends ClassCodeVisitorSupport {
     }
 
     private String genericTypesAsString(GenericsType[] genericsTypes) {
-        if (genericsTypes == null) return "";
-        StringBuilder result = new StringBuilder("<");
-        boolean first = true;
-        for (GenericsType genericsType : genericsTypes) {
-            if (!first) {
-                result.append(", ");
-            } else {
-                first = false;
-            }
-            result.append(genericsType.getName());
-        }
-        result.append(">");
-        return result.toString();
+        if (genericsTypes == null || genericsTypes.length == 0)
+            return "";
+        return "<" + DefaultGroovyMethods.join(genericsTypes, ", ") + ">";
     }
 
     private void processPropertiesFromGetterSetter(SimpleGroovyMethodDoc currentMethodDoc) {

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
@@ -74,6 +74,8 @@ public class SimpleGroovyClassDoc extends SimpleGroovyAbstractableElementDoc imp
         TAG_TEXT.put("author", "Authors");
         TAG_TEXT.put("version", "Version");
         TAG_TEXT.put("default", "Default");
+        // typeparam is used internally as a specialization of param to separate type params from regular params.
+        TAG_TEXT.put("typeparam", "Type Parameters");
     }
     private final List<GroovyConstructorDoc> constructors;
     private final List<GroovyFieldDoc> fields;
@@ -930,7 +932,13 @@ public class SimpleGroovyClassDoc extends SimpleGroovyAbstractableElementDoc imp
                     } else if ("param".equals(tagname)) {
                         int index = content.indexOf(' ');
                         if (index >= 0) {
-                            content = "<code>" + content.substring(0, index) + "</code> - " + content.substring(index);
+                            String paramName = content.substring(0, index);
+                            String paramDesc = content.substring(index);
+                            if (paramName.startsWith("<") && paramName.endsWith(">")) {
+                                paramName = paramName.substring(1, paramName.length() - 1);
+                                tagname = "typeparam";
+                            }
+                            content = "<code>" + paramName + "</code> - " + paramDesc;
                         }
                     }
                     if (TAG_TEXT.containsKey(tagname)) {

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/antlr4/GroovydocJavaVisitor.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/antlr4/GroovydocJavaVisitor.java
@@ -256,6 +256,7 @@ public class GroovydocJavaVisitor extends VoidVisitorAdapter<Object> {
     @Override
     public void visit(MethodDeclaration m, Object arg) {
         SimpleGroovyMethodDoc meth = new SimpleGroovyMethodDoc(m.getNameAsString(), currentClassDoc);
+        meth.setTypeParameters(genericTypesAsString(m.getTypeParameters()));
         meth.setReturnType(makeType(m.getType()));
         setConstructorOrMethodCommon(m, meth);
         currentClassDoc.add(meth);

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/antlr4/GroovydocJavaVisitor.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/antlr4/GroovydocJavaVisitor.java
@@ -185,7 +185,9 @@ public class GroovydocJavaVisitor extends VoidVisitorAdapter<Object> {
     }
 
     private String genericTypesAsString(NodeList<TypeParameter> typeParameters) {
-        return DefaultGroovyMethods.join(typeParameters, ", ");
+        if (typeParameters == null || typeParameters.size() == 0)
+            return "";
+        return "<" + DefaultGroovyMethods.join(typeParameters, ", ") + ">";
     }
 
     private SimpleGroovyClassDoc visit(TypeDeclaration<?> n) {

--- a/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
+++ b/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
@@ -80,7 +80,8 @@
     def isRequired = { f, v -> def req = f.constantValueExpression() == null; req.toString() == v }
     def upcase = { n -> n[0].toUpperCase() + n[1..-1] }
     def paramsOf = { n, boolean brief -> n.parameters().collect{ param -> (brief?'':annotations(param, ' ')) + linkable(param.isTypeAvailable()?param.type():param.typeName()) + (param.vararg()?'... ':' ') + param.name() + (param.defaultValue() ? " = " + param.defaultValue():"") }.join(", ") }
-    def nameFromParams = { n -> n.name() + '(' + n.parameters().collect{ param -> param.isTypeAvailable()?param.type().qualifiedTypeName():param.typeName() }.join(', ') + ')' }
+    def rawType = { n -> def g = n.indexOf("<"); g >= 0 ? n.substring(0, g) : n }
+    def nameFromParams = { n -> n.name() + '(' + n.parameters().collect{ param -> rawType(param.isTypeAvailable()?param.type().qualifiedTypeName():param.typeName()) }.join(', ') + ')' }
     def nameFromJavaParams = { n -> n.getName() + '(' + n.parameterTypes.collect{ param -> param.getName() }.join(', ') + ')' }
 %>
 <html>

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -759,6 +759,32 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertTrue("The title should have the generics information", title.find());
     }
 
+    public void testParamTagForTypeParams() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles/generics";
+        htmlTool.add(Arrays.asList(
+                base + "/Java.java",
+                base + "/Groovy.groovy"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String javadoc = output.getText(MOCK_DIR + "/" + base + "/Java.html");
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/Groovy.html");
+
+        final Pattern classTypeParams = Pattern.compile(
+                "<DL><DT><B>Type Parameters:</B></DT><DD><code>N</code> -  Doc.</DD></DL>"
+        );
+        final Pattern methodTypeParams = Pattern.compile(
+                "<DL><DT><B>Type Parameters:</B></DT><DD><code>A</code> -  Doc.</DD><DD><code>B</code> -  Doc.</DD></DL>"
+        );
+
+        assertTrue("The Java class doc should have type parameters definitions", classTypeParams.matcher(javadoc).find());
+        assertTrue("The Groovy class doc should have type parameters definitions", classTypeParams.matcher(groovydoc).find());
+        assertTrue("The Java method doc should have type parameters definitions", methodTypeParams.matcher(javadoc).find());
+        assertTrue("The Groovy method doc should have type parameters definitions", methodTypeParams.matcher(groovydoc).find());
+    }
+
     public void testScript() throws Exception {
         List<String> srcList = new ArrayList<String>();
         srcList.add("org/codehaus/groovy/tools/groovydoc/testfiles/Script.groovy");

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -740,6 +740,25 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertTrue("The title should have the generics information", title.find());
     }
 
+    public void testGroovyGenericsTitle() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles/generics";
+        htmlTool.add(Arrays.asList(
+                base + "/Groovy.groovy"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/Groovy.html");
+
+        final Matcher title = Pattern.compile(Pattern.quote(
+                "<h2 title=\"[Groovy] Trait Groovy&lt;N extends Number & Comparable&lt;? extends Number&gt;&gt;\" class=\"title\">"+
+                        "[Groovy] Trait Groovy&lt;N extends Number & Comparable&lt;? extends Number&gt;&gt;</h2>"
+        )).matcher(groovydoc);
+
+        assertTrue("The title should have the generics information", title.find());
+    }
+
     public void testScript() throws Exception {
         List<String> srcList = new ArrayList<String>();
         srcList.add("org/codehaus/groovy/tools/groovydoc/testfiles/Script.groovy");

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -811,6 +811,46 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertTrue("The Groovy method details should have type parameters", methodDetailsTypeParams.matcher(groovydoc).find());
     }
 
+    public void testMethodParamTypeParams() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles/generics";
+        htmlTool.add(Arrays.asList(
+                base + "/Java.java",
+                base + "/Groovy.groovy"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String javadoc = output.getText(MOCK_DIR + "/" + base + "/Java.html");
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/Groovy.html");
+
+        final Pattern methodSummary = Pattern.compile(Pattern.quote(
+                "<code><strong><a href=\"#compare(Class, Class)\">compare</a></strong>"
+                        + "("
+                        + "<a href='https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html' title='Class'>Class</a>&lt;A&gt; a, "
+                        + "<a href='https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html' title='Class'>Class</a>&lt;B&gt; b"
+                        + ")"
+                        + "</code>"
+        ));
+        final Pattern methodDetailAnchor = Pattern.compile(Pattern.quote(
+                "<a name=\"compare(Class, Class)\"><!-- --></a>"
+        ));
+        final Pattern methodDetailTitle = Pattern.compile(Pattern.quote(
+                "<strong>compare</strong>" +
+                        "(" +
+                        "<a href='https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html' title='Class'>Class</a>&lt;A&gt; a, " +
+                        "<a href='https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html' title='Class'>Class</a>&lt;B&gt; b" +
+                        ")"
+        ));
+
+        assertTrue("The Java method summary should include type parameters", methodSummary.matcher(javadoc).find());
+        assertTrue("The Java method detail anchor should NOT include type parameters", methodDetailAnchor.matcher(javadoc).find());
+        assertTrue("The Java method detail title should include type parameters", methodDetailTitle.matcher(javadoc).find());
+        assertTrue("The Groovy method summary should include type parameters", methodSummary.matcher(groovydoc).find());
+        assertTrue("The Groovy method detail anchor should NOT include type parameters", methodDetailAnchor.matcher(groovydoc).find());
+        assertTrue("The Groovy method detail title should include type parameters", methodDetailTitle.matcher(groovydoc).find());
+    }
+
     public void testScript() throws Exception {
         List<String> srcList = new ArrayList<String>();
         srcList.add("org/codehaus/groovy/tools/groovydoc/testfiles/Script.groovy");

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -721,6 +721,25 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertEquals("The constructor parameter link text should be Foo", "Foo", constructor.group(3));
     }
 
+    public void testJavaGenericsTitle() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles/generics";
+        htmlTool.add(Arrays.asList(
+                base + "/Java.java"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String javadoc = output.getText(MOCK_DIR + "/" + base + "/Java.html");
+
+        final Matcher title = Pattern.compile(Pattern.quote(
+                "<h2 title=\"[Java] Class Java&lt;N extends Number & Comparable&lt;? extends Number&gt;&gt;\" class=\"title\">"+
+                "[Java] Class Java&lt;N extends Number & Comparable&lt;? extends Number&gt;&gt;</h2>"
+        )).matcher(javadoc);
+
+        assertTrue("The title should have the generics information", title.find());
+    }
+
     public void testScript() throws Exception {
         List<String> srcList = new ArrayList<String>();
         srcList.add("org/codehaus/groovy/tools/groovydoc/testfiles/Script.groovy");

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -785,6 +785,32 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertTrue("The Groovy method doc should have type parameters definitions", methodTypeParams.matcher(groovydoc).find());
     }
 
+    public void testMethodTypeParams() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles/generics";
+        htmlTool.add(Arrays.asList(
+                base + "/Java.java",
+                base + "/Groovy.groovy"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String javadoc = output.getText(MOCK_DIR + "/" + base + "/Java.html");
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/Groovy.html");
+
+        final Pattern methodSummaryTypeParams = Pattern.compile(
+                "<td class=\"colFirst\"><code>&lt;A, B&gt;</code></td>"
+        );
+        final Pattern methodDetailsTypeParams = Pattern.compile(
+                "<h4>&lt;A, B&gt; (public&nbsp;)?static&nbsp;int <strong>compare</strong>"
+        );
+
+        assertTrue("The Java method summary should have type parameters", methodSummaryTypeParams.matcher(javadoc).find());
+        assertTrue("The Groovy method summary should have type parameters", methodSummaryTypeParams.matcher(groovydoc).find());
+        assertTrue("The Java method details should have type parameters", methodDetailsTypeParams.matcher(javadoc).find());
+        assertTrue("The Groovy method details should have type parameters", methodDetailsTypeParams.matcher(groovydoc).find());
+    }
+
     public void testScript() throws Exception {
         List<String> srcList = new ArrayList<String>();
         srcList.add("org/codehaus/groovy/tools/groovydoc/testfiles/Script.groovy");

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/generics/Groovy.groovy
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/generics/Groovy.groovy
@@ -1,4 +1,22 @@
 package org.codehaus.groovy.tools.groovydoc.testfiles.generics
 
+/**
+ * Generic class.
+ *
+ * @param <N> Doc.
+ */
 trait Groovy<N extends Number & Comparable<? extends Number>> {
+
+    /**
+     * Generic method.
+     *
+     * @param <A> Doc.
+     * @param <B> Doc.
+     * @param a Doc.
+     * @param b Doc.
+     * @return Doc.
+     */
+    static <A, B> int compare(Class<A> a, Class<B> b) {
+        0
+    }
 }

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/generics/Groovy.groovy
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/generics/Groovy.groovy
@@ -1,0 +1,4 @@
+package org.codehaus.groovy.tools.groovydoc.testfiles.generics
+
+trait Groovy<N extends Number & Comparable<? extends Number>> {
+}

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/generics/Java.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/generics/Java.java
@@ -1,4 +1,21 @@
 package org.codehaus.groovy.tools.groovydoc.testfiles.generics;
 
+/**
+ * Generic class.
+ *
+ * @param <N> Doc.
+ */
 public abstract class Java<N extends Number & Comparable<? extends Number>> {
+    /**
+     * Generic method.
+     *
+     * @param <A> Doc.
+     * @param <B> Doc.
+     * @param a Doc.
+     * @param b Doc.
+     * @return Doc.
+     */
+    public static <A, B> int compare(Class<A> a, Class<B> b) {
+        return 0;
+    }
 }

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/generics/Java.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/generics/Java.java
@@ -1,0 +1,4 @@
+package org.codehaus.groovy.tools.groovydoc.testfiles.generics;
+
+public abstract class Java<N extends Number & Comparable<? extends Number>> {
+}


### PR DESCRIPTION
Fixes the issues listed in https://issues.apache.org/jira/browse/GROOVY-9543

Please, see the commit messages for details.  But I will raise one quote from 724a4da:

> NOTE: This changes how groovydoc generates anchors for Java code.
> groovydoc is using raw types for Groovy code (same as javadoc), but
> types with type parameters for Java code.  With this change, the docs
> for Java code will use raw types, too.

I.e. whereas groovydoc used to generate anchors like `<a name="compare(Class<A>, Class<B>)">` for Java methods, it will now generate `<a name="compare(Class, Class)">`.  Which is what it did for Groovy methods all along, and what javadoc does, too.   If anyone anywhere in the Internet has linked to such Java method docs, the fragment part of those links will be broken.