### PR TITLE
GROOVY-7232: check resolve strategy of each closure during method search

### DIFF
--- a/src/test/gls/closures/ResolveStrategyTest.groovy
+++ b/src/test/gls/closures/ResolveStrategyTest.groovy
@@ -20,30 +20,31 @@ package gls.closures
 
 import groovy.test.GroovyTestCase
 import groovy.transform.CompileStatic
+
 import static groovy.lang.Closure.*
 
 class ResolveStrategyTest extends GroovyTestCase {
     void testDynamicSettingOfResolveStrategy() {
         new MyClass().with {
-            assert run(DELEGATE_ONLY) == 12340000 // (*)
-            assert run(DELEGATE_FIRST) == 12040030
             assert run(OWNER_ONLY) == 1234 // (*)
-            assert run(OWNER_FIRST) == 41230
-
-            assert runOwnerOnly { m1() + m2() + m3() } == 1230
             assert runOwnerOnly { m1() + m2() + m3() + m4() } == 1234 // (*)
-            assert runOwnerFirst { m1() + m2() + m3() + m4() } == 41230
+
+            assert run(DELEGATE_ONLY) == 12340000 // (*)
             assert runDelegateOnly { m1() + m2() + m3() + m4() } == 12340000 // (*)
-            assert runDelegateOnly { m1() + m2() + m4() } == 12040000
-            assert runDelegateFirst { m1() + m2() + m3() + m4() } == 12340000 // (**)
+
+            // (*) involves methodMissing as forced by ONLY strategy (no equivalent CS case below)
+
+            assert run(OWNER_FIRST) == 41230
+            assert runOwnerFirst { m1() + m2() + m3() + m4() } == 41230
+
+            assert run(DELEGATE_FIRST) == 12040030
+            assert runDelegateFirst { m1() + m2() + m3() + m4() } == 12040030
 
             // nested cases
-            assert runDelegateFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 41230
-            assert runOwnerFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12340000 // (**)
             assert runOwnerFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 41230
-            assert runDelegateFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12340000 // (**)
-            // (*) involves methodMissing as forced by ONLY strategy (no equivalent CS case below)
-            // (**) involves methodMissing since delegate methodMissing has precedence over explicit owner method
+            assert runOwnerFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12040030
+            assert runDelegateFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 12040030
+            assert runDelegateFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12040030
         }
     }
 
@@ -53,14 +54,13 @@ class ResolveStrategyTest extends GroovyTestCase {
             assert runOwnerOnly { m1() + m2() + m3() } == 1230
             assert runOwnerFirst { m1() + m2() + m3() + m4() } == 41230
             assert runDelegateOnly { m1() + m2() + m4() } == 12040000
-            assert runDelegateFirst { m1() + m2() + m3() + m4() } == 12040030 // (*)
+            assert runDelegateFirst { m1() + m2() + m3() + m4() } == 12040030
 
-            // nested cases (GROOVY-9086)
-            assert runDelegateFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 12040030 // (*)
-            assert runOwnerFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12040030 // (*)
+            // GROOVY-9086: nested cases
             assert runOwnerFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 41230
-            assert runDelegateFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12040030 // (*)
-            // (*) different to dynamic since static assumes no methodMissing
+            assert runDelegateFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 12040030
+            assert runOwnerFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12040030
+            assert runDelegateFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12040030
         }
     }
 }

--- a/src/test/groovy/lang/ClosureResolvingTest.groovy
+++ b/src/test/groovy/lang/ClosureResolvingTest.groovy
@@ -203,6 +203,47 @@ class ClosureResolvingTest extends GroovyTestCase {
         cout()
     }
 
+    // GROOVY-7232
+    void testOwnerDelegateChain2() {
+        assertScript '''
+            def outer = { ->
+                def inner = { ->
+                    [x, keySet()]
+                }
+                inner.resolveStrategy = Closure.DELEGATE_ONLY
+                inner.delegate = [x: 1, f: 0]
+                inner.call()
+            }
+            //outer.resolveStrategy = Closure.OWNER_FIRST
+            outer.delegate = [x: 0, g: 0]
+            def result = outer.call()
+
+            assert result.flatten() == [1, 'x', 'f']
+        '''
+    }
+
+    // GROOVY-7232
+    void testOwnerDelegateChain3() {
+        assertScript '''
+            def outer = { ->
+                def inner = { ->
+                    def inner_inner = { ->
+                        [x, keySet()]
+                    }
+                    //inner_inner.resolveStrategy = Closure.OWNER_FIRST
+                    return inner_inner.call()
+                }
+                inner.resolveStrategy = Closure.DELEGATE_ONLY
+                inner.delegate = [x: 1, f: 0]
+                inner()
+            }
+            //outer.resolveStrategy = Closure.OWNER_FIRST
+            outer.delegate = [x: 0, g: 0]
+            def result = outer.call()
+
+            assert result.flatten() == [1, 'x', 'f']
+        '''
+    }
 }
 
 class TestResolve1 {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-7232

I tried to respect the apparent design of preferring declared methods over calls to `methodMissing`.  However, there was some mixed behavior on that front as seen in "(**) involves methodMissing since delegate methodMissing has precedence over explicit owner method" test cases.  I stuck with it because this new design gives dynamic behavior that more closely matches the static compilation behavior.

If `methodMissing` is okay to call on delegate instead of declared method on owner -- in the case of `DELEGATE_FIRST` and vice versa in the case of `OWNER_FIRST` -- I have a simpler solution that leverages `InvokerHelper.invokeMethod`.