### PR TITLE
Make consistent with #1141

### DIFF
--- a/src/main/java/groovy/util/Node.java
+++ b/src/main/java/groovy/util/Node.java
@@ -709,7 +709,7 @@ public class Node implements Serializable, Cloneable {
      * @since 2.5.0
      */
     public void breadthFirst(Map<String, Object> options, Closure c) {
-        boolean preorder = Boolean.valueOf(options.get("preorder").toString());
+        boolean preorder = Boolean.parseBoolean(options.get("preorder").toString());
         if (preorder) callClosureForNode(c, this, 1);
         breadthFirstRest(preorder, 2, c);
         if (!preorder) callClosureForNode(c, this, 1);


### PR DESCRIPTION
In #1141, `Node#depthFirst` was modified to use `Boolean#parseBoolean` instead of `Boolean#valueOf` ([here](https://github.com/apache/groovy/pull/1141/files#diff-6ce3c6667b435203886c05db2ba7cd666bd9918d2af8881530a56f554ef1c30fR610)), but its similar method, `Node#breadthFirst` was not.
I modified the method to make consistent with the change.