### PR TITLE
GROOVY-10290: Dynamic Groovy code in Gradle doesn't compile because o…

### DIFF
--- a/src/main/java/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/java/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -707,7 +707,7 @@ public class JavaStubGenerator {
     private void printMethod(PrintWriter out, ClassNode clazz, MethodNode methodNode) {
         if (methodNode.isStaticConstructor()) return;
         if (methodNode.isPrivate() || !Utilities.isJavaIdentifier(methodNode.getName())) return;
-        if (methodNode.isSynthetic() && methodNode.getName().equals("$getStaticMetaClass")) return;
+        if (methodNode.isSynthetic() && (methodNode.getName().equals("$getStaticMetaClass") || methodNode.getName().equals("$getLookup"))) return;
 
         printAnnotations(out, methodNode);
         if (!isInterfaceOrTrait(clazz)) {

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/Groovy10290.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/Groovy10290.groovy
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.stubgenerator
+
+final class Groovy10290 extends StringSourcesStubTestCase {
+
+    @Override
+    Map<String, String> provideSources() {
+        [
+            'ResettableExpectations.java': '''
+                public interface ResettableExpectations { }
+            ''',
+            'SFTPServer.groovy': '''
+                class SFTPServer implements ResettableExpectations {
+                    static interface SftpExpectation { }
+                    @groovy.transform.CompileStatic
+                    static class SftpExpectOne implements SftpExpectation { }
+                    static class SftpExpectOnePath extends SftpExpectOne { }
+                    class SftpExpectOneOpen extends SftpExpectOnePath { }
+                }
+            '''
+        ]
+    }
+
+    @Override
+    void verifyStubs() {
+        String stub = stubJavaSourceFor('SFTPServer')
+        assert !stub.contains('$getLookup')
+    }
+}


### PR DESCRIPTION
…f $getLookup() method is not static