### PR TITLE
GROOVY-8433: Category transform implies static methods

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/InnerClassVisitor.java
+++ b/src/main/java/org/codehaus/groovy/classgen/InnerClassVisitor.java
@@ -227,7 +227,7 @@ public class InnerClassVisitor extends InnerClassVisitorHelper {
         innerClass.addConstructor(ACC_SYNTHETIC, parameters.toArray(Parameter.EMPTY_ARRAY), ClassNode.EMPTY_ARRAY, block);
     }
 
-    private boolean isStatic(InnerClassNode innerClass, VariableScope scope, ConstructorCallExpression call) {
+    private boolean isStatic(final ClassNode innerClass, final VariableScope scope, final ConstructorCallExpression call) {
         boolean isStatic = innerClass.isStaticClass();
         if (!isStatic) {
             if (currentMethod != null) {
@@ -255,6 +255,9 @@ public class InnerClassVisitor extends InnerClassVisitorHelper {
                 isStatic = currentField.isStatic();
             }
         }
+        // GROOVY-8433: Category transform implies static method
+        isStatic = isStatic || innerClass.getOuterClass().getAnnotations().stream()
+            .anyMatch(a -> a.getClassNode().getName().equals("groovy.lang.Category"));
         return isStatic;
     }
 

--- a/src/spec/test/metaprogramming/CategoryTest.groovy
+++ b/src/spec/test/metaprogramming/CategoryTest.groovy
@@ -56,4 +56,24 @@ class CategoryTest extends GroovyTestCase {
             // end::time_category_anno[]
         '''
     }
+
+    // GROOVY-8433
+    void testCategoryAnnotationAndAIC() {
+        assertScript '''
+            @Category(Number)
+            class NumberCategory {
+                def m() {
+                    String variable = 'works'
+                    new Object() { // "Cannot cast object '1' with class 'java.lang.Integer' to class 'NumberCategory'" due to implicit "this"
+                        String toString() { variable }
+                    }
+                }
+            }
+
+            use (NumberCategory) {
+                String result = 1.m()
+                assert result == 'works'
+            }
+        '''
+    }
 }


### PR DESCRIPTION
Another way to do this would be to add a second transform class to the annotation that runs during `SEMANTIC_ANALYSIS` (before `InnerClassVisitor`) and adds `static` to methods.

https://issues.apache.org/jira/browse/GROOVY-8433