### PR TITLE
GROOVY-9866: process discovered sources before units that depend on them

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
@@ -75,6 +75,7 @@ import java.util.Set;
 import static java.util.stream.Collectors.toList;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.classX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.reverse;
 import static org.codehaus.groovy.transform.sc.StaticCompilationMetadataKeys.DYNAMIC_OUTER_NODE_CALLBACK;
 import static org.codehaus.groovy.transform.stc.StaticTypesMarker.SWITCH_CONDITION_EXPRESSION_TYPE;
 
@@ -852,8 +853,10 @@ public class CompilationUnit extends ProcessingUnit {
          */
         @Override
         default void doPhaseOperation(final CompilationUnit unit) throws CompilationFailedException {
-            for (Map.Entry<String, SourceUnit> entry : unit.sources.entrySet()) {
-                SourceUnit source = entry.getValue();
+            String[] names = unit.sources.keySet().toArray(ResolveVisitor.EMPTY_STRING_ARRAY);
+            if (names.length > 1) reverse(names, true); // GROVY-9866: put dependencies first
+            for (String name : names) {
+                SourceUnit source = unit.sources.get(name);
                 if (source.phase < unit.phase || (source.phase == unit.phase && !source.phaseComplete)) {
                     try {
                         this.call(source);

--- a/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
@@ -427,7 +427,6 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         // GROOVY-4043: for type "X", try "A$X" with each type in the class hierarchy (except for Object)
         for (; cn != null && cycleCheck.add(cn) && !isObjectType(cn); cn = cn.getSuperClass()) {
             if (setRedirect(type, cn)) return true;
-            // GROOVY-9866: unresolvable interfaces
         }
 
         // Another case we want to check here is if we are in a

--- a/src/test/groovy/script/RuntimeResolveTests.groovy
+++ b/src/test/groovy/script/RuntimeResolveTests.groovy
@@ -18,7 +18,6 @@
  */
 package groovy.script
 
-import org.junit.Ignore
 import org.junit.Test
 
 import static groovy.test.GroovyAssert.isAtLeastJdk
@@ -67,7 +66,7 @@ final class RuntimeResolveTests {
         runScript('/groovy/bugs/groovy9243/Main.groovy')
     }
 
-    @Test @Ignore
+    @Test
     void testResolveOuterMemberWithoutAnImport3() {
         assumeTrue(isAtLeastJdk('9.0')) // System.Logger
         runScript('/groovy/bugs/groovy9866/Main.groovy')


### PR DESCRIPTION
> The discovery mechanism is present in `ClassNodeResolver`/`CompileUnit`/`CompilationUnit` to locate a source, add it and start resolve phase over. The map `sources` in `CompilationUnit` is insertion-ordered, which means the sources will be processed in the order they are discovered. A superclass or superinterface needs to be resolved before its subtype(s).

https://issues.apache.org/jira/browse/GROOVY-9866

To enable this order, process `sources` in reverse.