### PR TITLE
GROOVY-9860: makeRawType should reduce generic placeholder to bound type

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1127,7 +1127,7 @@ public abstract class StaticTypeCheckingSupport {
             String name = param.getType().getUnresolvedName();
             Optional<GenericsType> value = genericsPlaceholderAndTypeMap.entrySet().stream()
                 .filter(e -> e.getKey().getName().equals(name)).findFirst().map(Map.Entry::getValue);
-            ClassNode type = value.map(GenericsType::getType).orElseGet(() -> makeRawType(param.getType()));
+            ClassNode type = value.map(gt -> !gt.isPlaceholder() ? gt.getType() : makeRawType(gt.getType())).orElseGet(() -> makeRawType(param.getType()));
 
             return new Parameter(type, param.getName());
         }).toArray(Parameter[]::new);

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -427,6 +427,19 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-9860
+    void testGenericTypeArgumentInCtorCall() {
+        assertScript '''
+            def <T> void test() {
+                def bind = { T a, T b ->
+                    new Tuple2<T, T>(a, b)
+                }
+                assert bind('foo', 'bar').toString() == '[foo, bar]'
+            }
+            test()
+        '''
+    }
+
     void testReturnAnntationClass() {
         assertScript '''
             import java.lang.annotation.Documented


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9860

`Tuple2` constructor parameters are placeholders and should reduce to `Object` for argument matching