### PR TITLE
GROOVY-8999: super.@x should fail for private fields; no getX() or setX(_) workarounds

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -183,7 +183,7 @@ public class AsmClassGenerator extends ClassGenerator {
     private final Map genericParameterNames;
     private final SourceUnit source;
     private WriterController controller;
-    
+
     public AsmClassGenerator(
             SourceUnit source, GeneratorContext context,
             ClassVisitor classVisitor, String sourceFile
@@ -1039,7 +1039,7 @@ public class AsmClassGenerator extends ClassGenerator {
                     fieldX(field).visit(this);
                     return;
                 }
-                if (isSuperExpression(objectExpression)) {
+                if (isSuperExpression(objectExpression) && !(expression instanceof AttributeExpression)) {
                     if (controller.getCompileStack().isLHS()) {
                         setPropertyOfSuperClass(classNode, expression, mv);
                     } else {
@@ -2208,7 +2208,7 @@ public class AsmClassGenerator extends ClassGenerator {
         return false;
     }
 
-    private static boolean isSuperExpression(Expression expression) {
+    public static boolean isSuperExpression(Expression expression) {
         if (expression instanceof VariableExpression) {
             VariableExpression varExp = (VariableExpression) expression;
             return varExp.getName().equals("super");

--- a/src/test/groovy/transform/stc/TypeCheckingExtensionsTest.groovy
+++ b/src/test/groovy/transform/stc/TypeCheckingExtensionsTest.groovy
@@ -20,7 +20,6 @@ package groovy.transform.stc
 
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer
-import org.codehaus.groovy.transform.stc.GroovyTypeCheckingExtensionSupport
 
 /**
  * Units tests for type checking extensions.
@@ -235,7 +234,7 @@ class TypeCheckingExtensionsTest extends StaticTypeCheckingTestCase {
         extension = null
         shouldFailWithMessages '''
             'str'.@FOO
-        ''', 'No such property: FOO for class: java.lang.String'
+        ''', 'No such attribute: FOO for class: java.lang.String'
 
         extension = 'groovy/transform/stc/UnresolvedAttributeTestExtension.groovy'
         assertScript '''


### PR DESCRIPTION
@paulk-asert: Here are the changes from GROOVY-8999 that straighten out `super.@name` for Groovy 2.5.  The STC error was left out because the field access checks are not as complete as they are in Groovy 3.  The `InvocationWriter` changes are needed in Groovy 2.4 for `super.@name` to actually skip over `this.@name`.