### PR TITLE
GROOVY-9799: avoid using ClassNode#getTypeClass

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -439,7 +439,7 @@ public abstract class StaticTypeCheckingSupport {
      *
      * @return true if the class node is assignable to the other class node, false otherwise
      */
-    static boolean isAssignableTo(ClassNode type, ClassNode toBeAssignedTo) {
+    public static boolean isAssignableTo(ClassNode type, ClassNode toBeAssignedTo) {
         if (type == toBeAssignedTo || type == UNKNOWN_PARAMETER_TYPE) return true;
         if (isPrimitiveType(type)) type = getWrapper(type);
         if (isPrimitiveType(toBeAssignedTo)) toBeAssignedTo = getWrapper(toBeAssignedTo);


### PR DESCRIPTION
When using method references for local types, there is no Class to use for compatibility testing.  Switch to `isAssignableTo(ClassNode,ClassNode)` to make determination using Groovy model.

https://issues.apache.org/jira/browse/GROOVY-9799