### PR TITLE
GROOVY-9739: prevent typecast expression with null type

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/expr/CastExpression.java
+++ b/src/main/java/org/codehaus/groovy/ast/expr/CastExpression.java
@@ -21,6 +21,8 @@ package org.codehaus.groovy.ast.expr;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.GroovyCodeVisitor;
 
+import java.util.Objects;
+
 /**
  * Represents a typecast expression.
  */
@@ -43,9 +45,9 @@ public class CastExpression extends Expression {
     }
 
     public CastExpression(final ClassNode type, final Expression expression, final boolean ignoreAutoboxing) {
-        this.setType(type);
         this.expression = expression;
         this.ignoreAutoboxing = ignoreAutoboxing;
+        super.setType(Objects.requireNonNull(type));
     }
 
     public Expression getExpression() {
@@ -107,6 +109,6 @@ public class CastExpression extends Expression {
 
     @Override
     public void setType(final ClassNode type) {
-        super.setType(type);
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
This is a proposed change to help identify the source of the null cast.

https://issues.apache.org/jira/browse/GROOVY-9739