### PR TITLE
GROOVY-7512: add MapStyleConstructorCall override of transformExpression

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/sc/transformers/ConstructorCallTransformer.java
+++ b/src/main/java/org/codehaus/groovy/transform/sc/transformers/ConstructorCallTransformer.java
@@ -27,6 +27,7 @@ import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.ConstructorCallExpression;
 import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.ExpressionTransformer;
 import org.codehaus.groovy.ast.expr.MapEntryExpression;
 import org.codehaus.groovy.ast.expr.MapExpression;
 import org.codehaus.groovy.ast.expr.TupleExpression;
@@ -122,6 +123,18 @@ public class ConstructorCallTransformer {
                     ? ((TupleExpression) originalCall.getArguments()).getExpressions()
                     : null;
             this.innerClassCall = originalExpressions != null && originalExpressions.size() == 2;
+        }
+
+        @Override
+        public Expression transformExpression(final ExpressionTransformer transformer) {
+            Expression result = new MapStyleConstructorCall(
+                    staticCompilationTransformer, declaringClass,
+                    (MapExpression) map.transformExpression(transformer),
+                    (ConstructorCallExpression) originalCall.transformExpression(transformer)
+            );
+            result.copyNodeMetaData(this);
+            result.setSourcePosition(this);
+            return result;
         }
 
         @Override

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy7242.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy7242.groovy
@@ -102,6 +102,32 @@ final class Groovy7242 extends StaticTypeCheckingTestCase implements StaticCompi
         '''
     }
 
+    // GROOVY-7512
+    void testCallTraitMethodFromTraitClosureInMapConstructor() {
+        assertScript '''
+            class Foo {
+                Closure bar
+            }
+
+            trait T {
+                Foo getFoo() {
+                    new Foo(bar: { ->
+                        baz 'xyz' // ClassCastException: java.lang.Class cannot be cast to T
+                    })
+                }
+                def baz(text) {
+                    text
+                }
+            }
+
+            class C implements T {
+            }
+
+            Foo foo = new C().foo
+            assert foo.bar.call() == 'xyz'
+        '''
+    }
+
     // GROOVY-9586
     void testDelegateVsOwnerMethodFromTraitClosure1() {
         assertScript '''


### PR DESCRIPTION
- allow PostTypeCheckingExpressionReplacer to replace closure literals

https://issues.apache.org/jira/browse/GROOVY-7512