### PR TITLE
sort the methods from the trait when generating methods

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/trait/TraitComposer.java
+++ b/src/main/java/org/codehaus/groovy/transform/trait/TraitComposer.java
@@ -66,6 +66,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import static org.apache.groovy.ast.tools.ClassNodeUtils.addGeneratedMethod;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
@@ -130,7 +131,7 @@ public abstract class TraitComposer {
         ClassNode staticFieldHelperClassNode = helpers.getStaticFieldHelper();
         Map<String, ClassNode> genericsSpec = GenericsUtils.createGenericsSpec(trait, GenericsUtils.createGenericsSpec(cNode));
 
-        for (MethodNode methodNode : helperClassNode.getAllDeclaredMethods()) {
+        for (MethodNode methodNode : new TreeMap<>(helperClassNode.getDeclaredMethodsMap()).values()) {
             String name = methodNode.getName();
             Parameter[] helperMethodParams = methodNode.getParameters();
             int nParams = helperMethodParams.length;


### PR DESCRIPTION
This is a one of the possible solutions to solve [GROOVY-10704](https://issues.apache.org/jira/browse/GROOVY-10704).

see #1752 for an alternative version which always keeps the methods in the original order