### PR TITLE
GROOVY-9397: Make respondsTo thread safe

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -3455,18 +3455,22 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     @Override
     public synchronized void initialize() {
         if (!isInitialized()) {
-            fillMethodIndex();
-            try {
-                addProperties();
-            } catch (Throwable e) {
-                if (!AndroidSupport.isRunningAndroid()) {
-                    UncheckedThrow.rethrow(e);
-                }
-                // Introspection failure...
-                // May happen in Android
-            }
-            setInitialized(true);
+          reinitialize();
         }
+    }
+
+    protected synchronized void reinitialize() {
+      fillMethodIndex();
+      try {
+        addProperties();
+      } catch (Throwable e) {
+        if (!AndroidSupport.isRunningAndroid()) {
+          UncheckedThrow.rethrow(e);
+        }
+        // Introspection failure...
+        // May happen in Android
+      }
+      setInitialized(true);
     }
 
     private void addProperties() {

--- a/src/main/java/org/codehaus/groovy/runtime/metaclass/ClosureMetaClass.java
+++ b/src/main/java/org/codehaus/groovy/runtime/metaclass/ClosureMetaClass.java
@@ -690,9 +690,7 @@ public final class ClosureMetaClass extends MetaClassImpl {
 
     private synchronized void loadMetaInfo() {
         if (metaMethodIndex.isEmpty()) {
-            initialized = false;
-            super.initialize();
-            initialized = true;
+          reinitialize();
         }
     }
 


### PR DESCRIPTION
Because ClosureMetaClass.loadsMetaInfo() changes the initialized state 
of the Closure's Metaclass without any locking, if the Closure is visible to
another thread, then any call to invokeMethod can see the closure as
uninitialized and throw an exception.

This fix removes the need to change the initialized state of the
closure in loadMetaInfo().