### PR TITLE
GROOVY-10570: `@AnnotationCollector`: better error for missing `value()`

### DIFF
--- a/src/test/groovy/transform/AnnotationCollectorTest.groovy
+++ b/src/test/groovy/transform/AnnotationCollectorTest.groovy
@@ -257,8 +257,37 @@ class AnnotationCollectorTest extends GroovyTestCase {
             assert Foo.class.annotations.size() == 3
             assert new Foo(a: 1, b: 2).toString() == "Foo(2)"
         ''', { ex ->
-            assert ex.message.contains("Could not find class for Transformation Processor MyProcessor declared by Alias")
+            assert ex.message.contains('Could not find class for Transformation Processor MyProcessor declared by Alias')
         }
+    }
+
+    // GROOVY-10570
+    void testCollectorOnJavaAnno() {
+        shouldNotCompile '''
+            @groovy.transform.Groovy10570 // Java @interface with @AnnotationCollector
+            class Foo {
+                def bar
+            }
+        ''', { ex ->
+            assert ex.message.contains('Expecting static method `Object[][] value()` in groovy.transform.Groovy10570. Was it compiled from a Java source?')
+        }
+    }
+
+    // GROOVY-10570
+    void testCollectorOnJavaAnno2() {
+        assertScript '''
+            @groovy.transform.Groovy10570emu // Java @interface with @AnnotationCollector and value array
+            class Foo {
+                def bar
+            }
+            assert Foo.class.annotations.size() == 1
+            assert Foo.class.annotations[0].annotationType().name == 'groovy.transform.EqualsAndHashCode'
+
+            // test application of "@EqualsAndHashCode(canEqual=false)"
+            groovy.test.GroovyAssert.shouldFail NoSuchMethodException,{
+                Foo.class.getDeclaredMethod('canEqual', Object)
+            }
+        '''
     }
 
     void testAnnotationOnAnnotation() {

--- a/src/test/groovy/transform/Groovy10570.java
+++ b/src/test/groovy/transform/Groovy10570.java
@@ -1,0 +1,27 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform;
+
+import java.lang.annotation.*;
+
+@EqualsAndHashCode
+@AnnotationCollector
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Groovy10570 {  }

--- a/src/test/groovy/transform/Groovy10570emu.java
+++ b/src/test/groovy/transform/Groovy10570emu.java
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform;
+
+import java.lang.annotation.*;
+
+import static java.util.Collections.singletonMap;
+
+@AnnotationCollector(serializeClass=Groovy10570emu.Data.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Groovy10570emu {
+    class Data {
+        public static Object[][] value() {
+            return new Object[][] {{EqualsAndHashCode.class, singletonMap("useCanEqual", Boolean.FALSE)}};
+        }
+    }
+}


### PR DESCRIPTION
If user applies `@AnnotationCollector` to a Java class, it will be missing the `serializeClass` attribute.  Rather than "BUG! exception in phase 'semantic analysis' in source unit ..." produce an error message that indicates what was expected form the collector.

I also managed to produce an example Java annotation that emulates the serialized collected annotations.  This might be useful as a workaround for GROOVY-10571.

https://issues.apache.org/jira/browse/GROOVY-10570