### PR TITLE
GROOVY-9344 (part 1): SC: retain closure shared variable metadata for classgen

### DIFF
--- a/src/test/org/codehaus/groovy/classgen/asm/sc/StaticCompileFlowTypingTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/StaticCompileFlowTypingTest.groovy
@@ -43,7 +43,7 @@ final class StaticCompileFlowTypingTest {
         '''
     }
 
-    @NotYetImplemented @Test // GROOVY-9344
+    @Test // GROOVY-9344
     void testFlowTyping2() {
         assertScript '''
             class A {}
@@ -51,15 +51,33 @@ final class StaticCompileFlowTypingTest {
 
             @groovy.transform.CompileStatic
             String m() {
-                def var
-                var = new A()
+                def var = new A()
+                def c = { ->
+                    var = new B()
+                    var.class.simpleName
+                }
+                c()
+            }
+            assert m() == 'B'
+        '''
+    }
+
+    @NotYetImplemented @Test // GROOVY-9344
+    void testFlowTyping3() {
+        assertScript '''
+            class A {}
+            class B {}
+
+            @groovy.transform.CompileStatic
+            String m() {
+                def var = new A()
                 def c = { ->
                     var = new B()
                 }
                 c()
-                var.toString()
+                var.class.simpleName
             }
-            assert m() != null
+            assert m() == 'B'
         '''
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9344

This change prevents the cast exception within the closure due to loss of node metadata:
```groovy
class A {}
class B {}

@groovy.transform.CompileStatic
def test() {
    def var
    var = new A()
    def c = {
        var = new B() // Cannot cast object 'B@4e234c52' with class 'B' to class 'A'
    }
    c()
    //var.toString() // TODO: Cannot cast object 'B@4e234c52' with class 'B' to class 'A' -- coming in part 2
}

test()
```