### PR TITLE
Groovy 3: Gradle 7.2 for Java 16+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ matrix:
   include:
     - env: BC='legacy' FEATURE='17' TARGET_JAVA_HOME="/home/travis/openjdk$FEATURE" LICENSE='GPL'
       jdk: openjdk11
-    - env: BC='legacy' FEATURE='16' TARGET_JAVA_HOME="/home/travis/openjdk$FEATURE" LICENSE='GPL'
-      jdk: openjdk11
+    - env: BC='legacy'
+      jdk: openjdk16
     - env: BC='legacy'
       jdk: openjdk15
     - env: BC='legacy'
@@ -38,8 +38,8 @@ matrix:
 
     - env: BC='indy' FEATURE='17' TARGET_JAVA_HOME="/home/travis/openjdk$FEATURE" LICENSE='GPL'
       jdk: openjdk11
-    - env: BC='indy' FEATURE='16' TARGET_JAVA_HOME="/home/travis/openjdk$FEATURE" LICENSE='GPL'
-      jdk: openjdk11
+    - env: BC='indy'
+      jdk: openjdk16
     - env: BC='indy'
       jdk: openjdk15
     - env: BC='indy'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ buildscript {
         // using the old "classpath" style of plugins because the new one doesn't play well with multi-modules
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.3'
-        //classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
         classpath 'org.nosphere.apache:creadur-rat-gradle:0.7.1'
         classpath 'gradle.plugin.com.github.jk1:gradle-license-report:1.3'
     }
@@ -432,7 +431,7 @@ apply from: 'gradle/test.gradle'
 apply from: 'gradle/groovydoc.gradle'
 apply from: 'gradle/docs.gradle'
 apply from: 'gradle/assemble.gradle'
-apply from: 'gradle/upload.gradle'
+//apply from: 'gradle/upload.gradle' -- TODO: migrate to Gradle 7
 apply from: 'gradle/idea.gradle'
 apply from: 'gradle/eclipse.gradle'
 apply from: 'gradle/quality.gradle'

