### PR TITLE
GROOVY-9877: Add DGM `asReversed` to `List`

### DIFF
--- a/src/main/java/org/apache/groovy/util/ReversedList.java
+++ b/src/main/java/org/apache/groovy/util/ReversedList.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.util;
+
+import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.List;
+import java.util.RandomAccess;
+
+/**
+ * Represents view of reversed list
+ *
+ * @since 4.0.0
+ */
+public class ReversedList<E> extends AbstractList<E> implements RandomAccess, Serializable {
+    private static final long serialVersionUID = -1640781973848935560L;
+    private final List<E> delegate;
+
+    public ReversedList(List<E> list) {
+        this.delegate = list;
+    }
+
+    @Override
+    public E get(int index) {
+        return delegate.get(delegate.size() - 1 - index);
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+}

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -55,6 +55,7 @@ import groovy.util.OrderBy;
 import groovy.util.PermutationGenerator;
 import groovy.util.ProxyGenerator;
 import org.apache.groovy.io.StringBuilderWriter;
+import org.apache.groovy.util.ReversedList;
 import org.codehaus.groovy.classgen.Verifier;
 import org.codehaus.groovy.reflection.ClassInfo;
 import org.codehaus.groovy.reflection.MixinInMetaClass;
@@ -12072,6 +12073,23 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         Collections.shuffle(items, rnd);
         System.arraycopy(items.toArray(), 0, result, 0, items.size());
         return result;
+    }
+
+    /**
+     * Creates a view list with reversed order, and the order of original list will not change.
+     * <pre class="groovyTestCase">
+     * def list = ["a", 6, true]
+     * assert list.asReversed() == [true, 6, "a"]
+     * assert list == ["a", 6, true]
+     * </pre>
+     *
+     * @param self a list
+     * @param <T> the type of element
+     * @return the reversed list
+     * @since 4.0.0
+     */
+    public static <T> List<T> asReversed(List<T> self) {
+        return new ReversedList<>(self);
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9877

Though we have DGM `list.reverse()` already, it will create a new list containing all elements from the original list.
While the proposed `list.asReversed()` will create a view list, which just delegates method calls to the original list.