### PR TITLE
GROOVY-9548: groovydoc: use property modifiers

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/apache/groovy/antlr/GroovydocVisitor.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/apache/groovy/antlr/GroovydocVisitor.java
@@ -281,7 +281,7 @@ public class GroovydocVisitor extends ClassCodeVisitorSupport {
         String name = node.getName();
         SimpleGroovyFieldDoc fieldDoc = new SimpleGroovyFieldDoc(name, currentClassDoc);
         fieldDoc.setType(new SimpleGroovyType(makeType(node.getType())));
-        int mods = node.getField().getModifiers();
+        int mods = node.getModifiers();
         if (!hasAnno(node.getField(), "PackageScope")) {
             processModifiers(fieldDoc, node.getField(), mods);
             Groovydoc groovydoc = node.getGroovydoc();

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -1065,6 +1065,30 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertFalse("Private ctor should not be listed", matcher.find());
     }
 
+    public void testProperty() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
+        htmlTool.add(Arrays.asList(
+            base + "/Alias.groovy"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/Alias.html");
+
+        final Matcher summary = Pattern.compile(Pattern.quote(
+            "<code><strong><a href='https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html' " +
+                "title='ArrayList'>ArrayList</a></strong></code>"
+        )).matcher(groovydoc);
+        final Matcher detail = Pattern.compile(Pattern.quote(
+            "<h4><a href='https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html' " +
+                "title='ArrayList'>ArrayList</a> <strong>arrayList</strong></h4>"
+        )).matcher(groovydoc);
+
+        assertTrue("Property summary should be found", summary.find());
+        assertTrue("Property detail should be found", detail.find());
+    }
+
     public void testScript() throws Exception {
         List<String> srcList = new ArrayList<String>();
         srcList.add("org/codehaus/groovy/tools/groovydoc/testfiles/Script.groovy");


### PR DESCRIPTION
The property seems to contain the correct modifiers (public vs private
that the field has).

Note that this does not fully close the ticket: the property annotations are still not shown.
