### PR TITLE
GROOVY-5169, GROOVY-7682: JSON output: serialization fixes

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -2313,11 +2313,9 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         // simply return the values of the metaproperty map as a List
         List<MetaProperty> ret = new ArrayList<>(propertyMap.size());
         for (MetaProperty mp : propertyMap.values()) {
-            if (mp instanceof CachedField) continue;
-
             if (mp instanceof MetaBeanProperty) {
                 MetaBeanProperty mbp = (MetaBeanProperty) mp;
-                // filter out DGM beans
+                // filter out extrinsic properties (DGM, ...)
                 boolean getter = true, setter = true;
                 MetaMethod getterMetaMethod = mbp.getGetter();
                 if (getterMetaMethod == null || getterMetaMethod instanceof GeneratedMetaMethod || getterMetaMethod instanceof NewInstanceMetaMethod) {

--- a/src/test/groovy/ClosureTest.groovy
+++ b/src/test/groovy/ClosureTest.groovy
@@ -22,6 +22,8 @@ import groovy.test.GroovyTestCase
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 
 import static groovy.lang.Closure.IDENTITY
+import static java.lang.reflect.Modifier.isPublic
+import static java.lang.reflect.Modifier.isStatic
 
 final class ClosureTest extends GroovyTestCase {
 
@@ -204,8 +206,11 @@ final class ClosureTest extends GroovyTestCase {
         Closure.metaClass = null
 
         Closure.metaClass.properties.each { property ->
-            def closure = { println it }
-            closure."$property.name" == closure."${MetaProperty.getGetterName(property.name, property.type)}"()
+            int modifiers = property.modifiers
+            if (isPublic(modifiers) && !isStatic(modifiers)) {
+                Closure closure = { -> }
+                closure."$property.name" == closure."${MetaProperty.getGetterName(property.name, property.type)}"()
+            }
         }
     }
 

--- a/src/test/groovy/Property2Test.groovy
+++ b/src/test/groovy/Property2Test.groovy
@@ -23,7 +23,7 @@ import groovy.test.GroovyTestCase
 /**
  * Tests the use of getMetaPropertyValues() and getProperties() for Beans and Expandos.
  */
-class Property2Test extends GroovyTestCase {
+final class Property2Test extends GroovyTestCase {
 
     void testGetPropertiesBeanCheckingValues() {
         def foo = new Foo()
@@ -31,19 +31,16 @@ class Property2Test extends GroovyTestCase {
         // these are the properties and their values that should be there
         def props = ['name': 'James', 'count': 1, 'location': 'London', 'blah': 9]
         foo.properties.each { name, value ->
-            // GROOVY-996 - We should see protected properties, but not  private ones.
-            assert name != "invisible"
+            // GROOVY-996, GROOVY-10438: should see protected properties, but not private ones
+            if (name == 'invisible') return
 
-            def pvalue = props[name]
+            def pvalue = props.remove(name)
             if (pvalue != null)
                 assert pvalue == value
-
-            // remove this one from the map
-            props.remove(name)
         }
 
         // make sure there are none left over
-        assert props.size() == 0
+        assert props.isEmpty()
     }
 
     void testMetaPropertyValuesFromObject() {
@@ -71,4 +68,3 @@ class Property2Test extends GroovyTestCase {
         assert props.size() == 0
     }
 }
-

--- a/src/test/org/apache/groovy/parser/antlr4/util/ASTComparatorCategory.groovy
+++ b/src/test/org/apache/groovy/parser/antlr4/util/ASTComparatorCategory.groovy
@@ -219,14 +219,14 @@ class ASTComparatorCategory {
     static reflexiveEquals(a, b, ignore = []) {
         if (a.getClass() != b.getClass()) {
             log.warning(" !!!! DIFFERENCE WAS FOUND! ${a.getClass()} != ${b.getClass()}")
-            return false;
+            return false
         }
 
         def objects = [a, b]
         Boolean res = this.objects[objects]
         if (res != null) {
             log.info("Skipping [$a, $b] comparison as they are ${ res ? "" : "un" }equal.")
-            return res;
+            return res
         }
         else if (this.objects.containsKey(objects)) {
             log.info("Skipping as they are processed at higher levels.")
@@ -239,29 +239,21 @@ class ASTComparatorCategory {
             return true
 
         def difference = a.metaClass.properties.find { MetaProperty mp  ->
-            MetaBeanProperty p = (MetaBeanProperty) mp
-            if (!p.getter)
+            if (mp !instanceof MetaBeanProperty || !mp.getter)
                 return false
 
-            def name = p.name
+            def name = mp.name
             lastName = "$name :::: ${ a.getClass() } ${ a.hashCode() }"
 
-
             for (Map.Entry<Class, List<String>> me : COLLECTION_PROPERTY_CONFIGURATION) {
-                if (!(me.key.isCase(a) && me.key.isCase(b))) {
-                    continue;
+                if (name != me.value[0] || !(me.key.isCase(a) && me.key.isCase(b))) {
+                    continue
                 }
 
-                String propName = me.value[0];
+                def aValue = a."${name}" // FIXME when the name is "classes", a classNode will be added to moduleNode.classes
+                def bValue = b."${name}"
 
-                if (name != propName) {
-                    continue;
-                }
-
-                def aValue = a."${propName}"; // FIXME when the propName is "classes", a classNode will be added to moduleNode.classes
-                def bValue = b."${propName}";
-
-                String orderName = me.value[1];
+                String orderName = me.value[1]
 
                 return new LinkedList(aValue?.getClass()?.isArray() ? Arrays.asList(aValue) : (aValue ?: [])).sort {c1, c2 -> c1."${orderName}" <=> c2."${orderName}"} !=
                         new LinkedList(bValue?.getClass()?.isArray() ? Arrays.asList(bValue) : (bValue ?: [])).sort {c1, c2 -> c1."${orderName}" <=> c2."${orderName}"}

--- a/subprojects/groovy-json/build.gradle
+++ b/subprojects/groovy-json/build.gradle
@@ -21,13 +21,19 @@ plugins {
 }
 
 dependencies {
-    api rootProject  // JsonBuilder extends GroovyObjectSupport...
+    api rootProject // JsonBuilder extends GroovyObjectSupport...
+
     testImplementation project(':groovy-test')
     testImplementation project(':groovy-dateutil')
     testImplementation 'net.javacrumbs.json-unit:json-unit:2.28.0'
-    testRuntimeOnly "org.slf4j:slf4j-api:${versions.slf4j}"
-    testRuntimeOnly project(':groovy-ant') // for JavadocAssertionTests
-    testRuntimeOnly 'com.google.code.gson:gson:2.8.9' // json-unit requires gson, jackson1, or jackson2
+
+    testRuntimeOnly project(':'), {
+        capabilities {
+            requireCapability 'org.apache.groovy:groovy-grapes'
+        }
+    }
+    testRuntimeOnly project(':groovy-ant')
+    testRuntimeOnly 'com.google.code.gson:gson:2.8.9' // json-unit requires gson, jackson1 or jackson2
 }
 
 plugins.withId('eclipse') {

--- a/subprojects/groovy-json/src/main/java/groovy/json/DefaultJsonGenerator.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/DefaultJsonGenerator.java
@@ -55,6 +55,7 @@ import static groovy.json.JsonOutput.EMPTY_STRING_CHARS;
 import static groovy.json.JsonOutput.OPEN_BRACE;
 import static groovy.json.JsonOutput.OPEN_BRACKET;
 import static java.lang.reflect.Modifier.isPublic;
+import static java.lang.reflect.Modifier.isStatic;
 
 /**
  * A JsonGenerator that can be configured with various {@link JsonGenerator.Options}.
@@ -242,6 +243,7 @@ public class DefaultJsonGenerator implements JsonGenerator {
 
         for (MetaProperty mp : metaProperties) {
             if (!isPublic(mp.getModifiers())) continue; // GROOVY-5169
+            if ( isStatic(mp.getModifiers())) continue; // GROOVY-7682
 
             // skip write-only property: see File
             if (mp instanceof MetaBeanProperty) {

--- a/subprojects/groovy-json/src/main/java/groovy/json/DefaultJsonGenerator.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/DefaultJsonGenerator.java
@@ -21,8 +21,9 @@ package groovy.json;
 import org.apache.groovy.json.internal.CharBuf;
 import org.apache.groovy.json.internal.Chr;
 import groovy.lang.Closure;
+import groovy.lang.MetaBeanProperty;
+import groovy.lang.MetaProperty;
 import groovy.util.Expando;
-import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -36,6 +37,7 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -52,6 +54,7 @@ import static groovy.json.JsonOutput.EMPTY_MAP_CHARS;
 import static groovy.json.JsonOutput.EMPTY_STRING_CHARS;
 import static groovy.json.JsonOutput.OPEN_BRACE;
 import static groovy.json.JsonOutput.OPEN_BRACKET;
+import static java.lang.reflect.Modifier.isPublic;
 
 /**
  * A JsonGenerator that can be configured with various {@link JsonGenerator.Options}.
@@ -232,12 +235,27 @@ public class DefaultJsonGenerator implements JsonGenerator {
         }
     }
 
-    protected Map<?, ?> getObjectProperties(Object object) {
-        Map<?, ?> properties = DefaultGroovyMethods.getProperties(object);
-        properties.remove("class");
-        properties.remove("declaringClass");
-        properties.remove("metaClass");
-        return properties;
+    protected Map<?, ?> getObjectProperties(final Object object) {
+        List<MetaProperty> metaProperties = org.codehaus.groovy.runtime.InvokerHelper.getMetaClass(object).getProperties();
+
+        Map<String, Object> namesAndValues = new LinkedHashMap<>(metaProperties.size());
+
+        for (MetaProperty mp : metaProperties) {
+            if (!isPublic(mp.getModifiers())) continue; // GROOVY-5169
+
+            // skip write-only property: see File
+            if (mp instanceof MetaBeanProperty) {
+                MetaBeanProperty mbp = (MetaBeanProperty) mp;
+                if (mbp.getField() == null && mbp.getGetter() == null) continue;
+            }
+
+            String name = mp.getName();
+            if (name.equals("class") || name.equals("metaClass") || name.equals("declaringClass")) continue;
+
+            namesAndValues.put(name, mp.getProperty(object));
+        }
+
+        return namesAndValues;
     }
 
     /**
@@ -530,5 +548,4 @@ public class DefaultJsonGenerator implements JsonGenerator {
             return super.toString() + "<" + this.type.toString() + ">";
         }
     }
-
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/DefaultJsonGeneratorTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/DefaultJsonGeneratorTest.groovy
@@ -291,6 +291,11 @@ class DefaultJsonGeneratorTest extends GroovyTestCase {
 
 }
 
+class JsonObject {
+    String name
+    Map properties
+}
+
 class JsonBar {
     String favoriteDrink
     Date lastVisit

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -18,19 +18,22 @@
  */
 package groovy.json
 
-import groovy.test.GroovyTestCase
 import groovy.transform.Canonical
+import org.junit.Test
 
 import static groovy.json.JsonOutput.toJson
+import static groovy.test.GroovyAssert.assertScript
+import static groovy.test.GroovyAssert.shouldFail
 
-class JsonOutputTest extends GroovyTestCase {
+final class JsonOutputTest {
 
-    // Check for GROOVY-5918
+    @Test // GROOVY-5918
     void testExpando() {
         assert toJson(new Expando(a: 42)) == '{"a":42}'
         assert new JsonBuilder(new Expando(a: 42)).toString() == '{"a":42}'
     }
 
+    @Test
     void testBooleanValues() {
         assert toJson(Boolean.TRUE) == "true"
         assert toJson(Boolean.FALSE) == "false"
@@ -38,6 +41,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson(false) == "false"
     }
 
+    @Test
     void testNullValue() {
         assert toJson(null) == "null"
         // test every overloaded version
@@ -55,6 +59,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson((Map) null) == 'null'
     }
 
+    @Test
     void testNumbers() {
         assert toJson(-1) == "-1"
         assert toJson(1) == "1"
@@ -91,16 +96,19 @@ class JsonOutputTest extends GroovyTestCase {
         shouldFail { toJson(Float.NEGATIVE_INFINITY) }
     }
 
+    @Test
     void testEmptyListOrArray() {
         assert toJson([]) == "[]"
         assert toJson([] as Object[]) == "[]"
     }
 
+    @Test
     void testListOfPrimitives() {
         assert toJson([true, false, null, true, 4, 1.1234]) == "[true,false,null,true,4,1.1234]"
         assert toJson([true, [false, null], true, [4, [1.1234]]]) == "[true,[false,null],true,[4,[1.1234]]]"
     }
 
+    @Test
     void testPrimitiveArray() {
         assert toJson([1, 2, 3, 4] as byte[]) == "[1,2,3,4]"
         assert toJson([1, 2, 3, 4] as short[]) == "[1,2,3,4]"
@@ -108,16 +116,19 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson([1, 2, 3, 4] as long[]) == "[1,2,3,4]"
     }
 
+    @Test
     void testEmptyMap() {
         assert toJson([:]) == "{}"
     }
 
+    @Test
     void testMap() {
         assert toJson([a: 1]) == '{"a":1}'
         assert toJson([a: 1, b: 2]) == '{"a":1,"b":2}'
         assert toJson([a: 1, b: true, c: null, d: [], e: 'hello']) == '{"a":1,"b":true,"c":null,"d":[],"e":"hello"}'
     }
 
+    @Test
     void testString() {
         assert toJson("") == '""'
 
@@ -153,32 +164,38 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson("\u0019") == '"\\u0019"'
     }
 
+    @Test
     void testGString() {
         assert toJson("1 + 2 = ${1 + 2}") == '"1 + 2 = 3"'
     }
 
+    @Test
     void testStringBuilderBuffer() {
         assert toJson(new StringBuilder().append(14).append(' March ').append(2014)) == '"14 March 2014"'
         assert toJson(new StringBuffer().append(14).append(' March ').append(2014)) == '"14 March 2014"'
     }
 
+    @Test
     void testCharArray() {
         char[] charArray = ['a', 'b', 'c']
 
         assert toJson(charArray) == '["a","b","c"]'
     }
 
+    @Test
     void testDate() {
         def d = Date.parse("yyyy/MM/dd HH:mm:ss Z", "2008/03/04 13:50:00 +0100")
 
         assert toJson(d) == '"2008-03-04T12:50:00+0000"'
     }
 
+    @Test
     void testURL() {
         assert toJson(new URL("http://glaforge.appspot.com")) == '"http://glaforge.appspot.com"'
         assert toJson(new URL('file', '', 'C:\\this\\is\\windows\\path')) == '"file:C:\\\\this\\\\is\\\\windows\\\\path"' // GROOVY-6560
     }
 
+    @Test
     void testCalendar() {
         def c = GregorianCalendar.getInstance(TimeZone.getTimeZone('GMT+1'))
         c.clearTime()
@@ -187,6 +204,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson(c) == '"2008-03-04T12:50:00+0000"'
     }
 
+    @Test
     void testComplexObject() {
         assert toJson([name: 'Guillaume', age: 33, address: [line1: "1 main street", line2: "", zip: 1234], pets: ['dog', 'cat']]) ==
                 '{"name":"Guillaume","age":33,"address":{"line1":"1 main street","line2":"","zip":1234},"pets":["dog","cat"]}'
@@ -194,6 +212,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson([[:], [:]]) == '[{},{}]'
     }
 
+    @Test
     void testClosure() {
         assert toJson({
             a 1
@@ -208,11 +227,13 @@ class JsonOutputTest extends GroovyTestCase {
         }) == '{"a":1,"b":{"c":2,"d":{"e":[3,{"f":4}]}}}'
     }
 
+    @Test
     void testIteratorEnumeration() {
         assert toJson([1, 2, 3].iterator()) == '[1,2,3]'
         assert toJson(Collections.enumeration([1, 2, 3])) == '[1,2,3]'
     }
 
+    @Test
     void testPrettyPrint() {
         def json = new JsonBuilder()
 
@@ -271,6 +292,7 @@ class JsonOutputTest extends GroovyTestCase {
         return str.replaceAll(~/\s/, '')
     }
 
+    @Test
     void testPrettyPrintStringZeroLen() {
         def tree = [myStrings: [str3: 'abc', str0: '']]
         def result = stripWhiteSpace(new JsonBuilder(tree).toPrettyString())
@@ -278,6 +300,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert result == expected
     }
 
+    @Test
     void testPrettyPrintDoubleQuoteEscape() {
         def json = new JsonBuilder()
         json.text { content 'abc"def' }
@@ -289,6 +312,7 @@ class JsonOutputTest extends GroovyTestCase {
             }""".stripIndent()
     }
 
+    @Test
     void testSerializePogos() {
         def city = new JsonCity("Paris", [
                 new JsonDistrict(1, [
@@ -335,29 +359,38 @@ class JsonOutputTest extends GroovyTestCase {
             }'''.stripIndent()
     }
 
+    @Test
     void testMapWithNullKey() {
         shouldFail IllegalArgumentException, {
             toJson([(null): 1])
         }
     }
 
-    void testGROOVY5247() {
+    @Test // GROOVY-5247
+    void testTreeMap() {
         def m = new TreeMap()
         m.a = 1
         assert toJson(m) == '{"a":1}'
     }
 
-    void testObjectWithDeclaredPropertiesField() {
-        def person = new JsonObject(name: "pillow", properties: [state: "fluffy", color: "white"])
-        def json = toJson(person)
+    @Test
+    void testDeclaredPropertiesField() {
+        String json = toJson(new JsonObject(name: "pillow", properties: [state: "fluffy", color: "white"]))
         assert json == '{"name":"pillow","properties":{"state":"fluffy","color":"white"}}'
     }
 
-    void testGROOVY5494() {
-        def json = toJson(new JsonFoo(name: "foo"))
+    @Test // GROOVY-5494
+    void testDeclaredPropertiesMethod() {
+        String json = toJson(new Pogo5494(name: "foo"))
         assert json == '{"name":"foo","properties":0}'
     }
 
+    static class Pogo5494 {
+        String name
+        int getProperties() { return 0 }
+    }
+
+    @Test
     void testCharacter() {
         assert toJson('a' as char) == '"a"'
         assert toJson('"' as char) == '"\\""'
@@ -371,6 +404,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson('\u0002' as char) == '"\\u0002"'
     }
 
+    @Test
     void testEmptyValue() {
         assert toJson('') == '""'
         assert toJson(['']) == '[""]'
@@ -378,6 +412,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson(new Expando('': '')) == '{"":""}'
     }
 
+    @Test
     void testSpecialCharEscape() {
         // Map
         assert toJson(['"': 0]) == '{"\\"":0}'
@@ -413,6 +448,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson({'\u0002' 0}) == '{"\\u0002":0}'
     }
 
+    @Test
     void testFile() {
         def file  = File.createTempFile('test', 'file-json')
         file.deleteOnExit()
@@ -423,7 +459,23 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson(dir)
     }
 
+    @Test // GROOVY-5169
+    void testPropertyModifiers1() {
+        assertScript '''
+            class Pogo {
+                public    String foo = 'foo' //TODO
+                public    String getBar() { 'bar' }
+                protected String getBaz() { 'baz' }
+                private   String getBoo() { 'boo' }
+            }
+
+            String json = groovy.json.JsonOutput.toJson(new Pogo())
+            assert json == '{"bar":"bar"}'
+        '''
+    }
 }
+
+//------------------------------------------------------------------------------
 
 @Canonical
 class JsonCity {
@@ -441,16 +493,6 @@ class JsonDistrict {
 class JsonStreet {
     String streetName
     JsonStreetKind kind
-}
-
-class JsonObject {
-    String name
-    Map properties
-}
-
-class JsonFoo {
-    String name
-    int getProperties() { return 0 }
 }
 
 enum JsonStreetKind {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -463,14 +463,14 @@ final class JsonOutputTest {
     void testPropertyModifiers1() {
         assertScript '''
             class Pogo {
-                public    String foo = 'foo' //TODO
+                public    String foo = 'foo'
                 public    String getBar() { 'bar' }
                 protected String getBaz() { 'baz' }
                 private   String getBoo() { 'boo' }
             }
 
             String json = groovy.json.JsonOutput.toJson(new Pogo())
-            assert json == '{"bar":"bar"}'
+            assert json == '{"foo":"foo","bar":"bar"}'
         '''
     }
 


### PR DESCRIPTION
First commit covers the private property portion of 5169.  Third commit covers public fields.  Second commit drops static properties, which are the source of the cycles in 7682 and 8371.  10438 has been split off to determine if DGMs should return properties for private fields or methods.

There were some assumptions made about the return value of MetaClass#getProperties.  These were easy to address and probably represent the kind of breakage other projects might expect.

https://issues.apache.org/jira/browse/GROOVY-5169
https://issues.apache.org/jira/browse/GROOVY-7682
https://issues.apache.org/jira/browse/GROOVY-8371
https://issues.apache.org/jira/browse/GROOVY-10438