### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,6 +16,9 @@
 name: "Validate Gradle Wrapper"
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"

--- a/.github/workflows/grails-joint-validation.yml
+++ b/.github/workflows/grails-joint-validation.yml
@@ -28,6 +28,9 @@ on:
       - GROOVY_2_5_X
       - GROOVY_3_0_X
 #      - master
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/groovy-build-dist.yml
+++ b/.github/workflows/groovy-build-dist.yml
@@ -17,6 +17,9 @@ name: Distribute SNAPSHOT
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   dist:
     strategy:

--- a/.github/workflows/groovy-build-test.yml
+++ b/.github/workflows/groovy-build-test.yml
@@ -17,6 +17,9 @@ name: Build and test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/micronaut-joint-validation.yml
+++ b/.github/workflows/micronaut-joint-validation.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches:
       - GROOVY_3_0_X
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
