### PR TITLE
Support coerce for @NamedVariant

### DIFF
--- a/src/main/java/groovy/transform/NamedVariant.java
+++ b/src/main/java/groovy/transform/NamedVariant.java
@@ -124,4 +124,9 @@ public @interface NamedVariant {
      * @since 2.5.3
      */
     boolean autoDelegate() default false;
+
+    /**
+     * If true, will use {@code as} to convert map parameter to required class
+     */
+    boolean coerce() default false;
 }

--- a/src/main/java/org/codehaus/groovy/ast/tools/GeneralUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GeneralUtils.java
@@ -119,6 +119,10 @@ public class GeneralUtils {
         return args(Arrays.stream(names).map(GeneralUtils::varX).toArray(Expression[]::new));
     }
 
+    public static CastExpression asX(final ClassNode type, final Expression expression) {
+        return CastExpression.asExpression(type, expression);
+    }
+
     public static Statement assignS(final Expression target, final Expression value) {
         return stmt(assignX(target, value));
     }

--- a/src/test/groovy/transform/NamedVariantTest.groovy
+++ b/src/test/groovy/transform/NamedVariantTest.groovy
@@ -1,0 +1,86 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform
+
+import java.lang.reflect.Modifier
+import groovy.test.GroovyTestCase
+
+/**
+ * Unit tests for the NamedVariant annotation
+ */
+class NamedVariantTest extends GroovyTestCase {
+    void testMethod() {
+        def tester = new GroovyClassLoader().parseClass(
+                '''class MyClass {
+                  |    @groovy.transform.NamedVariant
+                  |    void run(int number) {
+                  |    }
+                  |}'''.stripMargin())
+        // Should have such method `void run(Map)`
+        def method = tester.getDeclaredMethod("run", Map)
+        assert method
+        assert Modifier.isPublic(method.modifiers)
+        assert method.returnType == void.class
+    }
+
+    void testMethodCall() {
+        def tester = new GroovyClassLoader().parseClass(
+                '''class MyClass {
+                  |    @groovy.transform.NamedVariant
+                  |    int run(int number) {
+                  |        number
+                  |    }
+                  |}'''.stripMargin()).getConstructor().newInstance()
+
+        assert tester.run(number: 123) == 123
+        try {
+            tester.run(number: "123")
+        } catch (MissingMethodException ignored) {
+            return
+        }
+        fail("Should have thrown MissingMethodException")
+    }
+
+    void testCoerceMethodCall() {
+        def tester = new GroovyClassLoader().parseClass(
+                '''class MyClass {
+                  |    @groovy.transform.NamedVariant(coerce = true)
+                  |    int run(int number) {
+                  |        number
+                  |    }
+                  |}'''.stripMargin()).getConstructor().newInstance()
+
+        assert tester.run(number: 123) == 123
+        assert tester.run(number: "123") == 123
+    }
+
+    void testStaticCoerceMethodCall() {
+        def tester = new GroovyClassLoader().parseClass(
+                '''@groovy.transform.CompileStatic
+                  |class MyClass {
+                  |    @groovy.transform.NamedVariant(coerce = true)
+                  |    int run(int number) {
+                  |        number
+                  |    }
+                  |}'''.stripMargin()).getConstructor().newInstance()
+
+        assert tester.run(number: 123) == 123
+        assert tester.run(number: "123") == 123
+    }
+}


### PR DESCRIPTION
Support `useAs` for `@NamedVariant`

For example:

```groovy
@NamedVariant
void run(int number) {
    println(number)
}
```

If we called this method with

```groovy
run(number: "123")
```

Groovy will throw out

```
groovy.lang.MissingMethodException: No signature of method: run() is applicable for argument types: (String) values: [123]
```

After support `useAs`, we can define method like this:

```groovy
@NamedVariant(useAs = true)
void run(int number) {
    println(number)
}
```

The generated method will automatically use the operator `as` convert `String` to `int`, and the will succeed now.

And in order to make the operator `as` work correctly, I also disable `@CompileStatic` for the generated method.