### PR TITLE
Fix grails validation workflow

### DIFF
--- a/.github/workflows/grails-joint-validation.yml
+++ b/.github/workflows/grails-joint-validation.yml
@@ -48,17 +48,17 @@ jobs:
       # Select correct Grails branch for this build:
       - name: Checkout Grails 4.1.x (master)
         run: cd .. && git clone --depth 1 https://github.com/grails/grails-core.git -b master
-        if: ${{ github.ref == 'refs/heads/GROOVY_3_0_X' }}
+        if: ${{ (github.event_name == 'pull_request' && github.base_ref == 'GROOVY_3_0_X') || github.ref == 'refs/heads/GROOVY_3_0_X' }}
       - name: Checkout Grails 4.0.x (4.0.x)
         run: cd .. && git clone --depth 1 https://github.com/grails/grails-core.git -b 4.0.x
-        if: ${{ github.ref == 'refs/heads/GROOVY_2_5_X' }}
+        if: ${{ (github.event_name == 'pull_request' && github.base_ref == 'GROOVY_2_5_X') || github.ref == 'refs/heads/GROOVY_2_5_X' }}
 
       - name: Build and install groovy (no docs)
         run: ./gradlew clean install -x groovydoc -x javadoc -x javadocAll -x groovydocAll -x asciidoc -x docGDK --no-build-cache --no-scan --no-daemon
         timeout-minutes: 60
 
       - name: Set CI_GROOVY_VERSION for Grails
-        run: echo "::set-env name=CI_GROOVY_VERSION::$(cat gradle.properties | grep groovyVersion | cut -d\= -f2 |  tr -d '[:space:]')"
+        run: echo "CI_GROOVY_VERSION=$(cat gradle.properties | grep groovyVersion | cut -d\= -f2 |  tr -d '[:space:]')" >> $GITHUB_ENV
       - name: echo CI_GROOVY_VERSION
         run: echo $CI_GROOVY_VERSION
       - name: Build Grails


### PR DESCRIPTION
While putting together a Micronaut validation workflow based on the Grails one, I noticed that the Grails one wasn't functioning due to  https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

I also noticed that in the event of pull requests, the workflow wasn't properly cloning grails-core, so I attempted to fix that too.

It wasn't clear to me where this change should be applied, so I picked GROOVY_3_0_X.

I ran this against a PR on my fork, and the workflow failed due to what appears to be a legitimate failure in building Grails 4.1.x:

```
Caused by:
        groovy.lang.MissingMethodException: No signature of method: grails.spring.BeanBuilder$1.doCall() is applicable for argument types: (Script1$_run_closure1) values: [Script1$_run_closure1@111bc280]
        Possible solutions: call(), call([Ljava.lang.Object;), call(java.lang.Object), call([Ljava.lang.Object;), findAll(), equals(java.lang.Object)
            at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:70)
            at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:80)
            at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:51)
            at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:171)
            at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:185)
            at Script1.run(Script1.groovy:1)
            at groovy.lang.GroovyShell.evaluate(GroovyShell.java:501)
            at groovy.lang.GroovyShell.evaluate(GroovyShell.java:488)
            at grails.spring.BeanBuilder.loadBeans(BeanBuilder.java:480)
            ... 33 more
```