### PR TITLE
GROOVY-9893: STC: findSetters must look in super types

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -2203,25 +2203,22 @@ public abstract class StaticTypeCheckingSupport {
     }
 
     public static List<MethodNode> findSetters(final ClassNode cn, final String setterName, final boolean voidOnly) {
-        List<MethodNode> result = null;
-        for (MethodNode method : cn.getDeclaredMethods(setterName)) {
-            if (setterName.equals(method.getName())
-                    && (!voidOnly || VOID_TYPE == method.getReturnType())
-                    && method.getParameters().length == 1) {
-                if (result == null) {
-                    result = new LinkedList<>();
-                }
-                result.add(method);
+        List<MethodNode> result = new ArrayList<>();
+        if (!cn.isInterface()) {
+            for (MethodNode method : cn.getMethods(setterName)) {
+                if (isSetter(method, voidOnly)) result.add(method);
             }
         }
-        if (result == null) {
-            ClassNode parent = cn.getSuperClass();
-            if (parent != null) {
-                return findSetters(parent, setterName, voidOnly);
+        for (ClassNode in : cn.getAllInterfaces()) {
+            for (MethodNode method : in.getDeclaredMethods(setterName)) {
+                if (isSetter(method, voidOnly)) result.add(method);
             }
-            return Collections.emptyList();
         }
         return result;
+    }
+
+    private static boolean isSetter(final MethodNode mn, final boolean voidOnly) {
+        return (!voidOnly || mn.isVoidMethod()) && mn.getParameters().length == 1;
     }
 
     public static ClassNode isTraitSelf(final VariableExpression vexp) {

--- a/src/test/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
+++ b/src/test/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
@@ -823,6 +823,62 @@ import org.codehaus.groovy.ast.stmt.AssertStatement
         '''
     }
 
+    // GROOVY-9893
+    void testPropertyWithMultipleSetters2() {
+        assertScript '''
+            abstract class A { String which
+                void setX(String s) { which = 'String' }
+            }
+            class C extends A {
+                void setX(boolean b) { which = 'boolean' }
+            }
+
+            void test() {
+                def c = new C()
+                c.x = 'value'
+                assert c.which == 'String'
+            }
+            test()
+        '''
+    }
+
+    // GROOVY-9893
+    void testPropertyWithMultipleSetters3() {
+        assertScript '''
+            interface I {
+                void setX(String s)
+            }
+            abstract class A implements I { String which
+                void setX(boolean b) { which = 'boolean' }
+            }
+
+            void test(A a) {
+                a.x = 'value'
+                assert a.which == 'String'
+            }
+            test(new A() { void setX(String s) { which = 'String' } })
+        '''
+    }
+
+    // GROOVY-9893
+    void testPropertyWithMultipleSetters4() {
+        assertScript '''
+            trait T { String which
+                void setX(String s) { which = 'String' }
+            }
+            class C implements T {
+                void setX(boolean b) { which = 'boolean' }
+            }
+
+            void test() {
+                def c = new C()
+                c.x = 'value'
+                assert c.which == 'String'
+            }
+            test()
+        '''
+    }
+
     void testPropertyAssignmentAsExpression() {
         assertScript '''
             class Foo {
@@ -831,7 +887,7 @@ import org.codehaus.groovy.ast.stmt.AssertStatement
             def f = new Foo()
             def v = f.x = 3
             assert v == 3
-'''
+        '''
     }
 
     void testPropertyAssignmentInSubClassAndMultiSetter() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9893

There is still a strong preference for field-based properties over setter-only properties.  Mixed cases of "real" and "virtual" properties may not work the same as the test cases added below.