### PR TITLE
GROOVY-10353: `evaluateExpression` can handle simple expression directly

### DIFF
--- a/src/main/java/groovy/lang/GroovyClassLoader.java
+++ b/src/main/java/groovy/lang/GroovyClassLoader.java
@@ -703,10 +703,10 @@ public class GroovyClassLoader extends URLClassLoader {
     }
 
     /**
-     * open up the super class define that takes raw bytes
+     * Converts an array of bytes into an instance of {@code Class}.
      */
-    public Class defineClass(String name, byte[] b) {
-        return super.defineClass(name, b, 0, b.length);
+    public Class defineClass(final String name, final byte[] bytes) throws ClassFormatError {
+        return super.defineClass(name, bytes, 0, bytes.length);
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-10353

When inspecting the `@ClosureParams` or `@DelegatesTo` metadata of methods, it is typical to require:
```
eval((java.lang.Integer) 1)
eval((java.lang.Integer) 1)
eval((java.lang.String) "")
eval((java.lang.Integer) 1)
eval((java.lang.Integer) -1)
eval((java.lang.String) "self")
eval((java.lang.String) "self")
eval((java.lang.Class<T>) groovy.transform.stc.FirstParam)
eval((java.lang.String[]) [])
eval((java.lang.Integer) 1)
eval((java.lang.Integer) 1)
eval((java.lang.String) "")
eval((java.lang.Integer) 1)
eval((java.lang.Integer) -1)
eval((java.lang.String) "self")
eval((java.lang.String) "self")
eval((java.lang.Class<T>) groovy.transform.stc.FirstParam)
eval((java.lang.String[]) [])
eval((java.lang.Class<T>) groovy.transform.stc.SimpleType)
eval((java.lang.String[]) ["java.io.File"])
eval("java.io.File")
```

I tried to return the class directly from `ClassExpression` where `getType()` returns a `ClassNode` with a class loaded -- `groovy.transform.stc.FirstParam` above -- but it did not like the typecast `Class<? extends ClosureSignatureHint) evaluateExpression(...)` since there were two different class loaders involved.  So these still go through the slow path.