### PR TITLE
StackTraceUtils: Add 'jdk.internal' to the list of ignored packages

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/StackTraceUtils.java
+++ b/src/main/java/org/codehaus/groovy/runtime/StackTraceUtils.java
@@ -64,7 +64,8 @@ public class StackTraceUtils {
                             "java.," +
                             "javax.," +
                             "sun.," +
-                            "gjdk.groovy.,"
+                            "gjdk.groovy.," +
+                            "jdk.internal."
             ).split("(\\s|,)+");
 
     private static final List<Closure> tests = new ArrayList<Closure>();


### PR DESCRIPTION
Include 'jdk.internal' in the default list of packages that are filtered out by StackTraceUtils' `sanitze()` methods