### PR TITLE
GROOVY-10527: add type arguments to `getProperties(Object)` return type

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -512,7 +512,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return meta properties as Map of key/value pairs
      * @since 1.0
      */
-    public static Map getProperties(Object self) {
+    public static Map<String, Object> getProperties(Object self) {
         List<PropertyValue> metaProps = getMetaPropertyValues(self);
         Map<String, Object> props = new LinkedHashMap<>(metaProps.size());
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-10527