### PR TITLE
GROOVY-7971: do not save instanceof types under logical or

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,9 +202,10 @@ dependencies {
 
     testImplementation project(':groovy-ant')
     testImplementation project(':groovy-xml')
-    testImplementation project(':groovy-dateutil')
+    testImplementation project(':groovy-json')
     testImplementation project(':groovy-test')
     testImplementation project(':groovy-macro')
+    testImplementation project(':groovy-dateutil')
 }
 
 ext.generatedDirectory = "${buildDir}/generated/sources"

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -219,6 +219,7 @@ import static org.codehaus.groovy.syntax.Types.INTDIV_EQUAL;
 import static org.codehaus.groovy.syntax.Types.KEYWORD_IN;
 import static org.codehaus.groovy.syntax.Types.KEYWORD_INSTANCEOF;
 import static org.codehaus.groovy.syntax.Types.LEFT_SQUARE_BRACKET;
+import static org.codehaus.groovy.syntax.Types.LOGICAL_OR;
 import static org.codehaus.groovy.syntax.Types.MINUS_MINUS;
 import static org.codehaus.groovy.syntax.Types.MOD;
 import static org.codehaus.groovy.syntax.Types.MOD_EQUAL;
@@ -727,6 +728,9 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         typeCheckingContext.pushEnclosingBinaryExpression(expression);
         try {
             int op = expression.getOperation().getType();
+            if (op == LOGICAL_OR) {
+                typeCheckingContext.pushTemporaryTypeInfo();
+            }
             Expression leftExpression = expression.getLeftExpression();
             Expression rightExpression = expression.getRightExpression();
 
@@ -735,6 +739,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             ClassNode lType = null;
             if (setterInfo != null) {
                 if (ensureValidSetter(expression, leftExpression, rightExpression, setterInfo)) {
+                    if (op == LOGICAL_OR) typeCheckingContext.popTemporaryTypeInfo();
                     return;
                 }
             } else {
@@ -780,6 +785,8 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                 elvisOperatorExpression.visit(this);
                 resultType = getType(elvisOperatorExpression);
                 storeType(leftExpression, resultType);
+            } else if (op == LOGICAL_OR) {
+                typeCheckingContext.popTemporaryTypeInfo();
             }
 
             if (resultType == null) {

--- a/src/test/groovy/transform/stc/MethodCallsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/MethodCallsSTCTest.groovy
@@ -401,7 +401,7 @@ class MethodCallsSTCTest extends StaticTypeCheckingTestCase {
                         foo(it)
                     }
                 }
-            ''', 'Reference to method is ambiguous'
+            ''', 'Cannot find matching method'
     }
 
     void testShouldFailWithMultiplePossibleMethods2() {
@@ -420,7 +420,26 @@ class MethodCallsSTCTest extends StaticTypeCheckingTestCase {
                         foo(argument)
                     }
                 }
-            ''', 'Reference to method is ambiguous'
+            ''', 'Cannot find matching method'
+    }
+
+    // GROOVY-7971
+    void testShouldNotFailWithMultiplePossibleMethods() {
+        assertScript '''
+            import groovy.json.JsonOutput
+
+            def test(value) {
+                def out = new StringBuilder()
+                def isString = value.class == String
+                if (isString || value instanceof Map) {
+                    out.append(JsonOutput.toJson(value))
+                }
+                return out.toString()
+            }
+
+            def string = test('two')
+            assert string == '"two"'
+        '''
     }
 
     void testInstanceOfOnExplicitParameter() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-7971

This is the simplest approach I could think of.  Instead of collecting all instanceof types when doing multiple checks like "it instanceof String || it instanceof Boolean || it instanceof Integer", do not collect the instanceof types because there could be any kind of boolean expresion on either side of the ||.