### PR TITLE
GROOVY-9945: findParameterizedType: fill type parameters of super types

### DIFF
--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -807,6 +807,23 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-9945
+    void testShouldUseMethodGenericType9() {
+        assertScript '''
+            interface I<T> {
+            }
+            class A<T> implements I<String> {
+                def m(T t) { 'works' }
+            }
+            class B<T> extends A<T> {
+            }
+
+            def bee = new B<Float>()
+            def obj = bee.m(3.14f)
+            assert obj == 'works'
+        '''
+    }
+
     // GROOVY-5516
     void testAddAllWithCollectionShouldBeAllowed() {
         assertScript '''import org.codehaus.groovy.transform.stc.ExtensionMethodNode

--- a/src/test/org/codehaus/groovy/ast/tools/GenericsUtilsTest.groovy
+++ b/src/test/org/codehaus/groovy/ast/tools/GenericsUtilsTest.groovy
@@ -19,307 +19,260 @@
 
 package org.codehaus.groovy.ast.tools
 
-import groovy.test.GroovyTestCase
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.GenericsType
-import org.codehaus.groovy.control.CompilationUnit
-import org.codehaus.groovy.control.Phases
+import org.codehaus.groovy.control.CompilePhase
+import org.junit.Test
 
-import java.util.function.BiFunction
+final class GenericsUtilsTest {
 
-import static groovy.lang.Tuple.tuple
+    private static List<ClassNode> compile(String code) {
+        def compiler = new org.codehaus.groovy.ast.builder.AstStringCompiler()
+        compiler.compile(code, CompilePhase.SEMANTIC_ANALYSIS, false).tail()
+    }
 
-class GenericsUtilsTest extends GroovyTestCase {
+    private static ClassNode findClassNode(String name, List<ClassNode> list) {
+        list.find { it.name == name }
+    }
+
+    //--------------------------------------------------------------------------
+
+    @Test
     void testFindParameterizedType1() {
-        def code = '''
-        class Base<T, S> {}
-        class Derived extends Base<String, List> {}
+        def classNodeList = compile '''
+            class Base<T, S> {}
+            class Derived extends Base<String, List> {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('Base', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
+        ClassNode result = GenericsUtils.findParameterizedType(target, source)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('Base', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
-
-        ClassNode parameterizedClass = GenericsUtils.findParameterizedType(genericsClass, actualReceiver, false)
-        assert parameterizedClass.isUsingGenerics()
-        assert 'Base' == parameterizedClass.name
-        GenericsType[] genericsTypes = parameterizedClass.getGenericsTypes()
-        assert 2 == genericsTypes.length
-        assert 'java.lang.String' == genericsTypes[0].type.name
-        assert 'java.util.List' == genericsTypes[1].type.name
-        assert genericsClass.is(parameterizedClass.redirect())
+        assert 'Base' == result.name
+        assert result.isUsingGenerics()
+        assert 2 == result.genericsTypes.length
+        assert 'java.lang.String' == result.genericsTypes[0].type.name
+        assert 'java.util.List'   == result.genericsTypes[1].type.name
+        assert target === result.redirect()
     }
 
+    @Test
     void testFindParameterizedType2() {
-        def code = '''
-        class Base<T, S> {}
-        class Derived2 extends Base<String, List> {}
-        class Derived extends Derived2 {}
+        def classNodeList = compile '''
+            class Base<T, S> {}
+            class Derived2 extends Base<String, List> {}
+            class Derived extends Derived2 {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('Base', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
+        ClassNode result = GenericsUtils.findParameterizedType(target, source)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('Base', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
-
-        ClassNode parameterizedClass = GenericsUtils.findParameterizedType(genericsClass, actualReceiver, false)
-        assert parameterizedClass.isUsingGenerics()
-        assert 'Base' == parameterizedClass.name
-        GenericsType[] genericsTypes = parameterizedClass.getGenericsTypes()
-        assert 2 == genericsTypes.length
-        assert 'java.lang.String' == genericsTypes[0].type.name
-        assert 'java.util.List' == genericsTypes[1].type.name
-        assert genericsClass.is(parameterizedClass.redirect())
+        assert 'Base' == result.name
+        assert result.isUsingGenerics()
+        assert 2 == result.genericsTypes.length
+        assert 'java.lang.String' == result.genericsTypes[0].type.name
+        assert 'java.util.List'   == result.genericsTypes[1].type.name
+        assert target === result.redirect()
     }
 
+    @Test
     void testFindParameterizedType3() {
-        def code = '''
-        class Base0 {}
-        class Base<T, S> extends Base0 {}
-        class Derived2 extends Base<String, List> {}
-        class Derived extends Derived2 {}
+        def classNodeList = compile '''
+            class Base0 {}
+            class Base<T, S> extends Base0 {}
+            class Derived2 extends Base<String, List> {}
+            class Derived extends Derived2 {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('Base', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
+        ClassNode result = GenericsUtils.findParameterizedType(target, source)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('Base', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
-
-        ClassNode parameterizedClass = GenericsUtils.findParameterizedType(genericsClass, actualReceiver, false)
-        assert parameterizedClass.isUsingGenerics()
-        assert 'Base' == parameterizedClass.name
-        GenericsType[] genericsTypes = parameterizedClass.getGenericsTypes()
-        assert 2 == genericsTypes.length
-        assert 'java.lang.String' == genericsTypes[0].type.name
-        assert 'java.util.List' == genericsTypes[1].type.name
-        assert genericsClass.is(parameterizedClass.redirect())
+        assert 'Base' == result.name
+        assert result.isUsingGenerics()
+        assert 2 == result.genericsTypes.length
+        assert 'java.lang.String' == result.genericsTypes[0].type.name
+        assert 'java.util.List'   == result.genericsTypes[1].type.name
+        assert target === result.redirect()
     }
 
+    @Test
     void testFindParameterizedType4() {
-        def code = '''
-        interface Base<T, S> {}
-        class Derived2 implements Base<String, List> {}
-        class Derived extends Derived2 {}
+        def classNodeList = compile '''
+            interface Base<T, S> {}
+            class Derived2 implements Base<String, List> {}
+            class Derived extends Derived2 {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('Base', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
+        ClassNode result = GenericsUtils.findParameterizedType(target, source)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('Base', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
-
-        ClassNode parameterizedClass = GenericsUtils.findParameterizedType(genericsClass, actualReceiver, false)
-        assert parameterizedClass.isUsingGenerics()
-        assert 'Base' == parameterizedClass.name
-        GenericsType[] genericsTypes = parameterizedClass.getGenericsTypes()
-        assert 2 == genericsTypes.length
-        assert 'java.lang.String' == genericsTypes[0].type.name
-        assert 'java.util.List' == genericsTypes[1].type.name
-        assert genericsClass.is(parameterizedClass.redirect())
+        assert 'Base' == result.name
+        assert result.isUsingGenerics()
+        assert 2 == result.genericsTypes.length
+        assert 'java.lang.String' == result.genericsTypes[0].type.name
+        assert 'java.util.List'   == result.genericsTypes[1].type.name
+        assert target === result.redirect()
     }
 
+    @Test
     void testFindParameterizedType5() {
-        def code = '''
-        interface Base<T, S> {}
-        interface Base2 extends Base<String, List> {}
-        class Derived2 implements Base2 {}
-        class Derived extends Derived2 {}
+        def classNodeList = compile '''
+            interface Base<T, S> {}
+            interface Base2 extends Base<String, List> {}
+            class Derived2 implements Base2 {}
+            class Derived extends Derived2 {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('Base', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
+        ClassNode result = GenericsUtils.findParameterizedType(target, source)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('Base', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
-
-        ClassNode parameterizedClass = GenericsUtils.findParameterizedType(genericsClass, actualReceiver, false)
-        assert parameterizedClass.isUsingGenerics()
-        assert 'Base' == parameterizedClass.name
-        GenericsType[] genericsTypes = parameterizedClass.getGenericsTypes()
-        assert 2 == genericsTypes.length
-        assert 'java.lang.String' == genericsTypes[0].type.name
-        assert 'java.util.List' == genericsTypes[1].type.name
-        assert genericsClass.is(parameterizedClass.redirect())
+        assert 'Base' == result.name
+        assert result.isUsingGenerics()
+        assert 2 == result.genericsTypes.length
+        assert 'java.lang.String' == result.genericsTypes[0].type.name
+        assert 'java.util.List'   == result.genericsTypes[1].type.name
+        assert target === result.redirect()
     }
 
+    @Test
     void testFindParameterizedType6() {
-        def code = '''
-        interface Base<T, S> {}
-        interface Base2 extends Base<String, List> {}
-        class Derived2 implements Base2 {}
-        class Derived3 extends Derived2 {}
-        class Derived extends Derived3 {}
+        def classNodeList = compile '''
+            interface Base<T, S> {}
+            interface Base2 extends Base<String, List> {}
+            class Derived2 implements Base2 {}
+            class Derived3 extends Derived2 {}
+            class Derived extends Derived3 {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('Base', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
+        ClassNode result = GenericsUtils.findParameterizedType(target, source)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('Base', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
-
-        ClassNode parameterizedClass = GenericsUtils.findParameterizedType(genericsClass, actualReceiver, false)
-        assert parameterizedClass.isUsingGenerics()
-        assert 'Base' == parameterizedClass.name
-        GenericsType[] genericsTypes = parameterizedClass.getGenericsTypes()
-        assert 2 == genericsTypes.length
-        assert 'java.lang.String' == genericsTypes[0].type.name
-        assert 'java.util.List' == genericsTypes[1].type.name
-        assert genericsClass.is(parameterizedClass.redirect())
+        assert 'Base' == result.name
+        assert result.isUsingGenerics()
+        assert 2 == result.genericsTypes.length
+        assert 'java.lang.String' == result.genericsTypes[0].type.name
+        assert 'java.util.List'   == result.genericsTypes[1].type.name
+        assert target === result.redirect()
     }
 
+    @Test
     void testFindParameterizedType7() {
-        def code = '''
-        interface Base0 {}
-        interface Base<T, S> extends Base0 {}
-        interface Base2 extends Base<String, List> {}
-        class Derived2 implements Base2 {}
-        class Derived3 extends Derived2 {}
-        class Derived extends Derived3 {}
+        def classNodeList = compile '''
+            interface Base0 {}
+            interface Base<T, S> extends Base0 {}
+            interface Base2 extends Base<String, List> {}
+            class Derived2 implements Base2 {}
+            class Derived3 extends Derived2 {}
+            class Derived extends Derived3 {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('Base', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
+        ClassNode result = GenericsUtils.findParameterizedType(target, source)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('Base', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
-
-        ClassNode parameterizedClass = GenericsUtils.findParameterizedType(genericsClass, actualReceiver, false)
-        assert parameterizedClass.isUsingGenerics()
-        assert 'Base' == parameterizedClass.name
-        GenericsType[] genericsTypes = parameterizedClass.getGenericsTypes()
-        assert 2 == genericsTypes.length
-        assert 'java.lang.String' == genericsTypes[0].type.name
-        assert 'java.util.List' == genericsTypes[1].type.name
-        assert genericsClass.is(parameterizedClass.redirect())
+        assert 'Base' == result.name
+        assert result.isUsingGenerics()
+        assert 2 == result.genericsTypes.length
+        assert 'java.lang.String' == result.genericsTypes[0].type.name
+        assert 'java.util.List'   == result.genericsTypes[1].type.name
+        assert target === result.redirect()
     }
 
+    @Test // GROOVY-9945
+    void testFindParameterizedType8() {
+        def classNodeList = compile '''
+            interface I<T> {}
+            class A<T> implements I<String> {}
+            class B<T> extends A<T> {}
+            class C extends B<Number> {}
+        '''
+        ClassNode target = findClassNode('A', classNodeList)
+        ClassNode source = findClassNode('C', classNodeList)
+        ClassNode result = GenericsUtils.findParameterizedType(target, source)
+
+        assert result.toString(false) == 'A <java.lang.Number>'
+    }
+
+    @Test
     void testMakeDeclaringAndActualGenericsTypeMapOfExactType() {
-        def code = '''
-        import java.util.function.*
-        interface Derived extends BinaryOperator<Integer> {}
+        def classNodeList = compile '''
+            import java.util.function.*
+            interface Derived extends BinaryOperator<Integer> {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = ClassHelper.makeWithoutCaching(java.util.function.BiFunction.class)
+        ClassNode source = findClassNode('Derived', classNodeList)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = ClassHelper.makeWithoutCaching(BiFunction.class)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
+        Map<GenericsType, GenericsType> m = GenericsUtils.makeDeclaringAndActualGenericsTypeMapOfExactType(target, source)
 
-        Map<GenericsType, GenericsType> m = GenericsUtils.makeDeclaringAndActualGenericsTypeMapOfExactType(genericsClass, actualReceiver)
-
-        assert m.entrySet().every { it.value.type.getTypeClass() == Integer }
-        assert m.entrySet().grep { it.key.name == 'T' }[0].value.type.getTypeClass() == Integer
-        assert m.entrySet().grep { it.key.name == 'U' }[0].value.type.getTypeClass() == Integer
-        assert m.entrySet().grep { it.key.name == 'R' }[0].value.type.getTypeClass() == Integer
+        assert m.entrySet().find { it.key.name == 'T' }.value.type.name == 'java.lang.Integer'
+        assert m.entrySet().find { it.key.name == 'U' }.value.type.name == 'java.lang.Integer'
+        assert m.entrySet().find { it.key.name == 'R' }.value.type.name == 'java.lang.Integer'
     }
 
+    @Test
     void testMakeDeclaringAndActualGenericsTypeMapOfExactType2() {
-        def code = '''
-        interface IBase<T, U> {}
-        class Base<U> implements IBase<String, U> {}
-        class Derived extends Base<Integer> {}
+        def classNodeList = compile '''
+            interface IBase<T, U> {}
+            class Base<U> implements IBase<String, U> {}
+            class Derived extends Base<Integer> {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('IBase', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('IBase', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
+        Map<GenericsType, GenericsType> m = GenericsUtils.makeDeclaringAndActualGenericsTypeMapOfExactType(target, source)
 
-        Map<GenericsType, GenericsType> m = GenericsUtils.makeDeclaringAndActualGenericsTypeMapOfExactType(genericsClass, actualReceiver)
-
-        assert m.entrySet().grep { it.key.name == 'T' }[0].value.type.getTypeClass() == String
-        assert m.entrySet().grep { it.key.name == 'U' }[0].value.type.getTypeClass() == Integer
+        assert m.entrySet().find { it.key.name == 'T' }.value.type.name == 'java.lang.String'
+        assert m.entrySet().find { it.key.name == 'U' }.value.type.name == 'java.lang.Integer'
+        assert m.size() == 2
     }
 
+    @Test
     void testMakeDeclaringAndActualGenericsTypeMapOfExactType3() {
-        def code = '''
-        interface IBase<T, U, R> {}
-        class Base<X, Y> implements IBase<Y, String, X> {}
-        class Derived extends Base<Boolean, Integer> {}
+        def classNodeList = compile '''
+            interface IBase<T, U, R> {}
+            class Base<X,Y> implements IBase<Y,String,X> {}
+            class Derived extends Base<Boolean, Integer> {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode target = findClassNode('IBase', classNodeList)
+        ClassNode source = findClassNode('Derived', classNodeList)
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode genericsClass = findClassNode('IBase', classNodeList)
-        ClassNode actualReceiver = findClassNode('Derived', classNodeList)
+        Map<GenericsType, GenericsType> m = GenericsUtils.makeDeclaringAndActualGenericsTypeMapOfExactType(target, source)
 
-        Map<GenericsType, GenericsType> m = GenericsUtils.makeDeclaringAndActualGenericsTypeMapOfExactType(genericsClass, actualReceiver)
-        println m
-
-        assert m.entrySet().grep { it.key.name == 'X' }[0].value.type.getTypeClass() == Boolean
-        assert m.entrySet().grep { it.key.name == 'Y' }[0].value.type.getTypeClass() == Integer
-        assert m.entrySet().grep { it.key.name == 'T' }[0].value.type.getTypeClass() == Integer
-        assert m.entrySet().grep { it.key.name == 'U' }[0].value.type.getTypeClass() == String
-        assert m.entrySet().grep { it.key.name == 'R' }[0].value.type.getTypeClass() == Boolean
+        assert m.entrySet().find { it.key.name == 'R' }.value.type.name == 'java.lang.Boolean'
+        assert m.entrySet().find { it.key.name == 'T' }.value.type.name == 'java.lang.Integer'
+        assert m.entrySet().find { it.key.name == 'U' }.value.type.name == 'java.lang.String'
+        assert m.size() == 3
     }
 
-    static ClassNode findClassNode(String name, List<ClassNode> classNodeList) {
-        return classNodeList.find { it.name == name }
-    }
-
+    @Test
     void testParameterizeSAM() {
-        def code = '''
-        import java.util.function.*
-        interface T extends Function<String, Integer> {}
+        def classNodeList = compile '''
+            import java.util.function.*
+            interface T extends Function<String, Integer> {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode samType = findClassNode('T', classNodeList).interfaces.find { it.name == 'java.util.function.Function' }
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode parameterizedClassNode = findClassNode('T', classNodeList).getAllInterfaces().find { it.name.equals('java.util.function.Function') }
+        def typeInfo = GenericsUtils.parameterizeSAM(samType)
 
-        Tuple2<ClassNode[], ClassNode> typeInfo = GenericsUtils.parameterizeSAM(parameterizedClassNode)
-        assert 1 == typeInfo.getV1().length
-        assert ClassHelper.STRING_TYPE == typeInfo.getV1()[0]
-        assert ClassHelper.Integer_TYPE == typeInfo.getV2()
+        assert 1 == typeInfo[0].length
+        assert ClassHelper.STRING_TYPE == typeInfo[0][0]
+
+        assert ClassHelper.Integer_TYPE == typeInfo[1]
     }
 
+    @Test
     void testParameterizeSAM2() {
-        def code = '''
-        import java.util.function.*
-        interface T extends BinaryOperator<Integer> {}
+        def classNodeList = compile '''
+            import java.util.function.*
+            interface T extends BinaryOperator<Integer> {}
         '''
-        def ast = new CompilationUnit().tap {
-            addSource 'hello.groovy', code
-            compile Phases.SEMANTIC_ANALYSIS
-        }.ast
+        ClassNode samType = findClassNode('T', classNodeList).interfaces.find { it.name == 'java.util.function.BinaryOperator' }
 
-        def classNodeList = ast.getModules()[0].getClasses()
-        ClassNode parameterizedClassNode = findClassNode('T', classNodeList).getAllInterfaces().find { it.name.equals('java.util.function.BinaryOperator') }
+        def typeInfo = GenericsUtils.parameterizeSAM(samType)
 
-        Tuple2<ClassNode[], ClassNode> typeInfo = GenericsUtils.parameterizeSAM(parameterizedClassNode)
-        assert 2 == typeInfo.getV1().length
-        assert ClassHelper.Integer_TYPE == typeInfo.getV1()[0]
-        assert ClassHelper.Integer_TYPE == typeInfo.getV1()[1]
-        assert ClassHelper.Integer_TYPE == typeInfo.getV2()
+        assert 2 == typeInfo[0].length
+        assert ClassHelper.Integer_TYPE == typeInfo[0][0]
+        assert ClassHelper.Integer_TYPE == typeInfo[0][1]
+
+        assert ClassHelper.Integer_TYPE == typeInfo[1]
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9945

There is quite a history to `findParameterizedType` and related methods.  I did not fully understand the reason for some of the looser checks.  I think they were to account for incomplete generics, which are now more complete.  Rather then building the whole type hierarchy at once, I took an approach of build as needed.  This should reduce some of the cost of searching.  I would have reduced the method count further, but it's all public api now.