### PR TITLE
GROOVY-9989: remove JCenter Bintray from default Ivy resolvers

### DIFF
--- a/src/resources/groovy/grape/defaultGrapeConfig.xml
+++ b/src/resources/groovy/grape/defaultGrapeConfig.xml
@@ -28,7 +28,6 @@
       </filesystem>
       <ibiblio name="localm2" root="${user.home.url}/.m2/repository/" checkmodified="true" changingPattern=".*" changingMatcher="regexp" m2compatible="true"/>
       <!-- TODO: add 'endorsed groovy extensions' resolver here -->
-      <ibiblio name="jcenter" root="https://jcenter.bintray.com/" m2compatible="true"/>
       <ibiblio name="ibiblio" m2compatible="true"/>
     </chain>
   </resolvers>


### PR DESCRIPTION
JCenter Bintray will be decommisioned
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

see also https://github.com/apache/groovy/pull/1523