### PR TITLE
GROOVY-8104: fix this$0 for closure with anon. inner class of inner type

### DIFF
--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -353,7 +353,7 @@ final class InnerClassTest {
         '''
     }
 
-    @Test @NotYetImplemented // GROOVY-8104
+    @Test // GROOVY-8104
     void testNonStaticInnerClass5() {
         assertScript '''
             class A {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-8104

```groovy
class Outer {
  class Inner {
    // requires Outer reference
  }
  def x = { ->
    new Inner() { // this.@this$0 returns closure; call getThisObject()
    }
  }
}
```