### PR TITLE
GROOVY-10029: SC: add toArray call for "Type[] array = collectionOfType"

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/ClassHelper.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassHelper.java
@@ -64,6 +64,7 @@ import java.lang.ref.SoftReference;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -148,6 +149,7 @@ public class ClassHelper {
             TUPLE_TYPE = makeWithoutCaching(Tuple.class),
             ITERABLE_TYPE = makeWithoutCaching(Iterable.class),
             REFERENCE_TYPE = makeWithoutCaching(Reference.class),
+            COLLECTION_TYPE = makeWithoutCaching(Collection.class),
             COMPARABLE_TYPE = makeWithoutCaching(Comparable.class),
             GROOVY_OBJECT_TYPE = makeWithoutCaching(GroovyObject.class),
             GENERATED_LAMBDA_TYPE = makeWithoutCaching(GeneratedLambda.class),

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -79,6 +79,7 @@ import static org.codehaus.groovy.ast.ClassHelper.Boolean_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Byte_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.CLASS_Type;
 import static org.codehaus.groovy.ast.ClassHelper.CLOSURE_TYPE;
+import static org.codehaus.groovy.ast.ClassHelper.COLLECTION_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Character_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Double_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Enum_Type;
@@ -162,7 +163,7 @@ public abstract class StaticTypeCheckingSupport {
 
     protected static final ClassNode Matcher_TYPE = makeWithoutCaching(Matcher.class);
     protected static final ClassNode ArrayList_TYPE = makeWithoutCaching(ArrayList.class);
-    protected static final ClassNode Collection_TYPE = makeWithoutCaching(Collection.class);
+    protected static final ClassNode Collection_TYPE = COLLECTION_TYPE; // TODO: deprecate?
     protected static final ClassNode Deprecated_TYPE = makeWithoutCaching(Deprecated.class);
     protected static final ClassNode LinkedHashMap_TYPE = makeWithoutCaching(LinkedHashMap.class);
     protected static final ClassNode LinkedHashSet_TYPE = makeWithoutCaching(LinkedHashSet.class);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-10029

I have verified that the end result no longer passes through `DefaultTypeTransformation#castToType`.  However there are more total bytecode instructions in the after state due to safe method call handling and cast of `toArray` result to the target type.  I suspect the new sequence is faster but I have no direct evidence of that.  Is that a concern?

**Before**
```
  public static void main(java.lang.String... args);
     0  ldc <Class C> [2]
     2  invokedynamic 0 invoke(java.lang.Class) : java.lang.Object [53]
     7  invokedynamic 1 cast(java.lang.Object) : java.lang.String[] [59]
    12  astore_1 [strings]
    13  aload_1 [strings]
    14  pop
    15  return
```

**After** _I have edited because GROOVY-10031 and GROOVY-10034 have reduced the sequence at offset 10_
```
  public static void main(java.lang.String... args);
     0  invokestatic C.m() : java.util.List [42]
     3  dup
     4  astore_1
     5  ifnull 27
     8  aload_1
     9  iconst_0
    10  anewarray java.lang.String [44]
    xx  invokeinterface java.util.List.toArray(java.lang.Object[]) : java.lang.Object[] [64] [nargs: 2]
    xx  goto xx
    xx  aconst_null
    xx  invokedynamic 0 cast(java.lang.Object[]) : java.lang.String[] [67]
    xx  astore_2 [strings]
    xx  aload_2 [strings]
    xx  pop
    xx  return
```