### PR TITLE
GROOVY-9558: drop receiver metadata from transformed property expression

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
@@ -659,7 +659,7 @@ public class StaticInvocationWriter extends InvocationWriter {
         if (implicitThis && implicitReceiver == null && origin instanceof MethodCallExpression) {
             implicitReceiver = ((MethodCallExpression) origin).getObjectExpression().getNodeMetaData(StaticTypesMarker.IMPLICIT_RECEIVER);
         }
-        if (implicitReceiver !=null && implicitThis) {
+        if (implicitThis && implicitReceiver != null) {
             String[] propertyPath = ((String) implicitReceiver).split("\\.");
             // GROOVY-6021
             PropertyExpression pexp = new PropertyExpression(new VariableExpression("this", CLOSURE_TYPE), propertyPath[0]);

--- a/src/main/java/org/codehaus/groovy/transform/sc/transformers/VariableExpressionTransformer.java
+++ b/src/main/java/org/codehaus/groovy/transform/sc/transformers/VariableExpressionTransformer.java
@@ -67,6 +67,7 @@ public class VariableExpressionTransformer {
             receiver.putNodeMetaData(StaticTypesMarker.INFERRED_TYPE, owner);
             receiver.putNodeMetaData(StaticTypesMarker.IMPLICIT_RECEIVER, val);
         }
+        pexp.removeNodeMetaData(StaticTypesMarker.IMPLICIT_RECEIVER);
 
         return pexp;
     }

--- a/src/test/groovy/transform/stc/ClosuresSTCTest.groovy
+++ b/src/test/groovy/transform/stc/ClosuresSTCTest.groovy
@@ -536,5 +536,16 @@ class ClosuresSTCTest extends StaticTypeCheckingTestCase {
             assert foo { -> 1 }  == 1
         '''
     }
+
+    // GROOVY-9558
+    void testPutAtClosureDelegateProperty() {
+        assertScript '''
+            def config = new org.codehaus.groovy.control.CompilerConfiguration()
+            config.tap {
+                optimizationOptions['indy'] = true
+                optimizationOptions.indy = true
+            }
+        '''
+    }
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9558