### PR TITLE
Switch Spock from SNAPSHOT to 2.0-M3-groovy-3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ ext {
     slf4jVersion = '1.7.25'
     xmlunitVersion = '1.6'
     xstreamVersion = '1.4.12'
-    spockVersion = '2.0-groovy-3.0-SNAPSHOT' // supports up to 9.9.99
+    spockVersion = '2.0-M3-groovy-3.0' // running with Groovy 4 can be allowed with '-Dspock.iKnowWhatImDoing.disableGroovyVersionCheck=true'
     spotbugsVersion = '4.0.3'
     spotbugsAnnotationsVersion = '4.0.3'
     checkstyleVersion = '8.32'
@@ -343,6 +343,9 @@ allprojects {
         classpath = (classpath != null) ? classpath + groovyClasspath : groovyClasspath
     }.configureEach {
         options.incremental = true
+        if (groovyVersion.startsWith('4')) {
+            options.forkOptions.jvmArgs += ["-Dspock.iKnowWhatImDoing.disableGroovyVersionCheck=true"]
+        }
     }
 }
 

--- a/subprojects/groovy-templates/build.gradle
+++ b/subprojects/groovy-templates/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    if (groovyVersion.startsWith('4')) {
+        systemProperty "spock.iKnowWhatImDoing.disableGroovyVersionCheck", "true"
+    }
 }
 
 task backportJar(type:Jar) {


### PR DESCRIPTION
With '-Dspock.iKnowWhatImDoing.disableGroovyVersionCheck=true' running
with the unsupported Groovy 4 is possible also with non-SNAPSHOT version.

https://github.com/spockframework/spock/pull/1164