### PR TITLE
better distinction between Object and dynamic types

### DIFF
--- a/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -874,7 +874,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     @Override
     public List<ClassNode> visitCatchType(final CatchTypeContext ctx) {
         if (!asBoolean(ctx)) {
-            return Collections.singletonList(ClassHelper.DYNAMIC_TYPE);
+            return Collections.singletonList(ClassHelper.makeDynamicType());
         }
 
         return ctx.qualifiedClassName().stream()
@@ -1706,7 +1706,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     @Override
     public ClassNode visitReturnType(final ReturnTypeContext ctx) {
         if (!asBoolean(ctx)) {
-            return ClassHelper.OBJECT_TYPE.getPlainNodeReference();
+            return ClassHelper.makeDynamicType();
         }
 
         if (asBoolean(ctx.type())) {
@@ -3633,7 +3633,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     public Parameter[] visitStandardLambdaParameters(final StandardLambdaParametersContext ctx) {
         if (asBoolean(ctx.variableDeclaratorId())) {
             VariableExpression variable = this.visitVariableDeclaratorId(ctx.variableDeclaratorId());
-            Parameter parameter = new Parameter(ClassHelper.OBJECT_TYPE.getPlainNodeReference(), variable.getName());
+            Parameter parameter = new Parameter(ClassHelper.makeDynamicType(), variable.getName());
             configureAST(parameter, variable);
             return new Parameter[]{parameter};
         }
@@ -3859,7 +3859,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     @Override
     public ClassNode visitType(final TypeContext ctx) {
         if (!asBoolean(ctx)) {
-            return ClassHelper.OBJECT_TYPE.getPlainNodeReference();
+            return ClassHelper.makeDynamicType();
         }
 
         ClassNode classNode = null;

--- a/src/main/java/org/codehaus/groovy/ast/ClassHelper.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassHelper.java
@@ -100,7 +100,9 @@ public class ClassHelper {
     };
 
     public static final ClassNode
-            DYNAMIC_TYPE = makeCached(Object.class),
+            DYNAMIC_TYPE = makeCached(Object.class).setDynamicTyped(true),
+            // todo OBJECT_TYPE should be make(Object.class.getName()) or similar to clearly distinguish from DYNAMIC_TYPE,
+            //      but there are still usages of OBJECT_TYPE around, that are meant to cover DYNAMIC_TYPE too
             OBJECT_TYPE = DYNAMIC_TYPE,
             CLOSURE_TYPE = makeCached(Closure.class),
             GSTRING_TYPE = makeCached(GString.class),
@@ -288,6 +290,10 @@ public class ClassHelper {
         return makeWithoutCaching(name);
     }
 
+    public static ClassNode makeDynamicType() {
+        return OBJECT_TYPE.getPlainNodeReference().setDynamicTyped(true);
+    }
+
     private static final Map<ClassNode, ClassNode> PRIMITIVE_TYPE_TO_WRAPPER_TYPE_MAP = Maps.of(
             boolean_TYPE, Boolean_TYPE,
             byte_TYPE, Byte_TYPE,
@@ -413,7 +419,7 @@ public class ClassHelper {
     }
 
     public static boolean isDynamicTyped(ClassNode type) {
-        return type != null && DYNAMIC_TYPE == type.redirect();
+        return type != null && type.isDynamicTyped();
     }
 
     public static boolean isPrimitiveBoolean(ClassNode type) {

--- a/src/main/java/org/codehaus/groovy/ast/ClassHelper.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassHelper.java
@@ -290,6 +290,11 @@ public class ClassHelper {
         return makeWithoutCaching(name);
     }
 
+    /**
+     * Create a dynamically typed ClassNode wrapping <em>java.lang.Object</em>.<br />
+     * A new instance will be returned to allow to attach annotations as well.
+     * @return the created ClassNode.
+     */
     public static ClassNode makeDynamicType() {
         return OBJECT_TYPE.getPlainNodeReference().setDynamicTyped(true);
     }

--- a/src/main/java/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassNode.java
@@ -472,11 +472,29 @@ public class ClassNode extends AnnotatedNode {
         return properties;
     }
 
+    /**
+     * Indicate that that ClassNode is dynamically typed, which means it is either weakly typed and
+     * replaced by <em>java.lang.Object</em> or that the type is to be inferred by Groovy.<br />
+     * This can apply to variables, parameters, return types and others.
+     * Usually this happens when the type is absent or in conjunction with the <em>def</em> or <em>var</em> keywords.<br />
+     * The method is package private and should only be accessed through {@link ClassHelper}.
+     * @param dynamicTyped true, if this ClassNode should be treated as dynamically typed.
+     * @return this ClassNode.
+     * @see #isDynamicTyped()
+     * @see ClassHelper#makeDynamicType()
+     */
     ClassNode setDynamicTyped(boolean dynamicTyped) {
         this.dynamicTyped = dynamicTyped;
         return this;
     }
 
+    /**
+     * Inquire, if this ClassNode is indicated to be dynamically typed.<br />
+     * The method is package private and should only be accessed through {@link ClassHelper}.
+     * @return true, if this ClassNode should be treated as dynamically typed.
+     * @see #setDynamicTyped(boolean)
+     * @see ClassHelper#isDynamicTyped(ClassNode)
+     */
     boolean isDynamicTyped() {
         return dynamicTyped;
     }

--- a/src/main/java/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassNode.java
@@ -144,6 +144,7 @@ public class ClassNode extends AnnotatedNode {
     private String name;
     private int modifiers;
     private boolean syntheticPublic;
+    private boolean dynamicTyped;
     private ClassNode[] interfaces;
     private MixinNode[] mixins;
     private List<Statement> objectInitializers;
@@ -469,6 +470,15 @@ public class ClassNode extends AnnotatedNode {
         if (properties == null)
             properties = new ArrayList<>();
         return properties;
+    }
+
+    ClassNode setDynamicTyped(boolean dynamicTyped) {
+        this.dynamicTyped = dynamicTyped;
+        return this;
+    }
+
+    boolean isDynamicTyped() {
+        return dynamicTyped;
     }
 
     public List<ConstructorNode> getDeclaredConstructors() {

--- a/src/test/org/codehaus/groovy/ast/DynamicTypeTest.groovy
+++ b/src/test/org/codehaus/groovy/ast/DynamicTypeTest.groovy
@@ -1,0 +1,191 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.ast
+
+import groovy.test.GroovyTestCase
+import org.codehaus.groovy.ast.builder.AstBuilder
+import org.codehaus.groovy.ast.expr.DeclarationExpression
+import org.codehaus.groovy.ast.expr.LambdaExpression
+import org.codehaus.groovy.ast.stmt.ExpressionStatement
+import org.codehaus.groovy.ast.stmt.TryCatchStatement
+import org.codehaus.groovy.control.CompilePhase
+
+/**
+ * Test aspects of dynamic typing, where it applies and where not.<br />
+ * Some aspects might be covered by other tests, too.
+ * @see MethodNodeTest
+ * @see org.codehaus.groovy.classgen.ClassCompletionVerifierTest#testDetectsInvalidCatchType()
+ */
+class DynamicTypeTest extends GroovyTestCase {
+
+    void testGenericProperties() {
+        def ast = new AstBuilder().buildFromString(CompilePhase.SEMANTIC_ANALYSIS, false, $/\
+            class C<T> {
+               private T x;
+               private def y;
+               private Object z;
+            }/$.stripIndent())
+        def fields = getClassNode(ast).fields
+        assertEquals(3, fields.size())
+        assertFalse(ClassHelper.isDynamicTyped(getFieldType(fields, 'x')))
+        assertTrue(ClassHelper.isDynamicTyped(getFieldType(fields, 'y')))
+        assertFalse(ClassHelper.isDynamicTyped(getFieldType(fields, 'z')))
+    }
+
+    void testCatchType() {
+        def ast = new AstBuilder().buildFromString(CompilePhase.SEMANTIC_ANALYSIS, false, $/\
+            class C<T> {
+               // this is allowed in phase SEMANTIC_ANALYSIS, but CLASS_GENERATION would fail 
+               def catching1() {
+                  try {
+                     42 / 0
+                  } catch (T ex) {
+                     ex.printStackTrace()
+                  }
+               }
+               def catching2() {
+                  try {
+                     42 / 0
+                  } catch (Throwable t) {
+                     t.printStackTrace()
+                  }
+               }
+            }
+            /$.stripIndent())
+        def methods = getClassNode(ast).methods
+        assertEquals(2, methods.size())
+        assertFalse(ClassHelper.isDynamicTyped(getOneCatchStatement(methods, 'catching1').variable.type))
+        assertFalse(ClassHelper.isDynamicTyped(getOneCatchStatement(methods, 'catching2').variable.type))
+        ast = new AstBuilder().buildFromString(CompilePhase.SEMANTIC_ANALYSIS, false, $/\
+            class C<T extends Throwable> {
+               def catching1() {
+                  try {
+                     42 / 0
+                  } catch (T ex) {
+                     ex.printStackTrace()
+                  }
+               }
+               def catching2() {
+                  try {
+                     42 / 0
+                  } catch (t) {
+                     t.printStackTrace()
+                  }
+               }
+            }
+            /$.stripIndent())
+        methods = getClassNode(ast).methods
+        assertEquals(2, methods.size())
+        assertFalse(ClassHelper.isDynamicTyped(getOneCatchStatement(methods, 'catching1').variable.type))
+        // the type is unspecified, but coerced to java.lang.Exception, hence it is not dynamic
+        assertFalse(ClassHelper.isDynamicTyped(getOneCatchStatement(methods, 'catching2').variable.type))
+        // only in the CONVERSION phase it is dynamic, before type coercion happened
+        // REMARK: this is an implementation specific behaviour and not strictly necessary for a correct result
+        // --> if this check fails it does not necessarily mean that parsing is broken
+        ast = new AstBuilder().buildFromString(CompilePhase.CONVERSION, false, $/\
+            class C<T extends Throwable> {
+               def catching() {
+                  try {
+                     42 / 0
+                  } catch (t) {
+                     t.printStackTrace()
+                  }
+               }
+            }
+            /$.stripIndent())
+        methods = getClassNode(ast).methods
+        assertEquals(1, methods.size())
+        assertTrue(ClassHelper.isDynamicTyped(getOneCatchStatement(methods, 'catching').variable.type))
+    }
+
+    void testLambdaParameters() {
+        def ast = new AstBuilder().buildFromString(CompilePhase.SEMANTIC_ANALYSIS, false, $/\
+            import java.util.function.Function
+            Function f = (s) -> { s.toUpperCase() }
+            /$.stripIndent())
+        def expression = getOneExpression(getClassNode(ast).methods, 'run')
+        assertTrue(expression instanceof DeclarationExpression)
+        assertTrue((expression as DeclarationExpression).rightExpression instanceof LambdaExpression)
+        def lambda = (expression as DeclarationExpression).rightExpression as LambdaExpression
+        assertTrue(ClassHelper.isDynamicTyped(lambda.parameters[0].type))
+        ast = new AstBuilder().buildFromString(CompilePhase.SEMANTIC_ANALYSIS, false, $/\
+            import java.util.function.Function
+            Function f = (String s) -> { s.toUpperCase() }
+            /$.stripIndent())
+        expression = getOneExpression(getClassNode(ast).methods, 'run')
+        assertTrue(expression instanceof DeclarationExpression)
+        assertTrue((expression as DeclarationExpression).rightExpression instanceof LambdaExpression)
+        lambda = (expression as DeclarationExpression).rightExpression as LambdaExpression
+        assertFalse(ClassHelper.isDynamicTyped(lambda.parameters[0].type))
+    }
+
+    void testDynamicReturnType() {
+        def ast = new AstBuilder().buildFromString(CompilePhase.SEMANTIC_ANALYSIS, false, $/\
+            class C<T> {
+               def m(p = 'x') {}
+               Object n() {}
+               T o() {}
+            }
+            /$.stripIndent())
+        def methods = getClassNode(ast).methods
+        assertEquals(3, methods.size())
+        assertTrue(ClassHelper.isDynamicTyped(methods.get(0).returnType))
+        assertFalse(ClassHelper.isDynamicTyped(methods.get(1).returnType))
+        assertFalse(ClassHelper.isDynamicTyped(methods.get(2).returnType))
+        assertTrue(methods.get(0).dynamicReturnType)
+        assertFalse(methods.get(1).dynamicReturnType)
+        assertFalse(methods.get(2).dynamicReturnType)
+    }
+
+    private static ClassNode getClassNode(List<ASTNode> ast) {
+        // the first node is an empty BlockStatement, the class is the second node
+        assertTrue(ast.size() > 1)
+        def classNode = ast.get(1)
+        assertTrue(classNode instanceof ClassNode)
+        classNode as ClassNode
+    }
+
+    private static def getFieldType(List<FieldNode> fields, String name) {
+        for (FieldNode field : fields) {
+            if (name == field.name) {
+                return field.getType()
+            }
+        }
+    }
+
+    private static def getOneCatchStatement(List<MethodNode> methods, String name) {
+        for (MethodNode method : methods) {
+            if (name == method.name) {
+                assertTrue(method.firstStatement instanceof TryCatchStatement)
+                def catchStatements = (method.firstStatement as TryCatchStatement).catchStatements
+                assertEquals(1, catchStatements.size())
+                return catchStatements.get(0)
+            }
+        }
+    }
+
+    private static def getOneExpression(List<MethodNode> methods, String name) {
+        for (MethodNode method : methods) {
+            if (name == method.name) {
+                assertTrue(method.firstStatement instanceof ExpressionStatement)
+                return (method.firstStatement as ExpressionStatement).expression
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Harald Fassler <harald.fassler+9974@gmail.com>

A proposal (draft) for a step towards better distinction between types of java.lang.Object and dynmic types.
More tests need to be added.