### PR TITLE
GROOVY-9891: return bound type for wildcard GenericsType -> ClassNode

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -411,6 +411,11 @@ public class GenericsUtils {
         if (type.isPlaceholder()) {
             String name = type.getName();
             ret = genericsSpec.get(name);
+        } else if (type.isWildcard()) { // GROOVY-9891
+            ret = type.getLowerBound(); // use lower or upper
+            if (ret == null && type.getUpperBounds() != null) {
+                ret = type.getUpperBounds()[0]; // ? supports 1
+            }
         }
         if (ret == null) ret = type.getType();
         return ret;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9891

```groovy
import static org.codehaus.groovy.ast.tools.GenericsUtils.*
import org.codehaus.groovy.ast.ClassHelper

def collection = ClassHelper.make(Collection.class)
// create an instance of "Collection<? extends Number>"
collection = collection.plainNodeReference.tap { genericsTypes = buildWildcardType(ClassHelper.Number_TYPE) }
// create parameterized version of Collection's super interface Iterable
def iterable = parameterizeType(collection, collection.interfaces[0])
// expecting "Iterable<? extends Number>" but get "Iterable<?>" where ? is like Object but not quite Object
```

This change will produce `Iterable<Number>` which matches what is produced for the pure Groovy version of the test case.