### PR TITLE
GROOVY-9632: Java 8 Type Param Annotation Not Generated in Byte Code

### DIFF
--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -199,7 +199,7 @@ typeParameters
     ;
 
 typeParameter
-    :   className (EXTENDS nls typeBound)?
+    :   annotationsOpt className (EXTENDS nls typeBound)?
     ;
 
 typeBound

--- a/src/main/java/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassNode.java
@@ -158,6 +158,7 @@ public class ClassNode extends AnnotatedNode {
     private ClassNode superClass;
     protected boolean isPrimaryNode;
     protected List<InnerClassNode> innerClasses;
+    private List<AnnotationNode> typeAnnotations = Collections.emptyList();
 
     /**
      * The AST Transformations to be applied during compilation.
@@ -1505,5 +1506,34 @@ public class ClassNode extends AnnotatedNode {
     @Override
     public String getText() {
         return getName();
+    }
+
+    public List<AnnotationNode> getTypeAnnotations() {
+        return typeAnnotations;
+    }
+
+    public List<AnnotationNode> getTypeAnnotations(ClassNode type) {
+        List<AnnotationNode> ret = new ArrayList<>(typeAnnotations.size());
+        for (AnnotationNode node : typeAnnotations) {
+            if (type.equals(node.getClassNode())) {
+                ret.add(node);
+            }
+        }
+        return ret;
+    }
+
+    public void addTypeAnnotation(AnnotationNode annotation) {
+        if (annotation != null) {
+            if (typeAnnotations == Collections.EMPTY_LIST) {
+                typeAnnotations = new ArrayList<>(3);
+            }
+            typeAnnotations.add(annotation);
+        }
+    }
+
+    public void addTypeAnnotations(List<AnnotationNode> annotations) {
+        for (AnnotationNode annotation : annotations) {
+            addTypeAnnotation(annotation);
+        }
     }
 }

--- a/src/main/java/org/codehaus/groovy/classgen/ExtendedVerifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/ExtendedVerifier.java
@@ -25,6 +25,7 @@ import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.ConstructorNode;
 import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.GenericsType;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.PackageNode;
 import org.codehaus.groovy.ast.Parameter;
@@ -48,11 +49,22 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.codehaus.groovy.ast.AnnotationNode.ANNOTATION_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.CONSTRUCTOR_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.FIELD_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.LOCAL_VARIABLE_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.METHOD_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.PACKAGE_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.PARAMETER_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.TYPE_PARAMETER_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.TYPE_TARGET;
+import static org.codehaus.groovy.ast.AnnotationNode.TYPE_USE_TARGET;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.correctToGenericsSpec;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.correctToGenericsSpecRecurse;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.createGenericsSpec;
@@ -70,6 +82,7 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport {
 
     private final SourceUnit source;
     private ClassNode currentClass;
+    private final Map<String, Boolean> repeatableCache = new HashMap<>();
 
     public ExtendedVerifier(SourceUnit sourceUnit) {
         this.source = sourceUnit;
@@ -86,41 +99,99 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport {
         acv.visitClass(node, this.source);
         this.currentClass = node;
         if (node.isAnnotationDefinition()) {
-            visitAnnotations(node, AnnotationNode.ANNOTATION_TARGET);
+            visitAnnotations(node, ANNOTATION_TARGET);
         } else {
-            visitAnnotations(node, AnnotationNode.TYPE_TARGET);
+            visitAnnotations(node, TYPE_TARGET);
+            visitTypeAnnotations(node);
         }
         PackageNode packageNode = node.getPackage();
         if (packageNode != null) {
-            visitAnnotations(packageNode, AnnotationNode.PACKAGE_TARGET);
+            visitAnnotations(packageNode, PACKAGE_TARGET);
+        }
+        visitTypeAnnotations(node.getUnresolvedSuperClass());
+        ClassNode[] interfaces = node.getInterfaces();
+        for (ClassNode anInterface : interfaces) {
+            visitTypeAnnotations(anInterface);
         }
         node.visitContents(this);
     }
 
     @Override
     public void visitField(FieldNode node) {
-        visitAnnotations(node, AnnotationNode.FIELD_TARGET);
+        visitAnnotations(node, FIELD_TARGET);
+        extractTypeUseAnnotations(node.getAnnotations(), node.getType(), FIELD_TARGET);
+        visitTypeAnnotations(node.getType());
     }
 
     @Override
     public void visitDeclarationExpression(DeclarationExpression expression) {
-        visitAnnotations(expression, AnnotationNode.LOCAL_VARIABLE_TARGET);
+        visitAnnotations(expression, LOCAL_VARIABLE_TARGET);
+        visitTypeAnnotations(expression.getType());
     }
 
     @Override
     public void visitConstructor(ConstructorNode node) {
-        visitConstructorOrMethod(node, AnnotationNode.CONSTRUCTOR_TARGET);
+        visitConstructorOrMethod(node, CONSTRUCTOR_TARGET);
     }
 
     @Override
     public void visitMethod(MethodNode node) {
-        visitConstructorOrMethod(node, AnnotationNode.METHOD_TARGET);
+        // by this stage annotations will be resolved so we can determine TYPE_USE ones
+        visitConstructorOrMethod(node, METHOD_TARGET);
+        visitTypeAnnotations(node.getReturnType());
+        extractTypeUseAnnotations(node.getAnnotations(), node.getReturnType(), METHOD_TARGET);
+    }
+
+    private void visitTypeAnnotations(ClassNode node) {
+        visitAnnotations(node, node.getTypeAnnotations(), TYPE_PARAMETER_TARGET);
+        visitGenericsTypeAnnotations(node);
+    }
+
+    private void visitGenericsTypeAnnotations(ClassNode node) {
+        if (node.isUsingGenerics() && node.getGenericsTypes() != null) {
+            for (GenericsType gt : node.getGenericsTypes()) {
+                visitTypeAnnotations(gt.getType());
+                if (gt.getLowerBound() != null) {
+                    visitTypeAnnotations(gt.getLowerBound());
+                }
+                if (gt.getUpperBounds() != null) {
+                    for (ClassNode ub : gt.getUpperBounds()) {
+                        visitTypeAnnotations(ub);
+                    }
+                }
+            }
+        }
+    }
+
+    private void extractTypeUseAnnotations(List<AnnotationNode> mixed, ClassNode targetType, Integer keepTarget) {
+        List<AnnotationNode> typeUseAnnos = new ArrayList<>();
+        for (AnnotationNode anno : mixed) {
+            if (anno.isTargetAllowed(TYPE_USE_TARGET)) {
+                typeUseAnnos.add(anno);
+            }
+        }
+        if (!typeUseAnnos.isEmpty()) {
+            targetType.addTypeAnnotations(typeUseAnnos);
+            targetType.setAnnotated(true);
+            for (AnnotationNode anno : typeUseAnnos) {
+                if (keepTarget != null && !anno.isTargetAllowed(keepTarget)) {
+                    mixed.remove(anno);
+                }
+            }
+        }
     }
 
     private void visitConstructorOrMethod(MethodNode node, int methodTarget) {
         visitAnnotations(node, methodTarget);
         for (Parameter parameter : node.getParameters()) {
-            visitAnnotations(parameter, AnnotationNode.PARAMETER_TARGET);
+            visitAnnotations(parameter, PARAMETER_TARGET);
+            visitTypeAnnotations(parameter.getType());
+            extractTypeUseAnnotations(parameter.getAnnotations(), parameter.getType(), PARAMETER_TARGET);
+        }
+        if (node.getExceptions() != null) {
+            for (ClassNode t : node.getExceptions()) {
+                visitTypeAnnotations(t);
+            }
         }
 
         if (this.currentClass.isAnnotationDefinition() && !node.isStaticConstructor()) {
@@ -152,7 +223,12 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport {
     }
 
     protected void visitAnnotations(AnnotatedNode node, int target) {
-        if (node.getAnnotations().isEmpty()) {
+        List<AnnotationNode> annotations = node.getAnnotations();
+        visitAnnotations(node, annotations, target);
+    }
+
+    private void visitAnnotations(AnnotatedNode node, List<AnnotationNode> annotations, int target) {
+        if (annotations.isEmpty()) {
             return;
         }
         this.currentClass.setAnnotated(true);
@@ -161,7 +237,7 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport {
             return;
         }
         Map<String, List<AnnotationNode>> nonSourceAnnotations = new LinkedHashMap<>();
-        for (AnnotationNode unvisited : node.getAnnotations()) {
+        for (AnnotationNode unvisited : annotations) {
             AnnotationNode visited;
             {
                 ErrorCollector errorCollector = new ErrorCollector(source.getConfiguration());
@@ -175,7 +251,7 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport {
                 List<AnnotationNode> seen = nonSourceAnnotations.get(name);
                 if (seen == null) {
                     seen = new ArrayList<>();
-                } else if (!isRepeatable(visited.getClassNode())) {
+                } else if (!isRepeatable(visited)) {
                     addError("Cannot specify duplicate annotation on the same member : " + name, visited);
                 }
                 seen.add(visited);
@@ -185,7 +261,7 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport {
             // Check if the annotation target is correct, unless it's the target annotating an annotation definition
             // defining on which target elements the annotation applies
             boolean isTargetAnnotation = name.equals("java.lang.annotation.Target");
-            if (!isTargetAnnotation && !visited.isTargetAllowed(target)) {
+            if (!isTargetAnnotation && !visited.isTargetAllowed(target) && !isTypeUseScenario(visited, target)) {
                 addError("Annotation @" + name + " is not allowed on element " + AnnotationNode.targetToName(target), visited);
             }
             visitDeprecation(node, visited);
@@ -194,13 +270,25 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport {
         processDuplicateAnnotationContainers(node, nonSourceAnnotations);
     }
 
-    private boolean isRepeatable(final ClassNode classNode) {
-        for (AnnotationNode anno : classNode.getAnnotations()) {
-            if (anno.getClassNode().getName().equals("java.lang.annotation.Repeatable")) {
-                return true;
+    private boolean isRepeatable(final AnnotationNode annoNode) {
+        ClassNode annoClassNode = annoNode.getClassNode();
+        String name = annoClassNode.getName();
+        if (!repeatableCache.containsKey(name)) {
+            boolean result = false;
+            for (AnnotationNode anno : annoClassNode.getAnnotations()) {
+                if (anno.getClassNode().getName().equals("java.lang.annotation.Repeatable")) {
+                    result = true;
+                    break;
+                }
             }
+            repeatableCache.put(name, result);
         }
-        return false;
+        return repeatableCache.get(name);
+    }
+
+    private boolean isTypeUseScenario(AnnotationNode visited, int target) {
+        // allow type use everywhere except package and constructors
+        return (visited.isTargetAllowed(TYPE_USE_TARGET) && ((target & (PACKAGE_TARGET | CONSTRUCTOR_TARGET)) == 0));
     }
 
     private void processDuplicateAnnotationContainers(AnnotatedNode node, Map<String, List<AnnotationNode>> nonSourceAnnotations) {


### PR DESCRIPTION

Currently marked as draft since it doesn't have tests yet but you can try Jqwik or Bean Validation Api 2.0 examples and they should work, e.g.:

```
@Grab('net.jqwik:jqwik:1.5.1')
import net.jqwik.api.*
import net.jqwik.api.constraints.*

class PropertyBasedTests {
    @Property
    def uniqueInList(@ForAll @Size(5) @UniqueElements List<@IntRange(min = 0, max = 10) Integer> aList) {
        //println aList
        assert aList.size() == aList.toSet().size()
        assert aList.every{ anInt -> anInt >= 0 && anInt <= 10 }
    }
}
```
Also, while the basics are in place for type annotations in code, they haven't been fully wired in yet. So, in the following example, the annotations number greater than 10 aren't wired in yet:

```
@TypeAnno @TypeUseAnno0 @TypeUseAnno1
class MainG<@TypeParameterAnno1 @TypeParameterAnno2 X, @TypeParameterAnno2 Y extends @TypeUseAnno8 File>
extends @TypeUseAnno9 Object
implements @TypeUseAnno5 Remote {

    @ConstructorAnno MainG() {}

    public @FieldAnno Map<@TypeUseAnno0 ? extends @TypeUseAnno1 CharSequence, @TypeUseAnno2 List<@TypeUseAnno3 ?>> documents = null;

    public @TypeUseAnno4 List<@TypeUseAnno5 ? super @TypeUseAnno6 Integer> numbers = Arrays.<@TypeUseAnno17 Integer>asList(5, 3, 50, 24, 40, 2, 9, 18);

    <@TypeUseAnno0 @TypeParameterAnno2 E extends @TypeUseAnno1 Number & @TypeUseAnno2 List<@TypeUseAnno3 E>> void foo(@TypeUseAnno4 E arg) {
        try {
            numbers.addAll(new @TypeUseAnno15 ArrayList<@TypeUseAnno16 Integer>());
        } catch (@TypeUseAnno17 Throwable ignore) {
        }
    }

    @TypeUseAnno0 Map<@TypeUseAnno1 ? extends X, ? super @TypeUseAnno2 Y>
    get(@TypeUseAnno3 @ParameterAnno @TypeUseAndParameterAnno List<@TypeUseAnno4 List<@TypeUseAnno5 X>> arg1,
        Map<@TypeUseAnno6 ? extends @TypeUseAnno7 X, @TypeUseAnno8 ? super @TypeUseAnno9 Y> arg2
    ) throws @TypeUseAnno0 RuntimeException {
        @TypeUseAnno10 List<@TypeUseAnno11 Integer> numbers = Arrays.<@TypeUseAnno13 Integer>asList(5, 3, 50, 24, 40, 2, 9, 18);
        if (arg2 instanceof @TypeUseAnno12 Number) {
            return (@TypeUseAnno13 Map<@TypeUseAnno14 ? extends X, ? super @TypeUseAnno15 Y>) null;
        }
        //if (numbers.stream().sorted(@TypeUseAnno16 Integer::compareTo).count() > 0) return null;
        return arg2;
    }
}
```
The commented out line (2nd last line of code) doesn't currently parse.