### PR TITLE
GROOVY-9618: index "static getX()" as "X" if class field X also exists

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -2606,11 +2606,16 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     }
 
     private static void createMetaBeanProperty(SingleKeyHashMap propertyIndex, String propName, boolean isGetter, MetaMethod propertyMethod) {
-        // is this property already accounted for?
-        MetaProperty mp = (MetaProperty) propertyIndex.get(propName);
-        MetaProperty newMp = makeReplacementMetaProperty(mp, propName, isGetter, propertyMethod);
-        if (newMp != mp) {
-            propertyIndex.put(propName, newMp);
+        // check if property is already accounted for
+        MetaProperty oldMP = (MetaProperty) propertyIndex.get(propName);
+        if (oldMP == null && propName.length() == 1 && propertyMethod.isStatic()) {
+            oldMP = (MetaProperty) propertyIndex.get(propName.toUpperCase());
+            if (oldMP != null) propName = propName.toUpperCase();
+        }
+
+        MetaProperty newMP = makeReplacementMetaProperty(oldMP, propName, isGetter, propertyMethod);
+        if (newMP != oldMP) {
+            propertyIndex.put(propName, newMP);
         }
     }
 

--- a/src/test/groovy/bugs/Groovy9618.groovy
+++ b/src/test/groovy/bugs/Groovy9618.groovy
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+final class Groovy9618 {
+
+    @Test
+    void testGetPropertyFromOuterClassOfSuper() {
+        assertScript '''
+            class A {
+              private static X = 1
+              static getX() { 2 }
+              static class B { }
+            }
+
+            class C extends A.B {
+              def m() {
+                return X
+              }
+            }
+
+            assert new C().m() == 2
+        '''
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9618
```groovy
    // one class meta-property "X"
    class C {
      static private X
      static getX()
    }

    // one class meta-property "x"
    class C {
      static private x
      static getX()
    }

    // one class meta-property "x" and one class meta-field "X"
    class C {
      static private x, X
      static getX()
    }

    // one class meta-property "X" and one instance meta-field "x"
    class C {
      static private X
      static getX()
      private x
    }
```