### PR TITLE
GROOVY-9984: null arguments provide no value for return type generics inference

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -5147,6 +5147,8 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         int paramLength = parameters.length;
         if (expressions.size() >= paramLength) {
             for (int i = 0; i < paramLength; i += 1) {
+                if (isNullConstant(expressions.get(i)))
+                    continue; // GROOVY-9984: skip null
                 boolean lastArg = (i == paramLength - 1);
                 ClassNode paramType = parameters[i].getType();
                 ClassNode argumentType = getType(expressions.get(i));

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -270,13 +270,26 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
     // GROOVY-9948
     void testDiamondInferrenceFromConstructor7() {
         assertScript '''
-            @groovy.transform.TupleConstructor
+            @groovy.transform.TupleConstructor(defaults=false)
             class C<T> {
                 T p
             }
 
             C<Integer> c = new C<>(1)
             assert c.p < 10
+        '''
+    }
+
+    // GROOVY-9984
+    void testDiamondInferrenceFromConstructor7a() {
+        assertScript '''
+            @groovy.transform.TupleConstructor(defaults=false)
+            class C<T> {
+                T p
+            }
+
+            C<Integer> c = new C<>(null)
+            assert c.p === null
         '''
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9984