### PR TITLE
last() method for LinkedList can be more efficient

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -9773,6 +9773,29 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return true;
     }
 
+
+     /**
+     * Returns the last item from the LinkedList.
+     * <pre class="groovyTestCase">
+     * def list = [3, 4, 2]
+     * assert list.last() == 2
+     * // check original is unaltered
+     * assert list == [3, 4, 2]
+     * </pre>
+     *
+     * @param self a List
+     * @return the last item from the List
+     * @throws NoSuchElementException if the list is empty and you try to access the last() item.
+     * @since 1.5.5
+     */
+    public static <T> T last(LinkedList<T> self) {
+
+        if (self.isEmpty()) {
+            throw new NoSuchElementException("Cannot access last() element from an empty List");
+        }
+        return self.getLast();
+    }
+
     /**
      * Returns the last item from the List.
      * <pre class="groovyTestCase">
@@ -9788,6 +9811,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.5.5
      */
     public static <T> T last(List<T> self) {
+
         if (self.isEmpty()) {
             throw new NoSuchElementException("Cannot access last() element from an empty List");
         }


### PR DESCRIPTION
A LinkedList has a method called getLast() which on a DoublyLinkedList is a direct reference. Using size and get() can take more overhead in testing. While this optimization is VERY small, it can have impacts on large list traversals