### PR TITLE
Persist the order of methods

### DIFF
--- a/src/main/java/org/apache/groovy/ast/tools/ClassNodeUtils.java
+++ b/src/main/java/org/apache/groovy/ast/tools/ClassNodeUtils.java
@@ -36,8 +36,8 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -165,7 +165,7 @@ public class ClassNodeUtils {
     public static Map<String, MethodNode> getDeclaredMethodsFromSuper(final ClassNode cNode) {
         ClassNode parent = cNode.getSuperClass();
         if (parent == null) {
-            return new HashMap<>();
+            return new LinkedHashMap<>();
         }
         return parent.getDeclaredMethodsMap();
     }
@@ -197,7 +197,7 @@ public class ClassNodeUtils {
      * @return A map of methods
      */
     public static Map<String, MethodNode> getDeclaredMethodsFromInterfaces(final ClassNode cNode) {
-        Map<String, MethodNode> methodsMap = new HashMap<>();
+        Map<String, MethodNode> methodsMap = new LinkedHashMap<>();
         addDeclaredMethodsFromInterfaces(cNode, methodsMap);
         return methodsMap;
     }


### PR DESCRIPTION
to ensure the generated trait classes are the same for the same source code.

This is a one of the possible solutions to solve [GROOVY-10704](https://issues.apache.org/jira/browse/GROOVY-10704).

see #1753 for an alternative version which only sorts the methods when generating the trait