### PR TITLE
GROOVY-9814: MethodClosure can run on sub-types for Type::name reference

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -1094,13 +1094,13 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
                 throw e;
             }
 
-            if (arguments.length <= 0 || !(arguments[0].getClass().equals(ownerClass))) {
+            if (arguments.length < 1 || !ownerClass.isAssignableFrom(arguments[0].getClass())) {
                 return invokeMissingMethod(object, methodName, arguments);
             }
 
-            Object newOwner = arguments[0];
+            Object newReceiver = arguments[0];
             Object[] newArguments = Arrays.copyOfRange(arguments, 1, arguments.length);
-            return ownerMetaClass.invokeMethod(ownerClass, newOwner, methodName, newArguments, false, false);
+            return ownerMetaClass.invokeMethod(ownerClass, newReceiver, methodName, newArguments, false, false);
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9814