### PR TITLE
[GROOVY-8100] MarkupBuilder - yield before any markup (state == 0)

### DIFF
--- a/subprojects/groovy-xml/src/main/java/groovy/xml/MarkupBuilder.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/xml/MarkupBuilder.java
@@ -270,7 +270,7 @@ public class MarkupBuilder extends BuilderSupport {
             this.nodeIsEmpty = false;
             out.print(">");
         }
-        if (state == 2 || state == 3) {
+        if (state == 0 || state == 2 || state == 3) {
             out.print(escaping ? escapeElementContent(value) : value);
         }
     }

--- a/subprojects/groovy-xml/src/test/groovy/groovy/xml/MarkupBuilderTest.groovy
+++ b/subprojects/groovy-xml/src/test/groovy/groovy/xml/MarkupBuilderTest.groovy
@@ -242,6 +242,22 @@ class MarkupBuilderTest extends BuilderTestSupport {
         '''
     }
 
+    void testMkpYield() {
+        xml.mkp.yieldUnescaped("<?xml version='1.0' encoding='UTF-8'?>\n")
+        xml.element {
+            mkp.yield("<>")
+            xml.inner("foo") { mkp.yield('bar') }
+            mkp.yieldUnescaped("\n  <inside>wow</inside>")
+        }
+        String expectedXml = '''\
+<?xml version='1.0' encoding='UTF-8'?>
+<element>&lt;&gt;
+  <inner>foobar</inner>
+  <inside>wow</inside>
+</element>'''
+        assertEquals expectedXml, fixEOLs(writer.toString())
+    }
+
     void testWithIndentPrinter() {
         xml = new MarkupBuilder(new IndentPrinter(new PrintWriter(writer), "", false))
         xml.element(att1:'attr') { subelement('foo') }


### PR DESCRIPTION
This will let MarkupBuilder yield output at initial state (0), before any markup is created, e.g. allowing the creation of "<!DOCTYPE html>" via MarkupBuilder.mkp.yieldUnescaped.