### PR TITLE
GROOVY-6882: STC: skip overridden methods when selecting best fit

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1038,7 +1038,7 @@ public abstract class StaticTypeCheckingSupport {
                 Person p = foo(b)
              */
 
-            Map<GenericsType, GenericsType> declaringAndActualGenericsTypeMap = GenericsUtils.makeDeclaringAndActualGenericsTypeMap(declaringClassForDistance, actualReceiverForDistance);
+            Map<GenericsType, GenericsType> declaringAndActualGenericsTypeMap = GenericsUtils.makeDeclaringAndActualGenericsTypeMapOfExactType(declaringClassForDistance, actualReceiverForDistance);
             Parameter[] params = makeRawTypes(safeNode.getParameters(), declaringAndActualGenericsTypeMap);
             int dist = measureParametersAndArgumentsDistance(params, safeArgs);
             if (dist >= 0) {

--- a/src/test/groovy/transform/stc/AnonymousInnerClassSTCTest.groovy
+++ b/src/test/groovy/transform/stc/AnonymousInnerClassSTCTest.groovy
@@ -68,7 +68,8 @@ class AnonymousInnerClassSTCTest extends StaticTypeCheckingTestCase {
     }
 
     void testCallMethodUsingAIC() {
-        assertScript '''abstract class Foo { abstract String item() }
+        assertScript '''
+            abstract class Foo { abstract String item() }
             boolean valid(Foo foo) {
                 foo.item() == 'ok'
             }
@@ -80,7 +81,8 @@ class AnonymousInnerClassSTCTest extends StaticTypeCheckingTestCase {
     }
 
     void testCallMethodUsingAICImplementingInterface() {
-        assertScript '''abstract class Foo implements Runnable { abstract String item() }
+        assertScript '''
+            abstract class Foo implements Runnable { abstract String item() }
             boolean valid(Foo foo) {
                 foo.item() == 'ok'
             }
@@ -93,7 +95,7 @@ class AnonymousInnerClassSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
-    void testAICIntoClass() {
+    void testAICReferencingOuterMethod() {
         assertScript '''
             class Outer {
                 int outer() { 1 }
@@ -108,6 +110,33 @@ class AnonymousInnerClassSTCTest extends StaticTypeCheckingTestCase {
                 }
             }
             assert new Outer().test() == 1
+        '''
+    }
+
+    // GROOVY-6882
+    void testAICReferencingOuterMethodOverride() {
+        assertScript '''
+            class B {
+                def m() { 'B' }
+            }
+
+            class C extends B {
+                @Override
+                def m() { 'C' }
+
+                void test() {
+                    def aic = new Runnable() {
+                        void run() {
+                            assert m() == 'C' // Cannot choose between [C#m(), B#m()]
+                        }
+                    }
+                    aic.run()
+
+                    assert m() == 'C'
+                }
+            }
+
+            new C().test()
         '''
     }
 

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -122,7 +122,7 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         shouldFailWithMessages '''
             List<Integer> list = new LinkedList<>()
             list.add 'Hello'
-        ''', '[Static type checking] - Cannot call java.util.LinkedList <java.lang.Integer>#add(java.lang.Integer) with arguments [java.lang.String]'
+        ''', '[Static type checking] - Cannot find matching method java.util.LinkedList#add(java.lang.String). Please check if the declared type is correct and if the method exists.'
     }
 
     void testAddOnListWithDiamondAndWrongTypeUsingLeftShift() {
@@ -537,25 +537,25 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
-    void testPutMethodWithPrimitiveValue() {
+    void testPutMethodWithPrimitiveValue1() {
         assertScript '''
-            Map<String, Integer> map = new HashMap<String,Integer>()
+            def map = new HashMap<String, Integer>()
             map.put('hello', 1)
+        '''
+    }
+
+    void testPutMethodWithPrimitiveValue2() {
+        assertScript '''
+            def map = new HashMap<String, Integer>()
+            map['hello'] = 1
         '''
     }
 
     void testPutMethodWithWrongValueType() {
         shouldFailWithMessages '''
-            Map<String, Integer> map = new HashMap<String,Integer>()
+            def map = new HashMap<String, Integer>()
             map.put('hello', new Object())
-        ''', '[Static type checking] - Cannot call java.util.HashMap <String, Integer>#put(java.lang.String, java.lang.Integer) with arguments [java.lang.String, java.lang.Object]'
-    }
-
-    void testPutMethodWithPrimitiveValueAndArrayPut() {
-        assertScript '''
-            Map<String, Integer> map = new HashMap<String,Integer>()
-            map['hello'] = 1
-        '''
+        ''', '[Static type checking] - Cannot find matching method java.util.HashMap#put(java.lang.String, java.lang.Object). Please check if the declared type is correct and if the method exists.'
     }
 
     void testShouldComplainAboutToInteger() {
@@ -1020,7 +1020,7 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
             })
             Map<Date, Date> map = new HashMap<>()
             map.put('foo', new Date())
-        ''', '[Static type checking] - Cannot call java.util.HashMap <java.util.Date, java.util.Date>#put(java.util.Date, java.util.Date) with arguments [java.lang.String, java.util.Date]'
+        ''', '[Static type checking] - Cannot find matching method java.util.HashMap#put(java.lang.String, java.util.Date). Please check if the declared type is correct and if the method exists.'
     }
     void testInferDiamondForAssignmentWithDatesAndIllegalKeyUsingSquareBracket() {
         shouldFailWithMessages '''
@@ -1058,7 +1058,7 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
             })
             Map<Date, Date> map = new HashMap<>()
             map.put(new Date(), 'foo')
-        ''', '[Static type checking] - Cannot call java.util.HashMap <java.util.Date, java.util.Date>#put(java.util.Date, java.util.Date) with arguments [java.util.Date, java.lang.String]'
+        ''', '[Static type checking] - Cannot find matching method java.util.HashMap#put(java.util.Date, java.lang.String). Please check if the declared type is correct and if the method exists.'
     }
     void testInferDiamondForAssignmentWithDatesAndIllegalValueUsingSquareBracket() {
         shouldFailWithMessages '''


### PR DESCRIPTION
First commit fixes `AbstractMap#put(K,V)` to have resolved generics just like `HashMap#put(K,V)`; `chooseBestMethod` rejects `HashMap#put(K,V)` but not `AbstractMap#put(K,V)` in current codebase.

https://issues.apache.org/jira/browse/GROOVY-6882