### PR TITLE
GROOVY-10034: do not cast non-primitive array when target is Object[]

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/OperandStack.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/OperandStack.java
@@ -338,6 +338,12 @@ public class OperandStack {
             return;
         }
 
+        // GROOVY-10034: no need to cast non-primitive array when target is "java.lang.Object[]"
+        if (targetType.isArray() && targetType.getComponentType().equals(ClassHelper.OBJECT_TYPE)
+                && top.isArray() && !ClassHelper.isPrimitiveType(top.getComponentType())) {
+            return;
+        }
+
         boolean primTarget = ClassHelper.isPrimitiveType(targetType);
         boolean primTop = ClassHelper.isPrimitiveType(top);
 

--- a/src/test/groovy/bugs/Groovy10034.groovy
+++ b/src/test/groovy/bugs/Groovy10034.groovy
@@ -1,0 +1,17 @@
+package groovy.bugs
+
+import org.codehaus.groovy.classgen.asm.AbstractBytecodeTestCase
+
+final class Groovy10034 extends AbstractBytecodeTestCase {
+    void testObjectArrayParam() {
+        def result = compile method:'test', '''
+            @groovy.transform.CompileStatic
+            def test() {
+                ["x"].toArray(new String[0])
+            }
+        '''
+        int offset = result.indexOf('ANEWARRAY java/lang/String', result.indexOf('--BEGIN--'))
+        assert result.hasStrictSequence(['ANEWARRAY java/lang/String','INVOKEINTERFACE java/util/List.toArray'], offset)
+        // there should be no 'INVOKEDYNAMIC cast' instruction here: ^
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-10034