### PR TITLE
The fork-join pool does not provide a good ClassLoader for Groovy types

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/ProcessingUnit.java
+++ b/src/main/java/org/codehaus/groovy/control/ProcessingUnit.java
@@ -101,8 +101,7 @@ public abstract class ProcessingUnit {
         // ClassLoaders should only be created inside a doPrivileged block in case
         // this method is invoked by code that does not have security permissions.
         this.classLoader = loader != null ? loader : AccessController.doPrivileged((PrivilegedAction<GroovyClassLoader>) () -> {
-            ClassLoader parent = Thread.currentThread().getContextClassLoader();
-            if (parent == null) parent = ProcessingUnit.class.getClassLoader();
+            ClassLoader parent = this.getClass().getClassLoader();
             return new GroovyClassLoader(parent, getConfiguration());
         });
     }


### PR DESCRIPTION
 - `Thread.currentThread().getContextClassLoader()` was used starting with 46b1fface0b17cf41f9681894bcb8d78fc831258 -- commit does not state that this parentage is required for any specific reason; fallback loader (the one that loaded `ProcessingUnit`) seems like a better option for Groovy.

 - `StaticTypeCheckingSupport.evaluateExpression(...)` relies on loader created by this block; it does not transfer loader(s) from it's context.


This came about for me because IDE is performing content assist asynchronously now and processing `ClosureParams`/`DelegatesTo` metadata relies on `evaluateExpression`.