### PR TITLE
GROOVY-9554: Script: before adding to binding, check for property setter

### DIFF
--- a/src/test/org/codehaus/groovy/transform/FieldTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/FieldTransformTest.groovy
@@ -260,6 +260,22 @@ class FieldTransformTest extends CompilableTestSupport {
         '''
     }
 
+    void testClosureReferencesToField() {
+        // GROOVY-9554
+        assertScript '''
+            @groovy.transform.Field String abc
+            binding.variables.clear()
+            abc = 'abc'
+            assert !binding.hasVariable('abc')
+            ['D','E','F'].each {
+                abc += it
+            }
+            assert !binding.hasVariable('abc')
+            assert this.@abc == 'abcDEF'
+            assert abc == 'abcDEF'
+        '''
+    }
+
     void testFieldTransformWithFinalField() {
         // GROOVY-8430
         assertScript '''


### PR DESCRIPTION
I looked for a shared function to check a `Class` for a setter, but came up empty.  Maybe someone knows of a utility call that can replace `hasSetterMethodFor`.

https://issues.apache.org/jira/browse/GROOVY-9554