### PR TITLE
Polish org.apache.groovy package documentation

### DIFF
--- a/src/main/java/org/apache/groovy/ast/tools/ClassNodeUtils.java
+++ b/src/main/java/org/apache/groovy/ast/tools/ClassNodeUtils.java
@@ -63,11 +63,11 @@ public class ClassNodeUtils {
     private ClassNodeUtils() { }
 
     /**
-     * Formats a type name into a human readable version. For arrays, appends "[]" to the formatted
+     * Formats a type name into a human-readable version. For arrays, appends "[]" to the formatted
      * type name of the component. For unit class nodes, uses the class node name.
      *
      * @param cNode the type to format
-     * @return a human readable version of the type name (java.lang.String[] for example)
+     * @return a human-readable version of the type name (java.lang.String[] for example)
      */
     public static String formatTypeName(final ClassNode cNode) {
         if (cNode.isArray()) {
@@ -350,7 +350,7 @@ public class ClassNodeUtils {
     }
 
     /**
-     * Detect whether a given ClassNode is a inner class (non-static).
+     * Detect whether a given ClassNode is an inner class (non-static).
      *
      * @param cNode the ClassNode of interest
      * @return true if the given node is a (non-static) inner class, else false
@@ -387,7 +387,7 @@ public class ClassNodeUtils {
     /**
      * Determine if an explicit (non-generated) constructor is in the class.
      *
-     * @param xform if non null, add an error if an explicit constructor is found
+     * @param xform if non-null, add an error if an explicit constructor is found
      * @param cNode the type of the containing class
      * @return true if an explicit (non-generated) constructor was found
      */

--- a/src/main/java/org/apache/groovy/ast/tools/ImmutablePropertyUtils.java
+++ b/src/main/java/org/apache/groovy/ast/tools/ImmutablePropertyUtils.java
@@ -61,7 +61,7 @@ public class ImmutablePropertyUtils {
      * Also, Color is not final so while not normally used with child
      * classes, it isn't strictly immutable. Use at your own risk.
      *
-     * This list can by extended by providing "known immutable" classes
+     * This list can be extended by providing "known immutable" classes
      * via Immutable.knownImmutableClasses
      */
     private static final Set<String> BUILTIN_IMMUTABLES = new HashSet<>(Arrays.asList(

--- a/src/main/java/org/apache/groovy/internal/metaclass/MetaClassConstant.java
+++ b/src/main/java/org/apache/groovy/internal/metaclass/MetaClassConstant.java
@@ -26,7 +26,7 @@ import org.apache.groovy.lang.annotation.Incubating;
 import java.lang.invoke.SwitchPoint;
 
 /**
- * The one and only implementation of a meta class.
+ * The one and only implementation of a metaclass.
  * INTERNAL USE ONLY.
  */
 @Incubating

--- a/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -3689,7 +3689,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
         InnerClassNode anonymousInnerClass;
         if (ctx.t == 1) {
             anonymousInnerClass = new EnumConstantClassNode(outerClass, innerClassName, superClass.getPlainNodeReference());
-            // and remove the final modifier from classNode to allow the sub class
+            // and remove the final modifier from classNode to allow the subclass
             superClass.setModifiers(superClass.getModifiers() & ~Opcodes.ACC_FINAL);
         } else {
             anonymousInnerClass = new InnerClassNode(outerClass, innerClassName, Opcodes.ACC_PUBLIC, superClass);
@@ -4703,7 +4703,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
             methodCallExpression.setSafe(false);
         }
 
-        // if the generics types meta data is not empty, it is a generic method call, e.g. obj.<Integer>a(1, 2)
+        // if the generics types metadata is not empty, it is a generic method call, e.g. obj.<Integer>a(1, 2)
         methodCallExpression.setGenericsTypes(
                 propertyExpression.getNodeMetaData(PATH_EXPRESSION_BASE_EXPR_GENERICS_TYPES));
 

--- a/src/main/java/org/apache/groovy/plugin/GroovyRunnerRegistry.java
+++ b/src/main/java/org/apache/groovy/plugin/GroovyRunnerRegistry.java
@@ -282,7 +282,7 @@ public class GroovyRunnerRegistry implements Map<String, GroovyRunner>, Iterable
     /**
      * Returns the registered runner for the specified key.
      *
-     * @param key used to lookup the runner
+     * @param key used to look up the runner
      * @return the runner registered with the given key
      */
     @Override

--- a/src/main/java/org/apache/groovy/util/SystemUtil.java
+++ b/src/main/java/org/apache/groovy/util/SystemUtil.java
@@ -138,7 +138,7 @@ public class SystemUtil {
     }
 
     /**
-     * Retrieves an Long System property
+     * Retrieves a Long System property
      *
      * @param name the name of the system property.
      * @param def the default value

--- a/src/main/java/org/apache/groovy/util/concurrent/LazyInitializable.java
+++ b/src/main/java/org/apache/groovy/util/concurrent/LazyInitializable.java
@@ -20,7 +20,7 @@ package org.apache.groovy.util.concurrent;
 
 /**
  *  A {@code LazyInitializable} is an object that can be initialized lazily.
- *  Note: the instance field {@code initialized} of sub-class should be {@code volatile} to avoid JVM instructions re-ordering
+ *  Note: the instance field {@code initialized} of subclass should be {@code volatile} to avoid JVM instructions re-ordering
  *
  * @since 3.0.0
  */

--- a/src/main/java/org/apache/groovy/util/concurrent/concurrentlinkedhashmap/ConcurrentLinkedHashMap.java
+++ b/src/main/java/org/apache/groovy/util/concurrent/concurrentlinkedhashmap/ConcurrentLinkedHashMap.java
@@ -947,7 +947,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Returns a unmodifiable snapshot {@link Set} view of the keys contained in
+   * Returns an unmodifiable snapshot {@link Set} view of the keys contained in
    * this map. The set's iterator returns the keys whose order of iteration is
    * the ascending order in which its entries are considered eligible for
    * retention, from the least-likely to be retained to the most-likely.
@@ -975,7 +975,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
    * of the keys.
    *
    * @param limit the maximum size of the returned set
-   * @return a ascending snapshot view of the keys in this map
+   * @return an ascending snapshot view of the keys in this map
    * @throws IllegalArgumentException if the limit is negative
    */
   public Set<K> ascendingKeySetWithLimit(int limit) {
@@ -1064,7 +1064,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
    * policy, determining the retention ordering requires a traversal of the
    * entries.
    *
-   * @return a ascending snapshot view of this map
+   * @return an ascending snapshot view of this map
    */
   public Map<K, V> ascendingMap() {
     return ascendingMapWithLimit(Integer.MAX_VALUE);
@@ -1083,7 +1083,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
    * entries.
    *
    * @param limit the maximum size of the returned map
-   * @return a ascending snapshot view of this map
+   * @return an ascending snapshot view of this map
    * @throws IllegalArgumentException if the limit is negative
    */
   public Map<K, V> ascendingMapWithLimit(int limit) {
@@ -1675,7 +1675,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
      * entry consumes. The default algorithm bounds the map by the number of
      * key-value pairs by giving each entry a weight of <tt>1</tt>.
      *
-     * @param weigher the algorithm to determine a entry's weight
+     * @param weigher the algorithm to determine an entry's weight
      * @throws NullPointerException if the weigher is null
      */
     public Builder<K, V> weigher(EntryWeigher<? super K, ? super V> weigher) {

--- a/src/main/java/org/apache/groovy/util/concurrent/concurrentlinkedhashmap/Weighers.java
+++ b/src/main/java/org/apache/groovy/util/concurrent/concurrentlinkedhashmap/Weighers.java
@@ -34,11 +34,11 @@ public final class Weighers {
   }
 
   /**
-   * A entry weigher backed by the specified weigher. The weight of the value
+   * An entry weigher backed by the specified weigher. The weight of the value
    * determines the weight of the entry.
    *
-   * @param weigher the weigher to be "wrapped" in a entry weigher.
-   * @return A entry weigher view of the specified weigher.
+   * @param weigher the weigher to be "wrapped" in an entry weigher.
+   * @return An entry weigher view of the specified weigher.
    */
   public static <K, V> EntryWeigher<K, V> asEntryWeigher(
       final Weigher<? super V> weigher) {


### PR DESCRIPTION
Fix typos and improve documentation (javadoc, comments) in the org.apache.groovy package.

Note that the following words / expressions were preferred :

- meta data -> metadata (incorrect, see https://www.merriam-webster.com/dictionary/metadata)
- sub-class -> subclass (more common, see https://docs.oracle.com/javase/tutorial/java/IandI/subclasses.html),
- meta class -> metaclass (incorrect, see https://en.wikipedia.org/wiki/Metaclass).