### PR TITLE
GROOVY-9006: STC: compare to null for types that overload equals

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -4474,6 +4474,11 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         if (mathResultType != null) {
             return mathResultType;
         }
+        // GROOVY-9006: compare to null for types that overload equals
+        if ("equals".equals(operationName) && (left == UNKNOWN_PARAMETER_TYPE
+                                            || right == UNKNOWN_PARAMETER_TYPE)) {
+            return boolean_TYPE;
+        }
         // GROOVY-5890: do not mix Class<Type> with Type
         if (leftExpression instanceof ClassExpression) {
             left = CLASS_Type.getPlainNodeReference();

--- a/src/test/groovy/transform/stc/BugsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/BugsSTCTest.groovy
@@ -788,6 +788,21 @@ Printer
         '''
     }
 
+    // GROOVY-9006
+    void testAmbiguousMethodResolutionTimestampComparedToNull() {
+        assertScript '''
+            import java.sql.Timestamp
+
+            def test(Timestamp timestamp) {
+                if (timestamp != null) { // Reference to method is ambiguous
+                    return 'not null'
+                }
+            }
+            def result = test(new Timestamp(new Date().getTime()))
+            assert result == 'not null'
+        '''
+    }
+
     // GROOVY-6911
     void testShouldNotThrowArrayIndexOfOutBoundsException() {
         assertScript '''


### PR DESCRIPTION
This seemed like the best place to check for compare to null in STC.  `getMathResultType` is pretty focused on numbers.  Dynamic code still delegates to `ScriptBytecodeAdapter#compareNotEqual` and static compilation converts to `CompareToNullExpression` as before.

https://issues.apache.org/jira/browse/GROOVY-9006