### PR TITLE
GROOVY-9892: fix operand stack for ++x / x++ in static compilation

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesCallSiteWriter.java
@@ -814,6 +814,10 @@ public class StaticTypesCallSiteWriter extends CallSiteWriter implements Opcodes
                             call.setMethodTarget(methodNode);
                             call.visit(controller.getAcg());
 
+                            // GROOVY-9892: assuming that the mutator method has a return value, make sure the operand
+                            //  stack is not polluted with the result of the method call
+                            controller.getOperandStack().pop();
+
                             controller.getCompileStack().removeVar(i);
                             return;
                         }

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy9892Bug.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/bugs/Groovy9892Bug.groovy
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.classgen.asm.sc.bugs
+
+import groovy.transform.stc.StaticTypeCheckingTestCase
+import org.codehaus.groovy.classgen.asm.sc.StaticCompilationTestSupport
+
+class Groovy9892Bug extends StaticTypeCheckingTestCase implements StaticCompilationTestSupport {
+    void testUnaryIncrementInGString() {
+        assertScript '''
+            class OuterClass {
+                int prefix
+                int postfix
+            
+                def call() {
+                    { ->
+                        "Hello${++prefix}World${postfix++}"
+                    }.call()
+                }
+            }
+            def instance = new OuterClass() 
+            assert instance.call() == 'Hello1World0'
+            assert instance.prefix == 1
+            assert instance.postfix == 1
+        '''
+    }
+}


### PR DESCRIPTION
40ee3fd0c19530b4308c7c1b3e30abd4d45ed54a replaced an invocation of
`ScriptBytecodeAdapter.setGroovyObjectProperty()` into an invocation of
the generated `pfaccess$0*` mutator method.
Contrary to `setGroovyObjectProperty()`, the mutator method has a return
value, which ends up pushed to the operand stack.

This commit discards the value being pushed to the stack by pop'ing it.