### PR TITLE
Fix typo

### DIFF
--- a/src/spec/doc/_working-with-numbers.adoc
+++ b/src/spec/doc/_working-with-numbers.adoc
@@ -33,7 +33,7 @@ The integral literal types are the same as in Java:
 * `short`
 * `int`
 * `long`
-* `java.lang.BigInteger`
+* `java.math.BigInteger`
 
 You can create integral numbers of those types with the following declarations:
 


### PR DESCRIPTION
`java.lang.BigDecimal` does not exist, but `java.math.BigDecimal`