### PR TITLE
GROOVY-7945: resolve type of "super" constructor call including type arguments

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -2183,11 +2183,13 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             extension.afterMethodCall(call);
             return;
         }
-        ClassNode receiver = call.getType();
+        ClassNode receiver;
         if (call.isThisCall()) {
-            receiver = typeCheckingContext.getEnclosingClassNode();
+            receiver = makeThis();
         } else if (call.isSuperCall()) {
-            receiver = typeCheckingContext.getEnclosingClassNode().getSuperClass();
+            receiver = makeSuper();
+        } else {
+            receiver = call.getType();
         }
         Expression arguments = call.getArguments();
         ArgumentListExpression argumentList = InvocationWriter.makeArgumentList(arguments);

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -737,6 +737,34 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-7945
+    void testSpecialCtorCallWithClassLiteral() {
+        shouldFailWithMessages '''
+            abstract class A<X, Y> {
+                private final Class<X> x
+                private final Class<Y> y
+
+                A(Class<X> x, Class<Y> y) {
+                    this.x = x
+                    this.y = y
+                }
+
+                void test() {
+                    println("{$x} and {$y}")
+                }
+            }
+
+            class B extends A<String, Integer> {
+                B() {
+                    super(Integer, String)
+                }
+            }
+
+            A<String, Integer> a = new B()
+            a.test()
+        ''', 'Cannot call A#<init>(java.lang.Class <String>, java.lang.Class <Integer>) with arguments [java.lang.Class <java.lang.Integer>, java.lang.Class <java.lang.String>]'
+    }
+
     // GROOVY-9460
     void testMethodCallWithClassParameterUnbounded() {
         assertScript '''


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-7945