### PR TITLE
Fix missleading error message in GroovyScriptEngine

### DIFF
--- a/src/main/java/groovy/util/GroovyScriptEngine.java
+++ b/src/main/java/groovy/util/GroovyScriptEngine.java
@@ -383,7 +383,7 @@ public class GroovyScriptEngine implements ResourceConnector {
                     se = new ResourceException(message, se);
                 }
             } catch (IOException e1) {
-                String message = "Cannot open URL: " + root + resourceName;
+                String message = "Cannot open URL: " + root + ", " + resourceName;
                 groovyScriptConn = null;
                 if (se == null) {
                     se = new ResourceException(message);


### PR DESCRIPTION
The error message is missleading and needs a fix. Otherwise it can show "Cannot open URL: folderfile" instead of "folder/file" and the user might wonder why is it looking for "folderfile".