### PR TITLE
GROOVY-9601: reduce checks made by findClassMember and getPropertyName

### DIFF
--- a/src/main/java/org/apache/groovy/ast/tools/MethodNodeUtils.java
+++ b/src/main/java/org/apache/groovy/ast/tools/MethodNodeUtils.java
@@ -86,17 +86,17 @@ public class MethodNodeUtils {
         if (nameLength > 2) {
             switch (name.charAt(0)) {
                 case 'g':
-                    if (nameLength > 3 && name.charAt(1) == 'e' && name.charAt(2) == 't' && mNode.getParameters().length == 0 && !ClassHelper.VOID_TYPE.equals(mNode.getReturnType())) {
+                    if (nameLength > 3 && name.charAt(1) == 'e' && name.charAt(2) == 't' && mNode.getParameters().length == 0 && !mNode.getReturnType().equals(ClassHelper.VOID_TYPE)) {
                         return decapitalize(name.substring(3));
                     }
                     break;
                 case 's':
-                    if (nameLength > 3 && name.charAt(1) == 'e' && name.charAt(2) == 't' && mNode.getParameters().length == 1 /*&& ClassHelper.VOID_TYPE.equals(mNode.getReturnType())*/) {
+                    if (nameLength > 3 && name.charAt(1) == 'e' && name.charAt(2) == 't' && mNode.getParameters().length == 1 /*&& mNode.getReturnType().equals(ClassHelper.VOID_TYPE)*/) {
                         return decapitalize(name.substring(3));
                     }
                     break;
                 case 'i':
-                    if (name.charAt(1) == 's' && mNode.getParameters().length == 0 && (ClassHelper.boolean_TYPE.equals(mNode.getReturnType()) /*|| ClassHelper.Boolean_TYPE.equals(mNode.getReturnType())*/)) {
+                    if (name.charAt(1) == 's' && mNode.getParameters().length == 0 && (mNode.getReturnType().equals(ClassHelper.boolean_TYPE) /*|| mNode.getReturnType().equals(ClassHelper.Boolean_TYPE)*/)) {
                         return decapitalize(name.substring(2));
                     }
                     break;

--- a/src/main/java/org/codehaus/groovy/classgen/VariableScopeVisitor.java
+++ b/src/main/java/org/codehaus/groovy/classgen/VariableScopeVisitor.java
@@ -167,7 +167,7 @@ public class VariableScopeVisitor extends ClassCodeVisitorSupport {
     }
 
     private Variable findClassMember(final ClassNode node, final String name) {
-        for (ClassNode cn = node; cn != null; cn = cn.getSuperClass()) {
+        for (ClassNode cn = node; cn != null && !cn.equals(ClassHelper.OBJECT_TYPE); cn = cn.getSuperClass()) {
             if (cn.isScript()) {
                 return new DynamicVariable(name, false);
             }
@@ -181,14 +181,15 @@ public class VariableScopeVisitor extends ClassCodeVisitorSupport {
             }
 
             for (MethodNode mn : cn.getMethods()) {
-                if (!mn.isAbstract() && name.equals(getPropertyName(mn))) {
-                    PropertyNode property = new PropertyNode(name, mn.getModifiers(), ClassHelper.OBJECT_TYPE, cn, null, null, null);
-                    final FieldNode field = property.getField();
-                    field.setHasNoRealSourcePosition(true);
-                    field.setSynthetic(true);
-                    field.setDeclaringClass(cn);
-                    property.setDeclaringClass(cn);
-                    return property;
+                if ((!mn.isAbstract() || node.isAbstract()) && name.equals(getPropertyName(mn))) {
+                    FieldNode fn = new FieldNode(name, mn.getModifiers() & 0xF, ClassHelper.OBJECT_TYPE, cn, null);
+                    fn.setHasNoRealSourcePosition(true);
+                    fn.setDeclaringClass(cn);
+                    fn.setSynthetic(true);
+
+                    PropertyNode pn = new PropertyNode(fn, fn.getModifiers(), null, null);
+                    pn.setDeclaringClass(cn);
+                    return pn;
                 }
             }
 


### PR DESCRIPTION
`findClassMember`
 - java.lang.Object has no fields, no properties, no interfaces, no isX methods, no setX methods and the only getX method is `getClass`, but "class" cannot be a free-standing variable name according to the parser
- it is possible to make bean-style reference to abstract method:
    ```groovy
    abstract class A {
        abstract getX()
        void test() {
          println x
        }
    }
    ```

`getPropertyName`
 - putting the cached class on the right side of `equals` triggers reference check instead of name string check for primitives
    ```java
    public boolean equals(Object that) {
        if (that == this) return true;
        if (!(that instanceof ClassNode)) return false;
        if (redirect != null) return redirect.equals(that); // go here so "that == this" check works for void, boolean, Object, etc.
        return (((ClassNode) that).getText().equals(getText()));
    }
    ```

https://issues.apache.org/jira/browse/GROOVY-9601