### PR TITLE
Polish org.codehaus.groovy.ast package documentation

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/ASTNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/ASTNode.java
@@ -104,7 +104,7 @@ public class ASTNode implements NodeMetaDataHandler {
     }
 
     /**
-     * Copies all node meta data from the other node to this one
+     * Copies all node metadata from the other node to this one
      * @param other - the other node
      */
     public void copyNodeMetaData(ASTNode other) {

--- a/src/main/java/org/codehaus/groovy/ast/ClassHelper.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassHelper.java
@@ -229,7 +229,7 @@ public class ClassHelper {
      * A new ClassNode object is only created if the class
      * is not one of the predefined ones
      *
-     * @param c class used to created the ClassNode
+     * @param c class used to create the ClassNode
      * @return ClassNode instance created from the given class
      */
     public static ClassNode make(Class c) {

--- a/src/main/java/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassNode.java
@@ -181,7 +181,7 @@ public class ClassNode extends AnnotatedNode {
 
     // clazz!=null when resolved
     protected Class<?> clazz;
-    // not null if if the ClassNode is an array
+    // not null if the ClassNode is an array
     private ClassNode componentType;
     // if not null this instance is handled as proxy
     // for the redirect
@@ -843,7 +843,7 @@ public class ClassNode extends AnnotatedNode {
         BlockStatement block = getCodeAsBlock(method);
 
         // while anything inside a static initializer block is appended
-        // we don't want to append in the case we have a initialization
+        // we don't want to append in the case we have an initialization
         // expression of a static field. In that case we want to add
         // before the other statements
         if (!fieldInit) {
@@ -884,7 +884,7 @@ public class ClassNode extends AnnotatedNode {
     }
 
     /**
-     * This methods returns a list of all methods of the given name
+     * This method returns a list of all methods of the given name
      * defined in the current class
      * @return the method list
      * @see #getMethods(String)
@@ -897,7 +897,7 @@ public class ClassNode extends AnnotatedNode {
     }
 
     /**
-     * This methods creates a list of all methods with this name of the
+     * This method creates a list of all methods with this name of the
      * current class and of all super classes
      * @return the methods list
      * @see #getDeclaredMethods(String)

--- a/src/main/java/org/codehaus/groovy/ast/CompileUnit.java
+++ b/src/main/java/org/codehaus/groovy/ast/CompileUnit.java
@@ -195,7 +195,7 @@ public class CompileUnit implements NodeMetaDataHandler {
     /**
      * this method actually does not compile a class. It's only
      * a marker that this type has to be compiled by the CompilationUnit
-     * at the end of a parse step no node should be be left.
+     * at the end of a parse step no node should be left.
      */
     public void addClassNodeToCompile(final ClassNode node, final SourceUnit location) {
         String nodeName = node.getName();

--- a/src/main/java/org/codehaus/groovy/ast/NodeMetaDataHandler.java
+++ b/src/main/java/org/codehaus/groovy/ast/NodeMetaDataHandler.java
@@ -31,10 +31,10 @@ import java.util.function.Function;
 @SuppressWarnings({"unchecked", "rawtypes"})
 public interface NodeMetaDataHandler {
     /**
-     * Gets the node meta data.
+     * Gets the node metadata.
      *
-     * @param key the meta data key
-     * @return the node meta data value for this key
+     * @param key the metadata key
+     * @return the node metadata value for this key
      */
     default <T> T getNodeMetaData(Object key) {
         Map metaDataMap = this.getMetaDataMap();
@@ -45,11 +45,11 @@ public interface NodeMetaDataHandler {
     }
 
     /**
-     * Gets the node meta data.
+     * Gets the node metadata.
      *
-     * @param key the meta data key
-     * @param valFn the meta data value supplier
-     * @return the node meta data value for this key
+     * @param key the metadata key
+     * @param valFn the metadata value supplier
+     * @return the node metadata value for this key
      */
     default <T> T getNodeMetaData(Object key, Function<?, ? extends T> valFn) {
         if (key == null) throw new GroovyBugError("Tried to get/set meta data with null key on " + this + ".");
@@ -63,7 +63,7 @@ public interface NodeMetaDataHandler {
     }
 
     /**
-     * Copies all node meta data from the other node to this one
+     * Copies all node metadata from the other node to this one
      *
      * @param other the other node
      */
@@ -82,10 +82,10 @@ public interface NodeMetaDataHandler {
     }
 
     /**
-     * Sets the node meta data.
+     * Sets the node metadata.
      *
-     * @param key   the meta data key
-     * @param value the meta data value
+     * @param key   the metadata key
+     * @param value the metadata value
      * @throws GroovyBugError if key is null or there is already meta
      *                        data under that key
      */
@@ -95,11 +95,11 @@ public interface NodeMetaDataHandler {
     }
 
     /**
-     * Sets the node meta data but allows overwriting values.
+     * Sets the node metadata but allows overwriting values.
      *
-     * @param key   the meta data key
-     * @param value the meta data value
-     * @return the old node meta data value for this key
+     * @param key   the metadata key
+     * @param value the metadata value
+     * @return the old node metadata value for this key
      * @throws GroovyBugError if key is null
      */
     default Object putNodeMetaData(Object key, Object value) {
@@ -114,9 +114,9 @@ public interface NodeMetaDataHandler {
     }
 
     /**
-     * Removes a node meta data entry.
+     * Removes a node metadata entry.
      *
-     * @param key the meta data key
+     * @param key the metadata key
      * @throws GroovyBugError if the key is null
      */
     default void removeNodeMetaData(Object key) {

--- a/src/main/java/org/codehaus/groovy/ast/VariableScope.java
+++ b/src/main/java/org/codehaus/groovy/ast/VariableScope.java
@@ -24,7 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Records declared and referenced variabes for a given scope.  Helps determine
+ * Records declared and referenced variables for a given scope.  Helps determine
  * variable sharing across closure and method boundaries.
  */
 public class VariableScope {

--- a/src/main/java/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/AsmDecompiler.java
@@ -62,7 +62,7 @@ public abstract class AsmDecompiler {
      * Loads the URL contents and parses them with ASM, producing a {@link ClassStub} object representing the structure of
      * the corresponding class file. Stubs are cached and reused if queried several times with equal URLs.
      *
-     * @param url an URL from a class loader, most likely a file system file or a JAR entry.
+     * @param url a URL from a class loader, most likely a file system file or a JAR entry.
      * @return the class stub
      * @throws IOException if reading from this URL is impossible
      */

--- a/src/main/java/org/codehaus/groovy/ast/decompiled/DecompiledClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/DecompiledClassNode.java
@@ -54,7 +54,7 @@ public class DecompiledClassNode extends ClassNode {
     /**
      * Handle the case of inner classes returning the correct modifiers from
      * the INNERCLASS reference since the top-level modifiers for inner classes
-     * wont include static or private/protected.
+     * won't include static or private/protected.
      */
     private static int getModifiers(ClassStub classData) {
         return (classData.innerClassModifiers != -1 ? classData.innerClassModifiers : classData.accessModifiers);

--- a/src/main/java/org/codehaus/groovy/ast/expr/GStringExpression.java
+++ b/src/main/java/org/codehaus/groovy/ast/expr/GStringExpression.java
@@ -61,7 +61,7 @@ public class GStringExpression extends Expression {
                 transformExpressions(values, transformer));
         ret.setSourcePosition(this);
         ret.copyNodeMetaData(this);
-        return ret;        
+        return ret;
     }
 
     @Override
@@ -90,7 +90,7 @@ public class GStringExpression extends Expression {
     }
 
     public void addValue(Expression value) {
-        // If the first thing is an value, then we need a dummy empty string in front of it so that when we
+        // If the first thing is a value, then we need a dummy empty string in front of it so that when we
         // toString it they come out in the correct order.
         if (strings.isEmpty())
             strings.add(ConstantExpression.EMPTY_STRING);

--- a/src/main/java/org/codehaus/groovy/ast/expr/VariableExpression.java
+++ b/src/main/java/org/codehaus/groovy/ast/expr/VariableExpression.java
@@ -169,7 +169,7 @@ public class VariableExpression extends Expression implements Variable {
 
     /**
      * For internal use only. This flag is used by compiler internals and should probably
-     * be converted to a node metadata in future.
+     * be converted to a node metadata in the future.
      *
      * @param useRef
      */
@@ -179,7 +179,7 @@ public class VariableExpression extends Expression implements Variable {
 
     /**
      * For internal use only. This flag is used by compiler internals and should probably
-     * be converted to a node metadata in future.
+     * be converted to a node metadata in the future.
      */
     public boolean isUseReferenceDirectly() {
         return useRef;

--- a/src/main/java/org/codehaus/groovy/ast/tools/GeneralUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GeneralUtils.java
@@ -290,7 +290,7 @@ public class GeneralUtils {
      * Builds a binary expression that compares two values.
      *
      * @param lhv expression for the value to compare from
-     * @param rhv expression for the value value to compare to
+     * @param rhv expression for the value to compare to
      * @return the expression comparing two values
      */
     public static BinaryExpression cmpX(final Expression lhv, final Expression rhv) {

--- a/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -838,7 +838,7 @@ public class GenericsUtils {
      * but the other will not try even if the parameterized type has placeholders
      *
      * @param declaringClass the generics class node declaring the generics types
-     * @param actualReceiver the sub-class class node
+     * @param actualReceiver the subclass class node
      * @return the placeholder-to-actualtype mapping
      *
      * @since 3.0.0

--- a/src/main/java/org/codehaus/groovy/ast/tools/WideningCategories.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/WideningCategories.java
@@ -95,7 +95,7 @@ public class WideningCategories {
     }
 
     /**
-     * Used to check if a type is an double or Double.
+     * Used to check if a type is a double or Double.
      * @param type the type to check
      */
     public static boolean isDouble(final ClassNode type) {
@@ -151,7 +151,7 @@ public class WideningCategories {
     }
 
     /**
-     * It is of a floating category, if the provided type is a
+     * It is of a floating category, if the provided type is
      * a float, double. C(type)=float
      */
     public static boolean isFloatingCategory(final ClassNode type) {
@@ -227,9 +227,9 @@ public class WideningCategories {
     }
 
     /**
-     * Given a lowest upper bound computed without generic type information but which requires to be parameterized
+     * Given the lowest upper bound computed without generic type information but which requires to be parameterized
      * and the two implementing classnodes which are parameterized with potentially two different types, returns
-     * a parameterized lowest upper bound.
+     * the parameterized lowest upper bound.
      *
      * For example, if LUB is Set&lt;T&gt; and a is Set&lt;String&gt; and b is Set&lt;StringBuffer&gt;, this
      * will return a LUB which parameterized type matches Set&lt;? extends CharSequence&gt;


### PR DESCRIPTION
Fix typos and improve documentation (javadoc, comments) in the org.codehaus.groovy.ast package.

Note that the following words / expressions were preferred :

- meta data -> metadata (incorrect, see https://www.merriam-webster.com/dictionary/metadata),
- sub-class -> subclass (more common, see https://www.merriam-webster.com/dictionary/subclass).

Trailing whitespaces were also removed in the process.