### PR TITLE
GROOVY-9549: groovydoc: show implemented interfaces in class header

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
+++ b/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
@@ -179,7 +179,8 @@ if (location.href.indexOf('is-external=true') == -1) {
 <%
 def pkg = classDoc.containingPackage().nameWithDots()
 def name = classDoc.getNameWithTypeArgs() ?: classDoc.name()
-String classDesc = "${classDoc.isGroovy() ? "[Groovy]" : "[Java]"} ${classDoc.typeDescription} ${org.codehaus.groovy.tools.groovydoc.SimpleGroovyClassDoc.encodeAngleBrackets(name)}"
+final nameEncoded = org.codehaus.groovy.tools.groovydoc.SimpleGroovyClassDoc.encodeAngleBrackets(name)
+String classDesc = "${classDoc.isGroovy() ? "[Groovy]" : "[Java]"} ${classDoc.typeDescription} $nameEncoded"
 if (pkg != "DefaultPackage") {
 %>
     <div class="subTitle">Package: <strong>${pkg}</strong></div>
@@ -230,13 +231,25 @@ if (classDoc.isInterface()) {
             <!-- todo: direct known subclasses -->
             <hr>
             <br>
-<pre>${annotations(classDoc, '\n') + modifiersWithOptions(classDoc, classDoc.isGroovy(), classDoc.isInterface() || classDoc.isAnnotationType()) + classDoc.typeSourceDescription + ' ' + classDoc.name()}
-<% if (classDoc.isInterface() && classDoc.interfaces()) {
-%>extends ${classDoc.interfaces().collect{ linkable(it) }.join(', ')}
-<% } else if (classDoc.superclass()) {
-%>extends ${linkable(classDoc.superclass())}
-<% } %>
-</pre>
+<%
+def declaration = annotations(classDoc, '\n') +
+    modifiersWithOptions(classDoc, classDoc.isGroovy(), classDoc.isInterface() || classDoc.isAnnotationType()) +
+    classDoc.typeSourceDescription +
+    ' ' +
+    nameEncoded
+final interfaces = classDoc.interfaces().collect{ linkable(it) }.join(', ')
+if (classDoc.isInterface() && classDoc.interfaces()) {
+    if (interfaces) {
+        declaration += "\nextends $interfaces"
+    }
+} else if (classDoc.superclass()) {
+    declaration += "\nextends ${linkable(classDoc.superclass())}"
+    if (interfaces) {
+        declaration += "\nimplements $interfaces"
+    }
+}
+%>
+<pre>${declaration}</pre>
 <% if (classDoc.commentText()) { %>
     <p>${classDoc.commentText()}</p>
 <% } %>

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -721,24 +721,66 @@ public class GroovyDocToolTest extends GroovyTestCase {
     }
 
     public void testClassDeclarationHeader() throws Exception {
-        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles/a";
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
         htmlTool.add(Arrays.asList(
-                base + "/Base.groovy"
+                base + "/JavaInterfaceWithTypeParam.java",
+                base + "/GroovyInterfaceWithTypeParam.groovy",
+                base + "/JavaInterfaceWithMultipleInterfaces.java",
+                base + "/GroovyInterfaceWithMultipleInterfaces.groovy",
+                base + "/ClassWithMethodComment.java",
+                base + "/DocumentedClass.groovy",
+                base + "/JavaClassWithMultipleInterfaces.java",
+                base + "/GroovyClassWithMultipleInterfaces.groovy"
         ));
 
         final MockOutputTool output = new MockOutputTool();
         htmlTool.renderToOutput(output, MOCK_DIR);
 
-        final String basedoc = output.getText(MOCK_DIR + "/" + base + "/Base.html");
+        final String javaBaseInterface = output.getText(MOCK_DIR + "/" + base + "/JavaInterfaceWithTypeParam.html");
+        final String groovyBaseInterface = output.getText(MOCK_DIR + "/" + base + "/GroovyInterfaceWithTypeParam.html");
+        final String javaDerivedInterface = output.getText(MOCK_DIR + "/" + base + "/JavaInterfaceWithMultipleInterfaces.html");
+        final String groovyDerivedInterface = output.getText(MOCK_DIR + "/" + base + "/GroovyInterfaceWithMultipleInterfaces.html");
+        final String javaBaseClass = output.getText(MOCK_DIR + "/" + base + "/ClassWithMethodComment.html");
+        final String groovyBaseClass = output.getText(MOCK_DIR + "/" + base + "/DocumentedClass.html");
+        final String javaDerivedClass = output.getText(MOCK_DIR + "/" + base + "/JavaClassWithMultipleInterfaces.html");
+        final String groovyDerivedClass = output.getText(MOCK_DIR + "/" + base + "/GroovyClassWithMultipleInterfaces.html");
 
-        final Matcher classDecl = Pattern.compile(Pattern.quote(
-                "<pre>class Base\n"+
-                        "extends <a href='https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html' title='Object'>Object</a>\n"+
-                        "\n"+
-                        "</pre>"
-        )).matcher(basedoc);
+        final String object = Pattern.quote(
+            "<a href='https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html' title='Object'>Object</a>");
+        final String interfaces = Pattern.quote(
+            "org.codehaus.groovy.tools.groovydoc.testfiles.GroovyInterface1, " +
+            "org.codehaus.groovy.tools.groovydoc.testfiles.JavaInterface1, " +
+            "<a href='https://docs.oracle.com/javase/8/docs/api/java/lang/Runnable.html' title='Runnable'>Runnable</a>");
 
-        assertTrue("The class declaration header should exist in class description", classDecl.find());
+        final Pattern baseInterface = Pattern.compile(
+            "<pre>" +
+            "(public&nbsp;)?interface (Java|Groovy)InterfaceWithTypeParam&lt;T&gt;" +
+            "</pre>");
+        final Pattern derivedInterface = Pattern.compile(
+            "<pre>" +
+            "(public&nbsp;)?interface (Java|Groovy)InterfaceWithMultipleInterfaces\n" +
+            "extends " + interfaces +
+            "</pre>");
+        final Pattern baseClass = Pattern.compile(
+            "<pre>" +
+            "(public&nbsp;)?class (ClassWithMethodComment|DocumentedClass)\n" +
+            "extends " + object +
+            "</pre>");
+        final Pattern derivedClass = Pattern.compile(
+            "<pre>" +
+            "(public&nbsp;)?abstract&nbsp;class (Java|Groovy)ClassWithMultipleInterfaces\n" +
+            "extends " + object + "\n" +
+            "implements " + interfaces +
+            "</pre>");
+
+        assertTrue("The Java base interface declaration header should match", baseInterface.matcher(javaBaseInterface).find());
+        assertTrue("The Groovy base interface declaration header should match", baseInterface.matcher(groovyBaseInterface).find());
+        assertTrue("The Java derived interface declaration header should match", derivedInterface.matcher(javaDerivedInterface).find());
+        assertTrue("The Groovy derived interface declaration header should match", derivedInterface.matcher(groovyDerivedInterface).find());
+        assertTrue("The Java base class declaration header should match", baseClass.matcher(javaBaseClass).find());
+        assertTrue("The Groovy base class declaration header should match", baseClass.matcher(groovyBaseClass).find());
+        assertTrue("The Java derived class declaration header should match", derivedClass.matcher(javaDerivedClass).find());
+        assertTrue("The Groovy derived class declaration header should match", derivedClass.matcher(groovyDerivedClass).find());
     }
 
     public void testJavaGenericsTitle() throws Exception {

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/GroovyInterfaceWithTypeParam.groovy
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/GroovyInterfaceWithTypeParam.groovy
@@ -1,0 +1,22 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.groovydoc.testfiles
+
+interface GroovyInterfaceWithTypeParam<T> {
+}

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaInterfaceWithTypeParam.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaInterfaceWithTypeParam.java
@@ -1,0 +1,22 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.groovydoc.testfiles;
+
+public interface JavaInterfaceWithTypeParam<T> {
+}


### PR DESCRIPTION
Also, add type params if any.