### PR TITLE
GROOVY-9575 ASTNode.hashCode violates Object.hashCode contract: does not return consistent value

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/ASTNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/ASTNode.java
@@ -18,7 +18,6 @@
  */
 package org.codehaus.groovy.ast;
 
-import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -120,10 +119,5 @@ public class ASTNode implements NodeMetaDataHandler {
     @Override
     public void setMetaDataMap(Map<?, ?> metaDataMap) {
         this.metaDataMap = metaDataMap;
-    }
-
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(new int[] {lineNumber, columnNumber, lastLineNumber, lastColumnNumber});
     }
 }

--- a/src/test/org/codehaus/groovy/ast/ASTNodeTest.java
+++ b/src/test/org/codehaus/groovy/ast/ASTNodeTest.java
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.ast;
+
+import junit.framework.TestCase;
+
+public class ASTNodeTest extends TestCase {
+
+    ASTNode astNode = new ASTNode();
+
+    public void testHashCode() {
+        int hashcode = astNode.hashCode();
+        
+        astNode.setLineNumber(astNode.getLineNumber() + 10);
+        assertEquals("hashCode is consistent", hashcode, astNode.hashCode());
+    }
+}


### PR DESCRIPTION
Remove unsuitable ASTNode.hashCode -- it does not conform to the Object
.hashCode general contract.