### PR TITLE
GROOVY-6668, GROOVY-8212, GROOVY-9617: STC: distance of `GString` for `String` target

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -923,6 +923,9 @@ public abstract class StaticTypeCheckingSupport {
         if (receiver.isArray() && compare.isArray()) {
             return getDistance(receiver.getComponentType(), compare.getComponentType());
         }
+        if (isGStringOrGStringStringLUB(receiver) && isStringType(compare)) {
+            return 3; // GROOVY-6668, GROOVY-8212: closer than Object and GroovyObjectSupport
+        }
         int dist = 0;
         ClassNode unwrapReceiver = getUnwrapper(receiver);
         ClassNode unwrapCompare = getUnwrapper(compare);

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -4520,7 +4520,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         }
 
         if (isArrayOp(op)) {
-            if (isOrImplements(left, MAP_TYPE) && isStringType(right)) { // GROOVY-5700, GROOVY-8788
+            if (isOrImplements(left, MAP_TYPE) && (isStringType(right) || isGStringOrGStringStringLUB(right))) { // GROOVY-5700, GROOVY-6668, GROOVY-8212, GROOVY-8788
                 PropertyExpression prop = propX(leftExpression, rightExpression); // m['xx'] -> m.xx
                 return existsProperty(prop, !typeCheckingContext.isTargetOfEnclosingAssignment(expr))
                             ? getType(prop) : getTypeForMapPropertyExpression(left, prop);

--- a/src/test/groovy/transform/stc/DefaultGroovyMethodsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/DefaultGroovyMethodsSTCTest.groovy
@@ -338,4 +338,46 @@ class DefaultGroovyMethodsSTCTest extends StaticTypeCheckingTestCase {
             test()
         '''
     }
+
+    // GROOVY-6668, GROOVY-8212
+    void testMapGetAtVsObjectGetAt2() {
+        assertScript '''
+            Map<String, String> map = [key:'val']
+
+            // no value type inference
+            assert map.getAt('key') == 'val'
+            assert map.getAt("${'key'}") == 'val'
+
+            // yes value type inference
+            assert map['key'].toUpperCase() == 'VAL'
+            assert map["${'key'}"].toUpperCase() == 'VAL'
+
+            assert map.get('key').toUpperCase() == 'VAL'
+            assert map.get("${'key'}")?.toUpperCase() == null // get(Object); no coerce
+        '''
+    }
+
+    // GROOVY-6668, GROOVY-8212
+    void testMapPutAtVsObjectPutAt() {
+        assertScript '''
+            Map<String, String> map = [:]
+
+            map['key'] = 'val'
+            assert map.remove('key') == 'val'
+
+            map["${'key'}"] = 'val'
+            assert map.remove('key') == 'val'
+
+            map.putAt('key','val')
+            assert map.remove('key') == 'val'
+
+            map.putAt("${'key'}",'val')
+            assert map.remove('key') == 'val'
+        '''
+        shouldFailWithMessages '''
+            Map<String, String> map = [:]
+            map.put("${'key'}",'val')
+        ''',
+        'Cannot call java.util.LinkedHashMap#put(java.lang.String, java.lang.String) with arguments [groovy.lang.GString, java.lang.String]'
+    }
 }


### PR DESCRIPTION
Here is the more controversial change of https://github.com/apache/groovy/pull/1766 so it can be debated/evaluated in isolation.

A small change in `StaticTypeCheckingSupport#getDistance` can resolve the `map["$key"]` issues. I know Cedric stated in 6668 that this should be an STC error, but if there is just one method and it accepts String, it will be chosen for a GString argument. This change just closes the distance between GString and String so that `m(String)` is selected over `m(Object)`. Yes, this puts `Map#get` and `Map#getAt` out of alignment for GString arguments, which was a stated concern.  But the gain is in alignment of dynamic and static behaviors.

I checked `put` and `putAt` and I think there is consistency with `get` and `getAt`.  You can read and write via GString or String interchangeably.  I think this is the expectation of most users as described in 6668.

https://github.com/apache/groovy/pull/708
https://github.com/apache/groovy/pull/1766
https://issues.apache.org/jira/browse/GROOVY-6668
https://issues.apache.org/jira/browse/GROOVY-8212
https://issues.apache.org/jira/browse/GROOVY-9529
https://issues.apache.org/jira/browse/GROOVY-9617