### PR TITLE
GROOVY-10383: SC: optimize `a !in b`

### DIFF
--- a/src/test/groovy/transform/stc/STCnAryExpressionTest.groovy
+++ b/src/test/groovy/transform/stc/STCnAryExpressionTest.groovy
@@ -172,6 +172,46 @@ class STCnAryExpressionTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-6137, GROOVY-7473, GROOVY-10383
+    void testInOperatorShouldEvaluateOperandsOnce2() {
+        assertScript '''
+            import groovy.transform.Field
+
+            @Field int i = 0
+            @Field int j = 0
+            int getA() { i++ }
+            int getB() { j++ }
+
+            assert !(a !in b)
+            assert i == 1
+            assert j == 1
+        '''
+        assertScript '''
+            import groovy.transform.Field
+
+            @Field int i = 0
+            @Field int j = 0
+            def getA() { i++; null }
+            def getB() { j++ }
+
+            assert a !in b
+            assert i == 1
+            assert j == 1
+        '''
+        assertScript '''
+            import groovy.transform.Field
+
+            @Field int i = 0
+            @Field int j = 0
+            def getA() { i++ }
+            def getB() { j++; null }
+
+            assert a !in b
+            assert i == 1
+            assert j == 1
+        '''
+    }
+
     void testComparisonOperatorCheckWithIncompatibleTypesOkIfComparableNotImplemented() {
         shouldFailWithMessages '''
             [] < 1


### PR DESCRIPTION
https://github.com/apache/groovy/commit/1cff465ee4eaa159192cbade013033af0b38be04 provides the necessary direct targets for this optimization.  `a !in b` is transformed into `b == null ? a != null : b.isNotCase(a)` instead of `ScriptBytecodeAdapter.isNotCase(a,b)`

https://issues.apache.org/jira/browse/GROOVY-10383