### PR TITLE
GROOVY-4990 Make File.write() create any missing directories. Add test.

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -852,6 +852,8 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
     public static void write(File file, String text, String charset, boolean writeBom) throws IOException {
         Writer writer = null;
         try {
+            file.getCanonicalFile().getParentFile().mkdirs();
+
             FileOutputStream out = new FileOutputStream(file);
             if (writeBom) {
                 writeUTF16BomIfRequired(out, charset);

--- a/src/test/org/codehaus/groovy/runtime/ResourceGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/ResourceGroovyMethodsTest.groovy
@@ -28,13 +28,27 @@ class ResourceGroovyMethodsTest {
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder()
 
+
+	@Test
+	void test_Should_write_should_create_missing_directories_and_write() {
+
+		final String filename = "testing.txt"
+		File file = new File(temporaryFolder.getRoot().getAbsolutePath() + "\\foo\\bar\\" + filename);
+		String text = "foobar"
+		String encoding = "UTF-8"
+
+		ResourceGroovyMethods.write(file, text, encoding)
+
+		assert file.getText(encoding) == text;
+	}
+
 	@Test
 	void test_Should_write_String_to_File_using_default_encoding() {
 		File file = temporaryFolder.newFile()
 		String text = 'Hello World'
 		
 		ResourceGroovyMethods.write(file, text)
-		
+
 		assert file.text == text
 	}
 


### PR DESCRIPTION
This PR will:
- Fix issue where `java.io.FileNotFoundException` is thrown when parent directories don't exists
- Add test

https://issues.apache.org/jira/browse/GROOVY-4990