### PR TITLE
GROOVY-10695: `Type.name` within `Type` gets explicit-`this` treatment

### DIFF
--- a/src/test/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
+++ b/src/test/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
@@ -347,6 +347,24 @@ class FieldsAndPropertiesSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-10695
+    void testStaticPropertyOfSelfType() {
+        for (qual in ['', 'this.', 'C.']) {
+            assertScript """
+                class C {
+                    private static Object value
+                    static Object getValue() {
+                        ${qual}value
+                    }
+                    static void setValue(v) {
+                        ${qual}value = v
+                    }
+                }
+                C.setValue(null) // StackOverflowError
+            """
+        }
+    }
+
     void testDateProperties() {
         assertScript '''
             Date d = new Date()


### PR DESCRIPTION
Provides consistent handling for read and write access of static fields:
```groovy
class Type {
  private static field
  static getField() {
    // not used
  }
  static sm() {
    Type.field
    this.field
    field
  }
}
```

All the usual caveats apply when "Type.field" is located within a closure, lambda or other inner-class scenario.  The accessor is used as before.

https://issues.apache.org/jira/browse/GROOVY-10695

This could be separated into a few commits:
* refactor of `MixinASTTransformation`
* removal of `implementsGroovyObject` from `AsmClassGenerator`
* removal of `isThisExpression`/`isSuperExpression`/`isNullConstant` from `AsmClassGenerator`
* add static field, non-static receiver checks to `visitAttributeExpression` and `visitPropertyExpression`