### PR TITLE
Fix GROOVY-9797: println(-0.0f) does not comply with IEEE754

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/OperandStack.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/OperandStack.java
@@ -551,7 +551,8 @@ public class OperandStack {
                 mv.visitLdcInsn(value);
             }
         } else if (ClassHelper.double_TYPE.equals(type)) {
-            if ((Double)value==0d) {
+            // GROOVY-9797: Use Double.equals to differentiate between positive and negative zero
+            if (value.equals(0d)) {
                 mv.visitInsn(DCONST_0);
             } else if ((Double)value==1d) {
                 mv.visitInsn(DCONST_1);

--- a/src/main/java/org/codehaus/groovy/classgen/asm/OperandStack.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/OperandStack.java
@@ -540,7 +540,8 @@ public class OperandStack {
                 mv.visitLdcInsn(value);
             }
         } else if (ClassHelper.float_TYPE.equals(type)) {
-            if ((Float)value==0f) {
+            // GROOVY-9797: Use Float.equals to differentiate between positive and negative zero
+            if (value.equals(0f)) {
                 mv.visitInsn(FCONST_0);
             } else if ((Float)value==1f) {
                 mv.visitInsn(FCONST_1);

--- a/src/test/groovy/bugs/Groovy9797.groovy
+++ b/src/test/groovy/bugs/Groovy9797.groovy
@@ -46,4 +46,19 @@ class Groovy9797 extends GroovyTestCase {
         int positiveZeroBits = Float.floatToIntBits(0.0f)
         assertNotSame(negativeZeroBits, positiveZeroBits)
     }
+
+    // Test with string conversion
+    void testDoubleToString() {
+        double negativeZero = -0.0d
+        double positiveZero = 0.0d
+        assertToString(negativeZero, '-0.0')
+        assertToString(positiveZero, '0.0')
+    }
+
+    // Test with long bits
+    void testNegativePositiveZeroDoubleLongBitsNotSame() {
+        long negativeZeroBits = Double.doubleToLongBits(-0.0d)
+        long positiveZeroBits = Double.doubleToLongBits(0.0d)
+        assertNotSame(negativeZeroBits, positiveZeroBits)
+    }
 }

--- a/src/test/groovy/bugs/Groovy9797.groovy
+++ b/src/test/groovy/bugs/Groovy9797.groovy
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import groovy.test.GroovyTestCase
+
+/*
+ * About bug fix:
+ * According to the IEEE-754 floating point standard, the sign of a negative zero
+ * must be preserved. However, when Groovy compiles code, it uses the ==
+ * operator to compare floats and uses the special constant instruction for
+ * (positive) zero if the float is equal to zero. The == operator does not
+ * differentiate between positive and negative zero, which complies with the
+ * standard. This fix uses Float.equals which can differentiate between positive
+ * and negative zero.
+ */
+
+class Groovy9797 extends GroovyTestCase {
+    // Test with string conversion
+    void testFloatToString() {
+        float negativeZero = -0.0f
+        float positiveZero = 0.0f
+        assertToString(negativeZero, '-0.0')
+        assertToString(positiveZero, '0.0')
+    }
+
+    // Test with int bits
+    void testNegativePositiveZeroFloatIntBitsNotSame() {
+        int negativeZeroBits = Float.floatToIntBits(-0.0f)
+        int positiveZeroBits = Float.floatToIntBits(0.0f)
+        assertNotSame(negativeZeroBits, positiveZeroBits)
+    }
+}


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/GROOVY-9797)

This PR fixes the mentioned issue and implements tests to make sure the issue does not surface again.

## Some details

This bug was actually a compiler bug. When inserting constants to the Java Bytecode, Groovy compiler checks if a float is 0.0f and inserts the instruction for this special constant in case it is. However, the `==` operator works according to the IEEE-754 standard, and compares negative and positive zero as equal. So, if there's a negative zero (-0.0f) in the original Groovy code, the instruction for a positive float would be inserted in the bytecode.

This PR fixes this issue by using `Float.equals()` instead, which, according to the [Javadoc](https://docs.oracle.com/javase/8/docs/api/java/lang/Float.html#equals-java.lang.Object-), does not compare negative and positive zero as equal.

This PR was a joint effort by four people:

@Exploder98
@EricssonWilli
@iiroki
@OttoVayrynen
