### PR TITLE
GROOVY-9932: Fix callCurrent invocation on MockProxyMetaClass

### DIFF
--- a/src/test/groovy/bugs/Groovy9932.groovy
+++ b/src/test/groovy/bugs/Groovy9932.groovy
@@ -1,0 +1,55 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import groovy.mock.interceptor.MockFor
+import org.junit.Test
+
+final class Groovy9932 {
+    @Test
+    void testCallCurrentOnMock() {
+        def mockForHelper = new MockFor(Helper)
+
+        mockForHelper.demand.helperMethod { -> 'intercepted' }
+        mockForHelper.ignore('getMyString')
+
+        mockForHelper.use {
+            def helper = new Helper()
+            assert helper.myString == 'intercepted'
+        }
+    }
+
+    static class Helper {
+        String myString
+
+        Helper() {
+            myString = internalMethod()
+        }
+
+        // separate method to ensure callCurrent is used.
+        // in the constructor it uses a direct call without checking stMC
+        private String internalMethod() {
+            return helperMethod()
+        }
+
+        String helperMethod() {
+            return 'not intercepted'
+        }
+    }
+}


### PR DESCRIPTION
Fix [GROOVY-9932](https://issues.apache.org/jira/browse/GROOVY-9932): Implement new signature of `ProxyMetaClass#invokeMethod` added by 34ad466ba6a87a5eb26cf4a444f817299b744edb.

I'm not sure if this is intended to be a supported usage. You can reject this if it isn't. But it worked in Groovy 2.4, and it looks easy enough to make it work again.