### PR TITLE
GROOVY-9993: clarify boundary cases for split property definition (field and property of same name)

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -293,6 +293,10 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
         return "field '" + node.getName() + "'";
     }
 
+    private static String getDescription(PropertyNode node) {
+        return "property '" + node.getName() + "'";
+    }
+
     private static String getDescription(Parameter node) {
         return "parameter '" + node.getName() + "'";
     }
@@ -537,6 +541,9 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
 
     @Override
     public void visitProperty(PropertyNode node) {
+        if (currentClass.getProperty(node.getName()) != node) {
+            addError("The " + getDescription(node) + " is declared multiple times.", node);
+        }
         checkDuplicateProperties(node);
         checkGenericsUsage(node, node.getType());
         super.visitProperty(node);

--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -28,6 +28,7 @@ import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassCodeVisitorSupport;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.GroovyClassVisitor;
+import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.classgen.GeneratorContext;
 import org.codehaus.groovy.control.ASTTransformationsContext;
@@ -199,6 +200,10 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
         return result;
     }
 
+    @Override
+    public void visitProperty(PropertyNode node) {
+        // ignore: we'll already have allocated to field or accessor method by now
+    }
 
     public static void addPhaseOperations(final CompilationUnit compilationUnit) {
         ASTTransformationsContext context = compilationUnit.getASTTransformationsContext();

--- a/src/main/java/org/codehaus/groovy/transform/StaticTypesTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/StaticTypesTransformation.java
@@ -24,6 +24,7 @@ import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.ListExpression;
@@ -69,7 +70,7 @@ public class StaticTypesTransformation implements ASTTransformation, Compilation
             visitor.setMethodsToBeVisited(Collections.singleton(methodNode));
             visitor.initialize();
             visitor.visitMethod(methodNode);
-        } else {
+        } else if (!(node instanceof PropertyNode)) {
             source.addError(new SyntaxException(STATIC_ERROR_PREFIX + "Unimplemented node type",
                     node.getLineNumber(), node.getColumnNumber(), node.getLastLineNumber(), node.getLastColumnNumber()));
         }

--- a/src/main/java/org/codehaus/groovy/transform/sc/StaticCompileTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/sc/StaticCompileTransformation.java
@@ -23,6 +23,7 @@ import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.classgen.asm.WriterControllerFactory;
 import org.codehaus.groovy.classgen.asm.sc.StaticTypesWriterControllerFactoryImpl;
