### PR TITLE
GROOVY-9465: groovydoc: show class declaration header for all types

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
+++ b/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
@@ -225,6 +225,8 @@ if (classDoc.isInterface()) {
                 <dt>All Implemented Interfaces and Traits:</dt>
                 <dd>${interfaces.collect{ linkable(it) }.join(', ')}</dd>
             </dl>
+    <% } %>
+<% } %>
             <!-- todo: direct known subclasses -->
             <hr>
             <br>
@@ -235,8 +237,6 @@ if (classDoc.isInterface()) {
 %>extends ${linkable(classDoc.superclass())}
 <% } %>
 </pre>
-<% } %>
-<% } %>
 <% if (classDoc.commentText()) { %>
     <p>${classDoc.commentText()}</p>
 <% } %>

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -720,6 +720,27 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertEquals("The constructor parameter link text should be Foo", "Foo", constructor.group(3));
     }
 
+    public void testClassDeclarationHeader() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles/a";
+        htmlTool.add(Arrays.asList(
+                base + "/Base.groovy"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String basedoc = output.getText(MOCK_DIR + "/" + base + "/Base.html");
+
+        final Matcher classDecl = Pattern.compile(Pattern.quote(
+                "<pre>class Base\n"+
+                        "extends <a href='https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html' title='Object'>Object</a>\n"+
+                        "\n"+
+                        "</pre>"
+        )).matcher(basedoc);
+
+        assertTrue("The class declaration header should exist in class description", classDecl.find());
+    }
+
     public void testJavaGenericsTitle() throws Exception {
         final String base = "org/codehaus/groovy/tools/groovydoc/testfiles/generics";
         htmlTool.add(Arrays.asList(


### PR DESCRIPTION
It seems a mistake that the template required that the type should implement at least one interface before showing the declaration.
