### PR TITLE
GROOVY-9576: groovydoc: hide enum $INIT static method

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/apache/groovy/antlr/GroovydocVisitor.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/apache/groovy/antlr/GroovydocVisitor.java
@@ -199,6 +199,8 @@ public class GroovydocVisitor extends ClassCodeVisitorSupport {
 
     @Override
     public void visitMethod(MethodNode node) {
+        if (currentClassDoc.isEnum() && "$INIT".equals(node.getName()))
+            return;
         SimpleGroovyMethodDoc meth = new SimpleGroovyMethodDoc(node.getName(), currentClassDoc);
         meth.setReturnType(new SimpleGroovyType(makeType(node.getReturnType())));
         setConstructorOrMethodCommon(node, meth);

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -668,6 +668,23 @@ public class GroovyDocToolTest extends GroovyTestCase {
         assertEquals("There has to be a reference to class Enum", "Enum", m.group(3));
     }
 
+    public void testEnumInitNotDocumented() throws Exception {
+        final String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
+        final String klass = "EnumWithDeprecatedConstants";
+        htmlTool.add(Arrays.asList(
+            base + "/"+ klass +".groovy"
+        ));
+
+        final MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        final String groovydoc = output.getText(MOCK_DIR + "/" + base + "/"+ klass +".html");
+
+        final Matcher ctor = Pattern.compile(Pattern.quote("$INIT")).matcher(groovydoc);
+
+        assertFalse("enum $INIT static method should not be documented", ctor.find());
+    }
+
     public void testClassAliasing() throws Exception {
 
         List<String> srcList = new ArrayList<String>();


### PR DESCRIPTION
This is just a hacky suggestion.  Not sure if this is the way to go because there are similar cases elsewhere:

 * https://issues.apache.org/jira/browse/GROOVY-9572
 * https://issues.apache.org/jira/browse/GROOVY-9576
