### PR TITLE
GROOVY-9562: same top-level type, not same module for private field read

### DIFF
--- a/src/test/groovy/bugs/Groovy9292.groovy
+++ b/src/test/groovy/bugs/Groovy9292.groovy
@@ -18,7 +18,6 @@
  */
 package groovy.bugs
 
-import groovy.test.NotYetImplemented
 import org.junit.Test
 
 import static groovy.test.GroovyAssert.shouldFail
@@ -27,27 +26,56 @@ final class Groovy9292 {
 
     private final GroovyShell shell = new GroovyShell()
 
-    @Test @NotYetImplemented
-    void 'test accessing a private super class field inside a closure - same package'() {
+    @Test
+    void 'test accessing a private super class field inside a closure - same module'() {
         shouldFail(MissingPropertyException) {
             shell.evaluate '''
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 class B extends A {
                     @groovy.transform.CompileStatic
                     def test() {
                         'something'.with {
-                            return superField // ClassCastException: a.B$_test_closure1 cannot be cast to a.A
+                            return superField
                         }
                     }
                 }
 
-                def obj = new B()
-                assert obj.test() == "works"
+                new B().test()
+            '''
+        }
+    }
+
+    @Test
+    void 'test accessing a private super class field inside a closure - same package'() {
+        shouldFail(MissingPropertyException) {
+            shell.evaluate '''
+                package a
+
+                class A {
+                    private String superField
+                }
+
+                assert true
+            '''
+
+            shell.evaluate '''
+                package a
+
+                class B extends A {
+                    @groovy.transform.CompileStatic
+                    def test() {
+                        'something'.with {
+                            return superField
+                        }
+                    }
+                }
+
+                new B().test()
             '''
         }
     }
@@ -59,7 +87,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 assert true
@@ -89,7 +117,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 class B extends A {
@@ -101,8 +129,7 @@ final class Groovy9292 {
                     }
                 }
 
-                def obj = new B()
-                assert obj.test() == "works"
+                new B().test()
             '''
         }
     }
@@ -114,7 +141,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 assert true
@@ -144,7 +171,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 class B extends A {
@@ -156,8 +183,7 @@ final class Groovy9292 {
                     }
                 }
 
-                def obj = new B()
-                assert obj.test() == "works"
+                new B().test()
             '''
         }
     }
@@ -169,7 +195,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 assert true
@@ -199,7 +225,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 class B extends A {
@@ -211,8 +237,7 @@ final class Groovy9292 {
                     }
                 }
 
-                def obj = new B()
-                assert obj.test() == "works"
+                new B().test()
             '''
         }
     }
@@ -224,7 +249,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 assert true
@@ -254,7 +279,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 class B extends A {
@@ -266,8 +291,7 @@ final class Groovy9292 {
                     }
                 }
 
-                def obj = new B()
-                assert obj.test() == "works"
+                new B().test()
             '''
         }
     }
@@ -279,7 +303,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 assert true
@@ -309,7 +333,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 class B extends A {
@@ -321,8 +345,7 @@ final class Groovy9292 {
                     }
                 }
 
-                def obj = new B()
-                assert obj.test() == "works"
+                new B().test()
             '''
         }
     }
@@ -334,7 +357,7 @@ final class Groovy9292 {
                 package a
 
                 class A {
-                    private String superField = 'works'
+                    private String superField
                 }
 
                 assert true

--- a/src/test/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
+++ b/src/test/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
@@ -423,6 +423,33 @@ class FieldsAndPropertiesSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-9562
+    void testSuperPropertyAccessInAIC() {
+        assertScript '''
+            abstract class One {
+                int prop = 1
+            }
+
+            abstract class Two {
+                int prop = 2
+
+                abstract baz()
+            }
+
+            class Foo extends One {
+                Two bar() {
+                    new Two() {
+                        def baz() {
+                            prop
+                        }
+                    }
+                }
+            }
+
+            assert new Foo().bar().baz() == 2
+        '''
+    }
+
     // GROOVY-5737
     void testAccessGeneratedFieldFromClosure() {
         assertScript '''

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/FieldsAndPropertiesStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/FieldsAndPropertiesStaticCompileTest.groovy
@@ -283,7 +283,7 @@ final class FieldsAndPropertiesStaticCompileTest extends FieldsAndPropertiesSTCT
         // no GETFIELD in getXX
         assert (astTrees['B'][1] =~ 'GETFIELD A.x').collect().size() == 0
         // getX in getXX
-        assert (astTrees['B'][1] =~ 'INVOKEVIRTUAL A.getX').collect().size() == 1
+        assert (astTrees['B'][1] =~ 'INVOKEVIRTUAL B.getX').collect().size() == 1
     }
 
     void testUseDirectReadFieldAccess() {
@@ -470,12 +470,11 @@ final class FieldsAndPropertiesStaticCompileTest extends FieldsAndPropertiesSTCT
 
     // GROOVY-5649
     void testShouldNotThrowStackOverflowUsingThis() {
-        new GroovyShell().evaluate '''class HaveOption {
+        new GroovyShell().evaluate '''
+        class HaveOption {
 
           private String helpOption;
 
-
-          @groovy.transform.CompileStatic
           public void setHelpOption(String helpOption) {
             this.helpOption = helpOption
           }
@@ -488,12 +487,11 @@ final class FieldsAndPropertiesStaticCompileTest extends FieldsAndPropertiesSTCT
     }
 
     void testShouldNotThrowStackOverflow() {
-        new GroovyShell().evaluate '''class HaveOption {
+        new GroovyShell().evaluate '''
+        class HaveOption {
 
           private String helpOption;
 
-
-          @groovy.transform.CompileStatic
           public void setHelpOption(String ho) {
             helpOption = ho
           }
@@ -791,7 +789,6 @@ import org.codehaus.groovy.transform.sc.ListOfExpressionsExpression
     // GROOVY-8753
     void testPrivateFieldWithPublicGetter() {
         assertScript '''
-            @groovy.transform.CompileStatic
             class A {
                private List<String> fooNames = []
                public A(Collection<String> names) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9562
https://issues.apache.org/jira/browse/GROOVY-9292

`StaticTypeCheckingVisitor.checkOrMarkPrivateAccess` marked reads and writes in the same module, but later classgen checks did not match field access across top-level types.  This led to a bad type saved for the "this" that is created for variable expressions in `VariableExpressionTransformer` and thus a `ClassCastException` at runtime.