### PR TITLE
Polish groovy.lang package documentation

### DIFF
--- a/src/main/java/groovy/lang/Binding.java
+++ b/src/main/java/groovy/lang/Binding.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * Represents the variable bindings of a script which can be altered
  * from outside the script object or created outside of a script and passed
  * into it.
- * <p> Binding instances are not supposed to be used in a multi-threaded context.
+ * <p> Binding instances are not supposed to be used in a multithreaded context.
  */
 public class Binding extends GroovyObjectSupport {
     private Map variables;

--- a/src/main/java/groovy/lang/Closure.java
+++ b/src/main/java/groovy/lang/Closure.java
@@ -850,7 +850,7 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
      * Builds a trampolined variant of the current closure.
      * To prevent stack overflow due to deep recursion, functions can instead leverage the trampoline mechanism
      * and avoid recursive calls altogether. Under trampoline, the function is supposed to perform one step of
-     * the calculation and, instead of a recursive call to itself or another function, it return back a new closure,
+     * the calculation and, instead of a recursive call to itself or another function, it returns a new closure,
      * which will be executed by the trampoline as the next step.
      * Once a non-closure value is returned, the trampoline stops and returns the value as the final result.
      * Here is an example:
@@ -874,7 +874,7 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
      * Builds a trampolined variant of the current closure.
      * To prevent stack overflow due to deep recursion, functions can instead leverage the trampoline mechanism
      * and avoid recursive calls altogether. Under trampoline, the function is supposed to perform one step of
-     * the calculation and, instead of a recursive call to itself or another function, it return back a new closure,
+     * the calculation and, instead of a recursive call to itself or another function, it returns a new closure,
      * which will be executed by the trampoline as the next step.
      * Once a non-closure value is returned, the trampoline stops and returns the value as the final result.
      * @return A closure, which will execute the original closure on a trampoline.

--- a/src/main/java/groovy/lang/ExpandoMetaClass.java
+++ b/src/main/java/groovy/lang/ExpandoMetaClass.java
@@ -244,12 +244,12 @@ import static org.codehaus.groovy.runtime.MetaClassHelper.EMPTY_TYPE_ARRAY;
  * When using the default implementations of MetaClass, methods are only allowed to be added before initialize() is called.
  * In other words you create a new MetaClass, add some methods and then call initialize(). If you attempt to add new methods
  * after initialize() has been called, an error will be thrown. This is to ensure that the MetaClass can operate appropriately
- * in multi-threaded environments as it forces you to do all method additions at the beginning, before using the MetaClass.
+ * in multithreaded environments as it forces you to do all method additions at the beginning, before using the MetaClass.
  * <p>
  * ExpandoMetaClass differs here from the default in that it allows you to add methods after initialize has been called.
  * This is done by setting the initialize flag internally to false and then add the methods. Since this is not thread
  * safe it has to be done in a synchronized block. The methods to check for modification and initialization are
- * therefore synchronized as well. Any method call done through this meta class will first check if the it is
+ * therefore synchronized as well. Any method call done through this metaclass will first check if the it is
  * synchronized. Should this happen during a modification, then the method cannot be selected or called unless the
  * modification is completed.
  * <p>
@@ -327,7 +327,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
      * in the MetaClassRegistry automatically
      *
      * @param theClass The class that the MetaClass applies to
-     * @param register True if the MetaClass should be registered inside the MetaClassRegistry. This defaults to true and ExpandoMetaClass will effect all instances if changed
+     * @param register True if the MetaClass should be registered inside the MetaClassRegistry. This defaults to true and ExpandoMetaClass will affect all instances if changed
      */
     public ExpandoMetaClass(Class theClass, boolean register) {
         this(theClass,register,false,null);
@@ -342,8 +342,8 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
      * in the MetaClassRegistry automatically
      *
      * @param theClass The class that the MetaClass applies to
-     * @param register True if the MetaClass should be registered inside the MetaClassRegistry. This defaults to true and ExpandoMetaClass will effect all instances if changed
-     * @param allowChangesAfterInit Should the meta class be modifiable after initialization. Default is false.
+     * @param register True if the MetaClass should be registered inside the MetaClassRegistry. This defaults to true and ExpandoMetaClass will affect all instances if changed
+     * @param allowChangesAfterInit Should the metaclass be modifiable after initialization. Default is false.
      */
     public ExpandoMetaClass(Class theClass, boolean register, boolean allowChangesAfterInit) {
         this(theClass, register, allowChangesAfterInit, null);
@@ -507,7 +507,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     }
 
     /**
-     * Checks if the meta class is initialized.
+     * Checks if the metaclass is initialized.
      * @see groovy.lang.MetaClassImpl#isInitialized()
      */
     @Override
@@ -901,7 +901,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
             if (isInitialized()) {
                 throw new RuntimeException("Already initialized, cannot add new method: " + metaMethod);
             }
-            // we always adds meta methods to class itself
+            // we always add meta methods to class itself
             addMetaMethodToIndex(metaMethod, metaMethodIndex.getHeader(theClass));
 
             dropMethodCache(methodName);
@@ -957,7 +957,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
             modified = true;
             // Implementation note: By default Groovy uses soft references to store MetaClass
             // this insures the registry doesn't grow and get out of hand. By doing this we're
-            // saying this this EMC will be a hard reference in the registry. As we're only
+            // saying this EMC will be a hard reference in the registry. As we're only
             // going have a small number of classes that have modified EMC this is ok
             if (inRegistry) {
                 MetaClass currMetaClass = registry.getMetaClass(theClass);
@@ -1251,7 +1251,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     /**
      * Returns true if the name of the method specified and the number of arguments make it a javabean property
      *
-     * @param name True if its a Javabean property
+     * @param name True if it's a Javabean property
      * @param args The arguments
      * @return True if it is a javabean property method
      */

--- a/src/main/java/groovy/lang/GString.java
+++ b/src/main/java/groovy/lang/GString.java
@@ -89,7 +89,7 @@ public abstract class GString extends GroovyObjectSupport implements Comparable,
         try {
             return super.invokeMethod(name, args);
         } catch (MissingMethodException e) {
-            // lets try invoke the method on the real String
+            // let's try to invoke the method on the real String
             return InvokerHelper.invokeMethod(toString(), name, args);
         }
     }

--- a/src/main/java/groovy/lang/Grab.java
+++ b/src/main/java/groovy/lang/Grab.java
@@ -128,7 +128,7 @@ public @interface Grab {
      * {@code group#module;version[confs]} (where only group and module are required and confs,
      * if used, is one or more comma separated configuration names)<br>
      * In addition, you can add any valid Ivy attributes at the end of your string value using
-     * semi-colon separated name = value pairs, e.g.:<br>
+     * semicolon separated name = value pairs, e.g.:<br>
      * {@code @Grab('junit:junit:*;transitive=false')}<br>
      * {@code @Grab('group=junit;module=junit;version=4.8.2;classifier=javadoc')}<br>
      */

--- a/src/main/java/groovy/lang/GroovyClassLoader.java
+++ b/src/main/java/groovy/lang/GroovyClassLoader.java
@@ -812,8 +812,8 @@ public class GroovyClassLoader extends URLClassLoader {
     }
 
     /**
-     * sets if the recompilation should be enable. There are 3 possible
-     * values for this. Any value different than null overrides the
+     * sets if the recompilation should be enabled. There are 3 possible
+     * values for this. Any value different from null overrides the
      * value from the compiler configuration. true means to recompile if needed
      * false means to never recompile.
      *
@@ -1032,8 +1032,8 @@ public class GroovyClassLoader extends URLClassLoader {
 
         File file = new File(path, fileWithoutPackage);
         if (file.exists()) {
-            // file.exists() might be case insensitive.
-            // Let's do case sensitive match for the filename
+            // file.exists() might be case-insensitive.
+            // Let's do case-sensitive match for the filename
             try {
                 String caseSensitiveName = file.getCanonicalPath();
                 int index = caseSensitiveName.lastIndexOf(File.separator);
@@ -1066,7 +1066,7 @@ public class GroovyClassLoader extends URLClassLoader {
      * @param source the source we may want to compile
      * @param cls    the former class
      * @return true if the source is newer, false else
-     * @throws IOException if it is not possible to open an
+     * @throws IOException if it is not possible to open a
      *                     connection for the given source
      * @see #getTimeStamp(Class)
      */

--- a/src/main/java/groovy/lang/MetaClass.java
+++ b/src/main/java/groovy/lang/MetaClass.java
@@ -106,7 +106,7 @@ public interface MetaClass extends MetaObjectProtocol {
      * @param propertyName The name of the property
      * @param optionalValue The value of the property which could be null in the case of a getter
      * @param isGetter Whether the missing property event was the result of a getter or a setter
-     * 
+     *
      * @return The result of the propertyMissing method or throws MissingPropertyException
      */
      Object invokeMissingProperty(Object instance, String propertyName, Object optionalValue, boolean isGetter);
@@ -136,12 +136,12 @@ public interface MetaClass extends MetaObjectProtocol {
 
     /**
      * Complete the initialisation process. After this method
-     * is called no methods should be added to the meta class.
+     * is called no methods should be added to the metaclass.
      * Invocation of methods or access to fields/properties is
-     * forbidden unless this method is called. This method 
+     * forbidden unless this method is called. This method
      * should contain any initialisation code, taking a longer
-     * time to complete. An example is the creation of the 
-     * Reflector. It is suggested to synchronize this 
+     * time to complete. An example is the creation of the
+     * Reflector. It is suggested to synchronize this
      * method.
      */
      void initialize();

--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -255,7 +255,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     /**
      * Returns the registry for this metaclass
      *
-     * @return The resgistry
+     * @return The registry
      */
     public MetaClassRegistry getRegistry() {
         return registry;
@@ -972,7 +972,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
      * @param instance      The instance
      * @param propertyName  The name of the property
      * @param optionalValue The value in the case of a setter
-     * @param isGetter      True if its a getter
+     * @param isGetter      True if it's a getter
      * @return The value in the case of a getter or a MissingPropertyException
      */
     protected Object invokeStaticMissingProperty(Object instance, String propertyName, Object optionalValue, boolean isGetter) {
@@ -1413,7 +1413,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
             try {
                 return metaClass.invokeMethod(closure.getClass(), closure, DO_CALL_METHOD, originalArguments, false, fromInsideClass);
             } catch (MissingMethodException mme) {
-                // fall through -- "doCall" is not instrisic to Closure
+                // fall through -- "doCall" is not intrinsic to Closure
             }
         }
 
@@ -1595,7 +1595,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 //        Class[] argClasses = MetaClassHelper.convertToTypeArray(arguments);
 
         MetaMethod method = retrieveStaticMethod(methodName, arguments);
-        // let's try use the cache to find the method
+        // let's try to use the cache to find the method
 
         if (method != null) {
             MetaClassHelper.unwrap(arguments);
@@ -3136,7 +3136,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 
     /**
      * adds a MetaMethod to this class. WARNING: this method will not
-     * do the neccessary steps for multimethod logic and using this
+     * do the necessary steps for multimethod logic and using this
      * method doesn't mean, that a method added here is replacing another
      * method from a parent class completely. These steps are usually done
      * by initialize, which means if you need these steps, you have to add
@@ -3284,7 +3284,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
                 return;
             }
         }
-        // the casese true and null for a match are through, the
+        // the cases true and null for a match are through, the
         // remaining case is false and that means adding the method
         // to our list
         list.add(method);
@@ -3456,7 +3456,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
 
     /**
      * Complete the initialisation process. After this method
-     * is called no methods should be added to the meta class.
+     * is called no methods should be added to the metaclass.
      * Invocation of methods or access to fields/properties is
      * forbidden unless this method is called. This method
      * should contain any initialisation code, taking a longer
@@ -3508,7 +3508,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
             for (Method listenerMethod : listenerMethods) {
                 final MetaMethod metaMethod = CachedMethod.find(descriptor.getAddListenerMethod());
                 // GROOVY-5202
-                // there might be a non public listener of some kind
+                // there might be a non-public listener of some kind
                 // we skip that here
                 if (metaMethod == null) continue;
                 addToAllMethodsIfPublic(metaMethod);
@@ -3963,20 +3963,20 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     }
 
     /**
-     * indicates is the meta class method invocation for non-static methods is done
+     * indicates is the metaclass method invocation for non-static methods is done
      * through a custom invoker object.
      *
-     * @return true - if the method invocation is not done by the meta class itself
+     * @return true - if the method invocation is not done by the metaclass itself
      */
     public boolean hasCustomInvokeMethod() {
         return invokeMethodMethod != null;
     }
 
     /**
-     * indicates is the meta class method invocation for static methods is done
+     * indicates is the metaclass method invocation for static methods is done
      * through a custom invoker object.
      *
-     * @return true - if the method invocation is not done by the meta class itself
+     * @return true - if the method invocation is not done by the metaclass itself
      */
     public boolean hasCustomStaticInvokeMethod() {
         return false;

--- a/src/main/java/groovy/lang/MetaClassRegistry.java
+++ b/src/main/java/groovy/lang/MetaClassRegistry.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Constructor;
 import java.util.Iterator;
 
 /**
- * A MetaClassRegistry is an object that is responsible for managing the a cache of MetaClass instances. Each
+ * A MetaClassRegistry is an object that is responsible for managing a cache of MetaClass instances. Each
  * java.lang.Class instance has an associated MetaClass and client code can query this interface for the MetaClass for
  * a given associated java.lang.Class
  *
@@ -36,7 +36,7 @@ public interface MetaClassRegistry {
 
     /**
      * The main function of the registry
-     * If a meta class exists then return it
+     * If a metaclass exists then return it
      * otherwise create one, put it in the registry and return it
      */
     MetaClass getMetaClass(Class theClass);
@@ -71,14 +71,14 @@ public interface MetaClassRegistry {
     void setMetaClassCreationHandle(MetaClassCreationHandle handle);
 
     /**
-     * Adds a meta class change listener for constant meta classes
+     * Adds a metaclass change listener for constant metaclasses
      *
      * @param listener - the update listener
      */
     void addMetaClassRegistryChangeEventListener(MetaClassRegistryChangeEventListener listener);
 
     /**
-     * Adds a meta class change listener for constant meta classes.
+     * Adds a metaclass change listener for constant metaclasses.
      * This listener cannot be removed!
      *
      * @param listener - the update listener
@@ -86,38 +86,38 @@ public interface MetaClassRegistry {
     void addNonRemovableMetaClassRegistryChangeEventListener(MetaClassRegistryChangeEventListener listener);
 
     /**
-     * Removes a meta class change listener for constant meta classes
+     * Removes a metaclass change listener for constant metaclasses
      *
      * @param listener - the update listener
      */
     void removeMetaClassRegistryChangeEventListener(MetaClassRegistryChangeEventListener listener);
 
     /**
-     * Returns all registered class change listener for constant meta classes.
+     * Returns all registered class change listener for constant metaclasses.
      *
      * @return an array containing all change listener
      */
     MetaClassRegistryChangeEventListener[] getMetaClassRegistryChangeEventListeners();
 
     /**
-     * Gets a snapshot of the current constant meta classes and returns it as Iterator.
+     * Gets a snapshot of the current constant metaclasses and returns it as Iterator.
      * Modifications done using this Iterator will not cause a ConcurrentModificationException.
      * If a MetaClass is removed using this Iterator, then the MetaClass will only
      * be removed if the MetaClass was not replaced by another MetaClass in the meantime.
      * If a MetaClass is added while using this Iterator, then it will be part of the Iteration.
-     * If a MetaClass replaces another constant meta class, then the Iteration might show two
-     * meta classes for the same class.
+     * If a MetaClass replaces another constant metaclass, then the Iteration might show two
+     * metaclasses for the same class.
      * <p>
-     * Note: This Iterator may not used with multiple threads.
+     * Note: This Iterator may not be used with multiple threads.
      *
-     * @return Iterator for the constant meta classes
+     * @return Iterator for the constant metaclasses
      */
     Iterator iterator();
 
     /**
      * Class used as base for the creation of MetaClass implementations.
      * The Class defaults to MetaClassImpl, if the class loading fails to
-     * find a special meta class. The name for such a meta class would be
+     * find a special metaclass. The name for such a metaclass would be
      * the class name it is created for with the prefix
      * "groovy.runtime.metaclass." By replacing the handle in the registry
      * you can have any control over the creation of what MetaClass is used
@@ -168,17 +168,17 @@ public interface MetaClassRegistry {
         }
 
         /**
-         * Returns whether custom meta classes are disabled.
+         * Returns whether custom metaclasses are disabled.
          */
         public boolean isDisableCustomMetaClassLookup() {
             return disableCustomMetaClassLookup;
         }
 
         /**
-         * Set flag saying to disable lookup of custom meta classes
+         * Set flag saying to disable lookup of custom metaclasses
          * It's enough to call this method only once in your application for handle which was set in to registry
          * as every new handle will inherit this property
-         * @param disableCustomMetaClassLookup flag saying to disable lookup of custom meta classes
+         * @param disableCustomMetaClassLookup flag saying to disable lookup of custom metaclasses
          */
         public void setDisableCustomMetaClassLookup(boolean disableCustomMetaClassLookup) {
             this.disableCustomMetaClassLookup = disableCustomMetaClassLookup;

--- a/src/main/java/groovy/lang/MetaClassRegistryChangeEvent.java
+++ b/src/main/java/groovy/lang/MetaClassRegistryChangeEvent.java
@@ -21,7 +21,7 @@ package groovy.lang;
 import java.util.EventObject;
 
 /**
- * An event used to propagate meta class updates
+ * An event used to propagate metaclass updates
  */
 public class MetaClassRegistryChangeEvent extends EventObject {
     private static final long serialVersionUID = 1647849176793457976L;

--- a/src/main/java/groovy/lang/MetaClassRegistryChangeEventListener.java
+++ b/src/main/java/groovy/lang/MetaClassRegistryChangeEventListener.java
@@ -30,7 +30,7 @@ import java.util.EventListener;
 public interface MetaClassRegistryChangeEventListener extends EventListener{
 
     /**
-     * Called when the a constant MetaClass is updated. If the new MetaClass is null, then the MetaClass
+     * Called when the constant MetaClass is updated. If the new MetaClass is null, then the MetaClass
      * is removed. Be careful, while this method is executed other updates may happen. If you want this
      * method thread safe, you have to take care of that by yourself.
      *

--- a/src/main/java/groovy/lang/MetaMethod.java
+++ b/src/main/java/groovy/lang/MetaMethod.java
@@ -94,7 +94,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
      * @throws IllegalArgumentException if the parameters are not valid
      */
     public void checkParameters(Class[] arguments) {
-        // lets check that the argument types are valid
+        // let's check that the argument types are valid
         if (!isValidMethod(arguments)) {
             throw new IllegalArgumentException(
                     "Parameters to method: "
@@ -107,7 +107,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
     }
 
     /**
-     *Returns true if this this metamethod represents the same method as the argument.
+     * Returns true if this metamethod represents the same method as the argument.
      *
      * @param method A metaMethod instance
      * @return true if method is for the same method as this method, false otherwise.
@@ -171,7 +171,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
     }
 
     /**
-     * Returns whether or not this method is static.
+     * Returns whether this method is static.
      * @return true if this method is static
      */
     public boolean isStatic() {
@@ -179,7 +179,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
     }
 
     /**
-     * Returns whether or not this method is abstract.
+     * Returns whether this method is abstract.
      * @return true if this method is abstract
      */
     public boolean isAbstract() {
@@ -187,7 +187,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
     }
 
     /**
-     * Returns whether or not this method is interface-default.
+     * Returns whether this method is interface-default.
      * @return true if this method is default
      */
     public boolean isDefault() {
@@ -195,7 +195,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
     }
 
     /**
-     * Returns whether or not this method is private.
+     * Returns whether this method is private.
      * @return true if this method is private
      */
     public final boolean isPrivate() {
@@ -203,7 +203,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
     }
 
     /**
-     * Returns whether or not this method is protected.
+     * Returns whether this method is protected.
      * @return true if this method is protected
      */
     public final boolean isProtected() {
@@ -211,7 +211,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
     }
 
     /**
-     * Returns whether or not this method is public.
+     * Returns whether this method is public.
      * @return true if this method is public
      */
     public final boolean isPublic() {
@@ -232,7 +232,7 @@ public abstract class MetaMethod extends ParameterTypes implements Cloneable {
 
     /**
      * Checks the compatibility between two modifier masks. Checks that they are equal
-     * with regards to access and static modifier.
+     * in regard to access and static modifier.
      *
      * @return true if the modifiers are compatible
      */

--- a/src/main/java/groovy/lang/MetaObjectProtocol.java
+++ b/src/main/java/groovy/lang/MetaObjectProtocol.java
@@ -29,14 +29,14 @@ import java.util.List;
 public interface MetaObjectProtocol {
 
     /**
-     * Obtain a list of all meta properties available on this meta class
+     * Obtain a list of all meta properties available on this metaclass
      *
      * @see groovy.lang.MetaProperty
      * @return A list of MetaProperty instances
      */
     List<MetaProperty> getProperties();
     /**
-     * Obtain a list of all the meta methods available on this meta class
+     * Obtain a list of all the meta methods available on this metaclass
      *
      * @see groovy.lang.MetaMethod
      * @return A list of MetaMethod instances

--- a/src/main/java/groovy/lang/Writable.java
+++ b/src/main/java/groovy/lang/Writable.java
@@ -28,7 +28,7 @@ import java.io.Writer;
  * of itself. This mechanism is particularly useful for templates and such like.
  * <p>
  * It is worth noting that writable implementations often override their
- * toString() implementation as well to allow rendering the same result 
+ * toString() implementation as well to allow rendering the same result
  * directly to a String; however this is not required.
  */
 public interface Writable {
@@ -37,14 +37,14 @@ public interface Writable {
      * Writes this object to the given writer.
      * <p>
      * This is used to defer content creation until the point when it is
-     * streamed to the output destination.  Oftentimes, content will be defined 
-     * but not necessarily created (as is may be the case with a Closure 
-     * definition.)  In that case, the output is then 'deferred' to the point 
-     * when it is serialized to the writer. This class may be used whenever an 
-     * object should be responsible for creating its own textual representation, 
+     * streamed to the output destination.  Oftentimes, content will be defined
+     * but not necessarily created (as it may be the case with a Closure
+     * definition.)  In that case, the output is then 'deferred' to the point
+     * when it is serialized to the writer. This class may be used whenever an
+     * object should be responsible for creating its own textual representation,
      * but creating the entire output as a single String would be inefficient
      * (such as outputting a multi-gigabyte XML document.)
-     * 
+     *
      * @param out the Writer to which this Writable should output its data.
      * @return the Writer that was passed
      * @throws IOException if an error occurred while outputting data to the writer


### PR DESCRIPTION
Fix typos and improve documentation (javadoc, comments) in the groovy.lang package.

Note that the following words / expressions were preferred :

- return back -> returns (when possible because it is easier to read),
- multi-threaded -> multithreaded (more common, see https://en.wikipedia.org/wiki/Multithreading)
- whether or not -> whether (when possible because it is easier to read),
- meta class -> metaclass (incorrect, see https://en.wikipedia.org/wiki/Metaclass).

Trailing whitespaces were also removed in the process.