### PR TITLE
Polish org.codehaus.groovy package documentation

### DIFF
--- a/src/main/groovy/org/codehaus/groovy/tools/GrapeMain.groovy
+++ b/src/main/groovy/org/codehaus/groovy/tools/GrapeMain.groovy
@@ -200,7 +200,7 @@ class GrapeMain implements Runnable {
     @Command(name = 'resolve', header = 'Enumerates the jars used by a grape',
             customSynopsis = 'grape resolve [-adhisv] (<groupId> <artifactId> <version>)+',
             description = [
-                    'Prints the file locations of the jars representing the artifcats for the specified module(s) and the respective transitive dependencies.',
+                    'Prints the file locations of the jars representing the artifacts for the specified module(s) and the respective transitive dependencies.',
                     '',
                     'Parameters:',
                     '      <group>     Which module group the module comes from. Translates directly',

--- a/src/main/java/org/codehaus/groovy/GroovyBugError.java
+++ b/src/main/java/org/codehaus/groovy/GroovyBugError.java
@@ -73,7 +73,7 @@ public class GroovyBugError extends AssertionError {
 
     /**
      * Returns the detail message string of this error. The message
-     * will consist of the bug text prefixed by "BUG! " if there this
+     * will consist of the bug text prefixed by "BUG! " if this
      * instance was created using a message. If this error was
      * constructed without using a bug text the message of the cause
      * is used prefixed by "BUG! UNCAUGHT EXCEPTION: "

--- a/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java
+++ b/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java
@@ -77,7 +77,7 @@ public class ClassNodeResolver {
          */
         public boolean isClassNode() { return cn!=null; }
         /**
-         * returns true if a SourecUnit is stored
+         * returns true if a SourceUnit is stored
          */
         public boolean isSourceUnit() { return su!=null; }
         /**
@@ -254,7 +254,7 @@ public class ClassNodeResolver {
             try {
                 asmClass = new DecompiledClassNode(AsmDecompiler.parseClass(resource), new AsmReferenceResolver(this, compilationUnit));
                 if (!asmClass.getName().equals(name)) {
-                    // this may happen under Windows because getResource is case insensitive under that OS!
+                    // this may happen under Windows because getResource is case-insensitive under that OS!
                     asmClass = null;
                 }
             } catch (IOException e) {

--- a/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
@@ -577,7 +577,7 @@ public class CompilationUnit extends ProcessingUnit {
     }
 
     /**
-     * Adds a ClassNode directly to the unit (ie. without source).
+     * Adds a ClassNode directly to the unit (i.e. without source).
      * WARNING: the source is needed for error reporting, using
      * this method without setting a SourceUnit will cause
      * NullPinterExceptions
@@ -774,7 +774,7 @@ public class CompilationUnit extends ProcessingUnit {
             visitor = new ExtendedVerifier(source);
             visitor.visitClass(classNode);
 
-            // because the class may be generated even if a error was found
+            // because the class may be generated even if an error was found
             // and that class may have an invalid format we fail here if needed
             getErrorCollector().failIfErrors();
 

--- a/src/main/java/org/codehaus/groovy/control/CompilePhase.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilePhase.java
@@ -30,7 +30,7 @@ public enum CompilePhase {
     INITIALIZATION(Phases.INITIALIZATION),
 
     /**
-    * the grammar is used to to produce tree of tokens representing the source code
+    * the grammar is used to produce tree of tokens representing the source code
     */
     PARSING(Phases.PARSING),
 
@@ -92,7 +92,7 @@ public enum CompilePhase {
     }
 
     /**
-    * Returns the underlieng integer Phase number.
+    * Returns the underlying integer Phase number.
     */
     public int getPhaseNumber() {
         return phaseNumber;

--- a/src/main/java/org/codehaus/groovy/control/ConfigurationException.java
+++ b/src/main/java/org/codehaus/groovy/control/ConfigurationException.java
@@ -52,7 +52,7 @@ public class ConfigurationException extends RuntimeException implements GroovyEx
     }
 
     /**
-     * Its always fatal.
+     * It's always fatal.
      */
     @Override
     public boolean isFatal() {

--- a/src/main/java/org/codehaus/groovy/control/ErrorCollector.java
+++ b/src/main/java/org/codehaus/groovy/control/ErrorCollector.java
@@ -117,7 +117,7 @@ public class ErrorCollector implements Serializable {
      * The message is not required to have a source line and column specified, but it is best practice to try
      * and include that information.
      * @param fatal
-     *      if true then then processing will stop
+     *      if true then processing will stop
      */
     public void addError(final Message message, final boolean fatal) throws CompilationFailedException {
         if (fatal) {

--- a/src/main/java/org/codehaus/groovy/control/GenericsVisitor.java
+++ b/src/main/java/org/codehaus/groovy/control/GenericsVisitor.java
@@ -167,7 +167,7 @@ public class GenericsVisitor extends ClassCodeVisitorSupport {
             addError(message, cn);
             return;
         }
-        // parameterize a type by using all of the parameters only
+        // parameterize a type by using all the parameters only
         if (cnTypes.length != rnTypes.length) {
             if (Boolean.FALSE.equals(isAIC) && cnTypes.length == 0) {
                 return; // allow Diamond for non-AIC cases from CCE

--- a/src/main/java/org/codehaus/groovy/control/InstanceOfVerifier.java
+++ b/src/main/java/org/codehaus/groovy/control/InstanceOfVerifier.java
@@ -45,7 +45,7 @@ public abstract class InstanceOfVerifier extends ClassCodeVisitorSupport {
                     addTypeError(expression.getRightExpression(), "type parameter " + referenceType.getUnresolvedName() +
                         ". Use its erasure " + referenceType.getNameWithoutPackage() + " instead since further generic type information will be erased at runtime");
                 } else if (referenceType.getGenericsTypes() != null) {
-                    // TODO: Cannot perform instanceof check against parameterized type Class<Type>. Use the form Class<?> instead since further eneric type information will be erased at runtime
+                    // TODO: Cannot perform instanceof check against parameterized type Class<Type>. Use the form Class<?> instead since further generic type information will be erased at runtime
                 }
             }
         }

--- a/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
@@ -154,7 +154,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
      * does when combining package names and class names. The idea
      * that if we use a package, then we do not want to replace the
      * '.' with a '$' for the package part, only for the class name
-     * part. There is also the case of a imported class, so this logic
+     * part. There is also the case of an imported class, so this logic
      * can't be done in these cases...
      */
     private static class ConstructedClassWithPackage extends ClassNode {
@@ -652,7 +652,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
                     // At this point we know that we have a match for pname. This may
                     // mean, that name[pname.length()..<-1] is a static inner class.
                     // For this the rest of the name does not need any dots in its name.
-                    // It is either completely a inner static class or it is not.
+                    // It is either completely an inner static class or it is not.
                     // Since we do not want to have useless lookups we create the name
                     // completely and use a ConstructedClassWithPackage to prevent lookups against the package.
                     String className = aliasedNode.getNameWithoutPackage() + "$" + name.substring(pname.length() + 1).replace('.', '$');
@@ -763,7 +763,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
             classNodeResolver = new ClassNodeResolver();
         // We do not need to check instances of LowerCaseClass
         // to be a Class, because unless there was an import for
-        // for this we do not lookup these cases. This was a decision
+        // this we do not look up these cases. This was a decision
         // made on the mailing list. To ensure we will not visit this
         // method again we set a NO_CLASS for this name
         if (type instanceof LowerCaseClass) {
@@ -871,7 +871,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         return tuple(name, Boolean.FALSE);
     }
 
-    // iterate from the inner most to the outer and check for classes
+    // iterate from the innermost to the outer and check for classes
     // this check will ignore a .class property, for Example Integer.class will be
     // a PropertyExpression with the ClassExpression of Integer as objectExpression
     // and class as property

--- a/src/main/java/org/codehaus/groovy/control/StaticVerifier.java
+++ b/src/main/java/org/codehaus/groovy/control/StaticVerifier.java
@@ -88,7 +88,7 @@ public class StaticVerifier extends ClassCodeVisitorSupport {
     @Override
     public void visitVariableExpression(VariableExpression ve) {
         if (ve.getAccessedVariable() instanceof DynamicVariable && (ve.isInStaticContext() || inSpecialConstructorCall) && !inClosure) {
-            // GROOVY-5687: interface constants not visible to implementing sub-class in static context
+            // GROOVY-5687: interface constants not visible to implementing subclass in static context
             if (methodNode != null && methodNode.isStatic()) {
                 FieldNode fieldNode = getDeclaredOrInheritedField(methodNode.getDeclaringClass(), ve.getName());
                 if (fieldNode != null && fieldNode.isStatic()) {

--- a/src/main/java/org/codehaus/groovy/control/customizers/ImportCustomizer.java
+++ b/src/main/java/org/codehaus/groovy/control/customizers/ImportCustomizer.java
@@ -29,7 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * This compilation customizer allows addiing various types of imports to the compilation unit. Supports adding:
+ * This compilation customizer allows adding various types of imports to the compilation unit. Supports adding:
  * <ul>
  *     <li>standard imports via {@link #addImports(String...)} or {@link #addImport(String, String)}</li>
  *     <li>star imports via {@link #addStarImports(String...)}</li>

--- a/src/main/java/org/codehaus/groovy/control/customizers/builder/PostCompletionFactory.java
+++ b/src/main/java/org/codehaus/groovy/control/customizers/builder/PostCompletionFactory.java
@@ -21,7 +21,7 @@ package org.codehaus.groovy.control.customizers.builder;
 import groovy.util.FactoryBuilderSupport;
 
 /**
- * A helper interface for factories which require post processing of generated nodes.
+ * A helper interface for factories which require post-processing of generated nodes.
  *
  * @since 2.1.0
  */

--- a/src/main/java/org/codehaus/groovy/control/io/AbstractReaderSource.java
+++ b/src/main/java/org/codehaus/groovy/control/io/AbstractReaderSource.java
@@ -37,8 +37,8 @@ public abstract class AbstractReaderSource implements ReaderSource {
     }
 
     /**
-     * Returns true if the source can be restarted (ie. if getReader()
-     * will return non-null on subsequent calls.
+     * Returns true if the source can be restarted (i.e. if getReader()
+     * will return non-null on subsequent calls).
      */
     @Override
     public boolean canReopenSource() {

--- a/src/main/java/org/codehaus/groovy/control/io/InputStreamReaderSource.java
+++ b/src/main/java/org/codehaus/groovy/control/io/InputStreamReaderSource.java
@@ -58,7 +58,7 @@ public class InputStreamReaderSource extends AbstractReaderSource {
 
     /**
      * Returns true if the source can be restarted (ie. if getReader()
-     * will return non-null on subsequent calls.
+     * will return non-null on subsequent calls).
      */
     @Override
     public boolean canReopenSource() {

--- a/src/main/java/org/codehaus/groovy/control/io/NullWriter.java
+++ b/src/main/java/org/codehaus/groovy/control/io/NullWriter.java
@@ -21,7 +21,7 @@ package org.codehaus.groovy.control.io;
 import java.io.Writer;
 
 /**
- *  An Writer than eats its input.
+ *  A Writer that eats its input.
  */
 public class NullWriter extends Writer {
     public static final NullWriter DEFAULT = new NullWriter();

--- a/src/main/java/org/codehaus/groovy/control/io/ReaderSource.java
+++ b/src/main/java/org/codehaus/groovy/control/io/ReaderSource.java
@@ -40,7 +40,7 @@ public interface ReaderSource extends HasCleanup {
 
    /**
     *  Returns true if the source can be restarted (ie. if getReader()
-    *  will return non-null on subsequent calls.
+    *  will return non-null on subsequent calls).
     * @return true if the resource can be reopened for reading
     */
     boolean canReopenSource();

--- a/src/main/java/org/codehaus/groovy/reflection/ClassInfo.java
+++ b/src/main/java/org/codehaus/groovy/reflection/ClassInfo.java
@@ -62,7 +62,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Handle for all information we want to keep about the class
  * <p>
- * This class handles caching internally and its advisable to not store
+ * This class handles caching internally and it's advisable to not store
  * references directly to objects of this class.  The static factory method
  * {@link ClassInfo#getClassInfo(Class)} should be used to retrieve an instance
  * from the cache.  Internally the {@code Class} associated with a {@code ClassInfo}
@@ -299,7 +299,7 @@ public class ClassInfo implements Finalizable {
      * If no {@code MetaClass} exists one will be created.
      * <p>
      * It is not safe to call this method without a {@code Class} associated with this {@code ClassInfo}.
-     * It is advisable to aways retrieve a ClassInfo instance from the cache by using the static
+     * It is advisable to always retrieve a ClassInfo instance from the cache by using the static
      * factory method {@link ClassInfo#getClassInfo(Class)} to ensure the referenced Class is
      * strongly reachable.
      *

--- a/src/main/java/org/codehaus/groovy/reflection/ParameterTypes.java
+++ b/src/main/java/org/codehaus/groovy/reflection/ParameterTypes.java
@@ -196,7 +196,7 @@ public class ParameterTypes {
             return newArgs;
         } else if (argumentArray.length == paramTypes.length) {
             // the number of arguments is correct, but if the last argument
-            // is no array we have to wrap it in a array. If the last argument
+            // is no array we have to wrap it in an array. If the last argument
             // is null, then we don't have to do anything
             Object lastArgument = argumentArray[argumentArray.length - 1];
             if (lastArgument != null && !lastArgument.getClass().isArray()) {
@@ -250,7 +250,7 @@ public class ParameterTypes {
     }
 
     private static boolean isValidExactMethod(Class[] arguments, CachedClass[] pt) {
-        // lets check the parameter types match
+        // let's check the parameter types match
         int size = pt.length;
         for (int i = 0; i < size; i++) {
             if (!pt[i].isAssignableFrom(arguments[i])) {
@@ -261,7 +261,7 @@ public class ParameterTypes {
     }
 
     public boolean isValidExactMethod(Object[] args) {
-        // lets check the parameter types match
+        // let's check the parameter types match
         getParametersTypes0();
         int size = args.length;
         if (size != parameterTypes.length)
@@ -277,7 +277,7 @@ public class ParameterTypes {
     }
 
     public boolean isValidExactMethod(Class[] args) {
-        // lets check the parameter types match
+        // let's check the parameter types match
         getParametersTypes0();
         int size = args.length;
         if (size != parameterTypes.length)

--- a/src/main/java/org/codehaus/groovy/reflection/ReflectionUtils.java
+++ b/src/main/java/org/codehaus/groovy/reflection/ReflectionUtils.java
@@ -78,7 +78,7 @@ public class ReflectionUtils {
     private static final ClassContextHelper HELPER = new ClassContextHelper();
 
     /**
-     * Determines whether or not the getCallingClass methods will return
+     * Determines whether the getCallingClass methods will return
      * any sensible results.  On JVMs that are not Sun derived i.e.
      * (gcj, Harmony) this will likely return false.  When not available
      * all getCallingClass methods will return null.

--- a/src/main/java/org/codehaus/groovy/reflection/v7/GroovyClassValueJava7.java
+++ b/src/main/java/org/codehaus/groovy/reflection/v7/GroovyClassValueJava7.java
@@ -20,7 +20,7 @@ package org.codehaus.groovy.reflection.v7;
 
 import org.codehaus.groovy.reflection.GroovyClassValue;
 
-/** GroovyClassValue implementaion that simply delegates to Java 7's java.lang.ClassValue
+/** GroovyClassValue implementation that simply delegates to Java 7's java.lang.ClassValue
  * @see java.lang.ClassValue
  *
  * @param <T>

--- a/src/main/java/org/codehaus/groovy/syntax/CSTNode.java
+++ b/src/main/java/org/codehaus/groovy/syntax/CSTNode.java
@@ -158,7 +158,7 @@ public abstract class CSTNode {
     }
 
     /**
-     * Returns true if the node an its first four children match the
+     * Returns true if the node and its first four children match the
      * specified types.  Missing nodes have type Types.NULL.
      */
     boolean matches(int type, int child1, int child2, int child3, int child4) {

--- a/src/main/java/org/codehaus/groovy/syntax/Types.java
+++ b/src/main/java/org/codehaus/groovy/syntax/Types.java
@@ -1106,7 +1106,7 @@ public class Types {
 
 
     /**
-     * Adds a element to the TEXTS and LOOKUP.
+     * Adds an element to the TEXTS and LOOKUP.
      */
     private static void addTranslation(String text, int type) {
         TEXTS.put(type, text);
@@ -1114,7 +1114,7 @@ public class Types {
     }
 
     /**
-     * Adds a element to the KEYWORDS, TEXTS and LOOKUP.
+     * Adds an element to the KEYWORDS, TEXTS and LOOKUP.
      */
     private static void addKeyword(String text, int type) {
         KEYWORDS.add(text);

--- a/src/main/java/org/codehaus/groovy/tools/StringHelper.java
+++ b/src/main/java/org/codehaus/groovy/tools/StringHelper.java
@@ -27,12 +27,12 @@ public class StringHelper {
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
     /**
-     * This method tokenizes a string by space characters, 
-     * but ignores spaces in quoted parts,that are parts in 
-     * '' or "". The method does allows the usage of "" in '' 
-     * and '' in "". The space character between tokens is not 
-     * returned. 
-     * 
+     * This method tokenizes a string by space characters,
+     * but ignores spaces in quoted parts,that are parts in
+     * '' or "". The method allows the usage of "" in ''
+     * and '' in "". The space character between tokens is not
+     * returned.
+     *
      * @param s the string to tokenize
      * @return the tokens
      */
@@ -82,5 +82,5 @@ public class StringHelper {
             pos++;
         }
         return pos;
-    } 
+    }
 }

--- a/src/main/java/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/java/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -329,7 +329,7 @@ public class JavaStubGenerator {
             };
             int origNumConstructors = classNode.getDeclaredConstructors().size();
             verifier.visitClass(classNode);
-            // undo unwanted side-effect of verifier
+            // undo unwanted side effect of verifier
             if (origNumConstructors == 0 && classNode.getDeclaredConstructors().size() == 1) {
                 classNode.getDeclaredConstructors().clear();
             }

--- a/src/main/java/org/codehaus/groovy/tools/shell/util/MessageSource.java
+++ b/src/main/java/org/codehaus/groovy/tools/shell/util/MessageSource.java
@@ -118,7 +118,7 @@ public class MessageSource
     }
 
     /**
-     * Format a message (based on {@link MessageFormat} using the message
+     * Format a message (based on {@link MessageFormat}) using the message
      * from the resource bundles using the given code as a pattern and the
      * given objects as arguments.
      */

--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -66,7 +66,7 @@ import java.util.Set;
  * <p>
  * {@link org.codehaus.groovy.transform.ASTTransformationCollectorCodeVisitor} will add a list
  * of annotations that this visitor should be concerned about.  All other
- * annotations are ignored, whether or not they are GroovyASTTransformation
+ * annotations are ignored, whether they are GroovyASTTransformation
  * annotated or not.
  * <p>
  * A Two-pass method is used. First all candidate annotations are added to a
@@ -140,7 +140,7 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
             // first pass, collect nodes
             super.visitClass(classNode);
 
-            // second pass, call visit on all of the collected nodes
+            // second pass, call visit on all the collected nodes
             List<Tuple2<ASTTransformation, ASTNode[]>> tuples = new ArrayList<>();
             for (ASTNode[] node : targetNodes) {
                 for (ASTTransformation snt : transforms.get(node[0])) {

--- a/src/main/java/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
+++ b/src/main/java/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
@@ -379,7 +379,7 @@ public class AnnotationCollectorTransform {
      * get the list of annotations we aliased from the collector and adds it to
      * aliasAnnotationUsage. The method will also map all members from
      * aliasAnnotationUsage to the aliased nodes. Should a member stay unmapped,
-     * we will ad an error. Further processing of those members is done by the
+     * we will add an error. Further processing of those members is done by the
      * annotations.
      *
      * @param collector                 reference to the annotation with {@link AnnotationCollector}

--- a/src/main/java/org/codehaus/groovy/transform/BaseScriptASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/BaseScriptASTTransformation.java
@@ -131,11 +131,11 @@ public class BaseScriptASTTransformation extends AbstractASTTransformation {
         // Method in base script that will contain the script body code.
         MethodNode runScriptMethod = ClassHelper.findSAM(baseScriptType);
 
-        // If they want to use a name other than than "run", then make the change.
+        // If they want to use a name other than "run", then make the change.
         if (isCustomScriptBodyMethod(runScriptMethod)) {
             MethodNode defaultMethod = cNode.getDeclaredMethod("run", Parameter.EMPTY_ARRAY);
             // GROOVY-6706: Sometimes an NPE is thrown here.
-            // The reason is that our transform is getting called more than once sometimes.  
+            // The reason is that our transform is getting called more than once sometimes.
             if (defaultMethod != null) {
                 cNode.removeMethod(defaultMethod);
                 MethodNode methodNode = new MethodNode(runScriptMethod.getName(), runScriptMethod.getModifiers() & ~ACC_ABSTRACT

--- a/src/main/java/org/codehaus/groovy/transform/InheritConstructorsASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/InheritConstructorsASTTransformation.java
@@ -78,7 +78,7 @@ public class InheritConstructorsASTTransformation extends AbstractASTTransformat
             // We need @InheritConstructors from parent classes processed first
             // so force that order here. The transformation is benign on an already
             // processed node so processing twice in any order won't matter bar
-            // a very small time penalty.
+            // a very small-time penalty.
             processClass(sNode, node);
         }
         for (ConstructorNode cn : sNode.getDeclaredConstructors()) {

--- a/src/main/java/org/codehaus/groovy/transform/stc/ExtensionMethodCache.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/ExtensionMethodCache.java
@@ -33,7 +33,7 @@ import static org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.EXTENS
 
 /**
  * This class is used to make extension methods lookup faster. Basically, it will only
- * collect the list of extension methods (see {@link ExtensionModule} if the list of
+ * collect the list of extension methods (see {@link ExtensionModule}) if the list of
  * extension modules has changed. It avoids recomputing the whole list each time we perform
  * a method lookup.
  */

--- a/src/main/java/org/codehaus/groovy/transform/stc/GroovyTypeCheckingExtensionSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/GroovyTypeCheckingExtensionSupport.java
@@ -57,7 +57,7 @@ import java.util.Objects;
 /**
  * Base class for type checking extensions written in Groovy. Compared to its superclass, {@link TypeCheckingExtension},
  * this class adds a number of utility methods aimed at leveraging the syntax of the Groovy language to improve
- * expressivity and conciseness.
+ * expressiveness and conciseness.
  *
  * @since 2.1.0
  */

--- a/src/main/java/org/codehaus/groovy/transform/stc/SecondPassExpression.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/SecondPassExpression.java
@@ -23,7 +23,7 @@ import org.codehaus.groovy.ast.expr.Expression;
 import java.util.Objects;
 
 /**
- * An utility class used to wrap an expression with additional metadata used by the type checker.
+ * A utility class used to wrap an expression with additional metadata used by the type checker.
  * In particular, this is used to detect closure shared variables misuses. We need in some circumstances
  * to store the method call expression and its argument types.
  */

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -226,7 +226,7 @@ public abstract class StaticTypeCheckingSupport {
 
     /**
      * This comparator is used when we return the list of methods from DGM which name correspond to a given
-     * name. As we also lookup for DGM methods of superclasses or interfaces, it may be possible to find
+     * name. As we also look up for DGM methods of superclasses or interfaces, it may be possible to find
      * two methods which have the same name and the same arguments. In that case, we should not add the method
      * from superclass or interface otherwise the system won't be able to select the correct method, resulting
      * in an ambiguous method selection for similar methods.
@@ -718,7 +718,7 @@ public abstract class StaticTypeCheckingSupport {
                     : implementsInterfaceOrSubclassOf(leftRedirect, rightRedirect); // GROOVY-10067, GROOVY-10342
 
         } else if (isBigDecimalType(leftRedirect) || Number_TYPE.equals(leftRedirect)) {
-            // BigDecimal or Number can be assigned any derivitave of java.lang.Number
+            // BigDecimal or Number can be assigned any derivative of java.lang.Number
             if (isNumberType(rightRedirect) || rightRedirect.isDerivedFrom(Number_TYPE)) {
                 return true;
             }
@@ -2248,8 +2248,8 @@ public abstract class StaticTypeCheckingSupport {
     }
 
     /**
-     * Returns true if the class node represents a the class node for the Class class
-     * and if the parametrized type is a neither a placeholder or a wildcard. For example,
+     * Returns true if the class node represents a class node for the Class class
+     * and if the parametrized type is a neither a placeholder nor a wildcard. For example,
      * the class node Class&lt;Foo&gt; where Foo is a class would return true, but the class
      * node for Class&lt;?&gt; would return false.
      *

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -903,7 +903,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                     if (!Modifier.isPublic(modifiers) && !enclosingType.equals(resultType)
                             && !getOutermost(enclosingType).equals(getOutermost(resultType))
                             && (Modifier.isPrivate(modifiers) || !Objects.equals(enclosingType.getPackageName(), resultType.getPackageName()))) {
-                        resultType = originType; // TODO: Find accesible type in hierarchy of resultType?
+                        resultType = originType; // TODO: Find accessible type in hierarchy of resultType?
                     } else if (GenericsUtils.hasUnresolvedGenerics(resultType)) { // GROOVY-9033, GROOVY-10089, et al.
                         Map<GenericsTypeName, GenericsType> enclosing = extractGenericsParameterMapOfThis(typeCheckingContext);
                         resultType = fullyResolveType(resultType, Optional.ofNullable(enclosing).orElseGet(Collections::emptyMap));
@@ -3806,7 +3806,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
      * In the case of a <em>Object.with { ... }</em> call, this method is supposed to retrieve
      * the inferred closure return type.
      *
-     * @param callArguments the argument list from the <em>Object#with(Closure)</em> call, ie. a single closure expression
+     * @param callArguments the argument list from the <em>Object#with(Closure)</em> call, i.e. a single closure expression
      * @return the inferred closure return type or <em>null</em>
      */
     protected ClassNode getInferredReturnTypeFromWithClosureArgument(final Expression callArguments) {
@@ -4629,7 +4629,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
 
     /**
      * For "{@code List<Type> x = [...]}" or "{@code Set<Type> y = [...]}", etc.
-     * the literal may be composed of sub-types of {@code Type}. In these cases,
+     * the literal may be composed of subtypes of {@code Type}. In these cases,
      * {@code ArrayList<Type>} is an appropriate result type for the expression.
      */
     private static ClassNode getLiteralResultType(final ClassNode targetType, final ClassNode sourceType, final ClassNode baseType) {
@@ -5539,7 +5539,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
 
     /**
      * Given method call like "m(Collections.emptyList())", the type of the call
-     * argument is {@code List<T>} without explicit type arguments. Knowning the
+     * argument is {@code List<T>} without explicit type arguments. Knowing the
      * method target of "m", {@code T} could be resolved.
      */
     private void resolvePlaceholdersFromImplicitTypeHints(final ClassNode[] actuals, final ArgumentListExpression argumentList, final Parameter[] parameterArray) {

--- a/src/main/java/org/codehaus/groovy/transform/tailrec/ReturnStatementToIterationConverter.java
+++ b/src/main/java/org/codehaus/groovy/transform/tailrec/ReturnStatementToIterationConverter.java
@@ -80,7 +80,7 @@ public class ReturnStatementToIterationConverter {
         }
 
         /*
-         * Assign the iteration variables their new value before recuring
+         * Assign the iteration variables their new value before recurring
          */
         for (int i = 0, n = arguments.size(); i < n; i++) {
             ExpressionStatement argAssignment = createAssignmentToIterationVariable(arguments.get(i), i, positionMapping);

--- a/src/main/java/org/codehaus/groovy/util/CharSequenceReader.java
+++ b/src/main/java/org/codehaus/groovy/util/CharSequenceReader.java
@@ -94,7 +94,7 @@ public class CharSequenceReader extends Reader implements Serializable {
     }
 
     /**
-     * Read the sepcified number of characters into the array.
+     * Read the specified number of characters into the array.
      *
      * @param array The array to store the characters in
      * @param offset The starting position in the array to store

--- a/src/main/java/org/codehaus/groovy/util/LongArrayIterator.java
+++ b/src/main/java/org/codehaus/groovy/util/LongArrayIterator.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 /**
- * Allow a longt array to be used where an Iterator is expected.
+ * Allow a long array to be used where an Iterator is expected.
  *
  * @since 3.0.8
  */

--- a/src/main/java/org/codehaus/groovy/util/ManagedLinkedList.java
+++ b/src/main/java/org/codehaus/groovy/util/ManagedLinkedList.java
@@ -122,7 +122,7 @@ public class ManagedLinkedList<T> {
     }
 
     /**
-     * Returns an array of non null elements from the source array.
+     * Returns an array of non-null elements from the source array.
      *
      * @param tArray the source array
      * @return the array

--- a/src/main/java/org/codehaus/groovy/vmplugin/VMPlugin.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/VMPlugin.java
@@ -131,7 +131,7 @@ public interface VMPlugin {
     /**
      * transform meta method
      *
-     * @param metaClass meta class
+     * @param metaClass metaclass
      * @param metaMethod the original meta method
      * @param caller caller class, whose method sets accessible for methods
      * @return the transformed meta method
@@ -163,7 +163,7 @@ public interface VMPlugin {
     /**
      * transform meta method.
      *
-     * @param metaClass meta class
+     * @param metaClass metaclass
      * @param metaMethod the original meta method
      * @return the transformed meta method
      */

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyInterface.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyInterface.java
@@ -173,7 +173,7 @@ public class IndyInterface {
     }
 
     /**
-     * Callback for constant meta class update change
+     * Callback for constant metaclass update change
      */
     protected static void invalidateSwitchPoints() {
         if (LOG_ENABLED) {

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyMath.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyMath.java
@@ -38,7 +38,7 @@ import static org.codehaus.groovy.vmplugin.v8.TypeHelper.replaceWithMoreSpecific
  * This class contains math operations used by indy instead of the normal
  * meta method and call site caching system. The goal is to avoid boxing, thus
  * use primitive types for parameters and return types where possible.
- * WARNING: This class is for internal use only. Do not use it outside of the
+ * WARNING: This class is for internal use only. Do not use it outside the
  * org.codehaus.groovy.vmplugin.v7 package of groovy-core.
  */
 public class IndyMath {

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java
@@ -205,7 +205,7 @@ public abstract class Selector {
 
             if (staticTargetType.isPrimitive()) {
                 handle = MethodHandles.insertArguments(GROOVY_CAST_EXCEPTION, 1, staticTargetType);
-                // need to call here here because we used the static target type
+                // need to call here because we used the static target type
                 // it won't be done otherwise because handle.type() == callSite.type()
                 castAndSetGuards();
             } else {
@@ -295,7 +295,7 @@ public abstract class Selector {
         }
 
         /**
-         * this method chooses a property from the meta class.
+         * this method chooses a property from the metaclass.
          */
         @Override
         public void chooseMeta(MetaClassImpl mci) {
@@ -353,8 +353,8 @@ public abstract class Selector {
 
         /**
          * Additionally to the normal {@link MethodSelector#setHandleForMetaMethod()}
-         * task we have to also take care of generic getter methods, that depend
-         * one the name.
+         * task we have to also take care of generic getter methods, that depends
+         * on the name.
          */
         @Override
         public void setHandleForMetaMethod() {
@@ -397,7 +397,7 @@ public abstract class Selector {
         }
 
         /**
-         * For a constructor call we always use the static meta class from the registry
+         * For a constructor call we always use the static metaclass from the registry
          */
         @Override
         public MetaClass getMetaClass() {
@@ -407,7 +407,7 @@ public abstract class Selector {
         }
 
         /**
-         * This method chooses a constructor from the meta class.
+         * This method chooses a constructor from the metaclass.
          */
         @Override
         public void chooseMeta(MetaClassImpl mci) {
@@ -447,7 +447,7 @@ public abstract class Selector {
             if (beanConstructor) {
                 // we have handle that takes no arguments to create the bean,
                 // we have to use its return value to call #setBeanProperties with it
-                // and the meta class.
+                // and the metaclass.
 
                 // to do this we first bind the values to #setBeanProperties
                 MethodHandle con = BEAN_CONSTRUCTOR_PROPERTY_SETTER.bindTo(mc);
@@ -501,7 +501,7 @@ public abstract class Selector {
 
     /**
      * Method invocation based {@link Selector}.
-     * This Selector is called for method invocations and is base for cosntructor
+     * This Selector is called for method invocations and is base for constructor
      * calls as well as getProperty calls.
      */
     private static class MethodSelector extends Selector {
@@ -560,7 +560,7 @@ public abstract class Selector {
         }
 
         /**
-         * Gives the meta class to an Object.
+         * Gives the metaclass to an Object.
          */
         public MetaClass getMetaClass() {
             Object receiver = args[0];
@@ -582,9 +582,9 @@ public abstract class Selector {
         }
 
         /**
-         * Uses the meta class to get a meta method for a method call.
-         * There will be no meta method selected, if the meta class is no MetaClassImpl
-         * or the meta class is an AdaptingMetaClass.
+         * Uses the metaclass to get a meta method for a method call.
+         * There will be no meta method selected, if the metaclass is no MetaClassImpl
+         * or the metaclass is an AdaptingMetaClass.
          */
         public void chooseMeta(MetaClassImpl mci) {
             if (mci == null) return;
@@ -701,7 +701,7 @@ public abstract class Selector {
         }
 
         /**
-         * Creates a MethodHandle, which will use the meta class path.
+         * Creates a MethodHandle, which will use the metaclass path.
          * This method is called only if no handle has been created before. This
          * is usually the case if the method selection failed.
          */
@@ -718,7 +718,7 @@ public abstract class Selector {
                 if (LOG_ENABLED) LOG.info("use invokeMethod with bound meta class");
 
                 if (receiver instanceof GroovyObject) {
-                    // if the meta class call fails we may still want to fall back to call
+                    // if the metaclass call fails we may still want to fall back to call
                     // GroovyObject#invokeMethod if the receiver is a GroovyObject
                     if (LOG_ENABLED) LOG.info("add MissingMethod handler for GroovyObject#invokeMethod fallback path");
                     handle = MethodHandles.catchException(handle, MissingMethodException.class, GROOVY_OBJECT_INVOKER);
@@ -926,7 +926,7 @@ public abstract class Selector {
                 }
             }
 
-            // handle constant meta class and category changes
+            // handle constant metaclass and category changes
             handle = switchPoint.guardWithTest(handle, fallback);
             if (LOG_ENABLED) LOG.info("added switch point guard");
 
@@ -1005,10 +1005,10 @@ public abstract class Selector {
 
         /**
          * setting a call site target consists of the following steps:
-         * # get the meta class
+         * # get the metaclass
          * # select a method/constructor/property from it, if it is a MetaClassImpl
          * # make a handle out of the selection
-         * # if nothing could be selected select a path through the given MetaClass or the GroovyObject
+         * # if nothing could be selected, select a path through the given MetaClass or the GroovyObject
          * # apply transformations for vargs, implicit null argument, coercion, wrapping, null receiver and spreading
          */
         @Override
@@ -1047,7 +1047,7 @@ public abstract class Selector {
 
     /**
      * Returns {@link NullObject#getNullObject()} if the receiver
-     * (args[0]) is null. If it is not null, the recevier itself
+     * (args[0]) is null. If it is not null, the receiver itself
      * is returned.
      */
     public Object getCorrectedReceiver() {

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/TypeTransformers.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/TypeTransformers.java
@@ -155,7 +155,7 @@ public class TypeTransformers {
                 // return ProxyGenerator.INSTANCE.instantiateAggregate(impl,Collections.singletonList(clazz));
                 // TO_SAMTRAIT_PROXY is a handle (Object,Object,ProxyGenerator,Class)GroovyObject
                 // where the second object is the input closure, everything else
-                // needs to be provide and is in remaining order: method name,
+                // needs to be provided and is in remaining order: method name,
                 // ProxyGenerator.INSTANCE and singletonList(parameter)
                 MethodHandle ret = TO_SAMTRAIT_PROXY;
                 ret = MethodHandles.insertArguments(ret, 2, ProxyGenerator.INSTANCE, Collections.singletonList(parameter));
@@ -168,8 +168,8 @@ public class TypeTransformers {
             //        new Class[]{parameter},
             //        new ConvertedClosure((Closure) arg));
             // TO_REFLECTIVE_PROXY will do that for us, though
-            // input is the closure, the method name, the class loader and the 
-            // class[]. All of that but the closure must be provided here  
+            // input is the closure, the method name, the class loader and the
+            // class[]. All of that but the closure must be provided here
             MethodHandle ret = TO_REFLECTIVE_PROXY;
             ret = MethodHandles.insertArguments(ret, 1,
                     method.getName(),
@@ -183,7 +183,7 @@ public class TypeTransformers {
             //            instantiateAggregateFromBaseClass(m, parameter);
             // TO_GENERATED_PROXY is a handle (Object,Object,ProxyGenerator,Class)GroovyObject
             // where the second object is the input closure, everything else
-            // needs to be provide and is in remaining order: method name, 
+            // needs to be provided and is in remaining order: method name,
             // ProxyGenerator.INSTANCE and parameter
             MethodHandle ret = TO_GENERATED_PROXY;
             ret = MethodHandles.insertArguments(ret, 2, ProxyGenerator.INSTANCE, parameter);

--- a/src/main/java/org/codehaus/groovy/vmplugin/v9/Java9.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v9/Java9.java
@@ -288,7 +288,7 @@ public class Java9 extends Java8 {
             } else if (declaringClass.isAssignableFrom(theClass)) {
                 // if caller can not access the method,
                 // try to find the corresponding method in its derived class
-                // GROOVY-9081: Sub-class derives the protected members from public class, "Invoke the members on the sub class instances"
+                // GROOVY-9081: Sub-class derives the protected members from public class, "Invoke the members on the subclass instances"
                 // e.g. StringBuilder sb = new StringBuilder(); sb.setLength(0);
                 // `setLength` is the method of `AbstractStringBuilder`, which is `package-private`
                 Optional<CachedMethod> cachedMethod = getAccessibleMetaMethod(metaMethod, paramTypes, caller, theClass, false);


### PR DESCRIPTION
Fix typos and improve documentation (javadoc, comments) in the org.codehaus.groovy package. A typo in the Grape resolve command were also fixed.

Note that the following words / expressions were preferred :

- all of the -> all the (when possible because it is easier to read),
- whether or not -> whether (when possible because it is easier to read),
- sub-type -> subtype (more common, see https://docs.oracle.com/javase/tutorial/java/generics/subtyping.html),
- sub-class -> subclass (more common, see https://docs.oracle.com/javase/tutorial/java/IandI/subclasses.html),
- meta class -> metaclass (incorrect, see https://en.wikipedia.org/wiki/Metaclass).

Trailing whitespaces were also removed in the process.