### PR TITLE
Implement GROOVY-9649: left-open and full-open ranges

### DIFF
--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -808,22 +808,24 @@ NullLiteral
 
 // Groovy Operators
 
-RANGE_INCLUSIVE     : '..';
-RANGE_EXCLUSIVE     : '..<';
-SPREAD_DOT          : '*.';
-SAFE_DOT            : '?.';
-SAFE_CHAIN_DOT      : '??.';
-ELVIS               : '?:';
-METHOD_POINTER      : '.&';
-METHOD_REFERENCE    : '::';
-REGEX_FIND          : '=~';
-REGEX_MATCH         : '==~';
-POWER               : '**';
-POWER_ASSIGN        : '**=';
-SPACESHIP           : '<=>';
-IDENTICAL           : '===';
-NOT_IDENTICAL       : '!==';
-ARROW               : '->';
+RANGE_INCLUSIVE         : '..';
+RANGE_EXCLUSIVE_LEFT    : '<..';
+RANGE_EXCLUSIVE_RIGHT   : '..<';
+RANGE_EXCLUSIVE_FULL    : '<..<';
+SPREAD_DOT              : '*.';
+SAFE_DOT                : '?.';
+SAFE_CHAIN_DOT          : '??.';
+ELVIS                   : '?:';
+METHOD_POINTER          : '.&';
+METHOD_REFERENCE        : '::';
+REGEX_FIND              : '=~';
+REGEX_MATCH             : '==~';
+POWER                   : '**';
+POWER_ASSIGN            : '**=';
+SPACESHIP               : '<=>';
+IDENTICAL               : '===';
+NOT_IDENTICAL           : '!==';
+ARROW                   : '->';
 
 // !internalPromise will be parsed as !in ternalPromise, so semantic predicates are necessary
 NOT_INSTANCEOF      : '!instanceof' { isFollowedBy(_input, ' ', '\t', '\r', '\n') }?;

--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -766,7 +766,9 @@ expression
                         |   dgOp=GT GT
                         )
             |   rangeOp=(    RANGE_INCLUSIVE
-                        |    RANGE_EXCLUSIVE
+                        |    RANGE_EXCLUSIVE_LEFT
+                        |    RANGE_EXCLUSIVE_RIGHT
+                        |    RANGE_EXCLUSIVE_FULL
                         )
             ) nls
         right=expression                                                                    #shiftExprAlt

--- a/src/main/java/groovy/lang/IntRange.java
+++ b/src/main/java/groovy/lang/IntRange.java
@@ -31,8 +31,8 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
- * Represents a list of Integer objects starting at a specified {@code from} value up (or down)
- * to and potentially including a given {@code to} value.
+ * Represents a list of Integer objects starting at and potentially including a specified
+ * {@code from} value up (or down) to and potentially including a given {@code to} value.
  * <p>
  * Instances of this class may be either inclusive aware or non-inclusive aware. See the
  * relevant constructors for creating each type. Inclusive aware IntRange instances are
@@ -40,14 +40,15 @@ import java.util.Objects;
  * might be negative. This normally happens underneath the covers but is worth keeping
  * in mind if creating these ranges yourself explicitly.
  * <p>
- * Note: the design of this class might seem a little strange at first. It contains a Boolean
- * field, {@code inclusive}, which can be {@code true}, {@code false} or {@code null}. This
- * design is for backwards compatibility reasons. Groovy uses this class under the covers
- * to represent range indexing, e.g. {@code someList[x..y]} and {@code someString[x..<y]}.
- * In early versions of Groovy the ranges in these expressions were represented under the
- * covers by the {@code new IntRange(x, y)} and {@code new IntRange(x, y-1)}. This turns
- * out to be a lossy abstraction when x and/or y are negative values. Now the latter case
- * is represented by {@code new IntRange(false, x, y)}.
+ * Note: the design of this class might seem a little strange at first. It contains Boolean
+ * flags, {@code inclusiveLeft} and {@code inclusiveRight}, which can be {@code true},
+ * {@code false} or {@code null}. This design is for backwards compatibility reasons.
+ * Groovy uses this class under the covers to represent range indexing, e.g.
+ * {@code someList[x..y]} and {@code someString[x..<y]}. In early versions of Groovy the
+ * ranges in these expressions were represented under the covers by the
+ * {@code new IntRange(x, y)} and {@code new IntRange(x, y-1)}. This turns out to be a
+ * lossy abstraction when x and/or y are negative values. Now the latter case is
+ * represented by {@code new IntRange(false, x, y)}.
  * <p>
  * Note: This class is a copy of {@link ObjectRange} optimized for <code>int</code>. If you make any
  * changes to this class, you might consider making parallel changes to {@link ObjectRange}.
@@ -134,6 +135,14 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
      */
     private final Boolean inclusiveRight;
 
+    /**
+     * If <code>true</code> or null, <code>from</code> is included in the range.
+     * If <code>false</code>, the range begins after the <code>from</code> value.
+     * <p>
+     * Null for non-inclusive-aware ranges (which are inclusive).
+     * <p>
+     * If true or false, the reverse flag is discarded.
+     */
     private final Boolean inclusiveLeft;
 
     /**
@@ -192,6 +201,14 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
         this(true, inclusiveRight, from, to);
     }
 
+    /**
+     * Creates a new inclusive aware <code>IntRange</code>
+     *
+     * @param inclusiveLeft     <code>true</code> if the from value is included in the range.
+     * @param inclusiveRight    <code>true</code> if the to value is included in the range.
+     * @param from              the first value in the range.
+     * @param to                the last value in the range.
+     */
     public IntRange(boolean inclusiveLeft, boolean inclusiveRight, int from, int to) {
         this.from = from;
         this.to = to;
@@ -210,7 +227,6 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
      * @since 2.5.0
      */
     public <T extends Number & Comparable> NumberRange by(T stepSize) {
-        // TODO edit NumberRange
         return new NumberRange(NumberRange.comparableNumber((Number)from), NumberRange.comparableNumber((Number)to), stepSize, inclusiveRight);
     }
 
@@ -307,16 +323,22 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
     }
 
     /**
-     * Returns the inclusive flag. Null for non-inclusive aware ranges or non-null for inclusive aware ranges.
+     * Returns the same as <code>getInclusiveRight</code>, kept here for backwards compatibility.
      */
     public Boolean getInclusive() {
         return inclusiveRight;
     }
 
+    /**
+     * Returns the inclusiveRight flag. Null for non-inclusive aware ranges or non-null for inclusive aware ranges.
+     */
     public Boolean getInclusiveRight() {
         return inclusiveRight;
     }
 
+    /**
+     * Returns the inclusiveLeft flag. Null for non-inclusive aware ranges or non-null for inclusive aware ranges.
+     */
     public Boolean getInclusiveLeft() {
         return inclusiveLeft;
     }

--- a/src/main/java/groovy/lang/IntRange.java
+++ b/src/main/java/groovy/lang/IntRange.java
@@ -298,11 +298,10 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
      */
     public boolean equals(IntRange that) {
         return that != null && from == that.from && to == that.to && (
-                (inclusiveRight == null && inclusiveLeft == null && reverse == that.reverse)
-                || (
-                        (inclusiveLeft == null || Objects.equals(inclusiveLeft, that.inclusiveLeft))
-                        && (inclusiveRight == null || Objects.equals(inclusiveRight, that.inclusiveRight))
-                )
+                // If inclusiveRight is null, then inclusive left is also null (see constructor)
+                (inclusiveRight == null) ? reverse == that.reverse:
+                        (Objects.equals(inclusiveLeft, that.inclusiveLeft)
+                                && Objects.equals(inclusiveRight, that.inclusiveRight))
         );
     }
 
@@ -417,8 +416,7 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
         if (inclusiveRight == null && inclusiveLeft == null)  {
                return reverse ? "" + to + ".." + from : "" + from + ".." + to;
         }
-        return "" + from + ((inclusiveLeft != null && inclusiveLeft) ? "" : "<") + ".."
-                  + ((inclusiveRight != null && inclusiveRight) ? "" : "<") + to;
+        return "" + from + (inclusiveLeft ? "" : "<") + ".." + (inclusiveRight ? "" : "<") + to;
     }
 
     @Override

