### PR TITLE
GROOVY-10497: `@NamedVariant`: don't replace explicit value with default

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/NamedVariantASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/NamedVariantASTTransformation.java
@@ -70,10 +70,12 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.entryX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.getAllProperties;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.list2args;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.mapX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.notNullX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.param;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.plusX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.stmt;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.ternaryX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
 
 @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
@@ -278,13 +280,17 @@ public class NamedVariantASTTransformation extends AbstractASTTransformation {
             defaultValue = defaultValueX(type);
         }
         if (defaultValue != null) {
-            value = elvisX(value, defaultValue);
+            if (isPrimitiveType(type)) { // handle null for primitive
+                value = ternaryX(notNullX(value), value, defaultValueX(type));
+            }
+            value = ternaryX(containsKey(mapParam, name), value, defaultValue);
         }
         return asType(value, type, coerce);
     }
 
     private static Expression containsKey(final Parameter mapParam, final String name) {
         MethodCallExpression call = callX(varX(mapParam), "containsKey", constX(name));
+        call.setImplicitThis(false); // required for use before super ctor call
         call.setMethodTarget(MAP_TYPE.getMethods("containsKey").get(0));
         return call;
     }

--- a/src/test/org/codehaus/groovy/transform/NamedVariantTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/NamedVariantTransformTest.groovy
@@ -192,7 +192,7 @@ final class NamedVariantTransformTest {
         '''
     }
 
-    @Test // GROOVY-9158
+    @Test // GROOVY-9158, GROOVY-10497
     void testNamedParamWithDefaultArgument() {
         assertScript '''
             import groovy.transform.*
@@ -225,6 +225,21 @@ final class NamedVariantTransformTest {
             shouldFail {
                 m()
             }
+        '''
+
+        assertScript '''
+            import groovy.transform.*
+
+            @NamedVariant
+            def m(int one, int two = 42) {
+                "$one $two"
+            }
+
+            String result = m(one:0, two:0)
+            assert result == '0 0'
+
+            result = m(one:0, two:null)
+            assert result == '0 0'
         '''
     }
 


### PR DESCRIPTION
For default values, I want to use `map.containsKey(name) ? map.name : defaultValue` instead of `map.name ?: defaultValue` -- in case `null` or `0` or another falsy value is supplied.  This change does not give the map a chance to supply a default value, but I thought that was okay in order to allow user to supply falsy value explicitly.

One case that was hard to understand comes form the `record` tests.  The example has `null` passed for an `int` and results in `0` whereas this code produces a cast exception.  I wanted to understand if that was desired or just a happy accident.
```groovy
assert new ColoredPoint(x: 0, y: null).toString() == 'ColoredPoint[x=0, y=0, color=white]'
```

A null test could be inserted for primitives, but it would be more complex and would probably mean one of the operands was evaluated twice.  Probably not a huge concern, but I thought I would meantion it.

https://issues.apache.org/jira/browse/GROOVY-10497