### PR TITLE
GROOVY-10543 Publish groovy-all as library

### DIFF
--- a/buildSrc/src/main/groovy/org.apache.groovy-all.gradle
+++ b/buildSrc/src/main/groovy/org.apache.groovy-all.gradle
@@ -112,4 +112,21 @@ configurations {
             }
         }
     }
+    // GROOVY-10543 - The platform configurations are published as libraries
+    apiElements {
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+        }
+    }
+    runtimeElements {
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+    }
 }


### PR DESCRIPTION
This is done by updating the attributes of the configurations
created by the Gradle java-platform plugin to match the
attributes of regular libraries.