### PR TITLE
Support launching of ObjectExplore when property rows are double clic…

### DIFF
--- a/src/main/java/groovy/inspect/Inspector.java
+++ b/src/main/java/groovy/inspect/Inspector.java
@@ -60,6 +60,7 @@ public class Inspector {
     public static final int MEMBER_PARAMS_IDX = 5;
     public static final int MEMBER_VALUE_IDX = 5;
     public static final int MEMBER_EXCEPTIONS_IDX = 6;
+    public static final int MEMBER_RAW_VALUE_IDX = 6;
 
     public static final String NOT_APPLICABLE = "n/a";
     public static final String GROOVY = "GROOVY";
@@ -210,6 +211,34 @@ public class Inspector {
         return withoutNulls(result);
     }
 
+    public Object[] getPropertyInfoWithRawValue() {
+        List props = DefaultGroovyMethods.getMetaPropertyValues(objectUnderInspection);
+        Object[] result = new Object[props.size()];
+        int i = 0;
+        for (Iterator iter = props.iterator(); iter.hasNext(); i++) {
+            PropertyValue pv = (PropertyValue) iter.next();
+            result[i] = fieldInfoWithRawValue(pv);
+        }
+        return result;
+    }
+
+    protected Object[] fieldInfoWithRawValue(PropertyValue pv) {
+        Object[] result = new Object[MEMBER_VALUE_IDX + 2];
+        result[MEMBER_ORIGIN_IDX] = GROOVY;
+        result[MEMBER_MODIFIER_IDX] = "public";
+        result[MEMBER_DECLARER_IDX] = NOT_APPLICABLE;
+        result[MEMBER_TYPE_IDX] = shortName(pv.getType());
+        result[MEMBER_NAME_IDX] = pv.getName();
+        try {
+            result[MEMBER_VALUE_IDX] = FormatHelper.inspect(pv.getValue());
+            result[MEMBER_RAW_VALUE_IDX] = pv.getValue();
+        } catch (Exception e) {
+            result[MEMBER_VALUE_IDX] = NOT_APPLICABLE;
+            result[MEMBER_RAW_VALUE_IDX] = null;
+        }
+        return withoutNullsWithRawValue(result);
+    }
+
     protected Class getClassUnderInspection() {
         return objectUnderInspection.getClass();
     }
@@ -290,6 +319,17 @@ public class Inspector {
         return toNormalize;
     }
 
+    protected Object[] withoutNullsWithRawValue(Object[] toNormalize) {
+        for (int i = 0; i < toNormalize.length; i++) {
+            if (toNormalize[i] instanceof String) {
+            } else if (toNormalize[i] instanceof Object) {
+            } else if (toNormalize[i] == null) {
+                toNormalize[i] = NOT_APPLICABLE;
+            }
+        }
+        return toNormalize;
+    }
+
     public static void print(Object[] memberInfo) {
         print(System.out, memberInfo);
     }
@@ -328,6 +368,33 @@ public class Inspector {
             result = aStr[Inspector.MEMBER_MODIFIER_IDX].compareTo(bStr[Inspector.MEMBER_MODIFIER_IDX]);
             if (0 != result) return result;
             result = aStr[Inspector.MEMBER_ORIGIN_IDX].compareTo(bStr[Inspector.MEMBER_ORIGIN_IDX]);
+            return result;
+        }
+    }
+
+    public static Collection sortWithRawValue(List<Object> memberInfo) {
+        memberInfo.sort(new MemberComparatorWithRawValue());
+        return memberInfo;
+    }
+
+    public static class MemberComparatorWithRawValue implements Comparator<Object>, Serializable {
+        private static final long serialVersionUID = -7691851726606749542L;
+
+        @Override
+        public int compare(Object a, Object b) {
+            Object[] aStr = (Object[]) a;
+            Object[] bStr = (Object[]) b;
+            int result = ((String) aStr[Inspector.MEMBER_NAME_IDX]).compareTo((String) bStr[Inspector.MEMBER_NAME_IDX]);
+            if (0 != result) return result;
+            result = ((String) aStr[Inspector.MEMBER_TYPE_IDX]).compareTo((String) bStr[Inspector.MEMBER_TYPE_IDX]);
+            if (0 != result) return result;
+            result = ((String)aStr[Inspector.MEMBER_PARAMS_IDX]).compareTo((String) bStr[Inspector.MEMBER_PARAMS_IDX]);
+            if (0 != result) return result;
+            result =((String) aStr[Inspector.MEMBER_DECLARER_IDX]).compareTo((String) bStr[Inspector.MEMBER_DECLARER_IDX]);
+            if (0 != result) return result;
+            result = ((String)aStr[Inspector.MEMBER_MODIFIER_IDX]).compareTo((String) bStr[Inspector.MEMBER_MODIFIER_IDX]);
+            if (0 != result) return result;
+            result = ((String) aStr[Inspector.MEMBER_ORIGIN_IDX]).compareTo((String) bStr[Inspector.MEMBER_ORIGIN_IDX]);
             return result;
         }
     }

