### PR TITLE
GROOVY-9999,GROOVY-8488:STC:make decimal literal parameter can auto c…

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/expr/ConstantExpression.java
+++ b/src/main/java/org/codehaus/groovy/ast/expr/ConstantExpression.java
@@ -39,7 +39,7 @@ public class ConstantExpression extends Expression {
     public static final ConstantExpression VOID = new ConstantExpression(Void.class);
     public static final ConstantExpression EMPTY_EXPRESSION = new ConstantExpression(null);
 
-    private final Object value;
+    private Object value;
     private String constantName;
 
     public ConstantExpression(Object value) {
@@ -121,5 +121,9 @@ public class ConstantExpression extends Expression {
 
     public boolean isEmptyStringExpression() {
         return "".equals(value);
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
     }
 }

--- a/src/test/groovy/bugs/Groovy8488.groovy
+++ b/src/test/groovy/bugs/Groovy8488.groovy
@@ -16,19 +16,33 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package groovy.bugs
+package bugs
 
+import groovy.test.GroovyTestCase
 import groovy.transform.CompileStatic
 import org.junit.Test
 
-import static groovy.test.GroovyAssert.assertScript
-
 @CompileStatic
-final class Groovy8948 {
+final class Groovy8488 extends GroovyTestCase{
+
     @Test
-    void test1() {
-        assertScript '''
-            assert 1.0 == Math.ceil(1/2)
+    void testMethodStaticCheckWithDecimalParameter(){
+        def shell = new GroovyShell()
+        shell.parse '''
+        import groovy.transform.CompileStatic
+
+        @CompileStatic
+        class Static {
+
+            def main() {
+                meth(1.0) // STC error
+            }
+
+            def meth(double val) {
+            }
+        }
         '''
     }
+
+
 }

--- a/src/test/groovy/bugs/Groovy9999.groovy
+++ b/src/test/groovy/bugs/Groovy9999.groovy
@@ -1,0 +1,71 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bugs
+
+import groovy.test.GroovyTestCase
+import groovy.transform.CompileStatic
+import org.junit.Test
+
+@CompileStatic
+final class Groovy9999 extends GroovyTestCase{
+
+    @Test
+    void testMethodStaticCheckWithDecimalParameter(){
+        def shell = new GroovyShell()
+        shell.evaluate '''
+        import groovy.transform.TypeChecked
+
+        @TypeChecked
+        def test() {
+            Math.sqrt(Math.PI*2)
+        }
+        '''
+    }
+    @Test
+    void testMethodStaticCheckWithDecimalLiteralParameter(){
+        def shell = new GroovyShell()
+        shell.evaluate '''
+        import groovy.transform.TypeChecked
+
+        @TypeChecked
+        def test() {
+            Math.sqrt(4.0)
+        }
+        '''
+    }
+
+    //additional test
+
+    @Test
+    void testMultiParameterMethodStaticCheckWithDecimalLiteralParameter(){
+        def shell = new GroovyShell()
+        shell.evaluate '''
+        import groovy.transform.TypeChecked
+        
+        @TypeChecked
+        def test() {
+            multiParameterMethod(1.0,2.0,3.0,2)
+        }
+        
+        def multiParameterMethod(double a,float b ,BigDecimal c,int d){
+        
+        }
+        '''
+    }
+}


### PR DESCRIPTION
fix GROOVY-9999,GROOVY-8488, in general, make literal such as "4.0" could be use in double param method such as "Math.sqrt(double a)".