### PR TITLE
GROOVY-9905: check for MOP method in inner class but not super types

### DIFF
--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -700,6 +700,29 @@ final class InnerClassTest {
         '''
     }
 
+    @Test // GROOVY-9905
+    void testUsageOfOuterSuperField3() {
+        assertScript '''
+            abstract class A {
+                protected final f = 'foo'
+                abstract static class B {}
+            }
+
+            class C extends A {
+                private class D extends A.B { // B is static inner
+                    String toString() {
+                        f + 'bar' // No such property: f for class: A
+                    }
+                }
+                def m() {
+                    new D().toString()
+                }
+            }
+
+            assert new C().m() == 'foobar'
+        '''
+    }
+
     @Test
     void testUsageOfOuterField_WrongCallToSuper() {
         shouldFail '''


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9905
https://issues.apache.org/jira/browse/GROOVY-8274