### PR TITLE
GROOVY-10467: trait: clear transient modifier from helper method

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/trait/TraitComposer.java
+++ b/src/main/java/org/codehaus/groovy/transform/trait/TraitComposer.java
@@ -346,8 +346,11 @@ public abstract class TraitComposer {
         }
         int modifiers = helperMethod.getModifiers();
         if (!isHelperForStaticMethod) {
-            modifiers ^= Opcodes.ACC_STATIC;
+            modifiers &= ~Opcodes.ACC_STATIC;
         }
+        // GROOVY-10467: added by classgen
+        modifiers &= ~Opcodes.ACC_VARARGS;
+
         MethodNode forwarder = new MethodNode(
                 helperMethod.getName(),
                 modifiers,

--- a/src/test/groovy/bugs/Groovy10467.groovy
+++ b/src/test/groovy/bugs/Groovy10467.groovy
@@ -1,0 +1,79 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+final class Groovy10467 {
+
+    @Test
+    void testAutoImplementVargs() {
+        assertScript """
+            @groovy.transform.AutoImplement
+            class C implements ${getClass().getName()}.I {
+            }
+
+            new C().m()
+        """
+    }
+
+    @Test
+    void testDelegateVargs() {
+        assertScript """
+            import ${getClass().getName()}.A
+            class C {
+                @Delegate A a = new A(null) {
+                    void m(String... strings) {
+                    }
+                }
+            }
+
+            new C().m()
+        """
+    }
+
+    @Test
+    void testTraitVargs() {
+        assertScript """
+            abstract class A {
+                class C implements ${getClass().getName()}.T {
+                }
+            }
+
+            def a = new A() {}
+            def c = new A.C(a)
+            c.m()
+        """
+    }
+
+    abstract class A {
+        abstract void m(String... strings)
+    }
+
+    interface I {
+        void m(String... strings)
+    }
+
+    trait T {
+        void m(String... strings) {
+        }
+    }
+}


### PR DESCRIPTION
In the case of a binary trait, a helper method may have the varargs modifier (same as transient for a field).  This change removes that before the transient modifier check that was added in Groovy 4 (GROOVY-10140).  I'm concerned this may be an issue elsewhere.  It may be possible to clear the modifier in the class decompiler; not sure if the modifier is important to the Groovy model.

https://issues.apache.org/jira/browse/GROOVY-10467
https://issues.apache.org/jira/browse/GROOVY-10140