### PR TITLE
GROOVY-9707: CompileStatic by configuration and TypeChecked by annotation

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/sc/StaticCompileTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/sc/StaticCompileTransformation.java
@@ -49,27 +49,29 @@ public class StaticCompileTransformation extends StaticTypesTransformation {
 
     @Override
     public void visit(final ASTNode[] nodes, final SourceUnit source) {
-        AnnotationNode annotationInformation = (AnnotationNode) nodes[0];
-        AnnotatedNode node = (AnnotatedNode) nodes[1];
-        StaticTypeCheckingVisitor visitor = null;
-        Map<String,Expression> members = annotationInformation.getMembers();
+        AnnotatedNode target = (AnnotatedNode) nodes[1];
+        if (Boolean.TRUE.equals(target.getNodeMetaData(StaticTypeCheckingVisitor.class))) {
+            return;
+        }
+        Map<String,Expression> members = ((AnnotationNode) nodes[0]).getMembers();
         Expression extensions = members.get("extensions");
-        if (node instanceof ClassNode) {
-            ClassNode classNode = (ClassNode) node;
+        StaticTypeCheckingVisitor visitor = null;
+        if (target instanceof ClassNode) {
+            ClassNode classNode = (ClassNode) target;
             visitor = newVisitor(source, classNode);
             visitor.setCompilationUnit(compilationUnit);
             addTypeCheckingExtensions(visitor, extensions);
             classNode.putNodeMetaData(WriterControllerFactory.class, factory);
-            node.putNodeMetaData(STATIC_COMPILE_NODE, !visitor.isSkipMode(node));
+            target.putNodeMetaData(STATIC_COMPILE_NODE, !visitor.isSkipMode(target));
             visitor.initialize();
             visitor.visitClass(classNode);
-        } else if (node instanceof MethodNode) {
-            MethodNode methodNode = (MethodNode) node;
+        } else if (target instanceof MethodNode) {
+            MethodNode methodNode = (MethodNode) target;
             ClassNode declaringClass = methodNode.getDeclaringClass();
             visitor = newVisitor(source, declaringClass);
             visitor.setCompilationUnit(compilationUnit);
             addTypeCheckingExtensions(visitor, extensions);
-            methodNode.putNodeMetaData(STATIC_COMPILE_NODE, !visitor.isSkipMode(node));
+            methodNode.putNodeMetaData(STATIC_COMPILE_NODE, !visitor.isSkipMode(target));
             if (declaringClass.getNodeMetaData(WriterControllerFactory.class) == null) {
                 declaringClass.putNodeMetaData(WriterControllerFactory.class, factory);
             }
@@ -77,17 +79,16 @@ public class StaticCompileTransformation extends StaticTypesTransformation {
             visitor.initialize();
             visitor.visitMethod(methodNode);
         } else {
-            source.addError(new SyntaxException(STATIC_ERROR_PREFIX + "Unimplemented node type",
-                    node.getLineNumber(), node.getColumnNumber(), node.getLastLineNumber(), node.getLastColumnNumber()));
+            source.addError(new SyntaxException(STATIC_ERROR_PREFIX + "Unimplemented node type", target));
         }
         if (visitor != null) {
             visitor.performSecondPass();
         }
         StaticCompilationTransformer transformer = new StaticCompilationTransformer(source, visitor);
-        if (node instanceof ClassNode) {
-            transformer.visitClass((ClassNode) node);
-        } else if (node instanceof MethodNode) {
-            transformer.visitMethod((MethodNode) node);
+        if (target instanceof ClassNode) {
+            transformer.visitClass((ClassNode) target);
+        } else if (target instanceof MethodNode) {
+            transformer.visitMethod((MethodNode) target);
         }
     }
 

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -414,6 +414,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             }
 
             node.putNodeMetaData(INFERRED_TYPE, node);
+            node.putNodeMetaData(StaticTypeCheckingVisitor.class, Boolean.TRUE);
             // mark all methods as visited. We can't do this in visitMethod because the type checker
             // works in a two pass sequence and we don't want to skip the second pass
             node.getMethods().forEach(n -> n.putNodeMetaData(StaticTypeCheckingVisitor.class, Boolean.TRUE));

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/TypeCheckingModeStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/TypeCheckingModeStaticCompileTest.groovy
@@ -23,11 +23,11 @@ import groovy.transform.stc.TypeCheckingModeTest
 /**
  * Unit tests for static type checking : type checking mode.
  */
-class TypeCheckingModeStaticCompileTest extends TypeCheckingModeTest implements StaticCompilationTestSupport {
+final class TypeCheckingModeStaticCompileTest extends TypeCheckingModeTest implements StaticCompilationTestSupport {
 
     void testEnsureBytecodeIsDifferentWhenSkipped() {
         assertScript '''
-            // transparent @CompileStatic
+            // @CompileStatic is implicit
             String foo() { 'foo'.toUpperCase() }
 
             @groovy.transform.CompileStatic(groovy.transform.TypeCheckingMode.SKIP)
@@ -51,8 +51,7 @@ class TypeCheckingModeStaticCompileTest extends TypeCheckingModeTest implements 
             public interface HibernateCallback<T> {
                 T doInHibernate()
             }
-
-            @CompileStatic
+            // @CompileStatic is implicit
             class Enclosing {
                 @CompileStatic(groovy.transform.TypeCheckingMode.SKIP)
                 def shouldBeSkipped(Closure callable) {
@@ -69,5 +68,17 @@ class TypeCheckingModeStaticCompileTest extends TypeCheckingModeTest implements 
             }
         '''
     }
-}
 
+    // GROOVY-9707: CompileStatic by configuration and TypeChecked by annotation
+    void testTypeCheckedAnnotation() {
+        assertScript '''
+            @groovy.transform.TypeChecked
+            class C {
+                def m() {
+                    'a' + 'b'
+                }
+            }
+            assert new C().m() == 'ab'
+        '''
+    }
+}


### PR DESCRIPTION
`StaticCompilationTransformer` is not idempotent; do not re-apply `StaticCompileTransformation`

https://issues.apache.org/jira/browse/GROOVY-9707