### PR TITLE
GROOVY-9547: groovydoc: resolve tags later for Groovy source code

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/antlr4/GroovyDocParser.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/antlr4/GroovyDocParser.java
@@ -79,11 +79,7 @@ public class GroovyDocParser implements GroovyDocParserI {
         ModuleNode root = unit.getAST();
         GroovydocVisitor visitor = new GroovydocVisitor(unit, packagePath, links);
         visitor.visitClass(root.getClasses().get(0));
-        Map<String, GroovyClassDoc> groovyClassDocs = visitor.getGroovyClassDocs();
-        for (GroovyClassDoc classDoc : groovyClassDocs.values()) {
-            replaceTags((SimpleGroovyClassDoc) classDoc);
-        }
-        return groovyClassDocs;
+        return visitor.getGroovyClassDocs();
     }
 
     private void replaceTags(SimpleGroovyClassDoc sgcd) {

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -850,6 +850,50 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertTrue("The Groovy method detail title should include type parameters", methodDetailTitle.matcher(groovydoc).find());
     }
 
+    public void testLinksToSamePackage() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
+        htmlTool.add(Arrays.asList(
+                base + "/GroovyInterface1.groovy",
+                base + "/JavaClassWithDiamond.java"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/GroovyInterface1.html");
+        final String javadoc = output.getText(MOCK_DIR + "/" + base + "/JavaClassWithDiamond.html");
+
+        final Matcher groovyClassComment = Pattern.compile(Pattern.quote(
+                "<p> <a href='../../../../../../org/codehaus/groovy/tools/groovydoc/testfiles/JavaClassWithDiamond.html#link()' title='Java'>Java</a> " +
+                        "<DL><DT><B>See Also:</B></DT>" +
+                        "<DD><a href='../../../../../../org/codehaus/groovy/tools/groovydoc/testfiles/JavaClassWithDiamond.html' title='JavaClassWithDiamond'>JavaClassWithDiamond</a></DD>" +
+                        "</DL></p>"
+        )).matcher(groovydoc);
+        final Matcher groovyMethodComment = Pattern.compile(Pattern.quote(
+                "<p> <a href='../../../../../../org/codehaus/groovy/tools/groovydoc/testfiles/JavaClassWithDiamond.html#link()' title='Java link'>Java link</a> " +
+                        "<DL><DT><B>See Also:</B></DT>" +
+                        "<DD><a href='../../../../../../org/codehaus/groovy/tools/groovydoc/testfiles/JavaClassWithDiamond.html#link()' title='JavaClassWithDiamond.link'>JavaClassWithDiamond.link</a></DD>" +
+                        "</DL></p>"
+        )).matcher(groovydoc);
+        final Matcher javaClassComment = Pattern.compile(Pattern.quote(
+                "<p> <a href='../../../../../../org/codehaus/groovy/tools/groovydoc/testfiles/GroovyInterface1.html#link()' title='Groovy link'>Groovy link</a>\n" +
+                        "  <DL><DT><B>See Also:</B></DT>" +
+                        "<DD><a href='../../../../../../org/codehaus/groovy/tools/groovydoc/testfiles/GroovyInterface1.html' title='GroovyInterface1'>GroovyInterface1</a></DD>" +
+                        "</DL></p>"
+        )).matcher(javadoc);
+        final Matcher javaMethodComment = Pattern.compile(Pattern.quote(
+                "<p> <a href='../../../../../../org/codehaus/groovy/tools/groovydoc/testfiles/GroovyInterface1.html#link()' title='Groovy link'>Groovy link</a>\n" +
+                        "      <DL><DT><B>See Also:</B></DT>" +
+                        "<DD><a href='../../../../../../org/codehaus/groovy/tools/groovydoc/testfiles/GroovyInterface1.html#link()' title='GroovyInterface1.link'>GroovyInterface1.link</a></DD>" +
+                        "</DL></p>"
+        )).matcher(javadoc);
+
+        assertTrue("The Groovy class comment should contain links", groovyClassComment.find());
+        assertTrue("The Groovy method comment should contain links", groovyMethodComment.find());
+        assertTrue("The Java class comment should contain links", javaClassComment.find());
+        assertTrue("The Java method comment should contain links", javaMethodComment.find());
+    }
+
     public void testScript() throws Exception {
         List<String> srcList = new ArrayList<String>();
         srcList.add("org/codehaus/groovy/tools/groovydoc/testfiles/Script.groovy");

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/GroovyInterface1.groovy
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/GroovyInterface1.groovy
@@ -18,6 +18,14 @@
  */
 package org.codehaus.groovy.tools.groovydoc.testfiles
 
+/**
+ * {@link JavaClassWithDiamond#link() Java}
+ * @see JavaClassWithDiamond
+ */
 interface GroovyInterface1 {
-
+    /**
+     * {@link JavaClassWithDiamond#link() Java link}
+     * @see JavaClassWithDiamond#link()
+     */
+    void link()
 }

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaClassWithDiamond.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaClassWithDiamond.java
@@ -21,6 +21,15 @@ package org.codehaus.groovy.tools.groovydoc.testfiles;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * {@link GroovyInterface1#link() Groovy link}
+ * @see GroovyInterface1
+ */
 public abstract class JavaClassWithDiamond {
     public List<String> stringList = new ArrayList<>();
+    /**
+     * {@link GroovyInterface1#link() Groovy link}
+     * @see GroovyInterface1#link()
+     */
+    public abstract void link();
 }


### PR DESCRIPTION
For Java source code, tags are resolved when the template asks for the
comments.  For Groovy, they were resolved as soon as the source file
was processes.  At that point, not all classes in the same package are
processes, so links to those failed to link.