### PR TITLE
SC: skip `ScriptBytecodeAdapter` for `!in` via `isNotCase` extension methods

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -1086,8 +1086,8 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         return InvokerHelper.invokeMethod(object, method, arguments);
     }
 
-    // isCase methods
     //-------------------------------------------------------------------------
+    // isCase/isNotCase
 
     /**
      * Method for overloading the behavior of the 'case' method in switch statements.
@@ -1219,6 +1219,50 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     public static boolean isCase(Number caseValue, Number switchValue) {
         return NumberMath.compareTo(caseValue, switchValue) == 0;
     }
+
+    /**
+     * @since 4.0.0
+     */
+    public static boolean isNotCase(Number caseValue, Number switchValue) {
+        return !isCase(caseValue, switchValue);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public static boolean isNotCase(Object caseValue, Object switchValue) {
+        return !isCase(caseValue, switchValue);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public static boolean isNotCase(Class<?> caseValue, Object switchValue) {
+        return !isCase(caseValue, switchValue);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public static boolean isNotCase(Closure<?> caseValue, Object switchValue) {
+        return !caseValue.isCase(switchValue);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public static boolean isNotCase(Collection<?> caseValue, Object switchValue) {
+        return !isCase(caseValue, switchValue);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public static boolean isNotCase(Map<?, ?>     caseValue, Object switchValue) {
+        return !isCase(caseValue, switchValue);
+    }
+
+    //--------------------------------------------------------------------------
 
     /**
      * Returns an iterator equivalent to this iterator with all duplicated items removed

--- a/src/main/java/org/codehaus/groovy/runtime/StringGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/StringGroovyMethods.java
@@ -1726,6 +1726,20 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * @since 4.0.0
+     */
+    public static boolean isNotCase(final CharSequence caseValue, final Object switchValue) {
+        return !isCase(caseValue, switchValue);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public static boolean isNotCase(final Pattern caseValue, final Object switchValue) {
+        return !isCase(caseValue, switchValue);
+    }
+
+    /**
      * Determines if a CharSequence can be parsed as a Number.
      *
      * @param self a CharSequence


### PR DESCRIPTION
Do these make sense to add as extension methods?  I would not expect to see these used directly in code, but they could be, I supppose, if user did not want to prefix expression with `!`.  Current STC checks for `"isNotCase"` and finds nothing so it falls back to `ScriptBytecodeAdapter`'s [implementation](https://github.com/apache/groovy/blob/master/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java#L714).

I chose to add `Closure`'s as an extension method rather than a new direct method.  Here is its `isCase`: https://github.com/apache/groovy/blob/master/src/main/java/groovy/lang/Closure.java#L398

https://issues.apache.org/jira/browse/GROOVY-10239