### PR TITLE
Fix documentation typo in CoercionTest

### DIFF
--- a/src/spec/test/CoercionTest.groovy
+++ b/src/spec/test/CoercionTest.groovy
@@ -240,7 +240,7 @@ assert filter(['Java','Groovy'], { it.contains 'G'} as Predicate) == ['Groovy']
 // end::method_call_with_explicit_coercion[]
 
 // tag::method_call_with_implicit_coercion[]
-assert filter(['Java','Groovy']) { it.contains 'G'} == ['Groovy']
+assert filter(['Java','Groovy'], { it.contains 'G'}) == ['Groovy']
 // end::method_call_with_implicit_coercion[]
 '''
     }


### PR DESCRIPTION
Noticed a small typo reading through the coercion documentation. Unless I'm misunderstanding something, this is the intended syntax. 