### PR TITLE
 JmxMetaMapBuilder.buildOperationMapFrom throw StringIndexOutOfBoundsException

### DIFF
--- a/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxMetaMapBuilder.groovy
+++ b/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxMetaMapBuilder.groovy
@@ -402,8 +402,7 @@ class JmxMetaMapBuilder {
             // avoid picking up extra methods from parents
             if ((declaredMethods.contains(method.name) && !OPS_EXCEPTION_LIST.contains(method.name)) || (!OPS_EXCEPTION_LIST.contains(method.name))) {
                 String mName = method.name
-                MetaProperty prop = (mName.startsWith("get") || mName.startsWith("set")) ?
-                        object.metaClass.getMetaProperty(JmxBuilderTools.uncapitalize(mName[3..-1])) : null
+                MetaProperty prop = (mName.startsWith("get") || mName.startsWith("set")) ? object.metaClass.getMetaProperty(JmxBuilderTools.uncapitalize(mName.length() == 3 ? mName : mName[3..-1])) : null
                 // skip exporting getters/setters to avoid dbl exposure.  They are exported differently.
                 if (!prop) {
                     def map = [:]
@@ -499,7 +498,7 @@ class JmxMetaMapBuilder {
      * to create a map object of the meta data provided with defaults where necessary.
      * @param method - the method being described
      * @param descriptor - the meta data collected from JmxBuilder.bean()
-     * @return fully-normalized meta map 
+     * @return fully-normalized meta map
      */
     private static Map createOperationMap(object, method, descriptor) {
         def desc = (descriptor && descriptor instanceof Map) ? descriptor : [:]

--- a/subprojects/groovy-jmx/src/test/groovy/groovy/jmx/builder/JmxMetaMapBuilderTest.groovy
+++ b/subprojects/groovy-jmx/src/test/groovy/groovy/jmx/builder/JmxMetaMapBuilderTest.groovy
@@ -301,7 +301,7 @@ class JmxMetaMapBuilderTest extends GroovyTestCase {
     void testBuildOperationMapFromObject() {
         def object = new MockManagedObject()
         def map = JmxMetaMapBuilder.buildOperationMapFrom(object)
-
+    
         assert map
         assert map."doSomethingElse".name == "doSomethingElse"
         assert map."doSomethingElse".displayName
@@ -311,6 +311,9 @@ class JmxMetaMapBuilderTest extends GroovyTestCase {
         assert map."doSomethingElse".params."int".displayName
         assert map."doSomethingElse".params."java.lang.String".name == "java.lang.String"
         assert map."doSomethingElse".params."java.lang.String".displayName
+    
+        assert map."get".name == "get"
+        assert map."set".name == "set"
     }
 
     void testBuildOperationFromDescriptorMap() {

--- a/subprojects/groovy-jmx/src/test/java/groovy/jmx/builder/MockManagedObject.java
+++ b/subprojects/groovy-jmx/src/test/java/groovy/jmx/builder/MockManagedObject.java
@@ -69,13 +69,20 @@ public class MockManagedObject {
     public void dontDoThis(Object param) {
         logger.log(Level.FINER, "Jmx Invoke - method dontDoThis() with param : " + param);
     }
-
+    
     public void setAvailable(boolean flag) {
         avail = flag;
     }
-
+    
     public boolean isAvailable() {
         return avail;
     }
-
+    
+    public String get(String str) {
+        return str;
+    }
+    
+    public String set(String str) {
+        return str;
+    }
 }


### PR DESCRIPTION
 JmxMetaMapBuilder.buildOperationMapFrom for method "get" or "set" throw StringIndexOutOfBoundsException
example:
```
class TestGet {
	String sb
	
	def get(String str) {
		str
	}
	
	static main(args) {
		def testGet = new TestGet()
		def property = testGet.metaClass.getMethods()
		def ms = testGet.getClass().getDeclaredMethods()*.name
		def jmx = new JmxBuilder()
		def beans = jmx.export {
			bean(
					target: new TestGet(),
					attributes: [],
					operations: "*"
			)
		}
	}
}
```
after run:
```
Exception in thread "main" java.lang.RuntimeException: Failed to create component for 'bean' reason: java.lang.StringIndexOutOfBoundsException: begin 2, end 4, length 3
```
