### PR TITLE
GROOVY-9571: groovydoc: don't add constructors for types that can't have them

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/apache/groovy/antlr/GroovydocVisitor.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/apache/groovy/antlr/GroovydocVisitor.java
@@ -139,8 +139,8 @@ public class GroovydocVisitor extends ClassCodeVisitorSupport {
         classDocs.put(currentClassDoc.getFullPathName(), currentClassDoc);
         super.visitClass(node);
         SimpleGroovyClassDoc parent = currentClassDoc;
-        if (currentClassDoc.constructors().length == 0) {
-            // add default no-arg constructor
+        if (currentClassDoc.isClass() && currentClassDoc.constructors().length == 0) {
+            // add default no-arg constructor, but not for interfaces, traits, enums, or annotation definitions
             SimpleGroovyConstructorDoc cons = new SimpleGroovyConstructorDoc(name, currentClassDoc);
             cons.setPublic(true);
             currentClassDoc.add(cons);

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -157,6 +157,23 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertTrue(constructorDoc.indexOf("<parameter type=\"java.lang.ClassLoader\" name=\"parent\" />") > 0);
     }
 
+    public void testInterfaceConstructor() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
+        final String groovyInterface = "GroovyInterface1";
+        htmlTool.add(Arrays.asList(
+            base + "/"+ groovyInterface +".groovy"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/"+ groovyInterface +".html");
+
+        final Matcher ctor = Pattern.compile(Pattern.quote("GroovyInterface1()")).matcher(groovydoc);
+
+        assertFalse("The Groovy interface should not have default constructor", ctor.find());
+    }
+
     public void testClassComment() throws Exception {
         List<String> srcList = new ArrayList<String>();
         String base = "org/codehaus/groovy/tools/groovydoc/testfiles/Builder";


### PR DESCRIPTION
just the default ctor removal