### PR TITLE
GROOVY-8788: STC: prefer closer parameter match over self-type match

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -8290,8 +8290,11 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
 
     /**
      * Support the subscript operator for a Map.
-     * <pre class="groovyTestCase">def map = [a:10]
-     * assert map["a"] == 10</pre>
+     * <pre class="groovyTestCase">
+     * def map = [:]
+     * map.put(1,10)
+     * assert map[1] == 10
+     * </pre>
      *
      * @param self a Map
      * @param key  an Object as a key for the map
@@ -8299,6 +8302,26 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static <K,V> V getAt(Map<K,V> self, Object key) {
+        return self.get(key);
+    }
+
+    /**
+     * Prevent {@link #getAt(Object,String)} for Map.
+     * <pre class="groovyTestCase">
+     * def map = [a:10]
+     * assert map["a"] == 10
+     *
+     * class HM extends HashMap {
+     *   String a = 'x'
+     * }
+     * map = new HM()
+     * map.put("a",1)
+     * assert map["a"] == 1 // not 'x'
+     * </pre>
+     *
+     * @since 5.0.0
+     */
+    public static <K,V> V getAt(Map<K,V> self, String key) {
         return self.get(key);
     }
 

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -2024,8 +2024,8 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
                 }
             }
         ''',
-        'Cannot find matching method java.util.Map#put(java.lang.String, java.util.LinkedHashMap<java.lang.String, java.util.List<ConfigAttribute>>). Please check if the declared type is correct and if the method exists.',
-        'Cannot call <K,V> org.codehaus.groovy.runtime.DefaultGroovyMethods#putAt(java.util.Map<K, V>, K, V) with arguments [java.util.Map<java.lang.String, java.util.Map<java.lang.String, java.util.List<java.lang.String>>>, java.lang.String, java.util.LinkedHashMap<java.lang.String, java.util.List<ConfigAttribute>>]'
+        'Cannot find matching method java.util.Map#put(java.lang.String, java.util.LinkedHashMap<java.lang.String, java.util.List<ConfigAttribute>>)',
+        'Cannot assign java.util.LinkedHashMap<java.lang.String, java.util.List<ConfigAttribute>> to: java.util.Map<java.lang.String, java.util.List<java.lang.String>>'
     }
 
     void testPutAtWithWrongValueType3() {

--- a/src/test/org/codehaus/groovy/transform/DelegateTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/DelegateTransformTest.groovy
@@ -112,12 +112,12 @@ final class DelegateTransformTest {
 
             def ms = new MapSet()
             assert ms.size() == 1
-            assert ms.toString() == '{a=1} [2, 3, 4]'
+            assert ms.toString() == '[a:1] [2, 3, 4]'
             ms.remove(3)
             assert ms.size() == 1
-            assert ms.toString() == '{a=1} [2, 4]'
+            assert ms.toString() == '[a:1] [2, 4]'
             ms.clear()
-            assert ms.toString() == '{a=1} []'
+            assert ms.toString() == '[a:1] []'
         '''
     }
 


### PR DESCRIPTION
Given choice between extension methods `m(String,Object)` and `m(Object,String)`, prefer closer parameter matching.  This aligns with the method selection of the dynamic runtime.  So there are some edge cases that were giving false STC errors or missing them.

This is a breaking change!  `getAt(Map,String)` was added to prevent STC errors for `Type obj = map[str]` expressions.

https://issues.apache.org/jira/browse/GROOVY-8788

https://issues.apache.org/jira/browse/GROOVY-6504
https://issues.apache.org/jira/browse/GROOVY-6849
https://issues.apache.org/jira/browse/GROOVY-6970
https://issues.apache.org/jira/browse/GROOVY-8787
https://issues.apache.org/jira/browse/GROOVY-9069
https://issues.apache.org/jira/browse/GROOVY-9420