### PR TITLE
GROOVY-10484: `@NamedVariant`: bind `@NamedParam` into `@NamedParams`

### DIFF
--- a/src/test/org/codehaus/groovy/transform/NamedVariantTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/NamedVariantTransformTest.groovy
@@ -254,7 +254,7 @@ final class NamedVariantTransformTest {
         '''
     }
 
-    @Test
+    @Test // GROOVY-10484
     void testNamedParamRequiredVersusOptional() {
         def err = shouldFail '''
             import groovy.transform.*
@@ -271,6 +271,25 @@ final class NamedVariantTransformTest {
             m(alpha: 123)
         '''
         assert err =~ /Missing required named argument 'color'/
+
+        err = shouldFail '''
+            import groovy.transform.*
+
+            class Color {
+                int r, g, b
+            }
+
+            @NamedVariant
+            String m(Color color, int alpha = 0) {
+                return [color, alpha].join(' ')
+            }
+
+            @TypeChecked
+            void test() {
+                m(alpha: 123)
+            }
+        '''
+        assert err =~ /required named param 'color' not found/
     }
 
     @Test // GROOVY-9183


### PR DESCRIPTION
Wrapping `NamedParam` annotations in a `NamedParams` container is straightforward.  ~For default values, I wanted to use `map.containsKey(name) ? map.name : defaultValue` instead of `map.name ? map.name : defaultValue` -- in case `null` or `0` or another falsy value is supplied.  This change does not give the map a chance to supply a default value, but I thought that was okay in order to allow user to supply falsy value explicitly.~

~@paulk-asert  One case that was hard to understand comes form the `record` tests.  The example has `null` passed for an `int` and results in `0` whereas this code produces a cast exception.  I wanted to understand if that was desired or just a happy accident.~
```groovy
assert new ColoredPoint(x: 0, y: null).toString() == 'ColoredPoint[x=0, y=0, color=white]'
```

https://issues.apache.org/jira/browse/GROOVY-10484