### PR TITLE
GROOVY-5744, GROOVY-10666: multi-assign via `iterator()` or `getAt(int)`

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/BytecodeVariable.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/BytecodeVariable.java
@@ -34,26 +34,32 @@ public class BytecodeVariable {
     private ClassNode type;
     private String name;
     private final int prevCurrent;
+    private boolean dynamicTyped;
     private boolean holder;
 
     // br for setting on the LocalVariableTable in the class file
     // these fields should probably go to jvm Operand class
-    private Label startLabel = null;
-    private Label endLabel = null;
-    private boolean dynamicTyped;
+    private Label startLabel;
+    private Label endLabel;
 
-    private BytecodeVariable(){
+    private BytecodeVariable() {
+        index = 0;
+        prevCurrent = 0;
         dynamicTyped = true;
-        index=0;
-        holder=false;
-        prevCurrent=0;
     }
 
-    public BytecodeVariable(int index, ClassNode type, String name, int prevCurrent) {
+    public BytecodeVariable(final int index, final ClassNode type, final String name, final int prevCurrent) {
         this.index = index;
         this.type = type;
         this.name = name;
         this.prevCurrent = prevCurrent;
+    }
+
+    /**
+     * @return the stack index for this variable
+     */
+    public int getIndex() {
+        return index;
     }
 
     public String getName() {
@@ -64,11 +70,21 @@ public class BytecodeVariable {
         return type;
     }
 
-    /**
-     * @return the stack index for this variable
-     */
-    public int getIndex() {
-        return index;
+    public void setType(final ClassNode type) {
+        this.type = type;
+        dynamicTyped = dynamicTyped || ClassHelper.isDynamicTyped(type);
+    }
+
+    public int getPrevIndex() {
+        return prevCurrent;
+    }
+
+    public boolean isDynamicTyped() {
+        return dynamicTyped;
+    }
+
+    public void setDynamicTyped(final boolean b) {
+        dynamicTyped = b;
     }
 
     /**
@@ -78,7 +94,7 @@ public class BytecodeVariable {
         return holder;
     }
 
-    public void setHolder(boolean holder) {
+    public void setHolder(final boolean holder) {
         this.holder = holder;
     }
 
@@ -86,7 +102,7 @@ public class BytecodeVariable {
         return startLabel;
     }
 
-    public void setStartLabel(Label startLabel) {
+    public void setStartLabel(final Label startLabel) {
         this.startLabel = startLabel;
     }
 
@@ -94,29 +110,12 @@ public class BytecodeVariable {
         return endLabel;
     }
 
-    public void setEndLabel(Label endLabel) {
+    public void setEndLabel(final Label endLabel) {
         this.endLabel = endLabel;
     }
 
     @Override
     public String toString() {
         return name + "(index=" + index + ",type=" + type + ",holder="+holder+")";
-    }
-
-    public void setType(ClassNode type) {
-        this.type = type;
-        dynamicTyped |= ClassHelper.isDynamicTyped(type);
-    }
-
-    public void setDynamicTyped(boolean b) {
-        dynamicTyped = b;
-    }
-
-    public boolean isDynamicTyped() {
-        return dynamicTyped;
-    }
-
-    public int getPrevIndex() {
-        return prevCurrent;
     }
 }

--- a/src/main/java/org/codehaus/groovy/classgen/asm/CompileStack.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/CompileStack.java
@@ -235,9 +235,12 @@ public class CompileStack {
         inSpecialConstructorCall = element.inSpecialConstructorCall;
     }
 
-    public void removeVar(final int tempIndex) {
+    /**
+     * Indicates that the specified temporary variable is no longer used.
+     */
+    public void removeVar(final int variableIndex) {
         BytecodeVariable head = temporaryVariables.removeFirst();
-        if (head.getIndex() != tempIndex) {
+        if (head.getIndex() != variableIndex) {
             temporaryVariables.addFirst(head);
             MethodNode methodNode = controller.getMethodNode();
             if (methodNode == null) {
@@ -246,7 +249,7 @@ public class CompileStack {
             throw new GroovyBugError(
                     "In method "+ (methodNode!=null?methodNode.getText():"<unknown>") + ", " +
                     "CompileStack#removeVar: tried to remove a temporary " +
-                    "variable with index "+ tempIndex + " in wrong order. " +
+                    "variable with index " + variableIndex + " in wrong order. " +
                     "Current temporary variables=" + temporaryVariables);
         }
     }
@@ -266,9 +269,9 @@ public class CompileStack {
     }
 
     /**
-     * creates a temporary variable.
+     * Creates a temporary variable.
      *
-     * @param var defines type and name
+     * @param var specifies name and type
      * @param store defines if the toplevel argument of the stack should be stored
      * @return the index used for this temporary variable
      */
@@ -276,7 +279,7 @@ public class CompileStack {
         return defineTemporaryVariable(var.getName(), var.getType(),store);
     }
 
-    public BytecodeVariable getVariable(final String variableName ) {
+    public BytecodeVariable getVariable(final String variableName) {
         return getVariable(variableName, true);
     }
 
@@ -627,7 +630,7 @@ public class CompileStack {
         nextVariableIndex = localVariableOffset;
     }
 
-    private void createReference(final BytecodeVariable reference) {
+    void createReference(final BytecodeVariable reference) {
         MethodVisitor mv = controller.getMethodVisitor();
         mv.visitTypeInsn(NEW, "groovy/lang/Reference");
         mv.visitInsn(DUP_X1);

--- a/src/test/gls/statements/MultipleAssignmentDeclarationTest.groovy
+++ b/src/test/gls/statements/MultipleAssignmentDeclarationTest.groovy
@@ -18,7 +18,6 @@
  */
 package gls.statements
 
-import groovy.test.NotYetImplemented
 import org.junit.Test
 
 import static groovy.test.GroovyAssert.assertScript
@@ -79,10 +78,10 @@ final class MultipleAssignmentDeclarationTest {
     }
 
     @Test
-    void testNestedScope() {
+    void testNestedScope1() {
         assertScript '''import static groovy.test.GroovyAssert.shouldFail
 
-            def c = {
+            def c = { ->
                 def (i,j) = [1,2]
                 assert i == 1
                 assert j == 2
@@ -108,6 +107,33 @@ final class MultipleAssignmentDeclarationTest {
     }
 
     @Test
+    void testNestedScope2() {
+        assertScript '''
+            class C {
+                int m() {
+                    def (i,j) = [1,2]
+                    assert i == 1
+                    assert j == 2
+
+                    def x = { ->
+                        assert i == 1
+                        assert j == 2
+
+                        i = 3
+                        assert i == 3
+                    }
+                    x()
+
+                    assert i == 3
+                    return j
+                }
+            }
+            int n = new C().m()
+            assert n == 2
+        '''
+    }
+
+    @Test
     void testMultiAssignChain() {
         assertScript '''
             def a,b
@@ -117,7 +143,24 @@ final class MultipleAssignmentDeclarationTest {
         '''
     }
 
-    @NotYetImplemented @Test // GROOVY-5744
+    @Test
+    void testMultiAssignFromObject() {
+        shouldFail MissingMethodException, '''
+            def obj = new Object()
+            def (x) = obj
+        '''
+    }
+
+    @Test
+    void testMultiAssignFromCalendar() {
+        assertScript '''
+            def (_, y, m) = Calendar.instance
+            assert y >= 2022
+            assert m in 0..11
+        '''
+    }
+
+    @Test // GROOVY-5744
     void testMultiAssignFromIterator() {
         assertScript '''
             def list = [1,2,3]
@@ -129,7 +172,7 @@ final class MultipleAssignmentDeclarationTest {
         '''
     }
 
-    @NotYetImplemented @Test // GROOVY-10666
+    @Test // GROOVY-10666
     void testMultiAssignFromIterable() {
         assertScript '''
             class MySet {
@@ -172,7 +215,7 @@ final class MultipleAssignmentDeclarationTest {
         '''
     }
 
-    @NotYetImplemented @Test // GROOVY-10666
+    @Test // GROOVY-10666
     void testMultiAssignFromJavaStream() {
         assertScript '''import java.util.stream.Stream
 


### PR DESCRIPTION
Support multi-assign for `Stream` and `Iterator`.  Improve efficiency of multi-assign for types that do not support direct indexing like `Set`.

Translate "def (one,two) = rhs" into (pseudo-code):
```groovy
def one, two;
{
  def iter = rhs.iterator(), first;
  if (iter.hasNext() && (first = iter.next()) !== rhs) {
    one = first
    two = iter.hasNext() ? iter.next() : null
  } else {
    one = rhs.getAt(0)
    two = rhs.getAt(1)
  }
}
```

https://issues.apache.org/jira/browse/GROOVY-10666
https://issues.apache.org/jira/browse/GROOVY-5744