### PR TITLE
GROOVY-10540: add `GroovyObject` interface before STC and classgen

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/GenericsType.java
+++ b/src/main/java/org/codehaus/groovy/ast/GenericsType.java
@@ -28,8 +28,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.codehaus.groovy.ast.ClassHelper.isGroovyObjectType;
 import static org.codehaus.groovy.ast.ClassHelper.isObjectType;
+import static org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport.implementsInterfaceOrIsSubclassOf;
 
 /**
  * This class is used to describe generic type signatures for ClassNodes.
@@ -248,33 +248,6 @@ public class GenericsType extends ASTNode {
         }
         // not placeholder or wildcard; no covariance allowed for type or bound(s)
         return classNode.equals(getType()) && compareGenericsWithBound(classNode, getType());
-    }
-
-    private static boolean implementsInterfaceOrIsSubclassOf(final ClassNode type, final ClassNode superOrInterface) {
-        if (type.equals(superOrInterface)
-                || type.isDerivedFrom(superOrInterface)
-                || type.implementsInterface(superOrInterface)) {
-            return true;
-        }
-        if (isGroovyObjectType(superOrInterface) && type.getCompileUnit() != null) {
-            // type is being compiled so it will implement GroovyObject later
-            return true;
-        }
-        if (superOrInterface instanceof WideningCategories.LowestUpperBoundClassNode) {
-            WideningCategories.LowestUpperBoundClassNode lub = (WideningCategories.LowestUpperBoundClassNode) superOrInterface;
-            boolean result = implementsInterfaceOrIsSubclassOf(type, lub.getSuperClass());
-            if (result) {
-                for (ClassNode face : lub.getInterfaces()) {
-                    result = implementsInterfaceOrIsSubclassOf(type, face);
-                    if (!result) break;
-                }
-            }
-            if (result) return true;
-        }
-        if (type.isArray() && superOrInterface.isArray()) {
-            return implementsInterfaceOrIsSubclassOf(type.getComponentType(), superOrInterface.getComponentType());
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -1163,7 +1163,7 @@ public class AsmClassGenerator extends ClassGenerator {
     }
 
     private static boolean implementsGroovyObject(final ClassNode cn) {
-        return cn.isDerivedFromGroovyObject() /*|| (!cn.isInterface() && cn.getCompileUnit() != null)*/;
+        return cn.isDerivedFromGroovyObject(); // GROOVY-10540: added before classgen
     }
 
     @Override

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -739,10 +739,6 @@ public abstract class StaticTypeCheckingSupport {
             return true;
         }
 
-        if (isGroovyObjectType(leftRedirect) && isBeingCompiled(right)) {
-            return true;
-        }
-
         if (right.isDerivedFrom(CLOSURE_TYPE) && isSAMType(left)) {
             return true;
         }
@@ -908,7 +904,7 @@ public abstract class StaticTypeCheckingSupport {
         if (type.isArray() && superOrInterface.isArray()) {
             return implementsInterfaceOrIsSubclassOf(type.getComponentType(), superOrInterface.getComponentType());
         }
-        if (isGroovyObjectType(superOrInterface) && !type.isInterface() && isBeingCompiled(type)) {
+        if (isGroovyObjectType(superOrInterface) && isBeingCompiled(type) && !type.isInterface()) {//TODO: !POJO !Trait
             return true;
         }
         return false;

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -152,7 +152,6 @@ import static org.codehaus.groovy.ast.ClassHelper.CLOSURE_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Character_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Double_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Float_TYPE;
-import static org.codehaus.groovy.ast.ClassHelper.GROOVY_OBJECT_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Integer_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.Iterator_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.LIST_TYPE;
@@ -2461,7 +2460,6 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                 receiverType = wrapTypeIfNecessary(currentReceiver.getType());
 
                 candidates = findMethodsWithGenerated(receiverType, nameText);
-                if (isBeingCompiled(receiverType)) candidates.addAll(GROOVY_OBJECT_TYPE.getMethods(nameText));
                 candidates.addAll(findDGMMethodsForClassNode(getSourceUnit().getClassLoader(), receiverType, nameText));
                 candidates = filterMethodsByVisibility(candidates, typeCheckingContext.getEnclosingClassNode());
 
@@ -4902,9 +4900,6 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
 
         if (isGStringType(receiver)) {
             return findMethod(STRING_TYPE, name, args);
-        }
-        if (isBeingCompiled(receiver)) {
-            return findMethod(GROOVY_OBJECT_TYPE, name, args);
         }
 
         return EMPTY_METHODNODE_LIST;

--- a/src/spec/test/typing/TypeCheckingTest.groovy
+++ b/src/spec/test/typing/TypeCheckingTest.groovy
@@ -625,7 +625,7 @@ import static org.codehaus.groovy.ast.tools.WideningCategories.lowestUpperBound 
             }
             // end::least_upper_bound_collection_inference[]
         ''',
-        'Cannot find matching method (Greeter or Salute)#exit()'
+        'Cannot find matching method (Greeter or Salute'
     }
 
     void testInstanceOfInference() {

--- a/src/test/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
+++ b/src/test/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
@@ -479,17 +479,20 @@ class FieldsAndPropertiesSTCTest extends StaticTypeCheckingTestCase {
     // GROOVY-5517
     void testShouldFindStaticPropertyEvenIfObjectImplementsMap() {
         assertScript '''
+            @groovy.transform.stc.POJO
+            @groovy.transform.CompileStatic
             class MyHashMap extends HashMap {
                 public static int version = 666
             }
             def map = new MyHashMap()
-            map['foo'] = 123
-            Object value = map.foo
+            map.foo = 123
+            def value = map.foo
             assert value == 123
+            map['foo'] = 4.5
             value = map['foo']
-            assert value == 123
-            int v = MyHashMap.version
-            assert v == 666
+            assert value == 4.5
+            value = map.version
+            assert value == 666
         '''
     }
 


### PR DESCRIPTION
Adding `GroovyObject` at the start of `INSTRUCTION_SELECTION` will impact the abstract methods of a class for that phase.  Not many transforms run there besides STC.  I think the risk is low.

I left `Verifier` alone because `JavaStubGenerator` runs it to get `GroovyObject` add-ons, etc.  And in rare cases if a class is added during `INSTRUCTION_SELECTION`.

https://issues.apache.org/jira/browse/GROOVY-10540