### PR TITLE
GROOVY-9587: don't check for property for non-empty call args

### DIFF
--- a/src/test/groovy/bugs/Groovy9587.groovy
+++ b/src/test/groovy/bugs/Groovy9587.groovy
@@ -1,0 +1,53 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+@CompileStatic
+final class Groovy9587 {
+
+    @Test
+    void testStaticPropertyAndInstanceMethodNameClash() {
+        assertScript '''
+            class C {
+                static foo
+
+                def getFoo() {
+                    if (foo == null) {
+                        getFoo(true)
+                    } else {
+                        foo
+                    }
+                }
+
+                def getFoo(flag) {
+                    return 'foo'
+                }
+
+                static main(args) {
+                  assert newInstance().getFoo() == 'foo'
+                }
+            }
+        '''
+    }
+}


### PR DESCRIPTION
`transformMethodCallExpression` had become very difficult to understand and modify, so I tried to reorganize it, reduce the repetition, and simplify the conditions as best as I could.

https://issues.apache.org/jira/browse/GROOVY-9587