### PR TITLE
GROOVY-9712: type name may start with more than A-Z (CapitalizedIdentifier)

### DIFF
--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -882,7 +882,7 @@ ELVIS_ASSIGN    : '?=';
 
 // §3.8 Identifiers (must appear after all keywords in the grammar)
 CapitalizedIdentifier
-    :   [A-Z] JavaLetterOrDigit*
+    :   JavaLetter {Character.isUpperCase(getInputStream().LA(-1))}? JavaLetterOrDigit*
     ;
 
 Identifier

--- a/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
+++ b/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/GroovyParserTest.groovy
@@ -318,7 +318,6 @@ final class GroovyParserTest extends GroovyTestCase {
     void "test groovy core - LocalVariableDeclaration"() {
         doTest('core/LocalVariableDeclaration_01.groovy', [Token]) // [class org.codehaus.groovy.syntax.Token][startLine]:: 9 != 8
         doRunAndTestAntlr4('core/LocalVariableDeclaration_02x.groovy')
-
     }
 
     void "test groovy core - MethodDeclaration"() {
@@ -334,6 +333,7 @@ final class GroovyParserTest extends GroovyTestCase {
         doTest('core/ClassDeclaration_05.groovy', [ExpressionStatement])
         doTest('core/ClassDeclaration_06.groovy')
         doTest('core/ClassDeclaration_07.groovy')
+        doTest('core/ClassDeclaration_08.groovy')
     }
 
     void "test groovy core - InterfaceDeclaration"() {

--- a/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/TestUtils.groovy
+++ b/subprojects/parser-antlr4/src/test/groovy/org/apache/groovy/parser/antlr4/TestUtils.groovy
@@ -59,21 +59,15 @@ final class TestUtils {
 
     public static final String RESOURCES_PATH = Optional.of('subprojects/parser-antlr4/src/test/resources').filter(path -> new File(path).exists()).orElse('src/test/resources')
 
-    static doTest(String path) {
-        doTest(path, ASTComparatorCategory.DEFAULT_CONFIGURATION)
-    }
-
-    static doTest(String path, conf) {
-        doTest(path, conf, new CompilerConfiguration(CompilerConfiguration.DEFAULT))
-    }
-
     static doTest(String path, Collection<Class> ignoreSourcePosition) {
         doTest(path, addIgnore(ignoreSourcePosition, ASTComparatorCategory.LOCATION_IGNORE_LIST))
     }
 
     @CompileDynamic
-    static doTest(String path, conf, CompilerConfiguration compilerConfiguration) {
-        def file = new File("$RESOURCES_PATH/$path")
+    static doTest(String path, conf = ASTComparatorCategory.DEFAULT_CONFIGURATION, CompilerConfiguration compilerConfiguration = CompilerConfiguration.DEFAULT) {
+        File file = new File("$RESOURCES_PATH/$path")
+        assert file.exists() : "Test resource not found: $file.absolutePath"
+
         def (newAST, newElapsedTime) = profile { buildAST(file, getAntlr4Config(compilerConfiguration)) }
 //        def (oldAST, oldElapsedTime) = profile { buildAST(file, getAntlr2Config(compilerConfiguration)) }
 
@@ -87,17 +81,15 @@ final class TestUtils {
         return [newAST, null]
     }
 
-    static void shouldFail(String path, boolean toCheckNewParserOnly = false) {
-        shouldFail(path, ASTComparatorCategory.DEFAULT_CONFIGURATION, toCheckNewParserOnly)
-    }
-
     static void shouldFail(String path, Collection<Class> ignoreSourcePosition, boolean toCheckNewParserOnly = false) {
         shouldFail(path, addIgnore(ignoreSourcePosition, ASTComparatorCategory.LOCATION_IGNORE_LIST), toCheckNewParserOnly)
     }
 
     @CompileDynamic
-    static void shouldFail(String path, conf, boolean toCheckNewParserOnly = false) {
-        def file = new File("$RESOURCES_PATH/$path")
+    static void shouldFail(String path, conf = ASTComparatorCategory.DEFAULT_CONFIGURATION, boolean toCheckNewParserOnly = false) {
+        File file = new File("$RESOURCES_PATH/$path")
+        assert file.exists() : "Test resource not found: $file.absolutePath"
+
         def (newAST, newElapsedTime) = profile { buildAST(file, antlr4Config) }
 //        def (oldAST, oldElapsedTime) = profile { buildAST(file, antlr2Config) }
 

--- a/subprojects/parser-antlr4/src/test/resources/core/ClassDeclaration_08.groovy
+++ b/subprojects/parser-antlr4/src/test/resources/core/ClassDeclaration_08.groovy
@@ -1,0 +1,25 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package core
+
+class À {
+    public À f
+           À p
+    static À m() {}
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9712

**Note:** The parser tests that use `TestUtils#doTest` are silently swallowing all parser errors since there is no longer comparison against any antlr2 result.