### PR TITLE
Fix minor typos in subprojects javadoc and comments

### DIFF
--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovy.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovy.java
@@ -716,7 +716,7 @@ public class Groovy extends Java {
     }
 
     /**
-     * Try to build a script name for the script of the groovy task to have an helpful value in stack traces in case of exception
+     * Try to build a script name for the script of the groovy task to have a helpful value in stack traces in case of exception
      *
      * @return the name to use when compiling the script
      */

--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
@@ -560,9 +560,9 @@ public class Groovyc extends MatchingTask {
     }
 
     /**
-     * Gets whether or not the ant classpath is to be included in the classpath.
+     * Gets whether the ant classpath is to be included in the classpath.
      *
-     * @return whether or not the ant classpath is to be included in the classpath
+     * @return whether the ant classpath is to be included in the classpath
      */
     public boolean getIncludeantruntime() {
         return includeAntRuntime;
@@ -578,7 +578,7 @@ public class Groovyc extends MatchingTask {
     }
 
     /**
-     * Gets whether or not the java runtime should be included in this
+     * Gets whether the java runtime should be included in this
      * task's classpath.
      *
      * @return the includejavaruntime attribute
@@ -1414,7 +1414,7 @@ public class Groovyc extends MatchingTask {
             /*
              * Iterate over the classpath provided to groovyc, and add any missing path
              * entries to the AntClassLoader.  This is a workaround, since for some reason
-             * 'directory' classpath entries were not added to the AntClassLoader' classpath.
+             * 'directory' classpath entries were not added to the 'AntClassLoader' classpath.
              */
             for (String cpEntry : classpath) {
                 boolean found = false;

--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/RootLoaderRef.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/RootLoaderRef.java
@@ -51,7 +51,7 @@ import java.security.PrivilegedAction;
  * the logging jar starts with "commons-logging-".
  *
  * This was needed because if ant wants to access a task argument that uses for example a Path
- * it look for a matching method which includes a matching class. But two classes of the same name
+ * it looks for a matching method which includes a matching class. But two classes of the same name
  * with different class loaders are different, so ant would not be able to find the method.
  *
  * @see org.codehaus.groovy.tools.RootLoader

--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/UberCompileTask.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/UberCompileTask.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  * This works by invoking the {@link GenerateStubsTask} task, then the
  * {@link Javac} task and then the {@link GroovycTask}.  Each task can be
  * configured by creating a nested element.  Common configuration such as
- * the source dir and classpath is picked up from this tasks configuration.
+ * the source dir and classpath is picked up from this task's configuration.
  */
 public class UberCompileTask extends Task {
     private Path src;

--- a/subprojects/groovy-astbuilder/src/test/groovy/org/codehaus/groovy/ast/builder/AstBuilderFromSpecificationTest.groovy
+++ b/subprojects/groovy-astbuilder/src/test/groovy/org/codehaus/groovy/ast/builder/AstBuilderFromSpecificationTest.groovy
@@ -91,7 +91,7 @@ import static org.objectweb.asm.Opcodes.ACC_PUBLIC
 import static org.objectweb.asm.Opcodes.ACC_STATIC
 
 /**
- * Unit test for the AST from Psuedo-specification feature.
+ * Unit test for the AST from Pseudo-specification feature.
  */
 class AstBuilderFromSpecificationTest extends GroovyTestCase {
 

--- a/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
+++ b/subprojects/groovy-cli-picocli/src/main/groovy/groovy/cli/picocli/CliBuilder.groovy
@@ -378,7 +378,7 @@ class CliBuilder {
      * For backwards compatibility with Apache Commons CLI, set this property to
      * <code>true</code> if the parser should recognize long options with both
      * a single hyphen and a double hyphen prefix. The default is <code>false</code>,
-     * so only long options with a double hypen prefix (<code>--option</code>) are recognized.
+     * so only long options with a double hyphen prefix (<code>--option</code>) are recognized.
      * @since 2.5
      */
     boolean acceptLongOptionsWithSingleHyphen = false

--- a/subprojects/groovy-console/src/main/groovy/groovy/console/ui/ConsoleActions.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/console/ui/ConsoleActions.groovy
@@ -219,7 +219,7 @@ loopModeAction = action(
         name: 'Loop Mode',
         closure: controller.&loopMode,
         mnemonic: 'p',
-        shortDescription: 'Run script continuously in a loop when run is envoked. Uncheck to stop loop'
+        shortDescription: 'Run script continuously in a loop when run is invoked. Uncheck to stop loop'
 )
 
 runSelectionAction = action(

--- a/subprojects/groovy-console/src/main/groovy/groovy/console/ui/text/StructuredSyntaxDocumentFilter.java
+++ b/subprojects/groovy-console/src/main/groovy/groovy/console/ui/text/StructuredSyntaxDocumentFilter.java
@@ -414,7 +414,7 @@ public class StructuredSyntaxDocumentFilter extends DocumentFilter {
             }
             if (matchEnd < checkPoint) {
                 // if we finished before hitting the end of the checkpoint from
-                // no mroe matches, then set ensure the text is reset to the
+                // no more matches, then set ensure the text is reset to the
                 // defaultStyle
                 styledDocument.setCharacterAttributes(matchEnd, checkPoint - matchEnd, defaultStyle, true);
             }

--- a/subprojects/groovy-console/src/main/groovy/groovy/console/ui/text/TextEditor.java
+++ b/subprojects/groovy-console/src/main/groovy/groovy/console/ui/text/TextEditor.java
@@ -346,7 +346,7 @@ public class TextEditor extends JTextPane implements Pageable, Printable {
         super.processKeyEvent(e);
 
         //  Handle release of Insert key to toggle overtype/insert mode
-        //  unless a modifier is active (eg Shift+Insert for paste or
+        //  unless a modifier is active (e.g. Shift+Insert for paste or
         //  Ctrl+Insert for Copy)
         if (e.getID() == KeyEvent.KEY_RELEASED &&
                 e.getKeyCode() == KeyEvent.VK_INSERT &&

--- a/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/ast/visitor/ASTNodeMetaData.java
+++ b/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/ast/visitor/ASTNodeMetaData.java
@@ -19,7 +19,7 @@
 package org.apache.groovy.contracts.ast.visitor;
 
 /**
- * Holds all constants to be used as AST node meta data keys.
+ * Holds all constants to be used as AST node metadata keys.
  */
 public interface ASTNodeMetaData {
     String PROCESSED = "org.apache.groovy.contracts.PROCESSED";

--- a/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/common/spi/Lifecycle.java
+++ b/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/common/spi/Lifecycle.java
@@ -25,7 +25,7 @@ import org.codehaus.groovy.ast.MethodNode;
  * <p>Specifies life-cycle hook-ins for applying AST transformation logic before and
  * after the annotation processors have been run.</p>
  *
- * <p>During excution of GContracts AST transformations, the following process is applied on each {@link ClassNode}
+ * <p>During execution of GContracts AST transformations, the following process is applied on each {@link ClassNode}
  * instance which qualifies for contract annotations:</P>
  *
  * <ol>
@@ -42,7 +42,7 @@ import org.codehaus.groovy.ast.MethodNode;
  *
  * <h3>Handling of AnnotationProcessor implementation classes</h3>
  *
- * <p>{@link AnnotationProcessor} implementatios are used to modify domain classes found in <tt>org.apache.groovy.contracts.domain</tt>. For that
+ * <p>{@link AnnotationProcessor} implementations are used to modify domain classes found in <tt>org.apache.groovy.contracts.domain</tt>. For that
  * reason, concrete annotation processor often don't modify AST nodes directly, but simply work with domain classes like
  * {@link org.apache.groovy.contracts.domain.Contract}. Whenever an annotation processor is done, it has finished its work on the
  * underlying domain model. </p>

--- a/subprojects/groovy-datetime/src/main/java/org/apache/groovy/datetime/extensions/DateTimeExtensions.java
+++ b/subprojects/groovy-datetime/src/main/java/org/apache/groovy/datetime/extensions/DateTimeExtensions.java
@@ -117,8 +117,8 @@ public final class DateTimeExtensions {
      * unit each iteration, calling the closure once per iteration. The closure may accept a single
      * {@link java.time.temporal.Temporal} argument.
      * <p>
-     * The particular unit incremented by depends on the specific sub-type of {@link java.time.temporal.Temporal}.
-     * Most sub-types use a unit of {@link java.time.temporal.ChronoUnit#SECONDS} except for
+     * The particular unit incremented by depends on the specific subtype of {@link java.time.temporal.Temporal}.
+     * Most subtypes use a unit of {@link java.time.temporal.ChronoUnit#SECONDS} except for
      * <ul>
      * <li>{@link java.time.chrono.ChronoLocalDate} and its sub-types use {@link java.time.temporal.ChronoUnit#DAYS}.
      * <li>{@link java.time.YearMonth} uses {@link java.time.temporal.ChronoUnit#MONTHS}.
@@ -185,8 +185,8 @@ public final class DateTimeExtensions {
      * unit each iteration, calling the closure once per iteration. The closure may accept a single
      * {@link java.time.temporal.Temporal} argument.
      * <p>
-     * The particular unit decremented by depends on the specific sub-type of {@link java.time.temporal.Temporal}.
-     * Most sub-types use a unit of {@link java.time.temporal.ChronoUnit#SECONDS} except for
+     * The particular unit decremented by depends on the specific subtype of {@link java.time.temporal.Temporal}.
+     * Most subtypes use a unit of {@link java.time.temporal.ChronoUnit#SECONDS} except for
      * <ul>
      * <li>{@link java.time.chrono.ChronoLocalDate} and its sub-types use {@link java.time.temporal.ChronoUnit#DAYS}.
      * <li>{@link java.time.YearMonth} uses {@link java.time.temporal.ChronoUnit#MONTHS}.
@@ -503,7 +503,7 @@ public final class DateTimeExtensions {
      * Returns an {@link java.time.Instant} that is one second after this instant.
      *
      * @param self an Instant
-     * @return an Instant one second ahead
+     * @return an Instant one-second ahead
      * @since 2.5.0
      */
     public static Instant next(final Instant self) {
@@ -514,7 +514,7 @@ public final class DateTimeExtensions {
      * Returns an {@link java.time.Instant} that one second before this instant.
      *
      * @param self an Instant
-     * @return an Instant one second behind
+     * @return an Instant one-second behind
      * @since 2.5.0
      */
     public static Instant previous(final Instant self) {
@@ -1372,7 +1372,7 @@ public final class DateTimeExtensions {
      * No normalization is performed.
      *
      * @param self a Period
-     * @return a Period one day longer in length
+     * @return a Period one-day longer in length
      * @since 2.5.0
      */
     public static Period next(final Period self) {
@@ -1384,7 +1384,7 @@ public final class DateTimeExtensions {
      * No normalization is performed.
      *
      * @param self a Period
-     * @return a Period one day shorter in length
+     * @return a Period one-day shorter in length
      * @since 2.5.0
      */
     public static Period previous(final Period self) {
@@ -2124,7 +2124,7 @@ public final class DateTimeExtensions {
         return ZoneOffset.ofTotalSeconds(offsetMillis / 1000);
     }
 
-    /* duplicated with DateUtilExtensions.toCalendar() but we don't want modulkes to depend on one another */
+    /* duplicated with DateUtilExtensions.toCalendar() but we don't want modules to depend on one another */
     private static Calendar toCalendar(Date self) {
         Calendar cal = Calendar.getInstance();
         cal.setTime(self);

--- a/subprojects/groovy-ginq/src/main/groovy/org/apache/groovy/ginq/dsl/expression/AbstractGinqExpression.java
+++ b/subprojects/groovy-ginq/src/main/groovy/org/apache/groovy/ginq/dsl/expression/AbstractGinqExpression.java
@@ -25,7 +25,7 @@ import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.ExpressionTransformer;
 
 /**
- * Represents GINQ expression which could hold meta data
+ * Represents GINQ expression which could hold metadata
  *
  * @since 4.0.0
  */

--- a/subprojects/groovy-ginq/src/main/groovy/org/apache/groovy/ginq/provider/collection/runtime/Queryable.java
+++ b/subprojects/groovy-ginq/src/main/groovy/org/apache/groovy/ginq/provider/collection/runtime/Queryable.java
@@ -354,7 +354,7 @@ public interface Queryable<T> {
 
     //  Built-in aggregate functions {
     /**
-     * Aggreate function {@code count}, similar to SQL's {@code count}
+     * Aggregate function {@code count}, similar to SQL's {@code count}
      *
      * @return count result
      * @since 4.0.0

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/groovydoc/GroovyType.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/groovydoc/GroovyType.java
@@ -24,7 +24,7 @@ public interface GroovyType {
 
     /**
      * The qualified name of this type excluding any dimension information.
-     * For example, a two dimensional array of String returns "<code>java.lang.String</code>".
+     * For example, a two-dimensional array of String returns "<code>java.lang.String</code>".
      */
     String qualifiedTypeName();
 
@@ -36,13 +36,13 @@ public interface GroovyType {
 
     /**
      * The unqualified name of this type excluding any dimension information.
-     * For example, a two dimensional array of String returns "<code>String</code>".
+     * For example, a two-dimensional array of String returns "<code>String</code>".
      */
     String typeName();
 
     /**
      * The qualified name including any dimension information.
-     * For example, a two dimensional array of String returns
+     * For example, a two-dimensional array of String returns
      * "<code>java.lang.String[][]</code>", and the parameterized type
      * <code>List&lt;Integer&gt;</code> returns "<code>java.util.List&lt;java.lang.Integer&gt;</code>".
      */

--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/InteractiveShellRunner.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/InteractiveShellRunner.groovy
@@ -140,7 +140,7 @@ class InteractiveShellRunner extends ShellRunner implements Runnable {
     }
 
     private void adjustHistory() {
-        // we save the evicted line in casesomeone wants to use it with history recall
+        // we save the evicted line in case someone wants to use it with history recall
         if (shell instanceof Groovysh) {
             def history = shell.history
             shell.historyFull = (history != null) && (history.size() >= history.maxSize)

--- a/subprojects/groovy-groovysh/src/test/groovy/org/apache/groovy/groovysh/completion/ImportsSyntaxCompleterTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/apache/groovy/groovysh/completion/ImportsSyntaxCompleterTest.groovy
@@ -55,7 +55,7 @@ class ImportsSyntaxCompleterTest extends CompleterTestSupport {
             def candidates = ['prefill']
             assert completer.findMatchingPreImportedClasses('Big', candidates)
             assert ['prefill', 'BigInteger', 'BigDecimal'] == candidates
-            // test again without invoking pakage Helper
+            // test again without invoking package Helper
             assert completer.findMatchingPreImportedClasses('Big', candidates)
             assert ['prefill', 'BigInteger', 'BigDecimal', 'BigInteger', 'BigDecimal'] == candidates
         }

--- a/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxMetaMapBuilder.groovy
+++ b/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxMetaMapBuilder.groovy
@@ -329,7 +329,7 @@ class JmxMetaMapBuilder {
 
                 // ctorName:[]
                 if (descriptor && (descriptor instanceof List && descriptor.size() == 0)) {
-                    params = null // represnts a ctor with no params
+                    params = null // represents a ctor with no params
                 }
                 // ctorName:["paramType1","paramType2"..."paramTypeN"]
                 if (descriptor && (descriptor instanceof List && descriptor.size() > 0)) {

--- a/subprojects/groovy-jmx/src/main/java/groovy/jmx/GroovyMBean.java
+++ b/subprojects/groovy-jmx/src/main/java/groovy/jmx/GroovyMBean.java
@@ -209,7 +209,7 @@ public class GroovyMBean extends GroovyObjectSupport {
     }
 
     /**
-     * List of string representations of all of the attributes on the MBean.
+     * List of string representations of all the attributes on the MBean.
      *
      * @return list of descriptions of each attribute on the mbean
      */
@@ -288,7 +288,7 @@ public class GroovyMBean extends GroovyObjectSupport {
     }
 
     /**
-     * Description of all of the operations available on the MBean.
+     * Description of all the operations available on the MBean.
      *
      * @return full description of each operation on the MBean
      */

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonBuilder.java
@@ -46,7 +46,7 @@ import java.util.Map;
  *       def builder = new groovy.json.JsonBuilder()
  *       def root = builder.people {
  *           person {
- *               firstName 'Guillame'
+ *               firstName 'Guillaume'
  *               lastName 'Laforge'
  *               // Named arguments are valid values for objects too
  *               address(

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonGenerator.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonGenerator.java
@@ -237,7 +237,7 @@ public interface JsonGenerator {
          *
          * <p>If two or more closures are registered for the exact same type the last
          * closure based on the order they were specified will be used.  When serializing an
-         * object its type is compared to the list of registered types in the order the were
+         * object its type is compared to the list of registered types in the order they were
          * given and the closure for the first suitable type will be called.  Therefore, it is
          * important to register more specific types first.
          *

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonOutput.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonOutput.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 
 /**
  * Class responsible for the actual String serialization of the possible values of a JSON structure.
- * This class can also be used as a category, so as to add <code>toJson()</code> methods to various types.
+ * This class can also be used as a category to add <code>toJson()</code> methods to various types.
  * <p>
  * This class does not provide the ability to customize the resulting output.  A {@link JsonGenerator}
  * can be used if the ability to alter the resulting output is required.

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonParserType.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonParserType.java
@@ -19,7 +19,7 @@
 package groovy.json;
 
 /**
- * Allows selection of parser type for new new JsonSlurper.
+ * Allows selection of parser type for new JsonSlurper.
  * <p />
  * To enable the INDEX_OVERLAY parser do this:
  *

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonToken.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonToken.java
@@ -55,8 +55,8 @@ public class JsonToken {
     private String text;
 
     /**
-     * Return the value represented by this token (ie. a number, a string, a boolean or null).
-     * For numbers, BigDecimal is returned for decimals and Integer, Long or BigInteger for 
+     * Return the value represented by this token (i.e. a number, a string, a boolean or null).
+     * For numbers, BigDecimal is returned for decimals and Integer, Long or BigInteger for
      * integral numbers.
      *
      * @return the represented value

--- a/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
@@ -41,7 +41,7 @@ import java.util.Map;
  * to be able to learn about the various possibilities of usage.
  * <p>
  * Unlike the JsonBuilder class which creates a data structure in memory,
- * which is handy in those situations where you want to alter the structure programatically before output,
+ * which is handy in those situations where you want to alter the structure programmatically before output,
  * the StreamingJsonBuilder streams to a writer directly without any memory data structure.
  * So if you don't need to modify the structure, and want a more memory-efficient approach,
  * please use the StreamingJsonBuilder.

--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharBuf.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharBuf.java
@@ -434,7 +434,7 @@ public class CharBuf extends Writer implements CharSequence {
                         _buffer[_location] = '\\';
                         _location++;
                         break;
-                    //There is not requirement to escape solidus so we will not.
+                    //There is no requirement to escape solidus so we will not.
 //                        case '/':
 //                            _buffer[_location] = '\\';
 //                            _location ++;

--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/LazyValueMap.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/LazyValueMap.java
@@ -60,7 +60,7 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
      */
     private int len = 0;
     /**
-     * Holds whether or not we ae in lazy chop mode or not.
+     * Holds whether we are in lazy chop mode.
      */
     private final boolean lazyChop;
 

--- a/subprojects/groovy-jsr223/src/main/java/org/codehaus/groovy/jsr223/GroovyScriptEngineFactory.java
+++ b/subprojects/groovy-jsr223/src/main/java/org/codehaus/groovy/jsr223/GroovyScriptEngineFactory.java
@@ -86,7 +86,7 @@ public class GroovyScriptEngineFactory implements ScriptEngineFactory {
     }
 
     /**
-     * This is also different than scripting.dev.java.net which used an
+     * This is also different from scripting.dev.java.net which used an
      * initial lowercase.  But these are proper names and should be capitalized.
      */
     @Override

--- a/subprojects/groovy-macro/src/main/groovy/org/codehaus/groovy/macro/transform/MacroCallTransformingVisitor.java
+++ b/subprojects/groovy-macro/src/main/groovy/org/codehaus/groovy/macro/transform/MacroCallTransformingVisitor.java
@@ -44,7 +44,7 @@ import java.util.List;
 /**
  * Visitor to find and transform macro method calls. For the performance reasons it's not a transformer,
  * but transforming visitor - it mutates {@link MethodCallExpression} if it's a macro method call by replacing
- * original call (i.e. {@code myMacroMethod("foo", "bar")} with something like:
+ * original call (i.e. {@code myMacroMethod("foo", "bar")}) with something like:
  * {@code MacroStub.INSTANCE.macroMethod(123)}
  * (where {@code myMacroMethod} returns constant expression {@code 123})
  *

--- a/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
+++ b/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
@@ -910,7 +910,7 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
     }
 
     /**
-     * Processes each descendant file in this directory and any sub-directories.
+     * Processes each descendant file in this directory and any subdirectories.
      * Processing consists of potentially calling <code>closure</code> passing it the current
      * file (which may be a normal file or subdirectory) and then if a subdirectory was encountered,
      * recursively processing the subdirectory. Whether the closure is called is determined by whether
@@ -939,7 +939,7 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
     }
 
     /**
-     * Processes each descendant file in this directory and any sub-directories.
+     * Processes each descendant file in this directory and any subdirectories.
      * Processing consists of potentially calling <code>closure</code> passing it the current
      * file (which may be a normal file or subdirectory) and then if a subdirectory was encountered,
      * recursively processing the subdirectory.
@@ -1078,7 +1078,7 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
     }
 
     /**
-     * Processes each descendant file in this directory and any sub-directories.
+     * Processes each descendant file in this directory and any subdirectories.
      * Convenience method for {@link #traverse(Path, java.util.Map, groovy.lang.Closure)} when
      * no options to alter the traversal behavior are required.
      *
@@ -1190,7 +1190,7 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
     }
 
     /**
-     * Processes each descendant file in this directory and any sub-directories.
+     * Processes each descendant file in this directory and any subdirectories.
      * Processing consists of calling <code>closure</code> passing it the current
      * file (which may be a normal file or subdirectory) and then if a subdirectory was encountered,
      * recursively processing the subdirectory.
@@ -1788,7 +1788,7 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
 
     /**
      * Create a new PrintWriter for this file which is then
-     * passed it into the given closure.  This method ensures its the writer
+     * passed it into the given closure. This method ensures the writer
      * is closed after the closure returns.
      *
      * @param self    a Path

--- a/subprojects/groovy-servlet/src/main/java/groovy/servlet/AbstractHttpServlet.java
+++ b/subprojects/groovy-servlet/src/main/java/groovy/servlet/AbstractHttpServlet.java
@@ -71,7 +71,7 @@ import java.util.regex.Pattern;
  * </pre>
  * <p>
  * If you experience class-loading-troubles with Tomcat 4 (or higher) or any
- * other servlet container using custom class loader setups, you can fallback
+ * other servlet container using custom class loader setups, you can fall back
  * to use (slower) reflection in Groovy's MetaClass implementation. Please
  * contact the dev team with your problem! Thanks.
  * The servlet init parameter name is:
@@ -147,7 +147,7 @@ public abstract class AbstractHttpServlet extends HttpServlet implements Resourc
     protected boolean reflection;
 
     /**
-     * Debug flag logging the class the class loader of the request.
+     * Debug flag logging the classloader of the request.
      */
     private boolean logGROOVY861;
 

--- a/subprojects/groovy-servlet/src/main/java/groovy/servlet/GroovyServlet.java
+++ b/subprojects/groovy-servlet/src/main/java/groovy/servlet/GroovyServlet.java
@@ -169,7 +169,7 @@ public class GroovyServlet extends AbstractHttpServlet {
     }
 
     /**
-     * Hook method to setup the GroovyScriptEngine to use.<br>
+     * Hook method to set up the GroovyScriptEngine to use.<br>
      * Subclasses may override this method to provide a custom engine.
      */
     protected GroovyScriptEngine createGroovyScriptEngine(){

--- a/subprojects/groovy-servlet/src/main/java/groovy/servlet/ServletBinding.java
+++ b/subprojects/groovy-servlet/src/main/java/groovy/servlet/ServletBinding.java
@@ -84,7 +84,7 @@ import java.util.Map;
  *
  * If <code>response.getWriter()</code> is called directly (without using out), then a write method
  * call on 'sout' will not cause the <code>IllegalStateException</code>, but it will still be invalid.
- * It is the responsibility of the user of this class, to not to mix these different usage
+ * It is the responsibility of the user of this class to not mix these different usage
  * styles. The same applies to calling <code>response.getOutputStream()</code> and using 'out' or 'html'.
  *
  * <h3>Methods</h3>

--- a/subprojects/groovy-servlet/src/test/groovy/groovy/servlet/ServletBindingTest.groovy
+++ b/subprojects/groovy-servlet/src/test/groovy/groovy/servlet/ServletBindingTest.groovy
@@ -133,7 +133,7 @@ class ServletBindingTest extends GroovyTestCase {
     }
 
     /**
-     * Tests that getVariables truely returns all variables
+     * Tests that getVariables truly returns all variables
      */
     void testGetVariables_Contract() {
         def expectedVariables = ['request', 'response', 'context', 'application',
@@ -226,7 +226,7 @@ class ServletBindingTest extends GroovyTestCase {
     }
 
     /**
-     * Tests the contract on setVarible().
+     * Tests the contract on setVariable().
      */
     void testSetVariable_Contract() {
         def request = makeDefaultRequest()

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/DataSet.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/DataSet.java
@@ -456,8 +456,7 @@ public class DataSet extends Sql {
     }
 
     /**
-     * Returns a List of all of the rows from the table a DataSet
-     * represents.
+     * Returns a List of all the rows from the DataSet.
      *
      * @return Returns a list of GroovyRowResult objects from the dataset
      * @throws SQLException if a database error occurs

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/GroovyResultSetExtension.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/GroovyResultSetExtension.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 /**
  * GroovyResultSetExtension implements additional logic for ResultSet. Due to
- * the version incompatibility between java6 and java5 this methods are moved
+ * the version incompatibility between java6 and java5 those methods were moved
  * here from the original GroovyResultSet class. The methods in this class are
  * used by the proxy GroovyResultSetProxy, which will try to invoke methods
  * on this class before invoking it on ResultSet.

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
@@ -1207,7 +1207,7 @@ public class Sql implements AutoCloseable {
      * Resource handling is performed automatically where appropriate.
      *
      * @param sql         the sql statement
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      */
@@ -1239,7 +1239,7 @@ public class Sql implements AutoCloseable {
      * @param sql         the sql statement
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      */
@@ -1306,7 +1306,7 @@ public class Sql implements AutoCloseable {
      * @param params      a list of parameters
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      */
@@ -1344,7 +1344,7 @@ public class Sql implements AutoCloseable {
      * @param map         a map containing the named parameters
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      * @since 1.8.7
@@ -1363,7 +1363,7 @@ public class Sql implements AutoCloseable {
      * @param sql         the sql statement
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      * @since 1.8.7
@@ -1404,7 +1404,7 @@ public class Sql implements AutoCloseable {
      *
      * @param sql         the sql statement
      * @param params      a list of parameters
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      */
@@ -1420,7 +1420,7 @@ public class Sql implements AutoCloseable {
      *
      * @param sql         the sql statement
      * @param params      a map of named parameters
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      * @since 1.8.7
@@ -1437,7 +1437,7 @@ public class Sql implements AutoCloseable {
      *
      * @param params      a map of named parameters
      * @param sql         the sql statement
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      * @since 1.8.7
@@ -1593,7 +1593,7 @@ public class Sql implements AutoCloseable {
      * Resource handling is performed automatically where appropriate.
      *
      * @param gstring     a GString containing the SQL query with embedded params
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param rowClosure  called for each row with a GroovyResultSet
      * @throws SQLException if a database access error occurs
      * @see #expand(Object)
@@ -1624,7 +1624,7 @@ public class Sql implements AutoCloseable {
      * "scrollable" type.
      *
      * @param gstring     a GString containing the SQL query with embedded params
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
      * @param rowClosure  called for each row with a GroovyResultSet
@@ -1751,7 +1751,7 @@ public class Sql implements AutoCloseable {
      * Resource handling is performed automatically where appropriate.
      *
      * @param sql         the SQL statement
-     * @param metaClosure called with meta data of the ResultSet
+     * @param metaClosure called with metadata of the ResultSet
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      */
@@ -1780,7 +1780,7 @@ public class Sql implements AutoCloseable {
      * @param sql         the SQL statement
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      */
@@ -1971,7 +1971,7 @@ public class Sql implements AutoCloseable {
      *
      * @param sql         the SQL statement
      * @param params      a list of parameters
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      */
@@ -1986,7 +1986,7 @@ public class Sql implements AutoCloseable {
      *
      * @param sql         the SQL statement
      * @param params      a map of named parameters
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      * @since 1.8.7
@@ -2002,7 +2002,7 @@ public class Sql implements AutoCloseable {
      *
      * @param params      a map of named parameters
      * @param sql         the SQL statement
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      * @since 1.8.7
@@ -2037,7 +2037,7 @@ public class Sql implements AutoCloseable {
      * @param params      a list of parameters
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      */
@@ -2061,7 +2061,7 @@ public class Sql implements AutoCloseable {
      * @param params      a map of named parameters
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      * @since 1.8.7
@@ -2079,7 +2079,7 @@ public class Sql implements AutoCloseable {
      * @param sql         the SQL statement
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      * @since 1.8.7
@@ -2154,7 +2154,7 @@ public class Sql implements AutoCloseable {
      * Resource handling is performed automatically where appropriate.
      *
      * @param gstring     a GString containing the SQL query with embedded params
-     * @param metaClosure called with meta data of the ResultSet
+     * @param metaClosure called with metadata of the ResultSet
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      * @see #expand(Object)
@@ -2187,7 +2187,7 @@ public class Sql implements AutoCloseable {
      * @param gstring     the SQL statement
      * @param offset      the 1-based offset for the first row to be processed
      * @param maxRows     the maximum number of rows to be processed
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return a list of GroovyRowResult objects
      * @throws SQLException if a database access error occurs
      */
@@ -2722,7 +2722,7 @@ public class Sql implements AutoCloseable {
      * @param params         The parameter values that will be substituted
      *                       into the SQL statement's parameter slots
      * @param keyColumnNames a list of column names indicating the columns that should be returned from the
-     *                       inserted row or rows (some drivers may be case sensitive, e.g. may require uppercase names)
+     *                       inserted row or rows (some drivers may be case-sensitive, e.g. may require uppercase names)
      * @return A list of the auto-generated row results for each inserted row (typically auto-generated keys)
      * @throws SQLException if a database access error occurs
      * @see Connection#prepareStatement(String, String[])
@@ -2771,7 +2771,7 @@ public class Sql implements AutoCloseable {
      * @param params         a map containing the named parameters
      * @param sql            The SQL statement to execute
      * @param keyColumnNames a list of column names indicating the columns that should be returned from the
-     *                       inserted row or rows (some drivers may be case sensitive, e.g. may require uppercase names)
+     *                       inserted row or rows (some drivers may be case-sensitive, e.g. may require uppercase names)
      * @return A list of the auto-generated row results for each inserted row (typically auto-generated keys)
      * @throws SQLException if a database access error occurs
      * @see Connection#prepareStatement(String, String[])
@@ -2810,7 +2810,7 @@ public class Sql implements AutoCloseable {
      *
      * @param sql            The SQL statement to execute
      * @param keyColumnNames an array of column names indicating the columns that should be returned from the
-     *                       inserted row or rows (some drivers may be case sensitive, e.g. may require uppercase names)
+     *                       inserted row or rows (some drivers may be case-sensitive, e.g. may require uppercase names)
      * @return A list of the auto-generated row results for each inserted row (typically auto-generated keys)
      * @throws SQLException if a database access error occurs
      * @since 2.3.2
@@ -2844,7 +2844,7 @@ public class Sql implements AutoCloseable {
      *
      * @param sql            The SQL statement to execute
      * @param keyColumnNames an array of column names indicating the columns that should be returned from the
-     *                       inserted row or rows (some drivers may be case sensitive, e.g. may require uppercase names)
+     *                       inserted row or rows (some drivers may be case-sensitive, e.g. may require uppercase names)
      * @param params         The parameter values that will be substituted
      *                       into the SQL statement's parameter slots
      * @return A list of the auto-generated row results for each inserted row (typically auto-generated keys)
@@ -2911,7 +2911,7 @@ public class Sql implements AutoCloseable {
      *
      * @param gstring        a GString containing the SQL query with embedded params
      * @param keyColumnNames a list of column names indicating the columns that should be returned from the
-     *                       inserted row or rows (some drivers may be case sensitive, e.g. may require uppercase names)
+     *                       inserted row or rows (some drivers may be case-sensitive, e.g. may require uppercase names)
      * @return A list of the auto-generated row results for each inserted row (typically auto-generated keys)
      * @throws SQLException if a database access error occurs
      * @see Connection#prepareStatement(String, String[])
@@ -4028,7 +4028,7 @@ public class Sql implements AutoCloseable {
      *
      * @param sql         query to execute
      * @param rs          the ResultSet to process
-     * @param metaClosure called for meta data (only once after sql execution)
+     * @param metaClosure called for metadata (only once after sql execution)
      * @return the resulting list of rows
      * @throws SQLException if a database error occurs
      */
@@ -4418,7 +4418,7 @@ public class Sql implements AutoCloseable {
      * Default behavior is to call a previously saved closure, if any, using the
      * statement as a parameter.
      *
-     * @param statement the statement to cleanup
+     * @param statement the statement to clean up
      * @since 4.0.1
      */
     protected void cleanup(Statement statement) {

--- a/subprojects/groovy-templates/src/main/groovy/groovy/text/StreamingTemplateEngine.java
+++ b/subprojects/groovy-templates/src/main/groovy/groovy/text/StreamingTemplateEngine.java
@@ -264,7 +264,7 @@ public class StreamingTemplateEngine extends TemplateEngine {
             private static final long serialVersionUID = -3786157136157691230L;
         }
 
-        //WE USE THIS AS REUSABLE        
+        //WE USE THIS AS REUSABLE
         //CHECKSTYLE.OFF: ConstantNameCheck - special case with a reusable exception
         private static final FinishedReadingException finishedReadingException;
         //CHECKSTYLE.ON: ConstantNameCheck
@@ -541,7 +541,7 @@ public class StreamingTemplateEngine extends TemplateEngine {
 
              Note: we don't do java escaping of slashes in the below
              example, i.e. the source string is what you would see in a text editor when looking at your template
-             file: 
+             file:
              source string     result
              'bob'            -> 'bob'
              '\bob'           -> '\bob'
@@ -559,7 +559,7 @@ public class StreamingTemplateEngine extends TemplateEngine {
                 //this means we have received a double backslash sequence
                 //if this is followed by ${ or <% we output one backslash
                 //and interpret the following sequences with groovy, if followed by anything
-                //else we output the two backslashes and continue as usual 
+                //else we output the two backslashes and continue as usual
                 source.mark(3);
                 int d = read(source, sourcePosition, lookAhead);
                 c = read(source, sourcePosition, lookAhead);
@@ -630,7 +630,7 @@ public class StreamingTemplateEngine extends TemplateEngine {
         }
 
         /**
-         * Parses a non curly dollar preceded identifier of the type
+         * Parses a non-curly dollar preceded identifier of the type
          * '$bird' in the following template example:
          *
          * <pre>
@@ -785,7 +785,7 @@ public class StreamingTemplateEngine extends TemplateEngine {
         /*
          * Create groovy assertion style error message for template error. Example:
          *
-         * Error parsing expression on line 71 column 15, message: no such property jboss for for class DUMMY
+         * Error parsing expression on line 71 column 15, message: no such property jboss for class DUMMY
          * templatedata${jboss}templateddatatemplateddata
          *             ^------^
          *                 |
@@ -853,7 +853,7 @@ public class StreamingTemplateEngine extends TemplateEngine {
             try {
                 msg += "\n" + getErrorContext(p.row);
             } catch (IOException e) {
-                //we opt for not doing anthing here...we just do not get context if
+                //we opt for not doing anything here...we just do not get context if
                 //this happens
             }
 

--- a/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/BaseTemplate.java
+++ b/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/BaseTemplate.java
@@ -382,8 +382,8 @@ public abstract class BaseTemplate implements Writable {
     }
 
     /**
-     * Imports a template and renders it using the specified model, allowing fine grained composition
-     * of templates and layouting. This works similarily to a template include but allows a distinct
+     * Imports a template and renders it using the specified model, allowing fine-grained composition
+     * of templates and layouting. This works similarly to a template include but allows a distinct
      * model to be used. This version doesn't inherit the model from the parent. If you need model
      * inheritance, see {@link #layout(java.util.Map, String, boolean)}.
      * @param model model to be passed to the template
@@ -397,8 +397,8 @@ public abstract class BaseTemplate implements Writable {
     }
 
     /**
-     * Imports a template and renders it using the specified model, allowing fine grained composition of templates and
-     * layouting. This works similarily to a template include but allows a distinct model to be used. If the layout
+     * Imports a template and renders it using the specified model, allowing fine-grained composition of templates and
+     * layouting. This works similarly to a template include but allows a distinct model to be used. If the layout
      * inherits from the parent model, a new model is created, with the values from the parent model, eventually
      * overridden with those provided specifically for this layout.
      *

--- a/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/TemplateResolver.java
+++ b/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/TemplateResolver.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.net.URL;
 
 /**
- * Interface for template resolvers, which, given a template identifier, return an URL where the template
+ * Interface for template resolvers, which, given a template identifier, return a URL where the template
  * can be loaded.
  */
 public interface TemplateResolver {

--- a/subprojects/groovy-test/src/main/groovy/groovy/mock/interceptor/package.html
+++ b/subprojects/groovy-test/src/main/groovy/groovy/mock/interceptor/package.html
@@ -29,7 +29,7 @@
     <dl>
         <dt>Collaborator</dt>
         <dd>An ordinary Groovy or Java class that's instance or class methods
-        are to be called. Calling them can be time consuming or produce side effects that
+        are to be called. Calling them can be time-consuming or produce side effects that
         are unwanted when testing (e.g. database operations). </dd>
 
         <dt>Caller</dt>

--- a/subprojects/groovy-typecheckers/build.gradle
+++ b/subprojects/groovy-typecheckers/build.gradle
@@ -10,7 +10,7 @@
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed oHistoryRecordGetTextToRunTestsn an
+ *  software distributed under the License is distributed on an
  *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  *  KIND, either express or implied.  See the License for the
  *  specific language governing permissions and limitations

--- a/subprojects/groovy-xml/src/main/groovy/groovy/xml/XmlParserFactory.groovy
+++ b/subprojects/groovy-xml/src/main/groovy/groovy/xml/XmlParserFactory.groovy
@@ -19,7 +19,7 @@
 package groovy.xml
 
 /**
- * Factory method targetting dynamic contexts which allows a new {@code XmlParser} to be created.
+ * Factory method targeting dynamic contexts which allows a new {@code XmlParser} to be created.
  * It is intended to assist with migration from Groovy 2.5.x to Groovy 3+.
  * Code using this factory will not need to change moving from 2.x to 3+.
  * In Groovy 2.5.x, a {@code groovy.util.XmlParser} will be returned.

--- a/subprojects/groovy-xml/src/main/groovy/groovy/xml/XmlSlurperFactory.groovy
+++ b/subprojects/groovy-xml/src/main/groovy/groovy/xml/XmlSlurperFactory.groovy
@@ -19,7 +19,7 @@
 package groovy.xml
 
 /**
- * Factory method targetting dynamic contexts which allows a new {@code XmlSlurper} to be created.
+ * Factory method targeting dynamic contexts which allows a new {@code XmlSlurper} to be created.
  * It is intended to assist with migration from Groovy 2.5.x to Groovy 3+.
  * Code using this factory will not need to change moving from 2.x to 3+.
  * In Groovy 2.5.x, a {@code groovy.util.XmlSlurper} will be returned.

--- a/subprojects/groovy-xml/src/main/java/groovy/xml/XmlParser.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/xml/XmlParser.java
@@ -245,7 +245,7 @@ public class XmlParser implements ContentHandler {
     /**
      * Parse the content of the specified URI into a tree of Nodes.
      *
-     * @param uri a String containing a uri pointing to the XML to be parsed
+     * @param uri a String containing a URI pointing to the XML to be parsed
      * @return the root node of the parsed tree of Nodes
      * @throws SAXException Any SAX exception, possibly
      *                      wrapping another exception.
@@ -366,7 +366,7 @@ public class XmlParser implements ContentHandler {
     }
 
     // ContentHandler interface
-    //-------------------------------------------------------------------------                    
+    //-------------------------------------------------------------------------
     @Override
     public void startDocument() throws SAXException {
         parent = null;

--- a/subprojects/groovy-xml/src/main/java/groovy/xml/XmlUtil.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/xml/XmlUtil.java
@@ -390,7 +390,7 @@ public class XmlUtil {
 
     /**
      * Factory method to create a SAXParser configured to validate according to a particular schema language and
-     * an URL pointing to the schema to validate against.
+     * a URL pointing to the schema to validate against.
      * The created SAXParser will be namespace-aware and not validate against DTDs.
      *
      * @param schemaLanguage the schema language used, e.g. XML Schema or RelaxNG (as per the String representation in javax.xml.XMLConstants)
@@ -407,7 +407,7 @@ public class XmlUtil {
 
     /**
      * Factory method to create a SAXParser configured to validate according to a particular schema language and
-     * an URL pointing to the schema to validate against.
+     * a URL pointing to the schema to validate against.
      *
      * @param schemaLanguage the schema language used, e.g. XML Schema or RelaxNG (as per the String representation in javax.xml.XMLConstants)
      * @param namespaceAware will the parser be namespace aware
@@ -567,20 +567,26 @@ public class XmlUtil {
         try {
             factory.setFeature(feature, value);
         }
-        catch (TransformerConfigurationException ignored) { }
+        catch (TransformerConfigurationException ignored) {
+            // feature is not supported, ignore
+        }
     }
 
     public static void setFeatureQuietly(DocumentBuilderFactory factory, String feature, boolean value) {
         try {
             factory.setFeature(feature, value);
         }
-        catch (ParserConfigurationException ignored) { }
+        catch (ParserConfigurationException ignored) {
+            // feature is not supported, ignore
+        }
     }
 
     public static void setFeatureQuietly(SAXParserFactory factory, String feature, boolean value) {
         try {
             factory.setFeature(feature, value);
         }
-        catch (ParserConfigurationException | SAXNotSupportedException | SAXNotRecognizedException ignored) { }
+        catch (ParserConfigurationException | SAXNotSupportedException | SAXNotRecognizedException ignored) {
+            // feature is not supported, ignore
+        }
     }
 }

--- a/subprojects/groovy-xml/src/main/java/groovy/xml/slurpersupport/Attribute.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/xml/slurpersupport/Attribute.java
@@ -148,7 +148,7 @@ public class Attribute extends GPathResult {
     }
 
     /**
-     * NOP, because an node can not be appended to an attribute.
+     * NOP, because a node can not be appended to an attribute.
      */
     @Override
     protected void appendNode(final Object newValue) {

--- a/subprojects/groovy-xml/src/main/java/groovy/xml/slurpersupport/GPathResult.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/xml/slurpersupport/GPathResult.java
@@ -284,7 +284,7 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
     }
 
     /**
-     * Converts the text of this GPathResult to a Integer object.
+     * Converts the text of this GPathResult to an Integer object.
      *
      * @return the GPathResult, converted to a <code>Integer</code>
      */
@@ -652,7 +652,7 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
                     } else {
                         delegate.invokeMethod("yield", new Object[]{child});
                     }
-                }                
+                }
             }
         };
     }

--- a/subprojects/performance/src/files/pleac01.groovy
+++ b/subprojects/performance/src/files/pleac01.groovy
@@ -249,7 +249,7 @@ assert v1 == 'omega' && v2 == 'alpha'
 
 // @@PLEAC@@_1.4
 //----------------------------------------------------------------------------------
-// char and int are interchangable, apart from precision difference
+// char and int are interchangeable, apart from precision difference
 // char use 16 bits while int use 32, requiring a cast from int to char
 char ch = 'e'
 int num = ch         // no problem

--- a/subprojects/stress/src/stressTest/java/org/codehaus/groovy/reflection/ClassInfoDeadlockStressTest.java
+++ b/subprojects/stress/src/stressTest/java/org/codehaus/groovy/reflection/ClassInfoDeadlockStressTest.java
@@ -47,7 +47,7 @@ public class ClassInfoDeadlockStressTest {
      * We first generate a large number of ClassInfo instances for classes
      * that are no longer reachable.  Then queue up threads to all request
      * ClassInfo instances for new classes simultaneously to ensure that
-     * clearing the old references wont deadlock the creation of new
+     * clearing the old references won't deadlock the creation of new
      * instances.
      * <p>
      * GROOVY-8067

--- a/subprojects/stress/src/stressTest/java/org/codehaus/groovy/util/ManagedConcurrentMapStressTest.java
+++ b/subprojects/stress/src/stressTest/java/org/codehaus/groovy/util/ManagedConcurrentMapStressTest.java
@@ -79,7 +79,7 @@ public class ManagedConcurrentMapStressTest {
     /**
      * This tests for deadlock which can happen if more than one thread is allowed
      * to process entries from the same RefQ. We run multiple iterations because it
-     * wont always be detected one run.
+     * won't always be detected in one run.
      *
      * @throws Exception
      */

--- a/subprojects/stress/src/stressTest/java/org/codehaus/groovy/util/ManagedConcurrentValueMapStressTest.java
+++ b/subprojects/stress/src/stressTest/java/org/codehaus/groovy/util/ManagedConcurrentValueMapStressTest.java
@@ -73,7 +73,7 @@ public class ManagedConcurrentValueMapStressTest {
     /**
      * This tests for deadlock which can happen if more than one thread is allowed
      * to process entries from the same RefQ. We run multiple iterations because it
-     * wont always be detected one run.
+     * won't always be detected in one run.
      *
      * @throws Exception
      */


### PR DESCRIPTION
Note that the following words / expressions were preferred :

- meta data -> metadata (incorrect, see https://www.merriam-webster.com/dictionary/metadata)
- sub-type -> subtype (more common, see https://www.merriam-webster.com/dictionary/subtype)
- sub-directory -> subdirectory (more common, see https://www.merriam-webster.com/dictionary/subdirectory)
- whether or not -> whether (when possible because it is easier to read)

The documentation of `DataSet#rows()` were altered because it did not look right. Let me know if this change should be reverted.