### PR TITLE
Add a null check so that the proper exception is thrown.

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Interpreter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Interpreter.groovy
@@ -96,7 +96,9 @@ class Interpreter implements Evaluator
         }
         finally {
             // Remove the script class generated
-            classLoader.removeClassCacheEntry(type?.name)
+            if (type?.name) {
+                classLoader.removeClassCacheEntry(type?.name)
+            }
 
             // Remove the inline closures from the cache as well
             classLoader.removeClassCacheEntry('$_run_closure')


### PR DESCRIPTION
This issue is resolved in 3.x and is essentially backported from 47d106cddc069d0f7c9b3e75f1a35aec44685b03 which was part of GROOVY-8279. 

This issue ends up being a problem for Apache TinkerPop which relies on groovysh fairly heavily. Without this change, a fail within `shell.parse()` within the `try` block leaves the `type` as `null` and then provides that argument to `removeClassCacheEntry()`. At that point no matter what exception `shell.parse()` threw, the `Interpreter.evaluate()` will end up throwing a `NullPointerException` thus masking the error. In our case at TinkerPop, the exception typically masked is a `StackOverflowError` which would be much more useful than the `NullPointerException` as it would point to a common specific problem that we could alert users to more readily.