### PR TITLE
GROOVY-10141: retain parse order of anon. inner types in module classes

### DIFF
--- a/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -3250,13 +3250,12 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
         anonymousInnerClass.setAnonymous(true);
         anonymousInnerClass.putNodeMetaData(CLASS_NAME, innerClassName);
         configureAST(anonymousInnerClass, ctx);
+        classNodeList.add(anonymousInnerClass);
 
         classNodeStack.push(anonymousInnerClass);
         ctx.classBody().putNodeMetaData(CLASS_DECLARATION_CLASS_NODE, anonymousInnerClass);
         this.visitClassBody(ctx.classBody());
         classNodeStack.pop();
-
-        classNodeList.add(anonymousInnerClass);
 
         return anonymousInnerClass;
     }

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -1758,6 +1758,26 @@ final class InnerClassTest {
         '''
     }
 
+    @Test // GROOVY-10141
+    void testInnerClassIn2xAIC() {
+        assertScript '''
+            class Outer {
+                class Inner {
+                }
+                def obj = new Object() {
+                    String toString() {
+                        new Object() {
+                            String toString() {
+                                new Inner()
+                            }
+                        }
+                    }
+                }
+            }
+            new Outer().obj.toString()
+        '''
+    }
+
     @Test // GROOVY-8274
     void testMissingMethodHandling() {
         assertScript '''


### PR DESCRIPTION
- InnerClassVisitor checks this$0 which isn't set up if C$1$1 before C$1

https://issues.apache.org/jira/browse/GROOVY-10141