### PR TITLE
GROOVY-8448: `this.name` from anon. inner class

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -1180,9 +1180,14 @@ public class AsmClassGenerator extends ClassGenerator {
                         if (expression.isImplicitThis()) fieldNode = classNode.getDeclaredField(name);
                     } else {
                         fieldNode = classNode.getDeclaredField(name);
-
+                        // GROOVY-8448: "this.name" from anon. inner class
+                        if (fieldNode != null && !expression.isImplicitThis()
+                                && (fieldNode.getModifiers() & ACC_SYNTHETIC) != 0
+                                && fieldNode.getType().equals(ClassHelper.REFERENCE_TYPE)) {
+                            fieldNode = null;
+                        }
+                        // GROOVY-9501, GROOVY-9569, GROOVY-9650, GROOVY-9655, GROOVY-9665, GROOVY-9683, GROOVY-9695
                         if (fieldNode == null && !isFieldDirectlyAccessible(getField(classNode, name), classNode)) {
-                            // GROOVY-9501, GROOVY-9569, GROOVY-9650, GROOVY-9655, GROOVY-9665, GROOVY-9683, GROOVY-9695
                             if (checkStaticOuterField(expression, name)) return;
                         }
                     }

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -52,6 +52,21 @@ final class InnerClassTest {
         '''
     }
 
+    @Test // GROOVY-8448
+    void testAccessLocalVariableVsGetterInAIC() {
+        assertScript '''
+            def x = 'local' // shared variable written as field in AIC
+            def c = new java.util.concurrent.Callable<String>() {
+                def getX() { 'getter' }
+                @Override String call() {
+                    x + ' then ' + this.x
+                }
+            }
+            String result = c()
+            assert result == 'local then getter'
+        '''
+    }
+
     @Test
     void testAccessLocalVariableFromClosureInAIC() {
         assertScript '''


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-8448