### PR TITLE
GROOVY-9866, GROOVY-10466: resolve all class headers before class bodies

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
@@ -199,9 +199,25 @@ public class CompilationUnit extends ProcessingUnit {
         }, Phases.CONVERSION);
 
         addPhaseOperation(source -> {
-            resolveVisitor.setClassNodeResolver(classNodeResolver);
-            for (ClassNode classNode : source.getAST().getClasses()) {
-                resolveVisitor.startResolving(classNode, source);
+            try {
+                resolveVisitor.phase = 1; // resolve head of each class
+                resolveVisitor.setClassNodeResolver(classNodeResolver);
+                for (ClassNode classNode : source.getAST().getClasses()) {
+                    resolveVisitor.startResolving(classNode, source);
+                }
+            } finally {
+                resolveVisitor.phase = 0;
+            }
+        }, Phases.SEMANTIC_ANALYSIS);
+
+        addPhaseOperation(source -> {
+            try {
+                resolveVisitor.phase = 2; // resolve body of each class
+                for (ClassNode classNode : source.getAST().getClasses()) {
+                    resolveVisitor.startResolving(classNode, source);
+                }
+            } finally {
+                resolveVisitor.phase = 0;
             }
         }, Phases.SEMANTIC_ANALYSIS);
 

--- a/src/test/groovy/bugs/Groovy10466.groovy
+++ b/src/test/groovy/bugs/Groovy10466.groovy
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.bugs
+
+import org.codehaus.groovy.control.CompilationUnit
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.junit.Test
+
+class Groovy10466 {
+
+    protected field
+
+    @Test
+    void testClassOrder() {
+        def config = new CompilerConfiguration(targetDirectory: File.createTempDir())
+
+        def parentDir = File.createTempDir()
+        try {
+            def a = new File(parentDir, 'A.groovy')
+            a.write '''
+                import org.codehaus.groovy.ast.FieldNode
+
+                class A extends B {
+                    @groovy.transform.ASTTest(value={
+                        def mce = node.code.statements[0].expression
+                        def var = mce.arguments[0] // "field" variable
+                        assert var.accessedVariable instanceof FieldNode
+                    })
+                    void test() {
+                        print field
+                    }
+                }
+            '''
+            def b = new File(parentDir, 'B.groovy')
+            b.write '''
+                class B extends groovy.bugs.Groovy10466 {
+                }
+            '''
+
+            def loader = new GroovyClassLoader(this.class.classLoader)
+            def cu = new CompilationUnit(config, null, loader)
+            cu.addSources(a, b)
+            cu.compile()
+        } finally {
+            config.targetDirectory.deleteDir()
+            parentDir.deleteDir()
+        }
+    }
+}

--- a/src/test/groovy/script/RuntimeResolveTests.groovy
+++ b/src/test/groovy/script/RuntimeResolveTests.groovy
@@ -18,7 +18,6 @@
  */
 package groovy.script
 
-import org.junit.Ignore
 import org.junit.Test
 
 import static groovy.test.GroovyAssert.isAtLeastJdk
@@ -67,7 +66,7 @@ final class RuntimeResolveTests {
         runScript('/groovy/bugs/groovy9243/Main.groovy')
     }
 
-    @Test @Ignore
+    @Test
     void testResolveOuterMemberWithoutAnImport3() {
         assumeTrue(isAtLeastJdk('9.0')) // System.Logger
         runScript('/groovy/bugs/groovy9866/Main.groovy')


### PR DESCRIPTION
Solve order issue by resolving all class headers before resolving class bodies (incl. `VariableScopeVisitor` application).  `ResolveVisitor#visitClass` is split into phases.  I chose not to refactor into separate methods to keep the change smaller and keep the external API pretty much the same.  `CompilationUnit` indicates which phase (1=head 2=body) to execute.  There is some overlap to preserve generics resolution for inner types.

https://issues.apache.org/jira/browse/GROOVY-10466
https://issues.apache.org/jira/browse/GROOVY-9866