--- a/buildSrc/src/main/groovy/org/codehaus/groovy/gradle/JarJarTask.groovy
+++ b/buildSrc/src/main/groovy/org/codehaus/groovy/gradle/JarJarTask.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -53,23 +54,19 @@ class JarJarTask extends DefaultTask {
     @org.gradle.api.tasks.Optional
     List<String> untouchedFiles = []
 
-    @Input
-    @org.gradle.api.tasks.Optional
+    @Optional @Input
     List<String> excludes = []
 
     @Input
     Map<String, String> patterns
 
-    @Input
-    @org.gradle.api.tasks.Optional
+    @Optional @Input
     Map<String, List<String>> excludesPerLibrary = [:]
 
-    @Input
-    @org.gradle.api.tasks.Optional
+    @Optional @Input
     Map<String, List<String>> includesPerLibrary = [:]
 
-    @Input
-    @org.gradle.api.tasks.Optional
+    @Optional @Input
     Map<String, String> includedResources = [:]
 
     @OutputFile
@@ -169,5 +166,4 @@ class JarJarTask extends DefaultTask {
     private static String baseName(File file) {
         file.name.substring(0, file.name.lastIndexOf('-'))
     }
-
 }

--- a/buildSrc/src/main/groovy/org/codehaus/groovy/gradle/WriteExtensionDescriptorTask.groovy
+++ b/buildSrc/src/main/groovy/org/codehaus/groovy/gradle/WriteExtensionDescriptorTask.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 
 /**
@@ -30,10 +31,12 @@ import org.gradle.api.tasks.OutputFile
 class WriteExtensionDescriptorTask extends DefaultTask {
     @Internal
     final String description = 'Generates the org.codehaus.groovy.runtime.ExtensionModule descriptor file of a module'
-    @Input String extensionClasses = ''
-    @Input String staticExtensionClasses = ''
-    @OutputFile File descriptor = computeDescriptorFile()
-
+    @OutputFile
+    File descriptor = computeDescriptorFile()
+    @Input
+    String staticExtensionClasses = ''
+    @Input
+    String extensionClasses = ''
 
     private File computeDescriptorFile() {
         def metaInfDir = new File("${project.buildDir}/resources/main/META-INF/groovy")

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ groovyVersion = 3.0.12-SNAPSHOT
 groovyBundleVersion = 3.0.12.SNAPSHOT
 
 binaryCompatibilityBaseline = 3.0.5
-gradle_version=6.9.2
+gradle_version=7.2
 
 groovyJUnit_ms=512m
 groovyJUnit_mx=2g

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/codehaus/groovy/reflection/ReflectionUtils.java
+++ b/src/main/java/org/codehaus/groovy/reflection/ReflectionUtils.java
@@ -135,6 +135,14 @@ public class ReflectionUtils {
         }
     }
 
+    private static boolean classShouldBeIgnored(final Class c, final Collection<String> extraIgnoredPackages) {
+        return (c != null
+                && (c.isSynthetic()
+                    || (c.getPackage() != null
+                        && (IGNORED_PACKAGES.contains(c.getPackage().getName())
+                          || extraIgnoredPackages.contains(c.getPackage().getName())))));
+    }
+
     public static List<Method> getDeclaredMethods(final Class<?> type, final String name, final Class<?>... parameterTypes) {
         return doGetMethods(type, name, parameterTypes, Class::getDeclaredMethods);
     }
@@ -233,14 +241,6 @@ public class ReflectionUtils {
         } catch (ReflectiveOperationException | SecurityException ignore) {
         }
         return false;
-    }
-
-    private static boolean classShouldBeIgnored(final Class c, final Collection<String> extraIgnoredPackages) {
-        return (c != null
-                && (c.isSynthetic()
-                    || (c.getPackage() != null
-                        && (IGNORED_PACKAGES.contains(c.getPackage().getName())
-                          || extraIgnoredPackages.contains(c.getPackage().getName())))));
     }
 
     private static class ClassContextHelper extends SecurityManager {

--- a/src/main/java/org/codehaus/groovy/runtime/ProxyGeneratorAdapter.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ProxyGeneratorAdapter.java
@@ -145,7 +145,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
             final ClassLoader proxyLoader,
             final boolean emptyBody,
             final Class<?> delegateClass) {
-        super(CompilerConfiguration.ASM_API_VERSION, new ClassWriter(0));
+        super(CompilerConfiguration.ASM_API_VERSION, new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS));
         this.loader = proxyLoader != null ? createInnerLoader(proxyLoader, interfaces) : findClassLoader(superClass, interfaces);
         this.visitedMethods = new LinkedHashSet<>();
         this.delegatedClosures = closureMap.isEmpty() ? EMPTY_DELEGATECLOSURE_MAP : new HashMap<>();
@@ -175,7 +175,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
         this.classList = new LinkedHashSet<>();
         this.classList.add(superClass);
         if (generateDelegateField) {
-            classList.add(delegateClass);
+            this.classList.add(delegateClass);
             for (Class<?> i : delegateClass.getInterfaces()) {
                 if (!isSealed(i)) this.classList.add(i);
             }
@@ -187,9 +187,9 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
         this.emptyBody = emptyBody;
 
         // generate bytecode
-        ClassWriter writer = (ClassWriter) cv;
-        this.visit(Opcodes.V1_5, ACC_PUBLIC, proxyName, null, null, null);
-        byte[] b = writer.toByteArray();
+        int bytecodeVersion = CompilerConfiguration.JDK_TO_BYTECODE_VERSION_MAP.get(CompilerConfiguration.DEFAULT.getTargetBytecode());
+        this.visit(bytecodeVersion, ACC_PUBLIC, proxyName, null, null, null);
+        byte[] b = ((ClassWriter) cv).toByteArray();
 //        CheckClassAdapter.verify(new ClassReader(b), true, new PrintWriter(System.err));
         cachedClass = loader.defineClass(proxyName.replace('/', '.'), b);
         // cache no-arg constructor
@@ -903,5 +903,4 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
             return value;
         }
     }
-
 }

--- a/subprojects/groovy-servlet/build.gradle
+++ b/subprojects/groovy-servlet/build.gradle
@@ -17,15 +17,12 @@
  *  under the License.
  */
 dependencies {
-    api("javax.servlet:javax.servlet-api:$servletApiVersion") { dep ->
-        provided dep
-    }
-    api("javax.servlet.jsp:javax.servlet.jsp-api:$jspApiVersion") { dep ->
-        provided dep
+    api rootProject  // ServletBinding extends Binding...
+    api "javax.servlet:javax.servlet-api:$servletApiVersion"
+    api("javax.servlet.jsp:javax.servlet.jsp-api:$jspApiVersion") {
         exclude(group: 'javax.servlet', module: 'javax.servlet-api')
     }
 
-    api rootProject  // ServletBinding extends Binding...
     implementation project(':groovy-xml') // needed for MarkupBuilder
     implementation project(':groovy-templates') // needed by TemplateServlet
 


### PR DESCRIPTION
Here are some changes to support running Groovy 3 builds with Java 16+ for purposes of evaluating issue reports.  `upload.gradle` still needs to be migrated to use the `maven-publish` plugin.