--- a/src/main/java/groovy/inspect/Inspector.java
+++ b/src/main/java/groovy/inspect/Inspector.java
@@ -229,14 +229,16 @@ public class Inspector {
         result[MEMBER_DECLARER_IDX] = NOT_APPLICABLE;
         result[MEMBER_TYPE_IDX] = shortName(pv.getType());
         result[MEMBER_NAME_IDX] = pv.getName();
+        Object rawValue = null;
         try {
             result[MEMBER_VALUE_IDX] = FormatHelper.inspect(pv.getValue());
-            result[MEMBER_RAW_VALUE_IDX] = pv.getValue();
+            rawValue = pv.getValue();
         } catch (Exception e) {
             result[MEMBER_VALUE_IDX] = NOT_APPLICABLE;
-            result[MEMBER_RAW_VALUE_IDX] = null;
         }
-        return withoutNullsWithRawValue(result);
+        result = withoutNullsWithRawValue(result);
+        result[MEMBER_RAW_VALUE_IDX] = rawValue;
+        return result;
     }
 
     protected Class getClassUnderInspection() {
@@ -321,9 +323,7 @@ public class Inspector {
 
     protected Object[] withoutNullsWithRawValue(Object[] toNormalize) {
         for (int i = 0; i < toNormalize.length; i++) {
-            if (toNormalize[i] instanceof String) {
-            } else if (toNormalize[i] instanceof Object) {
-            } else if (toNormalize[i] == null) {
+            if (toNormalize[i] == null) {
                 toNormalize[i] = NOT_APPLICABLE;
             }
         }

--- a/subprojects/groovy-console/src/main/groovy/groovy/console/ui/ObjectBrowser.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/console/ui/ObjectBrowser.groovy
@@ -48,7 +48,7 @@ import static groovy.inspect.Inspector.MEMBER_RAW_VALUE_IDX
 class ObjectBrowser {
 
     def inspector
-    def swing, frame, fieldTable, methodTable, itemTable, mapTable
+    def swing, frame, fieldTable, methodTable, arrayTable, collectionTable, mapTable
 
     static void main(args) {
         inspect('some String')
@@ -86,23 +86,25 @@ class ObjectBrowser {
                 tabbedPane(constraints: CENTER) {
                     if (inspector.object?.class?.array) {
                         scrollPane(name: ' Array data ') {
-                            def values
-                            itemTable = table {
-                                def list = Arrays.asList(inspector.object)
+                            arrayTable = table {
                                 int i = 0
-                                values = list
+                                def list = Arrays.asList(inspector.object)
                                 def data = list.collect { val -> [i++, val] }
                                 tableModel(list: data) {
                                     closureColumn(header: 'Index', read: { it[0] })
                                     closureColumn(header: 'Value', read: { it[1] })
+                                    closureColumn(header: 'Raw Value', read: { it[1] }) // to support sorting
                                 }
                             }
-                            itemTable.addMouseListener(new MouseAdapter() {
+                            arrayTable.getColumnModel().getColumn(2).setMinWidth(0);
+                            arrayTable.getColumnModel().getColumn(2).setMaxWidth(0);
+                            arrayTable.getColumnModel().getColumn(2).setWidth(0);
+                            arrayTable.addMouseListener(new MouseAdapter() {
                                 public void mouseClicked(MouseEvent e) {
                                     if (e.getClickCount() == 2) {
-                                        def selectedRow = itemTable.selectedRow
+                                        def selectedRow = arrayTable.selectedRow
                                         if (selectedRow != -1) {
-                                            def value = values[selectedRow]
+                                            def value = arrayTable.getModel().getValueAt(selectedRow, 2)
                                             if (value != null) {
                                                 ObjectBrowser.inspect(value)
                                             }
@@ -114,22 +116,24 @@ class ObjectBrowser {
                     }
                     if (inspector.object instanceof Collection) {
                         scrollPane(name: ' Collection data ') {
-                            def values
-                            itemTable = table {
+                            collectionTable = table {
                                 int i = 0
-                                values = inspector.object.collect { val -> val }
                                 def data = inspector.object.collect { val -> [i++, val] }
                                 tableModel(list: data) {
                                     closureColumn(header: 'Index', read: { it[0] })
                                     closureColumn(header: 'Value', read: { it[1] })
+                                    closureColumn(header: 'Raw Value', read: { it[1] }) // to support sorting
                                 }
                             }
-                            itemTable.addMouseListener(new MouseAdapter() {
+                            collectionTable.getColumnModel().getColumn(2).setMinWidth(0);
+                            collectionTable.getColumnModel().getColumn(2).setMaxWidth(0);
+                            collectionTable.getColumnModel().getColumn(2).setWidth(0);
+                            collectionTable.addMouseListener(new MouseAdapter() {
                                 public void mouseClicked(MouseEvent e) {
                                     if (e.getClickCount() == 2) {
-                                        def selectedRow = itemTable.selectedRow
+                                        def selectedRow = collectionTable.selectedRow
                                         if (selectedRow != -1) {
-                                            def value = values[selectedRow]
+                                            def value = collectionTable.getModel().getValueAt(selectedRow, 2)
                                             if (value != null) {
                                                 ObjectBrowser.inspect(value)
                                             }
@@ -141,23 +145,25 @@ class ObjectBrowser {
                     }
                     if (inspector.object instanceof Map) {
                         scrollPane(name: ' Map data ') {
-                            def values
-                            itemTable = table {
+                            mapTable = table {
                                 int i = 0
-                                values = inspector.object.collect { key, val -> val }
                                 def data = inspector.object.collect { key, val -> [i++, key, val] }
                                 tableModel(list: data) {
                                     closureColumn(header: 'Index', read: { it[0] })
                                     closureColumn(header: 'Key', read: { it[1] })
                                     closureColumn(header: 'Value', read: { it[2] })
+                                    closureColumn(header: 'Raw Value', read: { it[2] }) // to support sorting
                                 }
                             }
-                            itemTable.addMouseListener(new MouseAdapter() {
+                            mapTable.getColumnModel().getColumn(3).setMinWidth(0);
+                            mapTable.getColumnModel().getColumn(3).setMaxWidth(0);
+                            mapTable.getColumnModel().getColumn(3).setWidth(0);
+                            mapTable.addMouseListener(new MouseAdapter() {
                                 public void mouseClicked(MouseEvent e) {
                                     if (e.getClickCount() == 2) {
-                                        def selectedRow = itemTable.selectedRow
+                                        def selectedRow = mapTable.selectedRow
                                         if (selectedRow != -1) {
-                                            def value = values[selectedRow]
+                                            def value = mapTable.getModel().getValueAt(selectedRow, 2)
                                             if (value != null) {
                                                 ObjectBrowser.inspect(value)
                                             }
@@ -177,7 +183,7 @@ class ObjectBrowser {
                                 closureColumn(header: 'Origin', read: { it[MEMBER_ORIGIN_IDX] })
                                 closureColumn(header: 'Modifier', read: { it[MEMBER_MODIFIER_IDX] })
                                 closureColumn(header: 'Declarer', read: { it[MEMBER_DECLARER_IDX] })
-                                closureColumn(header: 'Raw Value', read: { it[MEMBER_RAW_VALUE_IDX] })
+                                closureColumn(header: 'Raw Value', read: { it[MEMBER_RAW_VALUE_IDX] }) // to support sorting
                             }
                         }
                         fieldTable.getColumnModel().getColumn(6).setMinWidth(0);
@@ -218,7 +224,8 @@ class ObjectBrowser {
         }
 
         // Add a bit of formatting
-        addSorter(itemTable)
+        addSorter(arrayTable)
+        addSorter(collectionTable)
         addSorter(mapTable)
         addSorter(fieldTable)
         addSorter(methodTable)


### PR DESCRIPTION
Support launching of ObjectExplore when property rows are double-clicked. Also, support the Array tab aside from Collection and Map Tabs.

Launch ObjectExplorer from Groovy Console or groovysh with **:inspect** command. Once ObjectExplorer is launched double-clicking on a property row will launch another instance of ObjectExplorer focused on that property's value. This works on Array, Collection, Map, and Properties table rows.