### PR TITLE
GROOVY-9735: connect placeholder from context with method generic params

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -54,7 +54,6 @@ import java.util.function.Predicate;
 import static groovy.lang.Tuple.tuple;
 import static org.apache.groovy.util.SystemUtil.getSystemPropertySafe;
 import static org.codehaus.groovy.runtime.DefaultGroovyMethods.plus;
-import static org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport.getCorrectedClassNode;
 import static org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport.implementsInterfaceOrIsSubclassOf;
 
 /**
@@ -513,12 +512,10 @@ public class GenericsUtils {
                 extractSuperClassGenerics(type.getGenericsTypes(), target.getGenericsTypes(), spec);
             }
         } else {
-            // have first to find matching super class or interface
+            // find matching super class or interface
             ClassNode superClass = getSuperClass(type, target);
-
             if (superClass != null) {
-                ClassNode corrected = getCorrectedClassNode(type, superClass, false);
-                extractSuperClassGenerics(corrected, target, spec);
+                extractSuperClassGenerics(correctToGenericsSpecRecurse(createGenericsSpec(type), superClass), target, spec);
             } else {
                 // if we reach here, we have an unhandled case
                 throw new GroovyBugError("The type " + type + " seems not to normally extend " + target + ". Sorry, I cannot handle this.");
@@ -906,39 +903,60 @@ public class GenericsUtils {
     }
 
     /**
-     * Check whether the ClassNode has non generics placeholders, aka not placeholder
+     * Checks if the type has any non-placeholder (aka resolved) generics.
      *
-     * @param parameterizedType the class node
-     * @return the result
      * @since 3.0.0
      */
-    public static boolean hasNonPlaceHolders(ClassNode parameterizedType) {
-        return checkPlaceHolders(parameterizedType, genericsType -> !genericsType.isPlaceholder());
+    public static boolean hasNonPlaceHolders(final ClassNode type) {
+        return checkPlaceHolders(type, gt -> !gt.isPlaceholder());
     }
 
     /**
-     * Check whether the ClassNode has generics placeholders
-     * @param parameterizedType the class node
-     * @return the result
+     * Checks if the type has any placeholder (aka unresolved) generics.
+     *
      * @since 3.0.0
      */
-    public static boolean hasPlaceHolders(ClassNode parameterizedType) {
-        return checkPlaceHolders(parameterizedType, GenericsType::isPlaceholder);
+    public static boolean hasPlaceHolders(final ClassNode type) {
+        return checkPlaceHolders(type, gt -> gt.isPlaceholder());
     }
 
-    private static boolean checkPlaceHolders(ClassNode parameterizedType, Predicate<GenericsType> p) {
-        if (null == parameterizedType) return false;
-
-        GenericsType[] genericsTypes = parameterizedType.getGenericsTypes();
-
-        if (null == genericsTypes) return false;
-
-        for (GenericsType genericsType : genericsTypes) {
-            if (p.test(genericsType)) {
-                return true;
+    private static boolean checkPlaceHolders(final ClassNode type, final Predicate<GenericsType> p) {
+        if (type != null) {
+            GenericsType[] genericsTypes = type.getGenericsTypes();
+            if (genericsTypes != null) {
+                for (GenericsType genericsType : genericsTypes) {
+                    if (p.test(genericsType)) {
+                        return true;
+                    }
+                }
             }
         }
+        return false;
+    }
 
+    /**
+     * Checks for any placeholder (aka unresolved) generics.
+     */
+    public static boolean hasUnresolvedGenerics(final ClassNode type) {
+        if (type.isGenericsPlaceHolder()) return true;
+        if (type.isArray()) {
+            return hasUnresolvedGenerics(type.getComponentType());
+        }
+        GenericsType[] genericsTypes = type.getGenericsTypes();
+        if (genericsTypes != null) {
+            for (GenericsType genericsType : genericsTypes) {
+                if (genericsType.isPlaceholder()) return true;
+                ClassNode lowerBound = genericsType.getLowerBound();
+                ClassNode[] upperBounds = genericsType.getUpperBounds();
+                if (lowerBound != null) {
+                    if (hasUnresolvedGenerics(lowerBound)) return true;
+                } else if (upperBounds != null) {
+                    for (ClassNode upperBound : upperBounds) {
+                        if (hasUnresolvedGenerics(upperBound)) return true;
+                    }
+                }
+            }
+        }
         return false;
     }
 

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -1764,11 +1764,9 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         return member;
     }
 
-    private void storeWithResolve(final ClassNode typeToResolve, final ClassNode receiver, final ClassNode declaringClass, final boolean isStatic, final Expression expressionToStoreOn) {
-        ClassNode type = typeToResolve;
-        if (missesGenericsTypes(type)) {
-            Map<GenericsTypeName, GenericsType> resolvedPlaceholders = resolvePlaceHoldersFromDeclaration(receiver, declaringClass, null, isStatic);
-            type = resolveGenericsWithContext(resolvedPlaceholders, type);
+    private void storeWithResolve(ClassNode type, final ClassNode receiver, final ClassNode declaringClass, final boolean isStatic, final Expression expressionToStoreOn) {
+        if (GenericsUtils.hasUnresolvedGenerics(type)) {
+            type = resolveGenericsWithContext(resolvePlaceHoldersFromDeclaration(receiver, declaringClass, null, isStatic), type);
         }
         if (expressionToStoreOn instanceof PropertyExpression) {
             storeInferredTypeForPropertyExpression((PropertyExpression) expressionToStoreOn, type);
@@ -5134,7 +5132,9 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                     Map<GenericsTypeName, GenericsType> connections = new HashMap<>();
                     extractGenericsConnections(connections, argumentType, paramType);
                     extractGenericsConnectionsForSuperClassAndInterfaces(resolvedPlaceholders, connections);
+
                     applyGenericsConnections(connections, resolvedPlaceholders);
+                    applyGenericsConnections(placeholdersFromContext, resolvedPlaceholders);
                 }
             }
         }

--- a/src/test/groovy/transform/stc/ClosureParamTypeInferenceSTCTest.groovy
+++ b/src/test/groovy/transform/stc/ClosureParamTypeInferenceSTCTest.groovy
@@ -1378,8 +1378,6 @@ method()
 
     void testGroovy9570() {
         assertScript '''
-            interface Item {}
-
             class C<I extends Item> {
                 Queue<I> queue
 
@@ -1395,6 +1393,37 @@ method()
                     }
                 }
             }
+
+            interface Item {}
+
+            new C()
+        '''
+    }
+
+    void testGroovy9735() {
+        assertScript '''
+            import groovy.transform.stc.*
+
+            class C<I extends Item> {
+                Queue<I> queue
+
+                def c = { ->
+                    x(queue) { I item ->
+                        println item
+                    }
+                }
+
+                def m() {
+                    x(queue) { I item ->
+                        println item
+                    }
+                }
+
+                def <T> T x(Collection<T> y, @ClosureParams(FirstParam.FirstGenericType) Closure z) {
+                }
+            }
+
+            interface Item {}
 
             new C()
         '''


### PR DESCRIPTION
```groovy
  @groovy.transform.TypeChecked
  class C<T extends Number> {
    List<T> list
    def test() {
      m(list) { /*...*/ } // "it" should infer as T/Number
    }
    def <U> void m(Iterable<U> items, @ClosureParams(FirstParam.FirstGenericType) Closure block) {
      // ...
    }
  }
```
https://issues.apache.org/jira/browse/GROOVY-9735