--- a/src/main/java/groovy/lang/IntRange.java
+++ b/src/main/java/groovy/lang/IntRange.java
@@ -233,7 +233,7 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
         if (inclusiveRight == null || inclusiveLeft == null) {
             throw new IllegalStateException("Should not call subListBorders on a non-inclusive aware IntRange");
         }
-        return subListBorders(from, to, inclusiveRight, size);
+        return subListBorders(from, to, inclusiveLeft, inclusiveRight, size);
     }
 
     static RangeInfo subListBorders(int from, int to, boolean inclusiveRight, int size) {

--- a/src/main/java/groovy/lang/IntRange.java
+++ b/src/main/java/groovy/lang/IntRange.java
@@ -326,7 +326,7 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
      * Returns the same as <code>getInclusiveRight</code>, kept here for backwards compatibility.
      */
     public Boolean getInclusive() {
-        return inclusiveRight;
+        return getInclusiveRight();
     }
 
     /**
@@ -414,9 +414,11 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
 
     @Override
     public String toString() {
-        return (inclusiveRight == null && inclusiveLeft == null) ? (reverse ? "" + to + ".." + from : "" + from + ".." + to)
-                : ("" + from + ((inclusiveLeft != null && inclusiveLeft) ? "" : "<") + ".."
-                             + ((inclusiveRight != null && inclusiveRight) ? "" : "<") + to);
+        if (inclusiveRight == null && inclusiveLeft == null)  {
+               return reverse ? "" + to + ".." + from : "" + from + ".." + to;
+        }
+        return "" + from + ((inclusiveLeft != null && inclusiveLeft) ? "" : "<") + ".."
+                  + ((inclusiveRight != null && inclusiveRight) ? "" : "<") + to;
     }
 
     @Override

--- a/src/main/java/groovy/lang/IntRange.java
+++ b/src/main/java/groovy/lang/IntRange.java
@@ -362,7 +362,8 @@ public class IntRange extends AbstractList<Integer> implements Range<Integer>, S
 
     @Override
     public int size() {
-        return getTo() - getFrom() + 1;
+        // If fully exclusive and borders are one apart, the size would be negative, take that into account
+        return Math.max(getTo() - getFrom() + 1, 0);
     }
 
     @Override

--- a/src/main/java/groovy/lang/NumberRange.java
+++ b/src/main/java/groovy/lang/NumberRange.java
@@ -624,9 +624,18 @@ public class NumberRange extends AbstractList<Comparable> implements Range<Compa
         @Override
         public boolean hasNext() {
             fetchNextIfNeeded();
-            return (next != null) && (isAscending
-                    ? (range.inclusiveRight ? compareLessThanEqual(next, range.getTo()) : compareLessThan(next, range.getTo()))
-                    : (range.inclusiveRight ? compareGreaterThanEqual(next, range.getFrom()) : compareGreaterThan(next, range.getFrom())));
+            if (next == null) {
+                return false;
+            }
+            if (isAscending) {
+                return range.inclusiveRight
+                        ? compareLessThanEqual(next, range.getTo())
+                        : compareLessThan(next, range.getTo());
+            }
+            return range.inclusiveRight
+                    ? compareGreaterThanEqual(next, range.getFrom())
+                    : compareGreaterThan(next, range.getFrom());
+
         }
 
         @Override
@@ -641,18 +650,18 @@ public class NumberRange extends AbstractList<Comparable> implements Range<Compa
         }
 
         private void fetchNextIfNeeded() {
-            if (!isNextFetched) {
-                isNextFetched = true;
-
-                if (next == null) {
-                    // make the first fetch lazy too
-                    next = isAscending ? range.getFrom() : range.getTo();
-                    if (!range.inclusiveLeft) {
-                        next = isAscending ? increment(next, step) : decrement(next, step);
-                    }
-                } else {
+            if (isNextFetched) {
+                return;
+            }
+            isNextFetched = true;
+            if (next == null) {
+                // make the first fetch lazy too
+                next = isAscending ? range.getFrom() : range.getTo();
+                if (!range.inclusiveLeft) {
                     next = isAscending ? increment(next, step) : decrement(next, step);
                 }
+            } else {
+                next = isAscending ? increment(next, step) : decrement(next, step);
             }
         }
 

--- a/src/main/java/groovy/lang/NumberRange.java
+++ b/src/main/java/groovy/lang/NumberRange.java
@@ -644,7 +644,7 @@ public class NumberRange extends AbstractList<Comparable> implements Range<Compa
                     // make the first fetch lazy too
                     next = isAscending ? range.getFrom() : range.getTo();
                     if (!range.inclusiveLeft) {
-                        next = next();
+                        next = isAscending ? increment(next, step) : decrement(next, step);
                     }
                 } else {
                     next = isAscending ? increment(next, step) : decrement(next, step);

--- a/src/main/java/groovy/lang/NumberRange.java
+++ b/src/main/java/groovy/lang/NumberRange.java
@@ -448,6 +448,10 @@ public class NumberRange extends AbstractList<Comparable> implements Range<Compa
     }
 
     void calcSize(Comparable from, Comparable to, Number stepSize) {
+        if (from == to && !inclusiveLeft && !inclusiveRight) {
+            size = 0;
+            return;
+        }
         int tempsize = 0;
         boolean shortcut = false;
         if (isIntegral(stepSize)) {

--- a/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -2665,7 +2665,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
         Expression right = (Expression) this.visit(ctx.right);
 
         if (asBoolean(ctx.rangeOp)) {
-            return configureAST(new RangeExpression(left, right, !ctx.rangeOp.getText().endsWith("<")), ctx);
+            return configureAST(new RangeExpression(left, right, ctx.rangeOp.getText().startsWith("<"), ctx.rangeOp.getText().endsWith("<")), ctx);
         }
 
         org.codehaus.groovy.syntax.Token op;

--- a/src/main/java/org/codehaus/groovy/ast/expr/RangeExpression.java
+++ b/src/main/java/org/codehaus/groovy/ast/expr/RangeExpression.java
@@ -27,17 +27,32 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
  * <pre>for i in 0..10 {...}</pre>
  */
 public class RangeExpression extends Expression {
-
     private final Expression from;
     private final Expression to;
-    private final boolean inclusive;
+    private final boolean inclusive; // Kept to keep old code depending on this working
+    // GROOVY-9649
+    private final boolean exclusiveLeft;
+    private final boolean exclusiveRight;
 
+    // Kept until sure this can be removed
     public RangeExpression(Expression from, Expression to, boolean inclusive) {
         this.from = from;
         this.to = to;
         this.inclusive = inclusive;
+        this.exclusiveLeft = false;
+        this.exclusiveRight = !inclusive;
         setType(ClassHelper.RANGE_TYPE);
     }
+
+    public RangeExpression(Expression from, Expression to, boolean exclusiveLeft, boolean exclusiveRight) {
+        this.from = from;
+        this.to = to;
+        this.inclusive = !exclusiveRight;
+        this.exclusiveLeft = exclusiveLeft;
+        this.exclusiveRight = exclusiveRight;
+        setType(ClassHelper.RANGE_TYPE);
+    }
+
 
     @Override
     public void visit(GroovyCodeVisitor visitor) {
@@ -46,7 +61,7 @@ public class RangeExpression extends Expression {
 
     @Override
     public Expression transformExpression(ExpressionTransformer transformer) {
-        Expression ret = new RangeExpression(transformer.transform(from), transformer.transform(to), inclusive);
+        Expression ret = new RangeExpression(transformer.transform(from), transformer.transform(to), exclusiveLeft, exclusiveRight);
         ret.setSourcePosition(this);
         ret.copyNodeMetaData(this);
         return ret;

--- a/src/main/java/org/codehaus/groovy/ast/expr/RangeExpression.java
+++ b/src/main/java/org/codehaus/groovy/ast/expr/RangeExpression.java
@@ -44,10 +44,11 @@ public class RangeExpression extends Expression {
         setType(ClassHelper.RANGE_TYPE);
     }
 
+    // GROOVY-9649
     public RangeExpression(Expression from, Expression to, boolean exclusiveLeft, boolean exclusiveRight) {
         this.from = from;
         this.to = to;
-        this.inclusive = !exclusiveRight;
+        this.inclusive = !exclusiveRight; // Old code depends on this
         this.exclusiveLeft = exclusiveLeft;
         this.exclusiveRight = exclusiveRight;
         setType(ClassHelper.RANGE_TYPE);
@@ -79,10 +80,20 @@ public class RangeExpression extends Expression {
         return inclusive;
     }
 
+    public boolean isExclusiveLeft() {
+        return exclusiveLeft;
+    }
+
+    public boolean isExclusiveRight() {
+        return exclusiveRight;
+    }
+
     @Override
     public String getText() {
         return "(" + from.getText() +
-               (!isInclusive()? "..<" : ".." ) +
-               to.getText() + ")";
+                (this.exclusiveLeft ? "<" : "") +
+                ".." +
+                (this.exclusiveRight ? "<" : "") +
+                to.getText() + ")";
     }
 }

--- a/src/main/java/org/codehaus/groovy/ast/expr/RangeExpression.java
+++ b/src/main/java/org/codehaus/groovy/ast/expr/RangeExpression.java
@@ -29,26 +29,18 @@ import org.codehaus.groovy.ast.GroovyCodeVisitor;
 public class RangeExpression extends Expression {
     private final Expression from;
     private final Expression to;
-    private final boolean inclusive; // Kept to keep old code depending on this working
-    // GROOVY-9649
     private final boolean exclusiveLeft;
     private final boolean exclusiveRight;
 
     // Kept until sure this can be removed
     public RangeExpression(Expression from, Expression to, boolean inclusive) {
-        this.from = from;
-        this.to = to;
-        this.inclusive = inclusive;
-        this.exclusiveLeft = false;
-        this.exclusiveRight = !inclusive;
-        setType(ClassHelper.RANGE_TYPE);
+        this(from, to, false, !inclusive);
     }
 
     // GROOVY-9649
     public RangeExpression(Expression from, Expression to, boolean exclusiveLeft, boolean exclusiveRight) {
         this.from = from;
         this.to = to;
-        this.inclusive = !exclusiveRight; // Old code depends on this
         this.exclusiveLeft = exclusiveLeft;
         this.exclusiveRight = exclusiveRight;
         setType(ClassHelper.RANGE_TYPE);
@@ -77,7 +69,7 @@ public class RangeExpression extends Expression {
     }
 
     public boolean isInclusive() {
-        return inclusive;
+        return !isExclusiveRight();
     }
 
     public boolean isExclusiveLeft() {

--- a/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -216,7 +216,9 @@ public class AsmClassGenerator extends ClassGenerator {
     // type conversions
     private static final MethodCaller createMapMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "createMap");
     private static final MethodCaller createListMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "createList");
-    private static final MethodCaller createRangeMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "createRange");
+    // The 3-parameter version of createRange is kept in for backwards compatibility, so we need to specify the
+    // parameter count here
+    private static final MethodCaller createRangeMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "createRange", 4);
     private static final MethodCaller createPojoWrapperMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "createPojoWrapper");
     private static final MethodCaller createGroovyObjectWrapperMethod = MethodCaller.newStatic(ScriptBytecodeAdapter.class, "createGroovyObjectWrapper");
 
@@ -1526,10 +1528,11 @@ public class AsmClassGenerator extends ClassGenerator {
         operandStack.box();
         expression.getTo().visit(this);
         operandStack.box();
-        operandStack.pushBool(expression.isInclusive());
+        operandStack.pushBool(expression.isExclusiveLeft());
+        operandStack.pushBool(expression.isExclusiveRight());
 
         createRangeMethod.call(controller.getMethodVisitor());
-        operandStack.replace(ClassHelper.RANGE_TYPE, 3);
+        operandStack.replace(ClassHelper.RANGE_TYPE, 4);
     }
 
     @Override

--- a/src/main/java/org/codehaus/groovy/classgen/asm/MethodCaller.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/MethodCaller.java
@@ -38,9 +38,15 @@ public class MethodCaller {
     private String name;
     private Class theClass;
     private String methodDescriptor;
+    private int parameterCount;
+    private static final int ANY_PARAMETER_COUNT = -1;
 
     public static MethodCaller newStatic(Class theClass, String name) {
         return new MethodCaller(INVOKESTATIC, theClass, name);
+    }
+
+    public static MethodCaller newStatic(Class theClass, String name, int parameterCount) {
+        return new MethodCaller(INVOKESTATIC, theClass, name, parameterCount);
     }
 
     public static MethodCaller newInterface(Class theClass, String name) {
@@ -57,11 +63,15 @@ public class MethodCaller {
     protected MethodCaller() {}
 
     public MethodCaller(int opcode, Class theClass, String name) {
+        this(opcode, theClass, name, ANY_PARAMETER_COUNT);
+    }
+
+    public MethodCaller(int opcode, Class theClass, String name, int parameterCount) {
         this.opcode = opcode;
         this.internalName = Type.getInternalName(theClass);
         this.theClass = theClass;
         this.name = name;
-
+        this.parameterCount = parameterCount;
     }
 
     public void call(MethodVisitor methodVisitor) {
@@ -78,11 +88,20 @@ public class MethodCaller {
 
     protected Method getMethod() {
         Method[] methods = theClass.getMethods();
-        for (Method method : methods) {
-            if (method.getName().equals(name)) {
-                return method;
+        if (parameterCount != ANY_PARAMETER_COUNT) {
+            for (Method method : methods) {
+                if (method.getName().equals(name) && method.getParameterCount() == parameterCount) {
+                    return method;
+                }
+            }
+        } else {
+            for (Method method : methods) {
+                if (method.getName().equals(name)) {
+                    return method;
+                }
             }
         }
-        throw new ClassGeneratorException("Could not find method: " + name + " on class: " + theClass);
+        throw new ClassGeneratorException("Could not find method: " + name +
+                (parameterCount >= 0 ? " with parameter count " + parameterCount : "") + " on class: " + theClass);
     }
 }

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -13944,7 +13944,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     @SuppressWarnings("unchecked")
     public static List<Byte> getAt(byte[] array, IntRange range) {
         RangeInfo info = subListBorders(array.length, range);
-        List<Byte> answer = primitiveArrayGet(array, new IntRange(true, info.from, info.to - 1));
+        List<Byte> answer = primitiveArrayGet(array, subListRange(info, range));
         return info.reverse ? reverse(answer) : answer;
     }
 
@@ -13959,7 +13959,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     @SuppressWarnings("unchecked")
     public static List<Character> getAt(char[] array, IntRange range) {
         RangeInfo info = subListBorders(array.length, range);
-        List<Character> answer = primitiveArrayGet(array, new IntRange(true, info.from, info.to - 1));
+        List<Character> answer = primitiveArrayGet(array, subListRange(info, range));
         return info.reverse ? reverse(answer) : answer;
     }
 
@@ -13974,7 +13974,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     @SuppressWarnings("unchecked")
     public static List<Short> getAt(short[] array, IntRange range) {
         RangeInfo info = subListBorders(array.length, range);
-        List<Short> answer = primitiveArrayGet(array, new IntRange(true, info.from, info.to - 1));
+        List<Short> answer = primitiveArrayGet(array, subListRange(info, range));
         return info.reverse ? reverse(answer) : answer;
     }
 
@@ -13989,7 +13989,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     @SuppressWarnings("unchecked")
     public static List<Integer> getAt(int[] array, IntRange range) {
         RangeInfo info = subListBorders(array.length, range);
-        List<Integer> answer = primitiveArrayGet(array, new IntRange(true, info.from, info.to - 1));
+        List<Integer> answer = primitiveArrayGet(array, subListRange(info, range));
         return info.reverse ? reverse(answer) : answer;
     }
 
@@ -14004,7 +14004,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     @SuppressWarnings("unchecked")
     public static List<Long> getAt(long[] array, IntRange range) {
         RangeInfo info = subListBorders(array.length, range);
-        List<Long> answer = primitiveArrayGet(array, new IntRange(true, info.from, info.to - 1));
+        List<Long> answer = primitiveArrayGet(array, subListRange(info, range));
         return info.reverse ? reverse(answer) : answer;
     }
 
@@ -14019,7 +14019,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     @SuppressWarnings("unchecked")
     public static List<Float> getAt(float[] array, IntRange range) {
         RangeInfo info = subListBorders(array.length, range);
-        List<Float> answer = primitiveArrayGet(array, new IntRange(true, info.from, info.to - 1));
+        List<Float> answer = primitiveArrayGet(array, subListRange(info, range));
         return info.reverse ? reverse(answer) : answer;
     }
 
@@ -14034,7 +14034,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     @SuppressWarnings("unchecked")
     public static List<Double> getAt(double[] array, IntRange range) {
         RangeInfo info = subListBorders(array.length, range);
-        List<Double> answer = primitiveArrayGet(array, new IntRange(true, info.from, info.to - 1));
+        List<Double> answer = primitiveArrayGet(array, subListRange(info, range));
         return info.reverse ? reverse(answer) : answer;
     }
 
@@ -14049,7 +14049,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     @SuppressWarnings("unchecked")
     public static List<Boolean> getAt(boolean[] array, IntRange range) {
         RangeInfo info = subListBorders(array.length, range);
-        List<Boolean> answer = primitiveArrayGet(array, new IntRange(true, info.from, info.to - 1));
+        List<Boolean> answer = primitiveArrayGet(array, subListRange(info, range));
         return info.reverse ? reverse(answer) : answer;
     }
 

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
@@ -101,6 +101,34 @@ public class DefaultGroovyMethodsSupport {
         return new RangeInfo(from, from, false);
     }
 
+    // Helper method for primitive array getAt
+    protected static IntRange subListRange(RangeInfo info, IntRange range) {
+        int from = info.from;
+        int to = info.to - 1;
+
+        // Undo inclusiveness effects done by subListBorders()
+        if (!info.reverse) {
+            if (!range.getInclusiveLeft()) {
+                from--;
+            }
+            if (!range.getInclusiveRight()) {
+                to++;
+            }
+        } else {
+            if (!range.getInclusiveLeft()) {
+                to++;
+            }
+            if (!range.getInclusiveRight()) {
+                from--;
+            }
+        }
+
+        boolean inclusiveLeft = info.reverse ? range.getInclusiveRight() : range.getInclusiveLeft();
+        boolean inclusiveRight = info.reverse ? range.getInclusiveLeft() : range.getInclusiveRight();
+
+        return new IntRange(inclusiveLeft, inclusiveRight, from, to);
+    }
+
     /**
      * This converts a possibly negative index to a real index into the array.
      *

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
@@ -108,17 +108,17 @@ public class DefaultGroovyMethodsSupport {
 
         // Undo inclusiveness effects done by subListBorders()
         if (!info.reverse) {
-            if (!range.getInclusiveLeft()) {
+            if (Boolean.FALSE.equals(range.getInclusiveLeft())) {
                 from--;
             }
-            if (!range.getInclusiveRight()) {
+            if (Boolean.FALSE.equals(range.getInclusiveRight())) {
                 to++;
             }
         } else {
-            if (!range.getInclusiveLeft()) {
+            if (Boolean.FALSE.equals(range.getInclusiveLeft())) {
                 to++;
             }
-            if (!range.getInclusiveRight()) {
+            if (Boolean.FALSE.equals(range.getInclusiveRight())) {
                 from--;
             }
         }

--- a/src/main/java/org/codehaus/groovy/runtime/InvokerHelper.java
+++ b/src/main/java/org/codehaus/groovy/runtime/InvokerHelper.java
@@ -933,14 +933,19 @@ public class InvokerHelper {
         return toArrayString(arguments, false, maxSize, safe);
     }
 
-    public static List createRange(Object from, Object to, boolean inclusive) {
+    public static List createRange(Object from, Object to, boolean exclusiveLeft, boolean exclusiveRight) {
         try {
-            return ScriptBytecodeAdapter.createRange(from, to, inclusive);
+            return ScriptBytecodeAdapter.createRange(from, to, exclusiveLeft, exclusiveRight);
         } catch (RuntimeException | Error re) {
             throw re;
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }
+    }
+
+    // Kept in for backwards compatibility
+    public static List createRange(Object from, Object to, boolean inclusive) {
+        return createRange(from, to, false, !inclusive);
     }
 
     public static Object bitwiseNegate(Object value) {

--- a/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
@@ -636,38 +636,53 @@ public class ScriptBytecodeAdapter {
     }
 
     public static List createRange(Object from, Object to, boolean exclusiveLeft, boolean exclusiveRight) throws Throwable {
-        if (from instanceof Integer && to instanceof Integer) {
-            int ifrom = (Integer) from;
-            int ito = (Integer) to;
-            if ((!exclusiveLeft && !exclusiveRight) || ifrom != ito) {
-                // Currently, empty ranges where from != to and the range is full exclusive (e.g. 0<..<-1) are
-                // constructed as IntRanges. This is because these ranges can still be used to index into lists.
-                return new IntRange(!exclusiveLeft, !exclusiveRight, ifrom, ito);
-            } // else fall through for EmptyRange
+        if (exclusiveLeft && exclusiveRight) {
+            if (compareEqual(from, to)) {
+                return new EmptyRange((Comparable) from);
+            }
+            Object tmpFrom;
+            if (compareLessThan(from, to)) {
+                tmpFrom = invokeMethod0(ScriptBytecodeAdapter.class, from, "next");
+            } else {
+                tmpFrom = invokeMethod0(ScriptBytecodeAdapter.class, from, "previous");
+            }
+            // Create an empty range if the difference between from and to is one and they have the same sign. This
+            // means that range syntaxes like 5<..<6 will result in an empty range, but 0<..<-1 won't, since the latter
+            // is used in list indexing where negative indices count from the end towards the beginning. Note that
+            // positive numbers and zeros are considered to have the same sign to make ranges like 0<..<1 be EmptyRanges
+            int fromComp = compareTo(from, 0);
+            int toComp = compareTo(to, 0);
+            boolean sameSign = (fromComp >= 0 && toComp >= 0) || (fromComp < 0 && toComp < 0);
+            if (compareEqual(tmpFrom, to) && sameSign) {
+                return new EmptyRange((Comparable) from);
+            }
         }
         if ((exclusiveLeft || exclusiveRight) && compareEqual(from, to)) {
             return new EmptyRange((Comparable) from);
         }
+        if (from instanceof Integer && to instanceof Integer) {
+            int ifrom = (Integer) from;
+            int ito = (Integer) to;
+            if ((!exclusiveLeft && !exclusiveRight) || ifrom != ito) {
+                // Currently, empty ranges where from != to, the range is full exclusive (e.g. 0<..<-1) and from and to
+                // have a different sign are constructed as IntRanges. This is because these ranges can still be used to
+                // index into lists.
+                return new IntRange(!exclusiveLeft, !exclusiveRight, ifrom, ito);
+            }
+        }
         if (from instanceof Number && to instanceof Number) {
             return new NumberRange(comparableNumber((Number) from), comparableNumber((Number) to), !exclusiveLeft, !exclusiveRight);
         }
-        Boolean greater = null;
+        // ObjectRange does not include information about inclusivity, so we need to consider it here
         if (exclusiveRight) {
-            greater = compareGreaterThan(from, to);
-            if (greater) {
+            if (compareGreaterThan(from, to)) {
                 to = invokeMethod0(ScriptBytecodeAdapter.class, to, "next");
             } else {
                 to = invokeMethod0(ScriptBytecodeAdapter.class, to, "previous");
             }
         }
         if (exclusiveLeft) {
-            if (greater == null) {
-                greater = compareGreaterThan(from, to);
-            }
-            if (compareEqual(from, to)) {
-                return new EmptyRange((Comparable) from);
-            }
-            if (greater) {
+            if (compareGreaterThan(from, to)) {
                 from = invokeMethod0(ScriptBytecodeAdapter.class, from, "previous");
             } else {
                 from = invokeMethod0(ScriptBytecodeAdapter.class, from, "next");

--- a/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
@@ -661,14 +661,10 @@ public class ScriptBytecodeAdapter {
             return new EmptyRange((Comparable) from);
         }
         if (from instanceof Integer && to instanceof Integer) {
-            int ifrom = (Integer) from;
-            int ito = (Integer) to;
-            if ((!exclusiveLeft && !exclusiveRight) || ifrom != ito) {
-                // Currently, empty ranges where from != to, the range is full exclusive (e.g. 0<..<-1) and from and to
-                // have a different sign are constructed as IntRanges. This is because these ranges can still be used to
-                // index into lists.
-                return new IntRange(!exclusiveLeft, !exclusiveRight, ifrom, ito);
-            }
+            // Currently, empty ranges where from != to, the range is full exclusive (e.g. 0<..<-1) and from and to
+            // have a different sign are constructed as IntRanges. This is because t3hese ranges can still be used to
+            // index into lists.
+            return new IntRange(!exclusiveLeft, !exclusiveRight, (Integer) from, (Integer) to);
         }
         if (from instanceof Number && to instanceof Number) {
             return new NumberRange(comparableNumber((Number) from), comparableNumber((Number) to), !exclusiveLeft, !exclusiveRight);

--- a/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
@@ -635,7 +635,8 @@ public class ScriptBytecodeAdapter {
         return InvokerHelper.createMap(values);
     }
 
-    public static List createRange(Object from, Object to, boolean inclusive) throws Throwable {
+    public static List createRange(Object from, Object to, boolean exclusiveLeft, boolean exclusiveRight) throws Throwable {
+        boolean inclusive = !exclusiveRight;
         if (from instanceof Integer && to instanceof Integer) {
             int ifrom = (Integer) from;
             int ito = (Integer) to;
@@ -658,6 +659,11 @@ public class ScriptBytecodeAdapter {
         }
 
         return new ObjectRange((Comparable) from, (Comparable) to);
+    }
+
+    // Kept in for backwards compatibility
+    public static List createRange(Object from, Object to, boolean inclusive) throws Throwable {
+        return createRange(from, to, false, !inclusive);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
@@ -641,7 +641,7 @@ public class ScriptBytecodeAdapter {
             int ifrom = (Integer) from;
             int ito = (Integer) to;
             if (inclusive || ifrom != ito) {
-                return new IntRange(inclusive, ifrom, ito);
+                return new IntRange(!exclusiveLeft, !exclusiveRight, ifrom, ito);
             } // else fall through for EmptyRange
         }
         if (!inclusive && compareEqual(from, to)) {

--- a/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
@@ -648,7 +648,7 @@ public class ScriptBytecodeAdapter {
             return new EmptyRange((Comparable) from);
         }
         if (from instanceof Number && to instanceof Number) {
-            return new NumberRange(comparableNumber((Number) from), comparableNumber((Number) to), inclusive);
+            return new NumberRange(comparableNumber((Number) from), comparableNumber((Number) to), !exclusiveLeft, !exclusiveRight);
         }
         if (!inclusive) {
             if (compareGreaterThan(from, to)) {

--- a/src/spec/doc/_working-with-collections.adoc
+++ b/src/spec/doc/_working-with-collections.adoc
@@ -341,6 +341,12 @@ contains the from and to value).
 Ranges defined with the `..<` notation are half-open, they include the
 first value but not the last value.
 
+Ranges defined with the `<..` notation are also half-open, they include the
+last value but not the first value.
+
+Ranges defined with the `<..<` notation are full-open, they do not include the
+first value nor the last value.
+
 [source,groovy]
 ----------------------------------------------------------------------------
 include::../test/gdk/WorkingWithCollectionsTest.groovy[tags=intrange,indent=0]

--- a/src/spec/doc/core-operators.adoc
+++ b/src/spec/doc/core-operators.adoc
@@ -705,8 +705,10 @@ include::../test/OperatorsTest.groovy[tags=intrange,indent=0]
 <1> a simple range of integers, stored into a local variable
 <2> an `IntRange`, with inclusive bounds
 <3> an `IntRange`, with exclusive upper bound
-<4> a `groovy.lang.Range` implements the `List` interface
-<5> meaning that you can call the `size` method on it
+<4> an `IntRange`, with exclusive lower bound
+<5> an `IntRange`, with exclusive lower and upper bounds
+<6> a `groovy.lang.Range` implements the `List` interface
+<7> meaning that you can call the `size` method on it
 
 Ranges implementation is lightweight, meaning that only the lower and upper bounds are stored. You can create a range
 from any `Comparable` object that has `next()` and `previous()` methods to determine the next / previous item in the range.

--- a/src/spec/doc/core-semantics.adoc
+++ b/src/spec/doc/core-semantics.adoc
@@ -1545,7 +1545,7 @@ Groovy provides a syntax for various type literals. There are three native colle
 
 * lists, using the `[]` literal
 * maps, using the `[:]` literal
-* ranges, using `from..to` (inclusive) and `from..<to` (exclusive)
+* ranges, using `from..to` (inclusive), `from..<to` (right exclusive),`from<..to` (left exclusive) and `from<..<to` (full exclusive)
 
 The inferred type of a literal depends on the elements of the literal, as illustrated in the following table:
 

--- a/src/spec/test/OperatorsTest.groovy
+++ b/src/spec/test/OperatorsTest.groovy
@@ -543,6 +543,8 @@ assert function(*args,5,6) == 26
         def range = 0..5                                    // <1>
         assert (0..5).collect() == [0, 1, 2, 3, 4, 5]       // <2>
         assert (0..<5).collect() == [0, 1, 2, 3, 4]         // <3>
+        assert (0<..5).collect() == [1, 2, 3, 4, 5]
+        assert (0<..<5).collect() == [1, 2, 3, 4]
         assert (0..5) instanceof List                       // <4>
         assert (0..5).size() == 6                           // <5>
         // end::intrange[]

--- a/src/spec/test/OperatorsTest.groovy
+++ b/src/spec/test/OperatorsTest.groovy
@@ -543,10 +543,10 @@ assert function(*args,5,6) == 26
         def range = 0..5                                    // <1>
         assert (0..5).collect() == [0, 1, 2, 3, 4, 5]       // <2>
         assert (0..<5).collect() == [0, 1, 2, 3, 4]         // <3>
-        assert (0<..5).collect() == [1, 2, 3, 4, 5]
-        assert (0<..<5).collect() == [1, 2, 3, 4]
-        assert (0..5) instanceof List                       // <4>
-        assert (0..5).size() == 6                           // <5>
+        assert (0<..5).collect() == [1, 2, 3, 4, 5]         // <4>
+        assert (0<..<5).collect() == [1, 2, 3, 4]           // <5>
+        assert (0..5) instanceof List                       // <6>
+        assert (0..5).size() == 6                           // <7>
         // end::intrange[]
         '''
         assertScript '''

--- a/src/test/groovy/GroovyMethodsTest.groovy
+++ b/src/test/groovy/GroovyMethodsTest.groovy
@@ -295,6 +295,9 @@ class GroovyMethodsTest extends GroovyTestCase {
         def list = ['a', 'b', 'c']
         assert list[1..2] == ['b', 'c']
         assert list[0..<0] == []
+        assert list[0<..0] == []
+        assert list[0<..<0] == []
+        assert list[0<..<1] == []
     }
 
     void testCharSequenceGetAt() {

--- a/src/test/groovy/ListTest.groovy
+++ b/src/test/groovy/ListTest.groovy
@@ -312,13 +312,21 @@ class ListTest extends GroovyTestCase {
         assert list[0..0] == [0]          , 'one element range'
         assert list[0..<0] == []          , 'empty range'
         assert list[3..0] == [3, 2, 1, 0] , 'reverse range'
-        assert list[3..<0] == [3, 2, 1]   , 'reverse exclusive range'
+        assert list[3..<0] == [3, 2, 1]   , 'reverse right exclusive range'
+        assert list[3<..0] == [2, 1, 0]   , 'reverse left exclusive range'
+        assert list[3<..<0] == [2, 1]     , 'reverse full exclusive range'
         assert list[-2..-1] == [2, 3]     , 'negative index range'
-        assert list[-2..<-1] == [2]       , 'negative index range exclusive'
+        assert list[-2..<-1] == [2]       , 'negative index range right exclusive'
+        assert list[-2<..-1] == [3]       , 'negative index range left exclusive'
+        assert list[-2<..<-1] == []       , 'negative index range full exclusive'
         assert list[-1..-2] == [3, 2]     , 'negative index range reversed'
-        assert list[-1..<-2] == [3]       , 'negative index range reversed exclusive'  // aaaahhhhh !
+        assert list[-1..<-2] == [3]       , 'negative index range reversed right exclusive'
+        assert list[-1<..-2] == [2]       , 'negative index range reversed left exclusive'
+        assert list[-1<..<-2] == []       , 'negative index range reversed full exclusive'  // aaaaaaahhhhh !
         assert list[0..-1] == list        , 'pos - neg value'
-        assert list[0..<-1] == [0, 1, 2]  , 'pos - neg value exclusive'
+        assert list[0..<-1] == [0, 1, 2]  , 'pos - neg value right exclusive'
+        assert list[0<..-1] == [1, 2, 3]  , 'pos - neg value left exclusive'
+        assert list[0<..<-1] == [1, 2]    , 'pos - neg value full exclusive'
         assert list[0..<-2] == [0, 1]     , 'pos - neg value exclusive'
         shouldFail(GroovyRuntimeException) { list[null] }
         shouldFail(IndexOutOfBoundsException) { list[5..6] }

--- a/src/test/groovy/RangeTest.groovy
+++ b/src/test/groovy/RangeTest.groovy
@@ -329,11 +329,29 @@ class RangeTest extends GroovyTestCase {
         assertSize(0..<0, 0)
         assertSize(1..<1, 0)
         assertSize(-1..<-1, 0)
+        assertSize(-1<..-1, 0)
+        assertSize(-1<..<-1, 0)
+        assertSize(-1<..<-2, 0)
         assertSize('a'..<'a', 0)
+        assertSize('a'<..'a', 0)
+        assertSize('a'<..<'a', 0)
+        assertSize('a'<..<'b', 0)
         assertSize(0.0G..<0.0G, 0)
+        assertSize(0.0G<..0.0G, 0)
+        assertSize(0.0G<..<0.0G, 0)
+        assertSize(0.0G<..<1.0G, 0)
         (0..<0).each { assert false }
+        (0<..0).each { assert false }
+        (0<..<0).each { assert false }
+        (0<..<1).each { assert false }
         (0..<0).step(1) { assert false }
+        (0<..0).step(1) { assert false }
+        (0<..<0).step(1) { assert false }
+        (0<..<1).step(1) { assert false }
         for (i in 0..<0) assert false
+        for (i in 0<..0) assert false
+        for (i in 0<..<0) assert false
+        for (i in 0<..<1) assert false
         assertToString(0..<0, '0..<0', '0..<0')
         assertToString('a'..<'a', 'a..<a', "'a'..<'a'")
         assertToString(null..<null, 'null..<null', 'null..<null')

--- a/src/test/groovy/RangeTest.groovy
+++ b/src/test/groovy/RangeTest.groovy
@@ -36,6 +36,18 @@ class RangeTest extends GroovyTestCase {
         assert x == 45
 
         x = 0
+        for (i in 1<..10) {
+            x = x + i
+        }
+        assert x == 54
+
+        x = 0
+        for (i in 1<..<10) {
+            x = x + i
+        }
+        assert x == 44
+
+        x = 0
         for (i in 0..'\u0009') {
             x = x + i
         }
@@ -54,13 +66,29 @@ class RangeTest extends GroovyTestCase {
             x = x + it
         }
         assert x == 45
+
+        x = 0
+        (1<..10).each {
+            x = x + it
+        }
+        assert x == 54
+
+        x = 0
+        (1<..<10).each {
+            x = x + it
+        }
+        assert x == 44
     }
 
     void testIntStep() {
         assertStep(0..9, 3, [0, 3, 6, 9])
         assertStep(0..<10, 3, [0, 3, 6, 9])
+        assertStep(0<..10, 3, [1, 4, 7, 10])
+        assertStep(0<..<10, 3, [1, 4, 7])
         assertStep(9..0, 3, [9, 6, 3, 0])
         assertStep(9..<0, 3, [9, 6, 3])
+        assertStep(9<..-1, 3, [8, 5, 2, -1])
+        assertStep(9<..<-1, 3, [8, 5, 2])
     }
 
 
@@ -75,8 +103,12 @@ class RangeTest extends GroovyTestCase {
         assertStep('a'..'f', 2, ['a', 'c', 'e'])
         assertStep('f'..'a', 2, ['f', 'd', 'b'])
         assertStep('a'..<'e', 2, ['a', 'c'])
+        assertStep('a'<..'f', 2, ['b', 'd', 'f'])
+        assertStep('a'<..<'f', 2, ['b', 'd'])
         assertStep('z'..'v', 2, ['z', 'x', 'v'])
         assertStep('z'..<'v', 2, ['z', 'x'])
+        assertStep('z'<..'u', 2, ['y', 'w', 'u'])
+        assertStep('z'<..<'u', 2, ['y', 'w'])
     }
 
     void testNegativeObjectStep() {
@@ -87,15 +119,23 @@ class RangeTest extends GroovyTestCase {
     void testIterateIntRange() {
         assertIterate(0..9, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         assertIterate(1..<8, [1, 2, 3, 4, 5, 6, 7])
+        assertIterate(1<..8, [2, 3, 4, 5, 6, 7, 8])
+        assertIterate(1<..<8, [2, 3, 4, 5, 6, 7])
         assertIterate(7..1, [7, 6, 5, 4, 3, 2, 1])
         assertIterate(6..<1, [6, 5, 4, 3, 2])
+        assertIterate(6<..1, [5, 4, 3, 2, 1])
+        assertIterate(6<..<1, [5, 4, 3, 2])
     }
 
     void testIterateObjectRange() {
         assertIterate('a'..'d', ['a', 'b', 'c', 'd'])
         assertIterate('a'..<'d', ['a', 'b', 'c'])
+        assertIterate('a'<..'d', ['b', 'c', 'd'])
+        assertIterate('a'<..<'d', ['b', 'c'])
         assertIterate('z'..'x', ['z', 'y', 'x'])
         assertIterate('z'..<'x', ['z', 'y'])
+        assertIterate('z'<..'x', ['y', 'x'])
+        assertIterate('z'<..<'x', ['y'])
     }
 
     enum RomanNumber {
@@ -146,6 +186,14 @@ class RangeTest extends GroovyTestCase {
         range = 0..<5
         assert range.contains(0) && 0 in range
         assert !range.contains(5) && !(5 in range)
+
+        range = 0<..5
+        assert !range.contains(0) && !(0 in range)
+        assert range.contains(5) && 5 in range
+
+        range = 0<..<5
+        assert !range.contains(0) && !(0 in range)
+        assert !range.contains(5) && !(5 in range)
     }
 
     void testBackwardsRangeContains() {
@@ -155,6 +203,14 @@ class RangeTest extends GroovyTestCase {
 
         range = 5..<1
         assert range.contains(5) && 5 in range
+        assert !range.contains(1) && !(1 in range)
+
+        range = 5<..1
+        assert !range.contains(5) && !(5 in range)
+        assert range.contains(1) && 1 in range
+
+        range = 5<..<1
+        assert !range.contains(5) && !(5 in range)
         assert !range.contains(1) && !(1 in range)
     }
 
@@ -169,6 +225,19 @@ class RangeTest extends GroovyTestCase {
         assert !range.contains('g')
         assert !range.contains('f')
         assert !range.contains('a')
+
+        range = 'b'<..'f'
+        assert range.contains('f')
+        assert !range.contains('b')
+        assert !range.contains('g')
+        assert !range.contains('a')
+
+        range = 'b'<..<'f'
+        assert !range.contains('b')
+        assert !range.contains('f')
+        assert !range.contains('a')
+        assert !range.contains('g')
+        assert range.contains('c')
     }
 
     void testBackwardsObjectRangeContains() {
@@ -182,6 +251,19 @@ class RangeTest extends GroovyTestCase {
         assert range.contains('f')
         assert range.contains('c')
         assert !range.contains('b')
+
+        range = 'f'<..'b'
+        assert !range.contains('f')
+        assert range.contains('b')
+        assert !range.contains('g')
+        assert !range.contains('a')
+
+        range = 'f'<..<'b'
+        assert !range.contains('b')
+        assert !range.contains('f')
+        assert !range.contains('a')
+        assert !range.contains('g')
+        assert range.contains('c')
     }
 
     void testIntRangeToString() {
@@ -191,25 +273,47 @@ class RangeTest extends GroovyTestCase {
         assertToString(0..<11, "0..<11")
         assertToString([1, 4..<11, 9], "[1, 4..<11, 9]")
 
+        assertToString(0<..11, "0<..11")
+        assertToString([1, 4<..11, 9], "[1, 4<..11, 9]")
+
+        assertToString(0<..<11, "0<..<11")
+        assertToString([1, 4<..<11, 9], "[1, 4<..<11, 9]")
+
         assertToString(10..0, "10..0")
         assertToString([1, 10..4, 9], "[1, 10..4, 9]")
 
         assertToString(11..<0, "11..<0")
         assertToString([1, 11..<4, 9], "[1, 11..<4, 9]")
+
+        assertToString(11<..0, "11<..0")
+        assertToString([1, 11<..4, 9], "[1, 11<..4, 9]")
+
+        assertToString(11<..<0, "11<..<0")
+        assertToString([1, 11<..<4, 9], "[1, 11<..<4, 9]")
     }
 
     void testObjectRangeToString() {
         assertToString('a'..'d', 'a..d', "'a'..'d'")
         assertToString('a'..<'d', 'a..c', "'a'..'c'")
+        assertToString('a'<..'d', 'b..d', "'b'..'d'")
+        assertToString('a'<..<'d', 'b..c', "'b'..'c'")
+
         assertToString('z'..'x', 'z..x', "'z'..'x'")
         assertToString('z'..<'x', 'z..y', "'z'..'y'")
+        assertToString('z'<..'x', 'y..x', "'y'..'x'")
+        assertToString('z'<..<'x', 'y..y', "'y'..'y'")
     }
 
     void testRangeSize() {
         assertSize(1..10, 10)
         assertSize(11..<21, 10)
+        assertSize(11<..21, 10)
+        assertSize(11<..<22, 10)
+
         assertSize(30..21, 10)
         assertSize(40..<30, 10)
+        assertSize(40<..30, 10)
+        assertSize(41<..<30, 10)
     }
 
     void testBorderCases() {
@@ -217,6 +321,8 @@ class RangeTest extends GroovyTestCase {
         assertIterate(0..0, [0])
         assertIterate(0..-1, [0, -1])
         assertIterate(0..<-1, [0])
+        assertIterate(0<..-1, [-1])
+        assertIterate(0<..<-1, [])
     }
 
     void testEmptyRanges() {

--- a/src/test/groovy/lang/IntRangeTest.groovy
+++ b/src/test/groovy/lang/IntRangeTest.groovy
@@ -218,4 +218,41 @@ class IntRangeTest extends GroovyTestCase {
         bais.withObjectInputStream { ois -> assert ois.readObject() == [4..1, 2..<5] }
     }
 
+    void testEquals() {
+        IntRange r1 = new IntRange(0, 10)
+        IntRange r2 = new IntRange(0, 10)
+        assert r1.equals(r2)
+        assert r2.equals(r1)
+
+        r1 = new IntRange(true, false, 0, 10)
+        r2 = new IntRange(true, false, 0, 10)
+        assert r1.equals(r2)
+        assert r2.equals(r1)
+
+        r1 = new IntRange(false, 1, 11)
+        r2 = new IntRange(1, 10)
+        assert !r1.equals(r2)
+        assert !r2.equals(r1)
+
+        r1 = new IntRange(false, 1, 10)
+        r2 = new IntRange(1, 10)
+        assert !r1.equals(r2)
+        // As before GROOVY-9649
+        assert r2.equals(r1)
+
+        r1 = new IntRange(false, true, -1, 10)
+        r2 = new IntRange(1, 10)
+        assert !r1.equals(r2)
+        assert !r2.equals(r1)
+
+        r1 = new IntRange(true, true, 10, 0)
+        r2 = new IntRange(0, 10, true)
+        assert !r1.equals(r2)
+        assert !r2.equals(r1)
+
+        r1 = new IntRange(0, 10, true)
+        r2 = new IntRange(0, 10, false)
+        assert !r1.equals(r2)
+        assert !r2.equals(r1)
+    }
 }

--- a/src/test/groovy/lang/IntRangeTest.groovy
+++ b/src/test/groovy/lang/IntRangeTest.groovy
@@ -54,6 +54,11 @@ class IntRangeTest extends GroovyTestCase {
         assert new IntRange(true, 0, 0).size() == 1
         assert new IntRange(false, 0, 1).size() == 1
         assert new IntRange(true, 0, 1).size() == 2
+        assert new IntRange(true, true, 0, 0).size() == 1
+        assert new IntRange(false, true, 0, 0).size() == 0
+        assert new IntRange(false, true, 0, 1).size() == 1
+        assert new IntRange(false, false, 0, 0).size() == 0
+        assert new IntRange(false, false, 0, 1).size() == 0
     }
 
     /**
@@ -90,37 +95,81 @@ class IntRangeTest extends GroovyTestCase {
 
     void testInclusiveRangesWithNegativesAndPositives() {
         final a = [1, 2, 3, 4]
-        assert a[-3..-2] == [2, 3]
-        assert a[-3..<-2] == [2]
-        assert a[2..-3] == [3, 2]
-        assert a[1..-1] == [2, 3, 4]
-        assert a[1..<-1] == [2, 3]
-        assert a[-2..<1] == [3]
-        assert a[-2..<-3] == [3]
-        assert a[5..<5] == []
-        assert a[-5..<-5] == []
+        assert a[-3..-2]   == [2, 3]
+        assert a[-3..<-2]  == [2]
+        assert a[-3<..2]   == [3]
+        assert a[-3<..<-2] == []
+
+        assert a[2..-3]    == [3, 2]
+
+        assert a[1..-1]    == [2, 3, 4]
+        assert a[1..<-1]   == [2, 3]
+        assert a[1<..-1]   == [3, 4]
+        assert a[1<..<-1]  == [3]
+
+        assert a[-2..<1]   == [3]
+        assert a[-2<..1]   == [2]
+        assert a[-2<..<1]  == []
+
+        assert a[-2..<-3]  == [3]
+        assert a[-2<..-3]  == [2]
+        assert a[-2<..<-3] == []
+
+        assert a[5..<5]    == []
+        assert a[5<..5]    == []
+        assert a[5<..<5]   == []
+        assert a[5<..<6]   == []
+        assert a[-5..<-5]  == []
     }
 
     void testInclusiveRangesWithNegativesAndPositivesStrings() {
         def items = 'abcde'
-        assert items[1..-2]   == 'bcd'
-        assert items[1..<-2]  == 'bc'
-        assert items[-3..<-2] == 'c'
-        assert items[-2..-4]  == 'dcb'
-        assert items[-2..<-4] == 'dc'
-        assert items[2..<2] == ''
-        assert items[-2..<-2] == ''
+        assert items[1..-2]    == 'bcd'
+        assert items[1..<-2]   == 'bc'
+        assert items[1<..-2]   == 'cd'
+        assert items[1<..<-2]  == 'c'
+
+        assert items[-3..<-2]  == 'c'
+        assert items[-3<..-2]  == 'd'
+        assert items[-3<..<-2] == ''
+
+        assert items[-2..-4]   == 'dcb'
+        assert items[-2..<-4]  == 'dc'
+        assert items[-2<..-4]  == 'cb'
+        assert items[-2<..<-4] == 'c'
+
+        assert items[2..<2]    == ''
+        assert items[2<..2]    == ''
+        assert items[2<..<2]   == ''
+        assert items[2<..<3]   == ''
+
+        assert items[-2..<-2]  == ''
+        assert items[-2<..-2]  == ''
+        assert items[-2<..<-2] == ''
+        assert items[-2<..<-3] == ''
     }
 
     void testInclusiveRangesWithNegativesAndPositivesPrimBoolArray() {
         boolean[] bs = [true, false, true, true]
-        assert bs[-3..-2]  == [false, true]
-        assert bs[-3..<-2] == [false]
-        assert bs[2..-3]   == [true, false]
-        assert bs[1..-1]   == [false, true, true]
-        assert bs[1..<-1]  == [false, true]
-        assert bs[-2..<1]  == [true]
-        assert bs[-2..<-3] == [true]
+        assert bs[-3..-2]   == [false, true]
+        assert bs[-3..<-2]  == [false]
+        assert bs[-3<..-2]  == [true]
+        assert bs[-3<..<-2] == []
+
+        assert bs[2..-3]    == [true, false]
+
+        assert bs[1..-1]    == [false, true, true]
+        assert bs[1..<-1]   == [false, true]
+        assert bs[1<..-1]   == [true, true]
+        assert bs[1<..<-1]  == [true]
+
+        assert bs[-2..<1]   == [true]
+        assert bs[-2<..1]   == [false]
+        assert bs[-2<..<1]  == []
+
+        assert bs[-2..<-3]  == [true]
+        assert bs[-2<..-3]  == [false]
+        assert bs[-2<..<-3] == []
     }
 
     void testInclusiveRangesWithNegativesAndPositivesBitset() {
@@ -132,13 +181,25 @@ class IntRangeTest extends GroovyTestCase {
         assert bs.toString() == '{1, 2, 6, 10, 14, 16, 17, 18, 23}'
         assert bs[bs.length()-1] == true
         assert bs[-1] == true
-        assert bs[6..17].toString() == '{0, 4, 8, 10, 11}'
-        assert bs[6..<17].toString() == '{0, 4, 8, 10}'
-        assert bs[17..6].toString() == '{0, 1, 3, 7, 11}'
-        assert bs[17..<6].toString() == '{0, 1, 3, 7}'
-        assert bs[-1..-7].toString() == '{0, 5, 6}'
-        assert bs[-1..<-7].toString() == '{0, 5}'
-        assert bs[20..<-8].toString() == '{2, 3}'
+
+        assert bs[6..17].toString()    == '{0, 4, 8, 10, 11}'
+        assert bs[6..<17].toString()   == '{0, 4, 8, 10}'
+        assert bs[6<..17].toString()   == '{3, 7, 9, 10}'
+        assert bs[6<..<17].toString()  == '{3, 7, 9}'
+
+        assert bs[17..6].toString()    == '{0, 1, 3, 7, 11}'
+        assert bs[17..<6].toString()   == '{0, 1, 3, 7}'
+        assert bs[17<..6].toString()   == '{0, 2, 6, 10}'
+        assert bs[17<..<6].toString()  == '{0, 2, 6}'
+
+        assert bs[-1..-7].toString()   == '{0, 5, 6}'
+        assert bs[-1..<-7].toString()  == '{0, 5}'
+        assert bs[-1<..-7].toString()  == '{4, 5}'
+        assert bs[-1<..<-7].toString() == '{4}'
+
+        assert bs[20..<-8].toString()  == '{2, 3}'
+        assert bs[20<..-8].toString()  == '{1, 2, 3}'
+        assert bs[20<..<-8].toString() == '{1, 2}'
     }
 
     void testHashCode(){

--- a/src/test/groovy/lang/NumberRangeTest.groovy
+++ b/src/test/groovy/lang/NumberRangeTest.groovy
@@ -23,9 +23,8 @@ import junit.framework.TestCase
 /**
  * Provides unit tests for the <code>NumberRange</code> class.
  */
-public class NumberRangeTest extends TestCase {
-
-    public void testStep() {
+class NumberRangeTest extends TestCase {
+    void testStep() {
         Range n = new NumberRange(1, 3)
         assert n.step(1) == [1, 2, 3]
         assert n.size() == 3
@@ -72,4 +71,15 @@ public class NumberRangeTest extends TestCase {
         assert Integer.MAX_VALUE == new NumberRange(new BigInteger("-10"), new BigInteger(Long.toString((long) Integer.MAX_VALUE) + 1L)).size()
     }
 
+    void testSizeEdgeCases() {
+        assert new NumberRange(0, 0, false).size() == 0
+        assert new NumberRange(0, 0, true).size() == 1
+        assert new NumberRange(0, 1, false).size() == 1
+        assert new NumberRange(0, 1, true).size() == 2
+        assert new NumberRange(0, 0, true, true).size() == 1
+        assert new NumberRange(0, 0, false, true).size() == 0
+        assert new NumberRange(0, 1, false, true).size() == 1
+        assert new NumberRange(0, 0, false, false).size() == 0
+        assert new NumberRange(0, 1, false, false).size() == 0
+    }
 }

--- a/src/test/org/codehaus/groovy/runtime/powerassert/AssertionRenderingTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/powerassert/AssertionRenderingTest.groovy
@@ -363,6 +363,26 @@ assert (a..<b) == null
             def b = 2
             assert (a..<b) == null
         }
+
+        isRendered '''
+assert (a<..b) == null
+        |   |  |
+        1   2  false
+        ''', { ->
+            def a = 1
+            def b = 2
+            assert (a<..b) == null
+        }
+
+        isRendered '''
+assert (a<..<b) == null
+        |    |  |
+        1    2  false
+        ''', { ->
+            def a = 1
+            def b = 2
+            assert (a<..<b) == null
+        }
     }
 
     @Test

--- a/src/test/org/codehaus/groovy/runtime/powerassert/EvaluationTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/powerassert/EvaluationTest.groovy
@@ -156,6 +156,8 @@ final class EvaluationTest extends GroovyTestCase {
     void testRangeExpression() {
         assert (1..3).contains(3)
         assert !((1..<3).contains(3))
+        assert !((1<..3).contains(1))
+        assert (!(1<..<3).contains(1) && !(1<..<3).contains(3))
     }
 
     void testPropertyExpression() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/completion/antlr4/ReflectionCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/completion/antlr4/ReflectionCompleter.groovy
@@ -69,7 +69,9 @@ import static org.apache.groovy.parser.antlr4.GroovyLexer.NOT
 import static org.apache.groovy.parser.antlr4.GroovyLexer.NOTEQUAL
 import static org.apache.groovy.parser.antlr4.GroovyLexer.OR
 import static org.apache.groovy.parser.antlr4.GroovyLexer.OR_ASSIGN
-import static org.apache.groovy.parser.antlr4.GroovyLexer.RANGE_EXCLUSIVE
+import static org.apache.groovy.parser.antlr4.GroovyLexer.RANGE_EXCLUSIVE_FULL
+import static org.apache.groovy.parser.antlr4.GroovyLexer.RANGE_EXCLUSIVE_LEFT
+import static org.apache.groovy.parser.antlr4.GroovyLexer.RANGE_EXCLUSIVE_RIGHT
 import static org.apache.groovy.parser.antlr4.GroovyLexer.RANGE_INCLUSIVE
 import static org.apache.groovy.parser.antlr4.GroovyLexer.RBRACK
 import static org.apache.groovy.parser.antlr4.GroovyLexer.RPAREN
@@ -349,7 +351,9 @@ class ReflectionCompleter {
                     break
             // may begin expression when outside brackets (from back)
                 case RANGE_INCLUSIVE:
-                case RANGE_EXCLUSIVE:
+                case RANGE_EXCLUSIVE_LEFT:
+                case RANGE_EXCLUSIVE_RIGHT:
+                case RANGE_EXCLUSIVE_FULL:
                 case COLON:
                 case COMMA:
                     if (expectedOpeners.empty()) {


### PR DESCRIPTION
[JIRA Issue](https://issues.apache.org/jira/browse/GROOVY-9649)

This Pull request implements the above feature and adds test cases related to left- and full-open ranges.
We have also added documentation.
This change *should* be backwards-compatible, as old right-exclusive ranges work as before.
We have tried to preserve all old constructors and methods so that this change would be as backwards-compatible as possible.

A few things to note:

- ranges like `0<..<1` where to and from differ by one, the range is full exclusive and to and from share the same sign (positive numbers and zero are considered to have the same sign) are created as `EmptyRange`s.
This is because ranges like `0<..<-1` can still be used to index into lists.
- while testing, we noticed that the following equality test produces different results when the operands are switched:
```groovy
IntRange r1 = new IntRange(false, 1, 10) // "Inclusive-aware" range
IntRange r2 = new IntRange(1, 10) // Non-inclusive-aware range
r1.equals(r2) // Returns false
r2.equals(r1) // Returns true
```
we have not changed this behaviour.

While implementing the feature, we noticed some inconsistencies between different ranges, which we have not altered due to backwards compatibility:
- `NumberRange` and `IntRange` contain information about their inclusivity, but `ObjectRange` inclusivity is taken into account when the range is created
- in `IntRange`, the `getFrom` and `getTo` methods return the actual bounds of that range, whereas `NumberRange`'s corresponging methods return the bounds that the object was created with, even if the bounds are not actually included in the range

This PR was a joint effort by 4 people:

@Exploder98 
@iiroki 
@OttoVayrynen 
@EricssonWilli