### PR TITLE
GROOVY-9567: groovydoc: show abstract modifier on abstract methods

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyMethodDoc.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyMethodDoc.java
@@ -40,10 +40,6 @@ public class SimpleGroovyMethodDoc extends SimpleGroovyExecutableMemberDoc imple
         this.returnType = returnType;
     }
 
-    public boolean isAbstract() {/*todo*/
-        return false;
-    }
-
     public GroovyClassDoc overriddenClass() {/*todo*/
         return null;
     }

--- a/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
+++ b/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
@@ -523,7 +523,7 @@ if (classDoc.isInterface() && classDoc.interfaces()) {
                         <% visibleMethods.eachWithIndex { method, i -> %>
                         <tr class="${i%2==0?'altColor':'rowColor'}">
                             <td class="colFirst"><code>${org.codehaus.groovy.tools.groovydoc.SimpleGroovyClassDoc.encodeAngleBrackets(method.typeParameters()) ?: ''}</code></td>
-                            <td class="colLast"><code>${modifiersBrief(method)}${linkable(method.returnType())}</code></td>
+                            <td class="colLast"><code>${modifiers(method)}${linkable(method.returnType())}</code></td>
                             <td class="colLast"><code><strong><a href="#${nameFromParams(method)}">${method.name()}</a></strong>(${paramsOf(method, true)})</code><br>${method.firstSentenceCommentText()}</td>
                         </tr>
                         <% } %>

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -983,6 +983,28 @@ public class GroovyDocToolTest extends GroovyTestCase {
         )).matcher(javadoc).find());
     }
 
+    public void testAbstractMethods() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
+        htmlTool.add(Arrays.asList(
+            base + "/GroovyClassWithMultipleInterfaces.groovy",
+            base + "/JavaClassWithDiamond.java"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/GroovyClassWithMultipleInterfaces.html");
+        final String javadoc = StringGroovyMethods.normalize(output.getText(MOCK_DIR + "/" + base + "/JavaClassWithDiamond.html"));
+
+        final Pattern methodSummary = Pattern.compile("<code>(public&nbsp;)?abstract&nbsp;void</code>");
+        final Pattern methodDetails = Pattern.compile("<h4>(public&nbsp;)?abstract&nbsp;void <strong>link</strong>");
+
+        assertTrue("The Groovy method summary should contain 'abstract'", methodSummary.matcher(groovydoc).find());
+        assertTrue("The Java method summary should contain 'abstract'", methodSummary.matcher(javadoc).find());
+        assertTrue("The Groovy method details should contain 'abstract'", methodDetails.matcher(groovydoc).find());
+        assertTrue("The Java method details should contain 'abstract'", methodDetails.matcher(javadoc).find());
+    }
+
     public void testLinksToSamePackage() throws Exception {
         final String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
         htmlTool.add(Arrays.asList(

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/GroovyClassWithMultipleInterfaces.groovy
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/GroovyClassWithMultipleInterfaces.groovy
@@ -19,4 +19,5 @@
 package org.codehaus.groovy.tools.groovydoc.testfiles
 
 abstract class GroovyClassWithMultipleInterfaces implements GroovyInterface1, JavaInterface1, Runnable {
+    abstract void link()
 }


### PR DESCRIPTION
Let `SimpleGroovyAbstractableElementDoc`, one of the ancestors of `SimpleGroovyMethodDoc`, answer to `isAbstract` questions.