### PR TITLE
GROOVY-10732: @Immutable handling of cloneable types should have the …

### DIFF
--- a/src/test/org/codehaus/groovy/transform/ImmutableTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/ImmutableTransformTest.groovy
@@ -139,7 +139,7 @@ class ImmutableTransformTest extends GroovyShellTestCase {
 
     @Test
     void testCloneableFieldNotCloneableObject() {
-        shouldFail(isAtLeastJdk('16.0') ? IllegalAccessException : CloneNotSupportedException, '''
+        shouldFail(CloneNotSupportedException, '''
                 import groovy.transform.Immutable
 
                 class Dolly {


### PR DESCRIPTION
…same behavior for non-cloneables on JDK16+