### PR TITLE
Fix minor typos in tests documentation

### DIFF
--- a/src/spec/test/ClassDesignASTTransformsTest.groovy
+++ b/src/spec/test/ClassDesignASTTransformsTest.groovy
@@ -399,7 +399,7 @@ long longComputation(int seed) {
 }
 
 def x = longComputation(1) // returns after 100 milliseconds
-def y = longComputation(1) // returns immediatly
+def y = longComputation(1) // returns immediately
 def z = longComputation(2) // returns after 200 milliseconds
 assert x==y
 assert x!=z

--- a/src/spec/test/DesignPatternsTest.groovy
+++ b/src/spec/test/DesignPatternsTest.groovy
@@ -1134,7 +1134,7 @@ class DesignPatternsTest extends CompilableTestSupport {
             }
 
             class Aircraft {
-                private type         // instrinsic state
+                private type         // intrinsic state
                 private assetNumber  // extrinsic state
                 private bought       // extrinsic state
                 Aircraft(typeCode, assetNumber, bought) {

--- a/src/tck/test/gls/ch03/s03/UnicodeEscapes2.groovy
+++ b/src/tck/test/gls/ch03/s03/UnicodeEscapes2.groovy
@@ -36,7 +36,7 @@ class UnicodeEscapes2 extends GroovyTestCase {
         def a = 1
         assert \u0061 == 1 // char 61 is 'a'
 
-        // Not intepreted as an escape
+        // Not interpreted as an escape
         // \\u0061 == 1 // @fail:parse
 
         assert "\u0061".length() == 1

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -1196,7 +1196,7 @@ final class InnerClassTest {
         // this does actually not do much, but before this
         // change the inner class was tried to be executed
         // because a class ordering bug. The main method
-        // makes the Foo class executeable, but Foo$Bar is
+        // makes the Foo class executable, but Foo$Bar is
         // not. So if Foo$Bar is returned, asserScript will
         // fail. If Foo is returned, asserScript will not
         // fail.

--- a/src/test/gls/invocation/CovariantReturnTest.groovy
+++ b/src/test/gls/invocation/CovariantReturnTest.groovy
@@ -159,7 +159,7 @@ class CovariantReturnTest extends CompilableTestSupport {
 
     void testImplementedInterfacesNotInfluencing() {
         // in GROOVY-3229 some methods from Appendable were not correctly recognized
-        // as already being overridden (PrintWriter<Writer<Appenable)
+        // as already being overridden (PrintWriter<Writer<Appendable)
         shouldCompile """
             class IndentWriter extends java.io.PrintWriter {
                public IndentWriter(Writer w)  { super(w, true) }

--- a/src/test/gls/invocation/DefaultParamTest.groovy
+++ b/src/test/gls/invocation/DefaultParamTest.groovy
@@ -106,7 +106,7 @@ final class DefaultParamTest extends GroovyTestCase {
 
     void testPrecendence() {
         // def meth(Closure cl = null) will produce a call meth(null)
-        // since interfaces are prefered over normal classes and since
+        // since interfaces are preferred over normal classes and since
         // def meth(Map args, Closure cl = null) will produce a method
         // meth(Map) a simple call with meth(null) would normally call
         // meth(Map). To ensure this will not happen the call has to

--- a/src/test/gls/syntax/OldClosureSyntaxRemovalTest.groovy
+++ b/src/test/gls/syntax/OldClosureSyntaxRemovalTest.groovy
@@ -29,7 +29,7 @@ class OldClosureSyntaxRemovalTest extends CompilableTestSupport {
         def oldClosure = { a | b }
         assert newClosure(1) == 1
         assert oldClosure.getMaximumNumberOfParameters() == 1
-        // the old closure would have cimply returned b
+        // the old closure would have simply returned b
         // after removal this is the logic or
         assert oldClosure(1) == (a | b)
     }

--- a/src/test/gls/syntax/UnderscoreInNumbersTest.groovy
+++ b/src/test/gls/syntax/UnderscoreInNumbersTest.groovy
@@ -47,7 +47,7 @@ class UnderscoreInNumbersTest extends CompilableTestSupport {
 
             // this one is mentioned in the proposal but I think is wrong
             // since we shouldn't allow _., ie. an underscore (or a series of underscores)
-            // should alwasy be surrounded with at least one number
+            // should always be surrounded with at least one number
             // double whyWouldYouEverDoThis = 0x1_.ffff_ffff_ffff_fp10_23
         '''
     }

--- a/src/test/groovy/CastTest.groovy
+++ b/src/test/groovy/CastTest.groovy
@@ -120,7 +120,7 @@ class CastTest extends GroovyTestCase {
         mySet = [2, 3, 4, 3] as Set
         assert mySet instanceof HashSet
 
-        // identitiy test
+        // identity test
         mySet = {} as Set
         assert mySet.is ( mySet as Set )
 

--- a/src/test/groovy/CategoryTest.groovy
+++ b/src/test/groovy/CategoryTest.groovy
@@ -190,7 +190,7 @@ final class CategoryTest extends GroovyTestCase {
         // this test will call a method using a POJO while a category is active
         // in call site caching this triggers the usage of POJOMetaClassSite,
         // which was missing a null check for the receiver. The last foo call
-        // uses null to exaclty check that path. I use multiple calls with foo(1)
+        // uses null to exactly check that path. I use multiple calls with foo(1)
         // before to ensure for example indy will do the right things as well,
         // since indy may need more than one call here.
         assertScript """

--- a/src/test/groovy/ClosureMethodTest.groovy
+++ b/src/test/groovy/ClosureMethodTest.groovy
@@ -249,7 +249,7 @@ class ClosureMethodTest extends GroovyTestCase {
         // Check edges
         try {
             [].inject { a, b -> a + b } == null
-            fail("inject(Closure) on an emtpy list should throw a NoSuchElementException")
+            fail("inject(Closure) on an empty list should throw a NoSuchElementException")
         }
         catch (NoSuchElementException e) {
         }
@@ -263,7 +263,7 @@ class ClosureMethodTest extends GroovyTestCase {
 
         try {
             ([] as Object[]).inject { c, item -> c + item }
-            fail("inject(Closure) on an emtpy Object[] should throw a NoSuchElementException")
+            fail("inject(Closure) on an empty Object[] should throw a NoSuchElementException")
         }
         catch (NoSuchElementException e) {
         }
@@ -278,7 +278,7 @@ class ClosureMethodTest extends GroovyTestCase {
         try {
             iter = [hasNext: { -> false }, next: { -> null }] as Iterator
             iter.inject { a, b -> a * b }
-            fail("inject(Closure) on an exhaused iterator should throw a NoSuchElementException")
+            fail("inject(Closure) on an exhausted iterator should throw a NoSuchElementException")
         }
         catch (NoSuchElementException e) {
         }

--- a/src/test/groovy/HexTest.groovy
+++ b/src/test/groovy/HexTest.groovy
@@ -75,7 +75,7 @@ class HexTest extends GroovyTestCase {
     }
 
     void testEncodeAndDecode() {
-        // test with an arbitary string
+        // test with an arbitrary string
         def testString = "00010fa011f000ff"
         assert testString.decodeHex().encodeHex().toString() == testString
 

--- a/src/test/groovy/bugs/CustomMetaClassTest.groovy
+++ b/src/test/groovy/bugs/CustomMetaClassTest.groovy
@@ -36,7 +36,7 @@ class CustomMetaClassTest extends GroovyTestCase {
 
     void testReplaceMetaClass() {
         /*
-         * Constructing first instance before meta class replacement
+         * Constructing first instance before metaclass replacement
          * is made.
          */
         def firstInstance = "first"
@@ -50,13 +50,13 @@ class CustomMetaClassTest extends GroovyTestCase {
         registry.setMetaClass(String.class, myMetaClass)
 
         /*
-         * Constructing second instance after meta class replacment
+         * Constructing second instance after metaclass replacement
          * is made.
          */
         def secondInstance = "second"
 
         /*
-         * Since we are replacing a meta class at the class level
+         * Since we are replacing a metaclass at the class level
          * we are changing the behavior of the first and second
          * instances of the string.
          */

--- a/src/test/groovy/bugs/DefVariableBug.groovy
+++ b/src/test/groovy/bugs/DefVariableBug.groovy
@@ -24,7 +24,7 @@ class DefVariableBug extends GroovyTestCase {
 
     void testBug() {
 
-     /* cpoirier - "def" can be refered to as a variable name,
+     /* cpoirier - "def" can be referred as a variable name,
         but cannot be declared as one (due to ambiguities)
 
         def = 123

--- a/src/test/groovy/bugs/Groovy4480Bug.groovy
+++ b/src/test/groovy/bugs/Groovy4480Bug.groovy
@@ -22,7 +22,7 @@ import groovy.test.GroovyTestCase
 
 /**
  * Checks that if else can be used on a single line.
- * A regression got introduced wiht extended command expression that dissallowed if else on the same line
+ * A regression got introduced wiht extended command expression that disallowed if else on the same line
  */
 class Groovy4480Bug extends GroovyTestCase {
 

--- a/src/test/groovy/bugs/Groovy8678.groovy
+++ b/src/test/groovy/bugs/Groovy8678.groovy
@@ -176,7 +176,7 @@ final class Groovy8678 {
     private class BigDecimalCategory {
         // using @Category here has a similar effect like
         //     BigDecimal.metaClass.call << { delegate * 2 }
-        // but without the side effects on the state of BigDecimal's meta class after the test
+        // but without the side effects on the state of BigDecimal's metaclass after the test
         def call() {
             return this * 2
         }
@@ -186,7 +186,7 @@ final class Groovy8678 {
     private class FloatCategory {
         // using @Category here has a similar effect like
         //     Float.metaClass.call << { delegate * 2 }
-        // but without the side effects on the state of Float's meta class after the test
+        // but without the side effects on the state of Float's metaclass after the test
         def call() {
             return this * 2
         }
@@ -196,7 +196,7 @@ final class Groovy8678 {
     private class DoubleCategory {
         // using @Category here has a similar effect like
         //     Double.metaClass.call << { delegate * 2 }
-        // but without the side effects on the state of Double's meta class after the test
+        // but without the side effects on the state of Double's metaclass after the test
         def call() {
             return this * 2
         }

--- a/src/test/groovy/bugs/SynchronizedBytecodeBug.groovy
+++ b/src/test/groovy/bugs/SynchronizedBytecodeBug.groovy
@@ -23,7 +23,7 @@ import groovy.test.GroovyTestCase
 class SynchronizedBytecodeBug extends GroovyTestCase {
 
     /**
-     * Groovy's bytecode associated with syncrhonized(foo) construct used to generate invalid bytecode
+     * Groovy's bytecode associated with synchronized(foo) construct used to generate invalid bytecode
      * This test method shows that the standard wait()/notify() works.
      */
     void testSynchronized() {

--- a/src/test/groovy/lang/ClassReloadingTest.groovy
+++ b/src/test/groovy/lang/ClassReloadingTest.groovy
@@ -83,7 +83,7 @@ class ClassReloadingTest extends GroovyTestCase {
         def message = groovyClass.newInstance().greeting
         assert "hello" == message
 
-        // (string, string) version should not do the caching as it breaks Spring integration (bean refreh)
+        // (string, string) version should not do the caching as it breaks Spring integration (bean refresh)
         classStr = """
             class Groovy3981 {
                 def greeting = "goodbye"

--- a/src/test/groovy/lang/DummyGString.java
+++ b/src/test/groovy/lang/DummyGString.java
@@ -19,7 +19,7 @@
 package groovy.lang;
 
 /**
- * A hand crafted example GString
+ * A handcrafted example GString
  */
 public class DummyGString extends DummyGStringBase {
 

--- a/src/test/groovy/lang/ExpandoMetaClassTest.groovy
+++ b/src/test/groovy/lang/ExpandoMetaClassTest.groovy
@@ -784,10 +784,10 @@ class ExpandoMetaClassTest extends GroovyTestCase {
 
     void testPickMethodForVarg() {
         // as of 1.6 a metaClass is often the HandleMetaclass, which delegates
-        // methods to an underlaying meta class. hasMethod is a Method on EMC
+        // methods to an underlying metaclass. hasMethod is a Method on EMC
         // that takes a Class[] vargs argument as last part. If that part is not
         // given, then hasMetaMethod will still work, but the code actually
-        // invoking the method in EMC.invokeMehod(String,Object) has to correct the
+        // invoking the method in EMC.invokeMethod(String,Object) has to correct the
         // arguments.
         assert "".metaClass.pickMethod("trim")
     }

--- a/src/test/groovy/lang/MetaClassRegistryTest.groovy
+++ b/src/test/groovy/lang/MetaClassRegistryTest.groovy
@@ -79,7 +79,7 @@ class MetaClassRegistryTest extends GroovyTestCase {
         def metaClasses = []
         registry.each { metaClasses << it }
 
-        // we add one more constant meta class and then count them to
+        // we add one more constant metaclass and then count them to
         // see if the number fits
         Integer.metaClass.foo = {}
 

--- a/src/test/groovy/transform/ReadWriteLockTest.groovy
+++ b/src/test/groovy/transform/ReadWriteLockTest.groovy
@@ -142,7 +142,7 @@ final class ReadWriteLockTest {
     void testDeadlockingDoesNotOccur() {
         def tester = new MyClass()
 
-        // this tests for deadlocks from not releaseing in finally block
+        // this tests for deadlocks from not releasing in finally block
         shouldFail { tester.namedReaderMethod1() }
         shouldFail { tester.namedReaderMethod2() }
         shouldFail { tester.namedWriterMethod1() }

--- a/src/test/groovy/txn/TransactionBuilder.java
+++ b/src/test/groovy/txn/TransactionBuilder.java
@@ -26,7 +26,7 @@ public class TransactionBuilder {
         closure.setDelegate(bean);
         closure.call(this);
 
-        // lets call the closures now
+        // let's call the closures now
         System.out.println("Performing normal transaction");
         bean.run().call(this);
         bean.onSuccess().call(this);

--- a/src/test/groovy/util/FactoryBuilderSupportTest.groovy
+++ b/src/test/groovy/util/FactoryBuilderSupportTest.groovy
@@ -256,7 +256,7 @@ class FactoryBuilderSupportTest extends GroovyTestCase {
         // property neither set in the binding or explicitly, should fail
         shouldFail { b.exp }
 
-        // setting first should set the value in the binding and make it usable 
+        // setting first should set the value in the binding and make it usable
         b.notExp = 1
         assert b.notExp == 1
 
@@ -274,7 +274,7 @@ class FactoryBuilderSupportTest extends GroovyTestCase {
         b.exp = 4
         assert val == 5
 
-        // symbols in the property closure shold also resolve to the builder...
+        // symbols in the property closure should also resolve to the builder...
         b.registerExplicitProperty ('exp2', {exp}, {exp = it })
 
         assert b.exp2 == val - 1
@@ -300,7 +300,7 @@ class FactoryBuilderSupportTest extends GroovyTestCase {
         b.exp(5)
         assert val == 8
 
-        // symbols in the method closure shold also resolve to the builder...
+        // symbols in the method closure should also resolve to the builder...
         b.registerExplicitMethod ('exp2', {exp(it)})
 
         assert b.exp2(-2) == 6
@@ -535,7 +535,7 @@ class FactoryBuilderSupportTest extends GroovyTestCase {
             withBuilder(c){
                fooz(){
                   baz()
-               }   
+               }
             }
         }
         assert b.@log == [
@@ -587,7 +587,7 @@ class FactoryBuilderSupportTest extends GroovyTestCase {
             withBuilder(c,'foo'){
                fooz(){
                   baz()
-               }   
+               }
             }
         }
 
@@ -646,7 +646,7 @@ class FactoryBuilderSupportTest extends GroovyTestCase {
             withBuilder(c,'foo',bar:'baz'){
                fooz(){
                   baz()
-               }   
+               }
             }
         }
 
@@ -723,7 +723,7 @@ class FactoryBuilderSupportTest extends GroovyTestCase {
                 'post_node_completion', 'x', 'x'/*,
             'node_completed',null,'x',
             'post_node_completion',null, 'x'*/
-                // node foo() was not completed successfuly
+                // node foo() was not completed successfully
         ]
         assert c.@log == [
                 'register', 'outest', 'Layers',
@@ -910,7 +910,7 @@ class XFactory extends AbstractFactory {
         builder.@log << 'handle_node_attributes'
         builder.@log << node
         attributes.each{entry -> builder.@log << entry.key; builder.@log << entry.value}
-        return false 
+        return false
     }
 
     public void onNodeCompleted( FactoryBuilderSupport builder, Object parent, Object node ) {

--- a/src/test/groovy/util/ProxyTest.groovy
+++ b/src/test/groovy/util/ProxyTest.groovy
@@ -29,9 +29,9 @@ class ProxyTest extends GroovyTestCase {
         assertSame original, proxy.adaptee
         // method, that is only known on adaptee is relayed through the proxy
         assertEquals original.size(), proxy.size()
-        // method, that is availabe in both objects should come from proxy
+        // method, that is available in both objects should come from proxy
         assertEquals 0, proxy.length()
-        // method, that is availabe in both objects
+        // method, that is available in both objects
         // but should come from adaptee needs explicit relay
         assertEquals original, proxy.toString()
         // method from decorator, that is not in adaptee
@@ -48,25 +48,25 @@ class ProxyTest extends GroovyTestCase {
 
   void testProxyCollect ( ) {
     def collection = [ 1 , 2 , 3 ]
-    def proxy = ( new Proxy ( ) ).wrap ( collection ) 
+    def proxy = ( new Proxy ( ) ).wrap ( collection )
     assertEquals ( [ 2 , 3 , 4 ] , proxy.collect { it + 1 } )
   }
 
   void testProxyAny ( ) {
     def collection = [ 1 , 2 , 3 ]
-    def proxy = ( new Proxy ( ) ).wrap ( collection ) 
+    def proxy = ( new Proxy ( ) ).wrap ( collection )
     assertEquals ( true , proxy.any { it == 2 } )
   }
 
   void testProxyFind ( ) {
     def collection = [ 1 , 2 , 3 ]
-    def proxy = ( new Proxy ( ) ).wrap ( collection ) 
+    def proxy = ( new Proxy ( ) ).wrap ( collection )
     assertEquals ( 2 , proxy.find { it == 2 } )
   }
 
   void testProxyEach ( ) {
     def collection = [ 1 , 2 , 3 ]
-    def proxy = ( new Proxy ( ) ).wrap ( collection ) 
+    def proxy = ( new Proxy ( ) ).wrap ( collection )
     def testString = ''
     proxy.each { testString += it }
     assertEquals ( '123' , testString )

--- a/src/test/org/apache/groovy/parser/antlr4/util/ASTComparatorCategory.groovy
+++ b/src/test/org/apache/groovy/parser/antlr4/util/ASTComparatorCategory.groovy
@@ -210,7 +210,7 @@ class ASTComparatorCategory {
 
     /**
      * Main method that makes the magic. Compares all properties for object a and object b.
-     * There is a lot of problems in this code, like omitted class checking and so on. Just belive, it will be used properly.
+     * There is a lot of problems in this code, like omitted class checking and so on. Just believe it will be used properly.
      * @param a
      * @param b
      * @return
@@ -280,7 +280,7 @@ class ASTComparatorCategory {
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Just a bunch of copypasted methods. Maybe will wrote AST transformation for them.
+    // Just a bunch of copy-pasted methods. Maybe will wrote AST transformation for them.
     ////////////////////////////////////////////////////////////////////////////////////////////////////
 
     static equals(ClassNode a, ClassNode b) {

--- a/src/test/org/codehaus/groovy/classgen/DumpingClassLoader.java
+++ b/src/test/org/codehaus/groovy/classgen/DumpingClassLoader.java
@@ -55,7 +55,7 @@ public class DumpingClassLoader extends GroovyClassLoader implements Opcodes {
         }
 
         public void call(ClassVisitor classWriter, ClassNode classNode) {
-            // lets test out the class verifier
+            // let's test out the class verifier
             if (DUMP_CLASS) {
                 dumper.visitClass(classNode);
             }

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/ArraysAndCollectionsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/ArraysAndCollectionsStaticCompileTest.groovy
@@ -67,7 +67,7 @@ class ArraysAndCollectionsStaticCompileTest extends ArraysAndCollectionsSTCTest 
 
                 for(String property in p.properties.keySet()){
                     props[property] = 'TEST'
-                    // I need to use calling put directy to make it work
+                    // I need to use calling put directly to make it work
                     // props.put property, 'TEST'
                 }
                 props

--- a/src/test/org/codehaus/groovy/reflection/utils/ReflectionUtilsTest.groovy
+++ b/src/test/org/codehaus/groovy/reflection/utils/ReflectionUtilsTest.groovy
@@ -21,7 +21,7 @@ package org.codehaus.groovy.reflection.utils
 import groovy.test.GroovyTestCase
 import org.codehaus.groovy.reflection.ReflectionUtils
 
-// note, this must be in a package other than org.codehause.groovy.reflection or else
+// note, this must be in a package other than org.codehaus.groovy.reflection or else
 // the tests will incorrectly miss the target
 
 class ReflectionUtilsTest extends GroovyTestCase {

--- a/src/test/org/codehaus/groovy/runtime/CustomBooleanCoercionTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/CustomBooleanCoercionTest.groovy
@@ -118,7 +118,7 @@ class CustomBooleanCoercionTest extends GroovyTestCase {
     }
 }
 
-/** A Predicate classe coercible to a boolea expression */
+/** A Predicate classe coercible to a boolean expression */
 class Predicate {
     boolean value
     boolean asBoolean() { value }

--- a/src/test/org/codehaus/groovy/runtime/MethodRankHelperTest.java
+++ b/src/test/org/codehaus/groovy/runtime/MethodRankHelperTest.java
@@ -76,7 +76,7 @@ public class MethodRankHelperTest extends TestCase {
     }
 
     /**
-     * turns a int array to a Integer array
+     * turns an int array to an Integer array
      */
     private Integer[] box(int[] ia) {
         Integer[] ret = new Integer[ia.length];

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/Groovy7966.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/Groovy7966.groovy
@@ -19,7 +19,7 @@
 package org.codehaus.groovy.tools.stubgenerator
 
 /**
- * Test that fileorder doesn't impact whether GroovyObject appears in implements list.
+ * Test that file order doesn't impact whether GroovyObject appears in implements list.
  */
 final class Groovy7966 extends StringSourcesStubTestCase {
 


### PR DESCRIPTION
Note that the following words / expressions were preferred :

- meta data -> metadata (incorrect, see https://www.merriam-webster.com/dictionary/metadata),
- meta class -> metaclass (incorrect, see https://en.wikipedia.org/wiki/Metaclass).

Some trailing whitespaces were removed and a few typos in failure messages were also fixed.