### PR TITLE
GROOVY-7232: prefer methodMissing over declared method on next candidate

### DIFF
--- a/src/test/gls/closures/ResolveStrategyTest.groovy
+++ b/src/test/gls/closures/ResolveStrategyTest.groovy
@@ -23,33 +23,32 @@ import groovy.transform.CompileStatic
 
 import static groovy.lang.Closure.*
 
-class ResolveStrategyTest extends GroovyTestCase {
-    void testDynamicSettingOfResolveStrategy() {
+final class ResolveStrategyTest extends GroovyTestCase {
+
+    void testDynamicResolveStrategy() {
         new MyClass().with {
-            assert run(OWNER_ONLY) == 1234 // (*)
-            assert runOwnerOnly { m1() + m2() + m3() + m4() } == 1234 // (*)
+            assert run(OWNER_ONLY) == 1234
+            assert runOwnerOnly { m1() + m2() + m3() + m4() } == 1234
 
-            assert run(DELEGATE_ONLY) == 12340000 // (*)
-            assert runDelegateOnly { m1() + m2() + m3() + m4() } == 12340000 // (*)
+            assert run(DELEGATE_ONLY) == 12340000
+            assert runDelegateOnly { m1() + m2() + m3() + m4() } == 12340000
 
-            // (*) involves methodMissing as forced by ONLY strategy (no equivalent CS case below)
+            assert run(OWNER_FIRST) == 1234
+            assert runOwnerFirst { m1() + m2() + m3() + m4() } == 1234
 
-            assert run(OWNER_FIRST) == 41230
-            assert runOwnerFirst { m1() + m2() + m3() + m4() } == 41230
-
-            assert run(DELEGATE_FIRST) == 12040030
-            assert runDelegateFirst { m1() + m2() + m3() + m4() } == 12040030
+            assert run(DELEGATE_FIRST) == 12340000
+            assert runDelegateFirst { m1() + m2() + m3() + m4() } == 12340000
 
             // nested cases
-            assert runOwnerFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 41230
-            assert runOwnerFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12040030
-            assert runDelegateFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 12040030
-            assert runDelegateFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12040030
+            assert runOwnerFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 1234
+            assert runOwnerFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12340000
+            assert runDelegateFirst { runOwnerFirst { m1() + m2() + m3() + m4() } } == 12340000
+            assert runDelegateFirst { runDelegateFirst { m1() + m2() + m3() + m4() } } == 12340000
         }
     }
 
     @CompileStatic
-    void testStaticCases() {
+    void testStaticResolveStrategy() {
         new MyClass().with {
             assert runOwnerOnly { m1() + m2() + m3() } == 1230
             assert runOwnerFirst { m1() + m2() + m3() + m4() } == 41230


### PR DESCRIPTION
Here is my discussed alternative that simplifies the implementation using `InvokerHelper#invokeMethod`.  If a delegate or owner implements `methodMissing` it will be called instead of trying `invokeMethod` on the next in line.  This is more consistent with the way property resolution works (see `Closure#getProperty`).

`StaticTypeCheckingVisitor` will need a block similar to the one added for GROOVY-7996 in order for static compilation to line up.

https://issues.apache.org/jira/browse/GROOVY-7232


**Note:** This does not address the change in behavior discussed here: https://github.com/apache/groovy/commit/640e9304fe8950400d94adaad474c0c341209df0#commitcomment-40953759