### PR TITLE
GROOVY-9816: AutoImplement: respect generated property methods

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/PropertyNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/PropertyNode.java
@@ -22,11 +22,10 @@ import groovy.lang.MetaProperty;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.stmt.Statement;
 
+import static org.apache.groovy.util.BeanUtils.capitalize;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
-
-import static org.apache.groovy.util.BeanUtils.capitalize;
 
 /**
  * Represents a property (member variable, a getter and setter)
@@ -82,12 +81,10 @@ public class PropertyNode extends AnnotatedNode implements Variable {
      * {@code isFoo} is the default if no {@code getFoo} method exists in the declaring class.
      */
     public String getGetterNameOrDefault() {
-//        return setterName != null ? setterName : MetaProperty.getSetterName(getName());
-
         if (getterName != null) return getterName;
         String defaultName = "get" + capitalize(getName());
         if (ClassHelper.boolean_TYPE.equals(getOriginType())
-                && getDeclaringClass().getMethod(defaultName, Parameter.EMPTY_ARRAY) == null) {
+                && !getDeclaringClass().hasMethod(defaultName, Parameter.EMPTY_ARRAY)) {
             defaultName = "is" + capitalize(getName());
         }
         return defaultName;

--- a/src/main/java/org/codehaus/groovy/transform/AutoImplementASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/AutoImplementASTTransformation.java
@@ -27,11 +27,12 @@ import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.EmptyStatement;
-import org.codehaus.groovy.ast.tools.ParameterUtils;
+import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.control.CompilePhase;
 import org.codehaus.groovy.control.SourceUnit;
 
@@ -42,16 +43,22 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.groovy.ast.tools.ClassNodeUtils.addGeneratedMethod;
+import static org.apache.groovy.ast.tools.MethodNodeUtils.getPropertyName;
 import static org.apache.groovy.ast.tools.MethodNodeUtils.methodDescriptorWithoutReturnType;
+import static org.apache.groovy.util.BeanUtils.capitalize;
 import static org.codehaus.groovy.antlr.PrimitiveHelper.getDefaultValueForPrimitive;
 import static org.codehaus.groovy.ast.expr.ArgumentListExpression.EMPTY_ARGUMENTS;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.callX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.getGetterName;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.returnS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.throwS;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.correctToGenericsSpec;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.correctToGenericsSpecRecurse;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.createGenericsSpec;
+import static org.codehaus.groovy.ast.tools.ParameterUtils.parametersEqual;
 
 /**
  * Generates code for the {@code @AutoImplement} annotation.
@@ -95,13 +102,24 @@ public class AutoImplementASTTransformation extends AbstractASTTransformation {
     private void createMethods(final ClassNode cNode, final ClassNode exception, final String message, final ClosureExpression code) {
         for (MethodNode candidate : getAllCorrectedMethodsMap(cNode).values()) {
             if (candidate.isAbstract()) {
+                Statement statement = buildMethodBody(exception, message, code, candidate.getReturnType());
+                String propertyName = getPropertyName(candidate);
+                if (propertyName != null && candidate.getParameters().length == 0) {
+                    String accessorName = candidate.getName().startsWith("is")
+                            ? getGetterName(propertyName) : "is" + capitalize(propertyName);
+                    if (cNode.hasMethod(accessorName, Parameter.EMPTY_ARRAY)) {
+                        // delegate to existing accessor to reduce the surprise
+                        statement = returnS(callX(varX("this"), accessorName));
+                    }
+                }
+
                 addGeneratedMethod(cNode,
                         candidate.getName(),
                         candidate.getModifiers() & 0x7, // visibility only
                         candidate.getReturnType(),
                         candidate.getParameters(),
                         candidate.getExceptions(),
-                        buildMethodBody(exception, message, code, candidate.getReturnType())
+                        statement
                 );
             }
         }
@@ -161,13 +179,38 @@ public class AutoImplementASTTransformation extends AbstractASTTransformation {
             }
             next = correctToGenericsSpecRecurse(updatedGenericsSpec, superClass);
         }
+
+        // GROOVY-9816: remove entries for to-be-generated property access and mutate methods
+        for (ClassNode cn = cNode; cn != null && !cn.equals(ClassHelper.OBJECT_TYPE); cn = cn.getSuperClass()) {
+            for (PropertyNode pn : cn.getProperties()) {
+                if (!pn.getField().isFinal()) {
+                    result.remove(pn.getSetterNameOrDefault() + ":" + pn.getType().getText() + ",");
+                }
+                if (!pn.getType().equals(ClassHelper.boolean_TYPE)) {
+                    result.remove(pn.getGetterNameOrDefault() + ":");
+                } else if (pn.getGetterName() != null) {
+                    result.remove(pn.getGetterName() + ":");
+                } else {
+                    // getter generated only if no explicit isser and vice versa
+                    String isserName  = "is" + capitalize(pn.getName());
+                    String getterName = getGetterName(pn.getName());
+                    if (!cNode.hasMethod(isserName, Parameter.EMPTY_ARRAY)) {
+                        result.remove(getterName + ":");
+                    }
+                    if (!cNode.hasMethod(getterName, Parameter.EMPTY_ARRAY)) {
+                        result.remove(isserName + ":");
+                    }
+                }
+            }
+        }
+
         return result;
     }
 
     private static MethodNode getDeclaredMethodCorrected(final Map<String, ClassNode> genericsSpec, final MethodNode origMethod, final ClassNode correctedClass) {
         for (MethodNode nameMatch : correctedClass.getDeclaredMethods(origMethod.getName())) {
             MethodNode correctedMethod = correctToGenericsSpec(genericsSpec, nameMatch);
-            if (ParameterUtils.parametersEqual(correctedMethod.getParameters(), origMethod.getParameters())) {
+            if (parametersEqual(correctedMethod.getParameters(), origMethod.getParameters())) {
                 return correctedMethod;
             }
         }

--- a/src/test/org/codehaus/groovy/transform/AutoImplementTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/AutoImplementTransformTest.groovy
@@ -72,6 +72,7 @@ final class AutoImplementTransformTest {
 
             @groovy.transform.AutoImplement
             class Foo extends WithNext implements Iterator<String> { }
+
             assert new Foo().next() == 'foo'
         '''
     }
@@ -88,20 +89,85 @@ final class AutoImplementTransformTest {
         '''
     }
 
-    @NotYetImplemented @Test // GROOVY-9816
+    @Test // GROOVY-9816
     void testPropertyMethodsNotOverwritten() {
         assertScript '''
             interface Bar {
-              def getBaz(); void setBaz(baz)
+                def getBaz(); void setBaz(baz)
             }
 
             @groovy.transform.AutoImplement
             class Foo implements Bar {
-              def baz
+                def baz
             }
 
             def foo = new Foo(baz: 123)
             assert foo.baz == 123
+        '''
+
+        assertScript '''
+            interface Bar {
+                def getBaz(); void setBaz(baz)
+            }
+
+            @groovy.transform.AutoImplement
+            class Foo implements Bar {
+                final baz = 123
+            }
+
+            // setter is independent of constant
+            def foo = new Foo(baz: 456)
+            assert foo.baz == 123
+        '''
+
+        assertScript '''
+            interface Bar {
+                boolean getBaz(); boolean isBaz()
+            }
+
+            @groovy.transform.AutoImplement
+            class Foo implements Bar {
+                boolean baz
+            }
+
+            def foo = new Foo(baz: true)
+            assert foo.getBaz()
+            assert foo.isBaz()
+            assert foo.baz
+        '''
+
+        assertScript '''
+            interface Bar {
+                boolean getBaz(); boolean isBaz()
+            }
+
+            @groovy.transform.AutoImplement
+            class Foo implements Bar {
+                boolean baz
+                boolean getBaz() { baz }
+            }
+
+            def foo = new Foo(baz: true)
+            assert foo.getBaz()
+            assert foo.isBaz()
+            assert foo.baz
+        '''
+
+        assertScript '''
+            interface Bar {
+                boolean getBaz(); boolean isBaz()
+            }
+
+            @groovy.transform.AutoImplement
+            class Foo implements Bar {
+                boolean baz
+                boolean isBaz() { baz }
+            }
+
+            def foo = new Foo(baz: true)
+            assert foo.getBaz()
+            assert foo.isBaz()
+            assert foo.baz
         '''
     }
 


### PR DESCRIPTION
- auto-implemented getter delegates to pre-existing isser and vice versa -- _implementing a default-value return when other accessor returns a value was confusing/surprising_

https://issues.apache.org/jira/browse/GROOVY-9816