### PR TITLE
GROOVY-9803: translate generics of method reference using SAM parameters

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1801,10 +1801,14 @@ public abstract class StaticTypeCheckingSupport {
         GenericsType[] gts = parameterUsage.getGenericsTypes();
         if (gts == null) return Collections.emptyMap();
 
-        GenericsType[] newGTs = applyGenericsContext(spec, gts);
-        ClassNode newTarget = parameterUsage.redirect().getPlainNodeReference();
-        newTarget.setGenericsTypes(newGTs);
-        return GenericsUtils.extractPlaceholders(newTarget);
+        ClassNode newType = parameterUsage.redirect().getPlainNodeReference();
+        newType.setGenericsTypes(applyGenericsContext(spec, gts));
+
+        Map<GenericsTypeName, GenericsType> newSpec = GenericsUtils.extractPlaceholders(newType);
+        newSpec.replaceAll((xx, gt) -> // GROOVY-9762, GROOVY-9803: reduce "? super T" to "T"
+            Optional.ofNullable(gt.getLowerBound()).map(GenericsType::new).orElse(gt)
+        );
+        return newSpec;
     }
 
     private static GenericsType[] applyGenericsContext(final Map<GenericsTypeName, GenericsType> spec, final GenericsType[] gts) {

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1862,7 +1862,7 @@ public abstract class StaticTypeCheckingSupport {
         return false;
     }
 
-    private static ClassNode[] applyGenericsContext(final Map<GenericsTypeName, GenericsType> spec, final ClassNode[] bounds) {
+    static ClassNode[] applyGenericsContext(final Map<GenericsTypeName, GenericsType> spec, final ClassNode[] bounds) {
         if (bounds == null) return null;
         ClassNode[] newBounds = new ClassNode[bounds.length];
         for (int i = 0, n = bounds.length; i < n; i += 1) {

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -742,6 +742,42 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         }
     }
 
+    // GROOVY-9803
+    void testShouldUseMethodGenericType8() {
+        assertScript '''
+            def opt = Optional.of(42)
+                .map(Collections::singleton)
+                .map(x -> x.first().intValue()) // Cannot find matching method java.lang.Object#intValue()
+            assert opt.get() == 42
+        '''
+        // same as above but with separate type parameter name for each location
+        assertScript '''
+            abstract class A<I,O> {
+                abstract O apply(I input)
+            }
+            class C<T> {
+                static <U> C<U> of(U item) {
+                    new C<U>()
+                }
+                def <V> C<V> map(A<? super T, ? super V> func) {
+                    new C<V>()
+                }
+            }
+            class D {
+                static <W> Set<W> wrap(W o) {
+                }
+            }
+
+            void test() {
+                def c = C.of(42)
+                def d = c.map(D.&wrap)
+                def e = d.map(x -> x.first().intValue())
+            }
+
+            test()
+        '''
+    }
+
     // GROOVY-5516
     void testAddAllWithCollectionShouldBeAllowed() {
         assertScript '''import org.codehaus.groovy.transform.stc.ExtensionMethodNode


### PR DESCRIPTION
Since this change resolves additional generics, the test case for GROOVY-9762 fails when comparing `List<? super Integer>` to `List<Integer>`.  Wherever `Collections::singletonList` is matched up with `Function<? super T, ? extends U>` is getting `List<? super Integer>`.  Java just shows `List<Integer>` for `Optional.of(123).map(Collections::singletonList)`.

https://issues.apache.org/jira/browse/GROOVY-9803