### PR TITLE
ExtensionModuleTest: add test for comparing LocalDateTime and LocalDate

### DIFF
--- a/src/test-resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/src/test-resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -21,5 +21,5 @@
 // TODO remove dup with src/spec/test-resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
 moduleName=Test module
 moduleVersion=1.0-test
-extensionClasses=support.MaxRetriesExtension,org.codehaus.groovy.runtime.m12n.TestStringExtension,org.codehaus.groovy.runtime.m12n.Groovy6496Extension,org.codehaus.groovy.runtime.m12n.TestPrimitiveWrapperExtension
+extensionClasses=support.MaxRetriesExtension,org.codehaus.groovy.runtime.m12n.TestStringExtension,org.codehaus.groovy.runtime.m12n.Groovy6496Extension,org.codehaus.groovy.runtime.m12n.TestPrimitiveWrapperExtension,org.codehaus.groovy.runtime.m12n.TestLocalDateTimeExtension
 staticExtensionClasses=support.StaticStringExtension,org.codehaus.groovy.runtime.m12n.TestStaticStringExtension

--- a/src/test/org/codehaus/groovy/runtime/m12n/ExtensionModuleTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/m12n/ExtensionModuleTest.groovy
@@ -116,4 +116,19 @@ class ExtensionModuleTest extends GroovyTestCase {
             """
         '''
     }
+
+    /**
+     * Just to make sure the custom override of {@code #compareTo} is possible and works.
+     * @see TestLocalDateTimeExtension
+     */
+    void testOverrideLocalDateTimeCompareTo() {
+        ExtensionModuleHelperForTests.doInFork '''
+            def d1 = java.time.LocalDateTime.now()
+            def d2 = java.time.LocalDate.now().plusDays(42)
+            def d3 = java.time.LocalDate.now().minusDays(42)
+            
+            assert d1 < d2
+            assert d1 > d3
+        '''
+    }
 }

--- a/src/test/org/codehaus/groovy/runtime/m12n/TestLocalDateTimeExtension.java
+++ b/src/test/org/codehaus/groovy/runtime/m12n/TestLocalDateTimeExtension.java
@@ -1,0 +1,12 @@
+package org.codehaus.groovy.runtime.m12n;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@SuppressWarnings("unused")
+public class TestLocalDateTimeExtension {
+
+    public static int compareTo(LocalDateTime self, LocalDate other) {
+        return self.compareTo(other.atStartOfDay());
+    }
+}


### PR DESCRIPTION
In our product we need the ability to compare `java.time.LocalDateTime` and `java.time.LocalDate`.    
To achieve this we can override java methods in groovy with help of `org.codehaus.groovy.runtime.ExtensionModule`.    
I think it's pretty important that this functionality is covered by tests in some way: 
for example, such overriding would not work as expected in the version before GROOVY-9711 (where a java `Comparable#compareTo` was used). 

See also the relevant discussion in dev@groovy.apache.org: https://lists.apache.org/thread/gtrq2cmk1hz75blx5smr81sqhohdnt6q