### PR TITLE
GROOVY-7288: fix for `@Delegate` target that implements trait(s)

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/DelegateASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/DelegateASTTransformation.java
@@ -38,7 +38,6 @@ import org.codehaus.groovy.ast.tools.BeanUtils;
 import org.codehaus.groovy.control.CompilePhase;
 import org.codehaus.groovy.control.SourceUnit;
 
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -199,7 +198,7 @@ public class DelegateASTTransformation extends AbstractASTTransformation {
             if (skipInterfaces) return;
 
             Set<ClassNode> addedInterfaces = getInterfacesAndSuperInterfaces(delegate.type);
-            addedInterfaces.removeIf(i -> !Modifier.isPublic(i.getModifiers()) || i.isSealed());
+            addedInterfaces.removeIf(i -> (i.getModifiers() & (ACC_PUBLIC | ACC_SYNTHETIC)) != ACC_PUBLIC || i.isSealed()); // GROOVY-7288 and JDK16+
             if (!addedInterfaces.isEmpty()) {
                 Set<ClassNode> ownerInterfaces = getInterfacesAndSuperInterfaces(delegate.owner);
                 for (ClassNode i : addedInterfaces) {

--- a/src/test/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
@@ -1773,6 +1773,26 @@ final class TraitASTTransformationTest {
         '''
     }
 
+    @Test // GROOVY-7288
+    void testClassWithTraitDelegate() {
+        assertScript '''
+            trait T {
+                final foo = 'bar'
+            }
+            class D implements T {
+                def m() {
+                    return 'baz'
+                }
+            }
+            class C { // The class must be declared abstract or the method 'java.lang.String T__foo$get()' must be implemented
+                private @Delegate D provider = new D()
+            }
+            def c = new C()
+            assert c.foo == 'bar'
+            assert c.m() == 'baz'
+        '''
+    }
+
     @Test // GROOVY-9739
     void testTraitExtendsTraitWithDelegate() {
         assertScript '''


### PR DESCRIPTION
Don't transfer synthetic interfaces like `T$Trait$FieldHelper` to owner class.

https://issues.apache.org/jira/browse/GROOVY-7288