### PR TITLE
GROOVY-9797 bug fix (DRAFT)

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/OperandStack.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/OperandStack.java
@@ -540,7 +540,9 @@ public class OperandStack {
                 mv.visitLdcInsn(value);
             }
         } else if (ClassHelper.float_TYPE.equals(type)) {
-            if ((Float)value==0f) {
+            // GROOVY-9797: Bug Fix Using Float.equals to differentiate between positive and negative zero
+            // This means -0.0f == 0.0f will be false unlike in Java
+            if (value.equals(0f)) {
                 mv.visitInsn(FCONST_0);
             } else if ((Float)value==1f) {
                 mv.visitInsn(FCONST_1);

--- a/src/test/groovy/bugs/groovy9797/groovy9797.groovy
+++ b/src/test/groovy/bugs/groovy9797/groovy9797.groovy
@@ -1,0 +1,42 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs.groovy9797
+
+import groovy.test.GroovyTestCase
+
+
+
+/** 
+ * Tests GROOVY-9797 fix
+ */
+class Groovy9797 extends GroovyTestCase {
+    
+    void testFloat() {
+        Float f = -0.0f
+        Object o = -0.0f
+
+        assert f.toString() == "-0.0"
+        assert o.toString() == "-0.0"
+        assert (-0.0f).toString() == "-0.0"
+
+        boolean x = -0.0f == 0.0f   
+        assert x == false
+ 
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9797

This fixes the above bug by using `Float.equals()` which also changes `-0.0f == 0.0f` to `false` instead of `true`. This corresponds with the https://docs.groovy-lang.org/docs/latest/html/documentation/#_identity_operator and https://docs.oracle.com/javase/8/docs/api/java/lang/Float.html#equals-java.lang.Object- documentations.

This PR was made by:
@tomikoskinen
@jonspe
@Justsofun
@rhanlol