### PR TITLE
GROOVY-9916: primitive boolean corner case: null casts to false

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
+++ b/src/main/java/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
@@ -215,7 +215,7 @@ public class DefaultTypeTransformation {
     }
 
     public static Object castToType(Object object, Class type) {
-        if (object == null) return null;
+        if (object == null) return type == boolean.class ? Boolean.FALSE : null;
         if (type == Object.class) return object;
 
         final Class aClass = object.getClass();

--- a/src/test/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformationTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformationTest.groovy
@@ -28,6 +28,15 @@ final class DefaultTypeTransformationTest {
     void testCastToType() {
         def input = null, result
 
+        result = DefaultTypeTransformation.castToType(input, int)
+        assert result === null
+
+        result = DefaultTypeTransformation.castToType(input, long)
+        assert result === null
+
+        result = DefaultTypeTransformation.castToType(input, boolean)
+        assert result === false // GROOVY-9916
+
         result = DefaultTypeTransformation.castToType(input, Object)
         assert result === null
 


### PR DESCRIPTION
```groovy
class C {
  private boolean b
  void m() {
    b = null; // DefaultTypeTransformation.booleanUnbox(null)
    { ->
      b = null // DefaultTypeTransformation.castToType(null,boolean)
    }.call()
  }
}
```

https://issues.apache.org/jira/browse/GROOVY-9916

I tried moving `if (type.isPrimitive()) return castToPrimitive(object, type);` to the top, but none of the other primitive types allow null and would throw a GroovyCastException.