### PR TITLE
GROOVY-9954: Stop incrementing index after comments to avoid skipping…

### DIFF
--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserLax.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserLax.java
@@ -157,12 +157,12 @@ public class JsonParserLax extends JsonParserCharArray {
 
                 case '/': /* */ //
                     handleComment();
-                    startIndexOfKey = __index;
+                    startIndexOfKey = __index + 1;
                     break;
 
                 case '#':
                     handleBashComment();
-                    startIndexOfKey = __index;
+                    startIndexOfKey = __index + 1;
                     break;
             }
         }
@@ -321,7 +321,6 @@ public class JsonParserLax extends JsonParserCharArray {
             __currentChar = charArray[__index];
 
             if (__currentChar == '\n') {
-                __index++;
                 return;
             }
         }
@@ -342,10 +341,7 @@ public class JsonParserLax extends JsonParserCharArray {
                                 __index++;
                                 __currentChar = charArray[__index];
                                 if (__currentChar == '/') {
-                                    if (hasMore()) {
-                                        __index++;
-                                        return;
-                                    }
+                                    return;
                                 }
                             } else {
                                 complain("missing close of comment");
@@ -358,12 +354,7 @@ public class JsonParserLax extends JsonParserCharArray {
                         __currentChar = charArray[__index];
 
                         if (__currentChar == '\n') {
-                            if (hasMore()) {
-                                __index++;
-                                return;
-                            } else {
-                                return;
-                            }
+                            return;
                         }
                     }
             }
@@ -635,9 +626,11 @@ public class JsonParserLax extends JsonParserCharArray {
                 switch (__currentChar) {
                     case '/':
                         handleComment();
+                        __index++;
                         continue;
                     case '#':
                         handleBashComment();
+                        __index++;
                         continue;
                     case ',':
                         __index++;

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
@@ -165,4 +165,25 @@ class JsonSlurperLaxTest extends JsonSlurperTest {
         assert !parser.parseText(jsonString).containsKey('appUserId')
     }
 
+    void testGroovy9954() {
+        String jsonString = """
+// first comment
+{
+// comment before foo
+foo:bar,
+/* comment before foo1 */'foo1': 'bar1',
+# comment before foo2
+"foo2": "bar2",
+array: [/* comment in array */"a"/* comment in array */,"b"]
+}
+// last comment
+"""
+
+        Map<String, Object> map = parser.parseText(jsonString)
+        assert map.foo == "bar"
+        assert map.foo1 == "bar1"
+        assert map.foo2 == "bar2"
+        assert map.array == ["a", "b"]
+    }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9954

Stopped incrementing index in handleComment() and handleBashComment().
These are called in three places.
In decodeJsonObjectLax(), the index is incremented by the for-loop, but startIndexOfKey needs to be set to the next character after the comment.
In decodeValueInternal(), the index is incremented by the for-loop.
In decodeJsonArrayLax(), the index is not incremented by the do-while-loop, it needs to be manually incremented.