### PR TITLE
GROOVY-10503: bump ASM to 9.2, making compiler work on Java 16-18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ configurations {
 
 ext {
     antVersion = '1.9.15'
-    asmVersion = '8.0.1'
+    asmVersion = '9.2'
     antlrVersion = '2.7.7'
     bridgerVersion = '1.5.Final'
     coberturaVersion = '1.9.4.1'

--- a/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -74,6 +74,12 @@ public class CompilerConfiguration {
     public static final String JDK14 = "14";
     /** This (<code>"15"</code>) is the value for targetBytecode to compile for a JDK 15. */
     public static final String JDK15 = "15";
+    /** This (<code>"16"</code>) is the value for targetBytecode to compile for a JDK 16. */
+    public static final String JDK16 = "16";
+    /** This (<code>"17"</code>) is the value for targetBytecode to compile for a JDK 17. */
+    public static final String JDK17 = "17";
+    /** This (<code>"18"</code>) is the value for targetBytecode to compile for a JDK 18. */
+    public static final String JDK18 = "18";
 
     /**
      * This constant is for comparing targetBytecode to ensure it is set to JDK 1.5 or later.
@@ -104,13 +110,16 @@ public class CompilerConfiguration {
             JDK12, Opcodes.V12,
             JDK13, Opcodes.V13,
             JDK14, Opcodes.V14,
-            JDK15, Opcodes.V15
+            JDK15, Opcodes.V15,
+            JDK16, Opcodes.V16,
+            JDK17, Opcodes.V17,
+            JDK18, Opcodes.V18
     );
 
     /** The valid targetBytecode values. */
     public static final String[] ALLOWED_JDKS = JDK_TO_BYTECODE_VERSION_MAP.keySet().toArray(new String[JDK_TO_BYTECODE_VERSION_MAP.size()]);
 
-    public static final int ASM_API_VERSION = Opcodes.ASM8;
+    public static final int ASM_API_VERSION = Opcodes.ASM9;
 
     @Deprecated
     public static final String CURRENT_JVM_VERSION = JDK7;

--- a/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -74,11 +74,14 @@ public class CompilerConfiguration {
     public static final String JDK14 = "14";
     /** This (<code>"15"</code>) is the value for targetBytecode to compile for a JDK 15. */
     public static final String JDK15 = "15";
-    /** This (<code>"16"</code>) is the value for targetBytecode to compile for a JDK 16. */
+    /** This (<code>"16"</code>) is the value for targetBytecode to compile for a JDK 16.
+     * Use it at your own risk, because JDK 16 is not officially supported in this Groovy release yet. */
     public static final String JDK16 = "16";
-    /** This (<code>"17"</code>) is the value for targetBytecode to compile for a JDK 17. */
+    /** This (<code>"17"</code>) is the value for targetBytecode to compile for a JDK 17.
+     * Use it at your own risk, because JDK 17 is not officially supported in this Groovy release yet. */
     public static final String JDK17 = "17";
-    /** This (<code>"18"</code>) is the value for targetBytecode to compile for a JDK 18. */
+    /** This (<code>"18"</code>) is the value for targetBytecode to compile for a JDK 18.
+     * Use it at your own risk, because JDK 18 is not officially supported in this Groovy release yet.*/
     public static final String JDK18 = "18";
 
     /**


### PR DESCRIPTION
This PR fixes [`GROOVY-10503`](https://issues.apache.org/jira/browse/GROOVY-10503).

ASM 9.2 is compatible with Java 18. So now when compiling under Java 16+, the compiler will be able to successfully analyse JDK or library files with class file versions 60-62. This helps to avoid errors coming from `groovyjarjarasm.asm.ClassReader` like:

```text
IllegalArgumentException: Unsupported class file major version 61
```

Using system property `groovy.target.bytecode`, e.g. setting it to `1.8` or `11`, users can of course still compile scripts to lower byte code versions than the current JRE, but at least the compiler does not trip over those JRE files with more recent class file versions anymore.