### PR TITLE
GROOVY-8678: allow floating point literals without leading zeroes

### DIFF
--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -633,7 +633,7 @@ FloatingPointLiteral
 
 fragment
 DecimalFloatingPointLiteral
-    :   Digits Dot Digits ExponentPart? FloatTypeSuffix?
+    :   Digits? Dot Digits ExponentPart? FloatTypeSuffix?
     |   Digits ExponentPart FloatTypeSuffix?
     |   Digits FloatTypeSuffix
     ;

--- a/src/spec/test/SyntaxTest.groovy
+++ b/src/spec/test/SyntaxTest.groovy
@@ -111,6 +111,7 @@ class SyntaxTest extends CompilableTestSupport {
         assert 456G == new BigInteger('456')
         assert 456g == new BigInteger('456')
         assert 123.45 == new BigDecimal('123.45') // default BigDecimal type used
+        assert .321 == new BigDecimal('.321')
         assert 1.200065D == new Double('1.200065')
         assert 1.234F == new Float('1.234')
         assert 1.23E23D == new Double('1.23E23')

--- a/src/test/groovy/bugs/Groovy8678.groovy
+++ b/src/test/groovy/bugs/Groovy8678.groovy
@@ -1,0 +1,38 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+@CompileStatic
+final class Groovy8678 {
+
+    @Test
+    void testFloatingPointLiteralWithoutLeadingZero() {
+        assertScript '''
+            def aFloat = .42
+            assert (aFloat as String) == '0.42'
+            assert aFloat / .21 == 2
+            assert aFloat / 2 == .21
+        '''
+    }
+}


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/GROOVY-8678

Signed-off-by: Harald Fassler <harald.fassler+9974@gmail.com>