### PR TITLE
Fix minor typos in subprojects spec documentations

### DIFF
--- a/subprojects/groovy-binary/src/spec/doc/index.adoc
+++ b/subprojects/groovy-binary/src/spec/doc/index.adoc
@@ -140,11 +140,11 @@ Creating Swing UIs is made easy thanks to the use of <<swingbuilder,SwingBuilder
 Security is a complex and multi-faceted issue and needs to be addressed in a holistic way.
 Groovy offers some features to improve security, but organisations
 concerned about security should already be addressing other necessary aspects
-such as network security, file-system security, operating sytem security, database security,
+such as network security, file-system security, operating system security, database security,
 passwords and potentially encryption.
 
 Also, since Groovy runs on the JDK and optionally uses other library dependencies,
-users should ensure their JDK and all depdendencies are up to date with respect to
+users should ensure their JDK and all dependencies are up-to-date with respect to
 the latest security fixes.
 
 With regard to security issues that may affect the Groovy project itself,
@@ -164,7 +164,7 @@ offer some of the same security features as Java programs, including:
 
 Special security support is provided through:
 
-* gapi:groovy.lang.GroovyShell[], gapi:groovy.lang.GroovyClassLoader[] and other parts of the Groovy runtime fully support the Java security manager which allows you to sandbox script execution with a security policy. (Note: this funtionality might be scaled back in future Groovy versions or when running
+* gapi:groovy.lang.GroovyShell[], gapi:groovy.lang.GroovyClassLoader[] and other parts of the Groovy runtime fully support the Java security manager which allows you to sandbox script execution with a security policy. (Note: this functionality might be scaled back in future Groovy versions or when running
 on particular JDK versions in line with https://openjdk.java.net/jeps/411[JEP 411])
 * gapi:org.codehaus.groovy.control.customizers.SecureASTCustomizer[]
 secures source code by controlling what code constructs are permitted or prohibited in a code base

--- a/subprojects/groovy-console/src/spec/doc/groovy-console.adoc
+++ b/subprojects/groovy-console/src/spec/doc/groovy-console.adoc
@@ -97,7 +97,7 @@ blank input area
 [[GroovyConsole-Historyandresults]]
 === History and results
 
-* You can pop-up a gui inspector on the last (non-null) result by
+* You can pop up a gui inspector on the last (non-null) result by
 selecting `Inspect Last` from the `Actions` menu. The inspector is a
 convenient way to view lists and maps.
 * The console remembers the last ten script runs. You can scroll back
@@ -118,7 +118,7 @@ find yourself running a script multiple times until it works the way you want
 it to. However, what if your code takes too long to finish or worse, creates
 an infinite loop? Interrupting script execution can be achieved by clicking
 the `interrupt` button on the small dialog box that pops up when a script
-is executing or through the `interrupt` icon in the tool bar.
+is executing or through the `interrupt` icon in the toolbar.
 
 image:{reldir_console}/assets/img/gconsole-toolbar.png[Toolbar]
 

--- a/subprojects/groovy-ginq/src/spec/doc/ginq-userguide.adoc
+++ b/subprojects/groovy-ginq/src/spec/doc/ginq-userguide.adoc
@@ -163,7 +163,7 @@ Also, it could be referenced by its index, e.g. `r[0]`
 include::../test/org/apache/groovy/ginq/GinqTest.groovy[tags=ginq_projection_01,indent=0]
 ----
 [NOTE]
-`select P1, P2, ..., Pn` is a simplifed syntax of `select new NamedRecord(P1, P2, ..., Pn)` when and only when `n` >= 2.
+`select P1, P2, ..., Pn` is a simplified syntax of `select new NamedRecord(P1, P2, ..., Pn)` when and only when `n` >= 2.
 Also, `NamedRecord` instance will be created if `as` clause is used.
 The values stored in the `NamedRecord` could be referenced by their names.
 

--- a/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
+++ b/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc
@@ -416,7 +416,7 @@ Set or list preferences.
 [[GroovyShell-Preferences]]
 === Preferences
 
-Some of aspects of `groovysh` behaviors can be customized by setting
+Some aspects of `groovysh` behaviors can be customized by setting
 preferences. Preferences are set using the `set` command or the `:=`
 shortcut.
 
@@ -480,7 +480,7 @@ Configures the editor used by the `edit` command.
 
 Default is the value of the system environment variable `EDITOR`.
 
-Mac OS XTo use TextEdit, the default text editor on Mac OS X, configure:
+To use TextEdit, the default text editor on macOS, configure:
 set editor /Applications/TextEdit.app/Contents/MacOS/TextEdit
 
 [[GroovyShell-SettingaPreference]]
@@ -499,7 +499,7 @@ To list the current _set_ preferences (and their values):
 groovy:000> :show preferences
 ----------------
 
-Limitation: At the moment, there is no way to list all of the
+Limitation: At the moment, there is no way to list all the
 known/available preferences to be set.
 
 [[GroovyShell-ClearingPreferencesieResettingtoDefaults]]

--- a/subprojects/groovy-jmx/src/spec/doc/jmx.adoc
+++ b/subprojects/groovy-jmx/src/spec/doc/jmx.adoc
@@ -628,7 +628,7 @@ image:{reldir_jmx}/assets/img/jconsole-implicit-export.png[]
 
 ==== JmxBuilder.bean() Syntax
 
-The JmxBuilder.bean() node supports an extensive set of descriptors to describe your bean for management. The JMX MBeanServer uses these descriptors to expose meta data about the bean exposed for management.
+The JmxBuilder.bean() node supports an extensive set of descriptors to describe your bean for management. The JMX MBeanServer uses these descriptors to expose metadata about the bean exposed for management.
 
 ----
 jmx.export {
@@ -800,7 +800,7 @@ In the snippet above, the **builder will only export methods start() and stop()*
 
 ==== Export Operations by Signature
 
-Using JmxBuilder, you can target methods to export for management using the methods's parameter signature. This is useful when you want to distinguish methods with the same name that you want to export (i.e. stop() instead of stop(boolean)).
+Using JmxBuilder, you can target methods to export for management using the methods' parameter signature. This is useful when you want to distinguish methods with the same name that you want to export (i.e. stop() instead of stop(boolean)).
 
 [source,groovy]
 ----
@@ -818,7 +818,7 @@ JmxBuilder supports detailed descriptors for bean operations. You can supply dee
 include::../test/JmxTest.groovy[tags=export_operations_with_explicit_descriptors,indent=0]
 ----
 
-The snippet above shows all of the ways JmxBuilder allows you to describe an operation targeted for management:
+The snippet above shows all the ways JmxBuilder allows you to describe an operation targeted for management:
 
 - Operations **start() and stop()** are described by the "desc" key (this is enough since there are no params).
 - In operation **setResource()** uses of a shorthand version of **params**: to describe the parameters for the method.
@@ -1015,7 +1015,7 @@ Here is an example of JmxBuilder's listener node:
 include::../test/JmxTest.groovy[tags=jmxbuilders_listener,indent=0]
 ----
 
-This example shows how you can use a stand alone listener (outside of an MBean export). Here, we **export a timer with a 1 second** resolution. Then, we specify a listener to that timer that will print "beep" every second.
+This example shows how you can use a stand-alone listener (outside an MBean export). Here, we **export a timer with a 1 second** resolution. Then, we specify a listener to that timer that will print "beep" every second.
 
 === Emitting JMX Events
 

--- a/subprojects/groovy-jsr223/src/spec/doc/_integrating-jsr223.adoc
+++ b/subprojects/groovy-jsr223/src/spec/doc/_integrating-jsr223.adoc
@@ -60,7 +60,7 @@ include::../test/JSR223SpecTest.java[tags=jsr223_invocable,indent=0]
 -------------------------------------------------------------------------------
 
 The engine keeps per default hard references to the script functions. To
-change this you should set a engine level scoped attribute to the script
+change this you should set an engine level scoped attribute to the script
 context of the name `#jsr223.groovy.engine.keep.globals` with a
 String being `phantom` to use phantom references, `weak` to use weak
 references or `soft` to use soft references - casing is ignored. Any

--- a/subprojects/groovy-servlet/src/spec/doc/servlet-userguide.adoc
+++ b/subprojects/groovy-servlet/src/spec/doc/servlet-userguide.adoc
@@ -65,7 +65,7 @@ The following variables are ready for use in Groovlets:
 1. The session variable is only set, if there was already a session object. See the `if (session == null)` checks in the examples above.
 2. These variables cannot be re-assigned inside a `Groovlet`. They are bound on first access, allowing to e.g. calling methods on the `response` object before using `out`.
 
-== Setting up groovylets
+== Setting up groovlets
 
 Add the following to your `web.xml`:
 [source,xml]

--- a/subprojects/groovy-swing/src/spec/doc/_swing-builder.adoc
+++ b/subprojects/groovy-swing/src/spec/doc/_swing-builder.adoc
@@ -30,7 +30,7 @@ endif::[]
 
 `SwingBuilder` allows you to create full-fledged Swing GUIs in a declarative and concise fashion. It accomplishes this by employing a common idiom in Groovy, builders.
 Builders handle the busywork of creating complex objects for you, such as instantiating children, calling Swing methods, and attaching these children to their parents.
-As a consequence, your code is much more readable and maintainable, while still allowing you access to the full range of Swing components.
+As a consequence, your code is much more readable and maintainable, while still allowing you to access to the full range of Swing components.
 
 Here's a simple example of using `SwingBuilder`:
 
@@ -46,7 +46,7 @@ image:{reldir_swing}/assets/img/SwingBuilder001.png[]
 This hierarchy of components would normally be created through a series of repetitive instantiations, setters, and finally attaching this child to its respective parent.
 Using `SwingBuilder`, however, allows you to define this hierarchy in its native form, which makes the interface design understandable simply by reading the code.
 
-The flexibility shown here is made possible by leveraging the many programming features built-in to Groovy, such as closures, implicit constructor calling, import aliasing, and string interpolation. 
+The flexibility shown here is made possible by leveraging the many programming features built-in to Groovy, such as closures, implicit constructor calling, import aliasing, and string interpolation.
 Of course, these do not have to be fully understood in order to use `SwingBuilder`; as you can see from the code above, their uses are intuitive.
 
 Here is a slightly more involved example, with an example of `SwingBuilder` code re-use via a closure.

--- a/subprojects/groovy-xml/src/spec/doc/xml-userguide.adoc
+++ b/subprojects/groovy-xml/src/spec/doc/xml-userguide.adoc
@@ -32,10 +32,10 @@ one of:
 * `groovy.xml.XmlParser`
 * `groovy.xml.XmlSlurper`
 
-Both have the same approach to parse an xml. Both come with a bunch of
+Both have the same approach to parse an XML. Both come with a bunch of
 overloaded parse methods plus some special methods such as `parseText`,
 parseFile and others. For the next example we will use the `parseText`
-method. It parses a XML `String` and recursively converts it to a list
+method. It parses an XML `String` and recursively converts it to a list
 or map of objects.
 
 [source,groovy]
@@ -98,7 +98,7 @@ frequency.
 === DOMCategory
 
 There is another way of parsing XML documents with Groovy with the
-used of `groovy.xml.dom.DOMCategory` which is a category class which
+use of `groovy.xml.dom.DOMCategory` which is a category class which
 adds GPath style operations to Java's DOM classes.
 
 NOTE: Java has in-built support for DOM processing of XML using classes
@@ -106,7 +106,7 @@ representing the various parts of XML documents, e.g. `Document`,
 `Element`, `NodeList`, `Attr` etc. For more information about these classes,
 refer to the respective JavaDocs.
 
-Having a XML like the following:
+Having an XML like the following:
 
 [source,groovy]
 ----
@@ -167,7 +167,7 @@ get the first book's author's name
 include::../test/UserGuideXmlSlurperTest.groovy[tags=testGettingANodeText,indent=0]
 ----
 
-First we parse the document with `XmlSlurper` and the we have to
+First we parse the document with `XmlSlurper` and then we have to
 consider the returning value as the root of the XML document, so in
 this case is "response".
 
@@ -181,7 +181,7 @@ wanted the text inside that node we should be calling the `text()`
 method.  The `author` node is an instance of `GPathResult` type and
 `text()` a method giving us the content of that node as a String.
 
-When using `GPath` with an xml parsed with `XmlSlurper` we'll have as a
+When using `GPath` with an XML parsed with `XmlSlurper` we'll have as a
 result a `GPathResult` object. `GPathResult` has many other convenient
 methods to convert the text inside a node to any other type such as:
 
@@ -192,12 +192,12 @@ methods to convert the text inside a node to any other type such as:
 
 All these methods try to convert a `String` to the appropriate type.
 
-If we were using a XML parsed with `XmlParser` we could be dealing with
+If we were using an XML parsed with `XmlParser` we could be dealing with
 instances of type `Node`. But still all the actions applied to
 `GPathResult` in these examples could be applied to a Node as
 well. Creators of both parsers took into account `GPath` compatibility.
 
-Next step is to get the some values from a given node's attribute. In the following sample
+Next step is to get some values from a given node's attribute. In the following sample
 we want to get the first book's author's id. We'll be using two different approaches. Let's see the code first:
 
 [source,groovy]
@@ -332,7 +332,7 @@ include::../test/UserGuideMarkupBuilderTest.groovy[tags=testCreateSimpleXml1,ind
 <1> We're creating a reference string to compare against
 <2> The `xmlWriter` instance is used by `MarkupBuilder` to convert the
 xml representation to a String instance eventually
-<3> The `xmlMarkup.movie(...)` call will create a XML node with a tag
+<3> The `xmlMarkup.movie(...)` call will create an XML node with a tag
 called `movie` and with content `the godfather`.
 
 [source,groovy]
@@ -409,7 +409,7 @@ include::../test/UserGuideStreamingMarkupBuilderTest.groovy[tags=testSimpleExamp
 
 <1> Note that `StreamingMarkupBuilder.bind` returns a `Writable`
 instance that may be used to stream the markup to a Writer
-<2> We're capturing the output in a String to parse it again an check
+<2> We're capturing the output in a String to parse it again and check
 the structure of the generated XML with `XmlSlurper`.
 
 === MarkupBuilderHelper
@@ -452,7 +452,7 @@ from within the `bind` method scope when using
 include::../test/UserGuideStreamingMarkupBuilderTest.groovy[tags=testMkp,indent=0]
 ----
 
-<1> If we want to generate a escaped value for the name attribute with
+<1> If we want to generate an escaped value for the name attribute with
 `mkp.yield`
 <2> Checking the values later on with `XmlSlurper`
 
@@ -469,9 +469,9 @@ the following example:
 include::../test/UserGuideMarkupBuilderTest.groovy[tags=testDOMToGroovy,indent=0]
 ----
 
-<1> Creating `DOMToGroovy` instance 
+<1> Creating `DOMToGroovy` instance
 <2> Converts the XML to `MarkupBuilder` calls which are available in the output `StringWriter`
-<3> Using `output` variable to create the whole MarkupBuilder 
+<3> Using `output` variable to create the whole MarkupBuilder
 <4> Back to XML string
 
 == Manipulating XML


### PR DESCRIPTION
A few trailing whitespaces were removed in the process.