@@ -78,7 +79,7 @@ public class StaticCompileTransformation extends StaticTypesTransformation {
             visitor.setMethodsToBeVisited(Collections.singleton(methodNode));
             visitor.initialize();
             visitor.visitMethod(methodNode);
-        } else {
+        } else if (!(target instanceof PropertyNode)) {
             source.addError(new SyntaxException(STATIC_ERROR_PREFIX + "Unimplemented node type", target));
         }
         if (visitor != null) {

--- a/src/spec/doc/core-object-orientation.adoc
+++ b/src/spec/doc/core-object-orientation.adoc
@@ -701,7 +701,7 @@ include::../test/ClassTest.groovy[tags=property_access,indent=0]
 <3> write access to the property is done outside of the `Person` class so it will implicitly call `setName`
 <4> read access to the property is done outside of the `Person` class so it will implicitly call `getName`
 <5> this will call the `name` method on `Person` which performs a direct access to the field
-<6> this will call the `wonder` method on `Person` which performs a direct read access to the field
+<6> this will call the `title` method on `Person` which performs a direct read access to the field
 
 It is worth noting that this behavior of accessing the backing field directly is done in order to prevent a stack
 overflow when using the property access syntax within a class that defines the property.
@@ -729,8 +729,9 @@ This syntactic sugar is at the core of many DSLs written in Groovy.
 
 ===== Property naming conventions
 
-It is generally recommended that the first two letters of a property name are lowercase and for multiword properties
-that camel case is used. In those cases, generated getters and setters will have a name formed by capitalizing the
+It is generally recommended that the first two letters of a property name are
+lowercase and for multi-word properties that camel case is used.
+In those cases, generated getters and setters will have a name formed by capitalizing the
 property name and adding a `get` or `set` prefix (or optionally "is" for a boolean getter).
 So, `getLength` would be a getter  for a `length` property and `setFirstName` a setter for a `firstName` property.
 `isEmpty` might be the getter method name for a property named `empty`.
@@ -761,6 +762,75 @@ Although we _never_ recommend it, it does allow you to have what might seem like
 e.g. you can have `aProp` and `AProp`, or `pNAME` and `PNAME`. The getters would be `getaProp` and `getAProp`,
 and `getpNAME` and `getPNAME` respectively.
 ====
+
+===== Annotations on a property
+
+Annotations, including those associated with AST transforms,
+are copied on to the backing field for the property.
+This allows AST transforms which are applicable to fields to
+be applied to properties, e.g.:
+
+[source,groovy]
+----
+include::../test/ClassTest.groovy[tags=annotated_properties,indent=0]
+----
+<1> Confirms no eager initialization
+<2> Normal property access
+<3> Confirms initialization upon property access
+
+===== Split property definition with an explicit backing field
+
+Groovy's property syntax is a convenient shorthand when your class design
+follows certain conventions which align with common JavaBean practice.
+If your class doesn't exactly fit these conventions,
+you can certainly write the getter, setter and backing field long hand like you would in Java.
+However, Groovy does provide a split definition capability which still provides
+a shortened syntax while allowing slight adjustments to the conventions.
+For a split definition, you write a field and a property with the same name and type.
+Only one of the field or property may have an initial value.
+
+For split properties, annotations on the field remain on the backing field for the property.
+Annotations on the property part of the definition are copied onto the getter and setter methods.
+
+This mechanism allows a number of common variations that property users may wish
+to use if the standard property definition doesn't exactly fit their needs.
+For example, if the backing field should be `protected` rather than `private`:
+
+[source,groovy]
+----
+class HasPropertyWithProtectedField {
+    protected String name  // <1>
+    String name            // <2>
+}
+----
+<1> Protected backing field for name property instead of normal private one
+<2> Declare name property
+
+Or, the same example but with a package-private backing field:
+
+[source,groovy]
+----
+class HasPropertyWithPackagePrivateField {
+    String name                // <1>
+    @PackageScope String name  // <2>
+}
+----
+<1> Declare name property
+<2> Package-private backing field for name property instead of normal private one
+
+As a final example, we may wish to apply method-related AST transforms,
+or in general, any annotation to the setters/getters,
+e.g. to have the accessors be synchronized:
+
+[source,groovy]
+----
+class HasPropertyWithSynchronizedAccessorMethods {
+    private String name        // <1>
+    @Synchronized String name  // <2>
+}
+----
+<1> Backing field for name property
+<2> Declare name property with annotation for setter/getter
 
 === Annotation
 

--- a/src/spec/test/ClassTest.groovy
+++ b/src/spec/test/ClassTest.groovy
@@ -333,17 +333,17 @@ class ClassTest extends GroovyTestCase {
             class Person {
                 String name
                 void name(String name) {
-                    this.name = "Wonder$name"       // <1>
+                    this.name = "Wonder $name"      // <1>
                 }
-                String wonder() {
+                String title() {
                     this.name                       // <2>
                 }
             }
             def p = new Person()
-            p.name = 'Marge'                        // <3>
-            assert p.name == 'Marge'                // <4>
-            p.name('Marge')                         // <5>
-            assert p.wonder() == 'WonderMarge'      // <6>
+            p.name = 'Diana'                        // <3>
+            assert p.name == 'Diana'                // <4>
+            p.name('Woman')                         // <5>
+            assert p.title() == 'Wonder Woman'      // <6>
             // end::property_access[]
         '''
 

--- a/src/spec/test/ClassTest.groovy
+++ b/src/spec/test/ClassTest.groovy
@@ -378,6 +378,21 @@ class ClassTest extends GroovyTestCase {
             p.groovy = true                     // <3>
             // end::pseudo_properties[]
         '''
+
+        assertScript '''
+            // tag::annotated_properties[]
+            class Animal {
+                int lowerCount = 0
+                @Lazy String name = { lower().toUpperCase() }()
+                String lower() { lowerCount++; 'sloth' }
+            }
+
+            def a = new Animal()
+            assert a.lowerCount == 0  // <1>
+            assert a.name == 'SLOTH'  // <2>
+            assert a.lowerCount == 1  // <3>
+            // end::annotated_properties[]
+        '''
     }
 
 

--- a/src/test/gls/scope/MultipleDefinitionOfSameVariableTest.groovy
+++ b/src/test/gls/scope/MultipleDefinitionOfSameVariableTest.groovy
@@ -163,4 +163,34 @@ class MultipleDefinitionOfSameVariableTest extends CompilableTestSupport {
         '''
     }
 
+    void testFieldAndPropertyWithInit() {
+        assertScript '''
+            class X {
+                def foo = 3
+                public foo
+                public bar
+                def bar = 4
+            }
+
+            def x = new X()
+            def result = [x.foo, x.bar]
+            assert result == [3, 4]
+        '''
+    }
+
+    void testPropertyAndFieldWithInit() {
+        assertScript '''
+            class Y {
+                def foo
+                public foo = 5
+                public bar = 6
+                def bar
+            }
+
+            def y = new Y()
+            result = [y.foo, y.bar]
+            assert result == [5, 6]
+        '''
+    }
+
 }

--- a/src/test/gls/scope/MultipleDefinitionOfSameVariableTest.groovy
+++ b/src/test/gls/scope/MultipleDefinitionOfSameVariableTest.groovy
@@ -23,68 +23,68 @@ import gls.CompilableTestSupport
 class MultipleDefinitionOfSameVariableTest extends CompilableTestSupport {
 
     void testInSameBlock() {
-        shouldNotCompile """
+        shouldNotCompile '''
             def foo = 1
             def foo = 2
-        """
+        '''
 
-        shouldNotCompile """
+        shouldNotCompile '''
             class Foo {
                 def foo() {
                     def bar=1
                     def bar=2
                 }
             }
-        """
+        '''
     }
 
     void testInSubBlocks() {
-        shouldNotCompile """
+        shouldNotCompile '''
              def foo = 1
              5.times { def foo=2 }
-        """
+        '''
 
-        shouldNotCompile """
+        shouldNotCompile '''
             def foo = 1
             label1: { def foo=2 }
-        """
+        '''
 
-        shouldNotCompile """
+        shouldNotCompile '''
             def foo = 1
             for (i in []) { def foo=2 }
-        """
+        '''
 
-        shouldNotCompile """
+        shouldNotCompile '''
             def foo = 1
             while (true) { def foo=2 }
-        """
+        '''
     }
 
     void testInNestedClosure() {
-        shouldNotCompile """
+        shouldNotCompile '''
             def foo = 1
             5.times { 6.times {def foo=2 }
-        """
+        '''
 
-        assertScript """
+        assertScript '''
             def foo = 1
             5.times { 6.times {foo=2 } }
             assert foo == 2
-        """
+        '''
     }
 
     void testBindingHiding() {
-        assertScript """
+        assertScript '''
             foo = 1
             def foo = 3
             assert foo==3
             assert this.foo == 1
             assert binding.foo == 1
-        """
+        '''
     }
 
     void testBindingAccessInMethod() {
-        assertScript """
+        assertScript '''
             def methodUsingBinding() {
                 try {
                     s = "  bbb  ";
@@ -95,72 +95,72 @@ class MultipleDefinitionOfSameVariableTest extends CompilableTestSupport {
             }
             methodUsingBinding()
             assert s == "bbb"
-        """
+        '''
     }
 
     void testMultipleOfSameName() {
-        shouldNotCompile """
+        shouldNotCompile '''
             class DoubleField {
                 def zero = 0
                 def zero = 0
             }
-        """
+        '''
     }
 
     void testPropertyField() {
-        shouldCompile """
+        shouldCompile '''
             class A {
                 def foo
                 private foo
             }
-        """
+        '''
     }
 
     void testPropertyFieldBothInit() {
-        shouldNotCompile """
+        shouldNotCompile '''
             class A {
                 def foo = 3
                 private foo = 4
             }
-        """
+        '''
     }
 
     void testFieldProperty() {
-        shouldCompile """
+        shouldCompile '''
             class A {
                 private foo
                 def foo
             }
-        """
+        '''
     }
 
     void testFieldPropertyBothInit() {
-        shouldNotCompile """
+        shouldNotCompile '''
             class A {
                 private foo = 'a'
                 def foo = 'b'
             }
-        """
+        '''
     }
 
     void testFieldPropertyProperty() {
-        shouldNotCompile """
+        shouldNotCompile '''
             class A {
                 private foo
                 def foo
                 def foo
             }
-        """
+        '''
     }
 
     void testPropertyFieldField() {
-        shouldNotCompile """
+        shouldNotCompile '''
             class A {
                 def foo
                 private foo
                 private foo
             }
-        """
+        '''
     }
 
 }

--- a/src/test/org/codehaus/groovy/ast/LineColumnCheck.txt
+++ b/src/test/org/codehaus/groovy/ast/LineColumnCheck.txt
@@ -39,7 +39,7 @@ class Test {
 :::[FieldNode,(2:2),(2:24)][ConstantExpression,(2:17),(2:24)];
 [FieldNode,(3:2),(3:15)];
 [FieldNode,(4:2),(4:26)];
-[FieldNode,(6:2),(6:15)][ConstantExpression,(5:26),(5:40)];
+[FieldNode,(5:2),(5:40)][ConstantExpression,(5:26),(5:40)];
 [FieldNode,(8:2),(8:38)][ConstantExpression,(8:25),(8:38)]
 
 ###wholeAnnotationExpressionSelection:::


### PR DESCRIPTION
When defining a property, getters and setters are automatically supplied unless an existing one is found. This same rule also applies to the backing field but to date many aspects of this rule have been under specified, e.g. what happens if the type given for the field and property aren't the same? This PR clarifies these edge cases and provides a more formal definition of the behavior (the different types mentioned earlier for example becomes a compiler error).