### PR TITLE
GROOVY-9852: closure/lambda match @FunctionalInterface vs Object methods

### DIFF
--- a/src/test/gls/invocation/MethodSelectionTest.groovy
+++ b/src/test/gls/invocation/MethodSelectionTest.groovy
@@ -384,27 +384,37 @@ class MethodSelectionTest extends CompilableTestSupport {
       """
   }
   
-  //GROOVY-6189
-  void testSAMs(){
+  // GROOVY-6189, GROOVY-9852
+  void testSAMs() {
       // simple direct case
-      assertScript """
+      assertScript '''
           interface MySAM {
               def someMethod()
           }
           def foo(MySAM sam) {sam.someMethod()}
           assert foo {1} == 1
-      """
+      '''
 
       // overloads with classes implemented by Closure
-      ["java.util.concurrent.Callable", "Object", "Closure", "GroovyObjectSupport", "Cloneable", "Runnable", "GroovyCallable", "Serializable", "GroovyObject"].each {
-          className ->
+      [
+          'groovy.lang.Closure'            : 'not',
+          'groovy.lang.GroovyCallable'     : 'not',
+          'groovy.lang.GroovyObject'       : 'not',
+          'groovy.lang.GroovyObjectSupport': 'not',
+
+          'java.lang.Object'               : 'sam',
+          'java.lang.Runnable'             : 'not',
+          'java.lang.Cloneable'            : 'not',
+          'java.io.Serializable'           : 'not',
+          'java.util.concurrent.Callable'  : 'not',
+      ].each { type, which ->
           assertScript """
               interface MySAM {
                   def someMethod()
               }
-              def foo(MySAM sam) {sam.someMethod()}
-              def foo($className x) {2}
-              assert foo {1} == 2
+              def foo($type ref) { 'not' }
+              def foo(MySAM sam) { sam.someMethod() }
+              assert foo { 'sam' } == '$which' : '$type'
           """
       }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9852
https://issues.apache.org/jira/browse/GROOVY-6188
https://issues.apache.org/jira/browse/GROOVY-5114

```
given:
  def m(AutoCloseable ac) // functional interface
  def m(InputStream is) // SAM type
  def m(Object o)
expect:
  "m { }" should choose the AutoCloseable method

given:
  def m(InputStream x)
  def m(Object o)
expect:
  "m { }" should choose the Object method

given:
  def m(AutoCloseable x)
  def m(GroovyObject o)
expect:
  "m { }" should choose the GroovyObject method
```