### PR TITLE
GROOVY-9017 DGM methods

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -16786,6 +16786,17 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return left || Boolean.TRUE.equals(right);
     }
 
+    /**   
+     * Logical not for a boolean operator, null input will return true
+     * 
+     * @param self this
+     * @param target boolean operator
+     * @return result of logical not
+     */
+    public static Boolean not(Object self, Boolean target) {
+        return !Boolean.TRUE.equals(target);
+    }
+
     /**
      * Logical implication of two boolean operators
      *
@@ -16810,9 +16821,6 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return left ^ Boolean.TRUE.equals(right);
     }
 
-//    public static Boolean negate(Boolean left) {
-//        return Boolean.valueOf(!left.booleanValue());
-//    }
 
     /**
      * Allows a simple syntax for using timers. This timer will execute the

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.groovy
@@ -293,6 +293,12 @@ class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertFalse(DefaultGroovyMethods.and(true, null))
     }
 
+    void testBooleanNot() {
+        assertTrue(DefaultGroovyMethods.not(false))
+        assertFalse(DefaultGroovyMethods.not(true))
+        assertTrue(DefaultGroovyMethods.not(null))
+    }
+
     void testBooleanXor() {
         assertFalse(DefaultGroovyMethods.xor(true, true))
         assertTrue(DefaultGroovyMethods.xor(true, false))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-9017

Instead of making keywords for and, or and not, we added a Boolean not() method in DefaultGroovyMethods to get most of what was wanted. DGM already had a or() and and() methods.

This PR was made by:
@tomikoskinen
@jonspe
@Justsofun
@rhanlol