### PR TITLE
GROOVY-7549, GROOVY-9847: getOuterClass, getOuterClasses and getOuterField must check redirect

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassNode.java
@@ -772,32 +772,31 @@ public class ClassNode extends AnnotatedNode implements Opcodes {
     }
 
     /**
-     * @return the field node on the outer class or null if this is not an
-     *         inner class
+     * @return outer class field or {@code null} if not found or this is not an inner class
      */
-    public FieldNode getOuterField(String name) {
+    public FieldNode getOuterField(final String name) {
+        if (redirect != null) {
+            return redirect.getOuterField(name);
+        }
         return null;
     }
 
-    /**
-     * Helper method to avoid casting to inner class
-     */
     public ClassNode getOuterClass() {
+        if (redirect != null) {
+            return redirect.getOuterClass();
+        }
         return null;
     }
 
     public List<ClassNode> getOuterClasses() {
-        if (!(this instanceof InnerClassNode)) {
+        ClassNode outer = getOuterClass();
+        if (outer == null) {
             return Collections.emptyList();
         }
-
-        List<ClassNode> result = new LinkedList<>();
-        ClassNode outestClass = ((InnerClassNode) this).getOuterMostClass();
-        ClassNode cn = this;
-
+        List<ClassNode> result = new ArrayList<>();
         do {
-            result.add(cn = cn.getOuterClass());
-        } while (!cn.equals(outestClass));
+            result.add(outer);
+        } while ((outer = outer.getOuterClass()) != null);
 
         return result;
     }

--- a/src/test/groovy/transform/stc/TypeInferenceSTCTest.groovy
+++ b/src/test/groovy/transform/stc/TypeInferenceSTCTest.groovy
@@ -864,6 +864,39 @@ Thing.run()
         }
     }
 
+    // GROOVY-9847
+    void testShouldKeepInferredTypeWhenPrivateInnerClass() {
+        assertScript '''
+            class Test {
+                @groovy.transform.ToString(excludes='children')
+                private static class TreeAttr {
+                    String name
+                    Integer val = 0
+                    List<TreeAttr> children = []
+                }
+
+                static main(args) {
+                    new Test().test(1)
+                }
+
+                void test(Integer count) {
+                    TreeAttr root = new TreeAttr(name:'foo')
+                    List<TreeAttr> collector = root.children
+
+                    for (name in ['bar','baz']) { // tokens in a path
+                        def item = collector.find { it.name == name }
+                        if (!item) {
+                            item = new TreeAttr(name: name)
+                            collector.add(item)
+                        }
+                        collector = item.children
+                        if (count) item.val += count
+                    }
+                }
+            }
+        '''
+    }
+
     // GROOVY-9077
     void testInferredTypeForPropertyThatResolvesToMethod() {
         assertScript '''


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9847
https://issues.apache.org/jira/browse/GROOVY-7549

This also applies to `2_4_X` but should already be present in `3_0_X` and newer.