### PR TITLE
GROOVY-6363: allow category to override private method of self-type impl

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -3266,7 +3266,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         // replace if self type is the same or the category self type is more specific
         if (selfType1 == selfType2 || selfType1.isAssignableFrom(selfType2)) return Boolean.TRUE;
         // GROOVY-6363: replace if the private method self type is more specific
-        // if (aMethod.isPrivate() && selfType2.isAssignableFrom(selfType1)) return Boolean.TRUE;
+        if (aMethod.isPrivate() && selfType2.isAssignableFrom(selfType1)) return Boolean.TRUE;
 
         return null;
     }

--- a/src/test/groovy/lang/CategoryAnnotationTest.groovy
+++ b/src/test/groovy/lang/CategoryAnnotationTest.groovy
@@ -18,7 +18,6 @@
  */
 package groovy.lang
 
-import groovy.test.NotYetImplemented
 import org.junit.Test
 
 import static groovy.test.GroovyAssert.assertScript
@@ -283,7 +282,7 @@ final class CategoryAnnotationTest {
         '''
     }
 
-    @NotYetImplemented @Test // GROOVY-6363
+    @Test // GROOVY-6363
     void testCategoryMethodOverridesPrivateMethod() {
         assertScript '''
             import groovy.transform.CompileStatic


### PR DESCRIPTION
category with same or more specific self-type can already replace method (of any visibility)

https://issues.apache.org/jira/browse/GROOVY-6363