### PR TITLE
GROOVY-9863: save type into synthetic property (backed by getter/setter)

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/StatementMetaTypeChooser.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/StatementMetaTypeChooser.java
@@ -45,17 +45,16 @@ public class StatementMetaTypeChooser implements TypeChooser {
         if (type != null) return type;
 
         if (exp instanceof VariableExpression) {
-            VariableExpression ve = (VariableExpression) exp;
-            if (ve.isClosureSharedVariable()) return ve.getType();
-            if (ve.isSuperExpression()) return current.getSuperClass();
+            VariableExpression vexp = (VariableExpression) exp;
+            if (vexp.isClosureSharedVariable()) return vexp.getType();
+            if (vexp.isSuperExpression()) return current.getSuperClass();
 
-            type = ve.getOriginType();
-        } else if (exp instanceof Variable) {
-            Variable v = (Variable) exp;
-            type = v.getOriginType();
+            Variable var = vexp.getAccessedVariable();
+            if (var == null) var = vexp;
+            type = var.getOriginType();
         } else {
             type = exp.getType();
         }
-        return type.redirect();
+        return type;
     }
 }

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -4232,8 +4232,10 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             if (accessedVariable != exp && accessedVariable instanceof VariableExpression) {
                 storeType((VariableExpression) accessedVariable, cn);
             }
-            if (accessedVariable instanceof Parameter) {
-                ((Parameter) accessedVariable).putNodeMetaData(INFERRED_TYPE, cn);
+            if (accessedVariable instanceof Parameter
+                    || (accessedVariable instanceof PropertyNode
+                        && ((PropertyNode) accessedVariable).getField().isSynthetic())) {
+                ((ASTNode) accessedVariable).putNodeMetaData(INFERRED_TYPE, cn);
             }
             if (var.isClosureSharedVariable() && cn != null) {
                 List<ClassNode> assignedTypes = typeCheckingContext.closureSharedVariablesAssignmentTypes.computeIfAbsent(var, k -> new LinkedList<ClassNode>());

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
@@ -23,9 +23,10 @@ import groovy.transform.stc.BugsSTCTest
 /**
  * Unit tests for static type checking : bugs.
  */
-class BugsStaticCompileTest extends BugsSTCTest implements StaticCompilationTestSupport {
+final class BugsStaticCompileTest extends BugsSTCTest implements StaticCompilationTestSupport {
 
-    void testGroovy5498PropertyAccess() {
+    // GROOVY-5498
+    void testPropertyAccess() {
         assertScript '''
             class Test {
 
@@ -114,6 +115,24 @@ class BugsStaticCompileTest extends BugsSTCTest implements StaticCompilationTest
                     if (pluginDir?.exists()) { true } else { false }
                 }
                 assert getDescriptorForPlugin(null) == false
+        '''
+    }
+
+    // GROOVY-9863
+    void testPlusShouldNotThrowGroovyBugError() {
+        assertScript '''
+            import static org.junit.Assert.assertEquals
+
+            class C {
+                double getSomeValue() {
+                    0.0d
+                }
+                double test() {
+                    1.0d + someValue
+                }
+            }
+
+            assertEquals(1.0d, new C().test(), 0.00000001d)
         '''
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9863

`VariableScopeVisitor#findClassMember` makes `PropertyNode` for method-only properties but does not set any type information