### PR TITLE
GROOVY-10282: GenericsUtils: do not mix type parameter contexts

### DIFF
--- a/src/test/groovy/transform/stc/LambdaTest.groovy
+++ b/src/test/groovy/transform/stc/LambdaTest.groovy
@@ -117,7 +117,7 @@ final class LambdaTest {
         '''
     }
 
-    @Test @NotYetImplemented
+    @Test // GROOVY-10282
     void testBiFunctionAndBinaryOperatorWithSharedTypeParameter() {
         assertScript '''
             import groovy.transform.CompileStatic


### PR DESCRIPTION
collect for `BiFunction<U, ? super T, U>` yields `[T:U, U:? super T, R:U]` not `[T:? super T, U:? super T, R:? super T]`

https://issues.apache.org/jira/browse/GROOVY-10282