### PR TITLE
Polish groovy package documentation

### DIFF
--- a/src/main/groovy/groovy/cli/internal/CliBuilderInternal.groovy
+++ b/src/main/groovy/groovy/cli/internal/CliBuilderInternal.groovy
@@ -66,7 +66,7 @@ class CliBuilderInternal {
      * For backwards compatibility with Apache Commons CLI, set this property to
      * <code>true</code> if the parser should recognize long options with both
      * a single hyphen and a double hyphen prefix. The default is <code>false</code>,
-     * so only long options with a double hypen prefix (<code>--option</code>) are recognized.
+     * so only long options with a double hyphen prefix (<code>--option</code>) are recognized.
      * @since 2.5
      */
     boolean acceptLongOptionsWithSingleHyphen = false

--- a/src/main/java/groovy/cli/Option.java
+++ b/src/main/java/groovy/cli/Option.java
@@ -54,9 +54,9 @@ public @interface Option {
     String longName() default "";
 
     /**
-     * The value separator for this multi-valued option. Only allowed for array-typed arguments.
+     * The value separator for this multivalued option. Only allowed for array-typed arguments.
      *
-     * @return the value separator for this multi-valued option
+     * @return the value separator for this multivalued option
      */
     String valueSeparator() default "";
 

--- a/src/main/java/groovy/grape/GrabAnnotationTransformation.java
+++ b/src/main/java/groovy/grape/GrabAnnotationTransformation.java
@@ -384,7 +384,7 @@ public class GrabAnnotationTransformation extends ClassCodeVisitorSupport implem
                 }
             } catch (RuntimeException re) {
                 // Decided against syntax exception since this is not a syntax error.
-                // The down side is we lose line number information for the offending
+                // The downside is we lose line number information for the offending
                 // @Grab annotation.
                 source.addException(re);
             }

--- a/src/main/java/groovy/transform/AutoFinal.java
+++ b/src/main/java/groovy/transform/AutoFinal.java
@@ -89,7 +89,7 @@ import java.lang.annotation.Target;
 public @interface AutoFinal {
     /**
      * Indicates that adding final to parameters should not be applied on this node.
-     * <p>Normally not required since leaving off the annotation will achieve the same affect.
+     * <p>Normally not required since leaving off the annotation will achieve the same effect.
      * However, it can be useful for selectively disabling this annotation in just a small part
      * of an otherwise annotated class. As an example, it would make sense to set this to {@code false} on
      * a method which altered parameters in a class already marked as {@code @AutoFinal}.

--- a/src/main/java/groovy/transform/InheritConstructors.java
+++ b/src/main/java/groovy/transform/InheritConstructors.java
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Class annotation to make constructors from a super class available in a sub class.
+ * Class annotation to make constructors from a super class available in a subclass.
  * Should be used with care with other annotations which create constructors - see "Known
  * Limitations" for more details.
  * <p>
@@ -70,7 +70,7 @@ import java.lang.annotation.Target;
  * Typical Groovy style is to use named-arg constructors when possible.
  * This is easy to do for Groovy objects or any objects following JavaBean
  * conventions. In other cases, inheriting the constructors may be useful.
- * However, sub-classes often introduce new properties and these are often best
+ * However, subclasses often introduce new properties and these are often best
  * set in a constructor; especially if that matches the style adopted
  * in parent classes. So, even for the example above, it may have been
  * better style to define an explicit constructor for <code>PersonAge</code>

--- a/src/main/java/groovy/transform/Synchronized.java
+++ b/src/main/java/groovy/transform/Synchronized.java
@@ -43,7 +43,7 @@ import java.lang.annotation.Target;
  * parameter to the {@code @Synchronized} annotation. In this usage variant, the lock field
  * will not be created automatically, and you must explicitly create it yourself.
  * <p>
- * <em>Rationale:</em> Locking on <code>this</code> or your own class object can have unfortunate side-effects,
+ * <em>Rationale:</em> Locking on <code>this</code> or your own class object can have unfortunate side effects,
  * as other code not under your control can lock on these objects as well, which can
  * cause race conditions and other nasty threading-related bugs.
  * <p>

--- a/src/main/java/groovy/transform/options/LegacyHashMapPropertyHandler.java
+++ b/src/main/java/groovy/transform/options/LegacyHashMapPropertyHandler.java
@@ -50,7 +50,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
  * tried to be compatible with both expected tuple behavior and expected named-argument behavior
  * by peeking into the supplied map and guessing as to which approach might be applicable.
  * Recent versions of Groovy now allow both {@code @TupleConstructor} and {@code @MapConstructor}
- * annotations to co-exist which provide's a more flexible solution to this problem. While more
+ * annotations to co-exist which provides a more flexible solution to this problem. While more
  * flexible, the new approach isn't fully compatible with the previous approach. If for some
  * reason you need the old behavior, you can try this property handler. Some features of the
  * new approach won't be available to you.

--- a/src/main/java/groovy/transform/stc/PickAnyArgumentHint.java
+++ b/src/main/java/groovy/transform/stc/PickAnyArgumentHint.java
@@ -46,7 +46,7 @@ public class PickAnyArgumentHint extends SingleSignatureClosureHint {
     private final int genericTypeIndex;
 
     /**
-     * Creates the an argument picker which extracts the type of the first parameter.
+     * Creates an argument picker which extracts the type of the first parameter.
      */
     public PickAnyArgumentHint() {
         this(0,-1);

--- a/src/main/java/groovy/ui/GroovyMain.java
+++ b/src/main/java/groovy/ui/GroovyMain.java
@@ -84,7 +84,7 @@ public class GroovyMain {
     // automatically output the result of each script
     private boolean autoOutput;
 
-    // automatically split each line using the splitpattern
+    // automatically split each line using the splitPattern
     private boolean autoSplit;
 
     // The pattern used to split the current line

--- a/src/main/java/groovy/util/CharsetToolkit.java
+++ b/src/main/java/groovy/util/CharsetToolkit.java
@@ -140,14 +140,14 @@ public class CharsetToolkit {
     /**
      * Guess the encoding of the provided buffer.
      * If Byte Order Markers are encountered at the beginning of the buffer, we immediately
-     * return the charset implied by this BOM. Otherwise, the file would not be a human
-     * readable text file.
+     * return the charset implied by this BOM. Otherwise, the file would not be a
+     * human-readable text file.
      * <p>
      * If there is no BOM, this method tries to discern whether the file is UTF-8 or not.
      * If it is not UTF-8, we assume the encoding is the default system encoding
      * (of course, it might be any 8-bit charset, but usually, an 8-bit charset is the default one).
      * <p>
-     * It is possible to discern UTF-8 thanks to the pattern of characters with a multi-byte sequence.
+     * It is possible to discern UTF-8 thanks to the pattern of characters with a multibyte sequence.
      * <pre>
      * UCS-4 range (hex.)        UTF-8 octet sequence (binary)
      * 0000 0000-0000 007F       0xxxxxxx
@@ -163,7 +163,7 @@ public class CharsetToolkit {
      */
     private Charset guessEncoding() {
         // if the file has a Byte Order Marker, we can assume the file is in UTF-xx
-        // otherwise, the file would not be human readable
+        // otherwise, the file would not be human-readable
         if (hasUTF8Bom())
             return StandardCharsets.UTF_8;
         if (hasUTF16LEBom())
@@ -197,7 +197,7 @@ public class CharsetToolkit {
                 // a two-bytes sequence was encountered
                 if (isTwoBytesSequence(b0)) {
                     // there must be one continuation byte of the form 10xxxxxx,
-                    // otherwise the following character is is not a valid UTF-8 construct
+                    // otherwise the following character is not a valid UTF-8 construct
                     if (!isContinuationChar(b1))
                         validU8Char = false;
                     else
@@ -206,7 +206,7 @@ public class CharsetToolkit {
                 // a three-bytes sequence was encountered
                 else if (isThreeBytesSequence(b0)) {
                     // there must be two continuation bytes of the form 10xxxxxx,
-                    // otherwise the following character is is not a valid UTF-8 construct
+                    // otherwise the following character is not a valid UTF-8 construct
                     if (!(isContinuationChar(b1) && isContinuationChar(b2)))
                         validU8Char = false;
                     else
@@ -215,7 +215,7 @@ public class CharsetToolkit {
                 // a four-bytes sequence was encountered
                 else if (isFourBytesSequence(b0)) {
                     // there must be three continuation bytes of the form 10xxxxxx,
-                    // otherwise the following character is is not a valid UTF-8 construct
+                    // otherwise the following character is not a valid UTF-8 construct
                     if (!(isContinuationChar(b1) && isContinuationChar(b2) && isContinuationChar(b3)))
                         validU8Char = false;
                     else
@@ -224,7 +224,7 @@ public class CharsetToolkit {
                 // a five-bytes sequence was encountered
                 else if (isFiveBytesSequence(b0)) {
                     // there must be four continuation bytes of the form 10xxxxxx,
-                    // otherwise the following character is is not a valid UTF-8 construct
+                    // otherwise the following character is not a valid UTF-8 construct
                     if (!(isContinuationChar(b1)
                         && isContinuationChar(b2)
                         && isContinuationChar(b3)
@@ -236,7 +236,7 @@ public class CharsetToolkit {
                 // a six-bytes sequence was encountered
                 else if (isSixBytesSequence(b0)) {
                     // there must be five continuation bytes of the form 10xxxxxx,
-                    // otherwise the following character is is not a valid UTF-8 construct
+                    // otherwise the following character is not a valid UTF-8 construct
                     if (!(isContinuationChar(b1)
                         && isContinuationChar(b2)
                         && isContinuationChar(b3)
@@ -253,7 +253,7 @@ public class CharsetToolkit {
                 break;
             i++;
         }
-        // if no byte with an high order bit set, the encoding is US-ASCII
+        // if no byte with a high order bit set, the encoding is US-ASCII
         // (it might have been UTF-7, but this encoding is usually internally used only by mail systems)
         if (!highOrderBit) {
             // returns the default charset rather than US-ASCII if the enforce8Bit flag is set.
@@ -263,7 +263,7 @@ public class CharsetToolkit {
                 return StandardCharsets.US_ASCII;
         }
         // if no invalid UTF-8 were encountered, we can assume the encoding is UTF-8,
-        // otherwise the file would not be human readable
+        // otherwise the file would not be human-readable
         if (validU8Char)
             return StandardCharsets.UTF_8;
         // finally, if it's not UTF-8 nor US-ASCII, let's assume the encoding is the default encoding

--- a/src/main/java/groovy/util/ConfigObject.java
+++ b/src/main/java/groovy/util/ConfigObject.java
@@ -145,7 +145,7 @@ public class ConfigObject extends GroovyObjectSupport implements Writable, Map, 
 
 
     /**
-     * Converts this ConfigObject into a the java.util.Properties format, flattening the tree structure beforehand
+     * Converts this ConfigObject into the java.util.Properties format, flattening the tree structure beforehand
      *
      * @return A java.util.Properties instance
      */

--- a/src/main/java/groovy/util/FactoryBuilderSupport.java
+++ b/src/main/java/groovy/util/FactoryBuilderSupport.java
@@ -54,7 +54,7 @@ import static org.apache.groovy.util.BeanUtils.capitalize;
  * Mix of BuilderSupport and SwingBuilder's factory support.
  *
  * Warning: this implementation is not thread safe and should not be used
- * across threads in a multi-threaded environment.  A locking mechanism
+ * across threads in a multithreaded environment.  A locking mechanism
  * should be implemented by the subclass if use is expected across
  * multiple threads.
  */
@@ -735,7 +735,7 @@ public abstract class FactoryBuilderSupport extends Binding {
     }
 
     /**
-     * This is a hook for subclasses to plugin a custom strategy for mapping
+     * This is a hook for subclasses to plug in a custom strategy for mapping
      * names to factories.
      *
      * @param name       the name of the factory
@@ -749,7 +749,7 @@ public abstract class FactoryBuilderSupport extends Binding {
     }
 
     /**
-     * This is a hook for subclasses to plugin a custom strategy for mapping
+     * This is a hook for subclasses to plug in a custom strategy for mapping
      * names to explicit methods.
      *
      * @param methodName the name of the explicit method
@@ -762,7 +762,7 @@ public abstract class FactoryBuilderSupport extends Binding {
     }
 
     /**
-     * This is a hook for subclasses to plugin a custom strategy for mapping
+     * This is a hook for subclasses to plug in a custom strategy for mapping
      * names to property methods.
      *
      * @param propertyName the name of the explicit method
@@ -892,7 +892,7 @@ public abstract class FactoryBuilderSupport extends Binding {
                         getProxyBuilder().getContext().put(PARENT_NAME, parentName);
                         getProxyBuilder().getContext().put(PARENT_BUILDER, parentContext.get(CURRENT_BUILDER));
                         getProxyBuilder().getContext().put(CURRENT_BUILDER, parentContext.get(CHILD_BUILDER));
-                        // lets register the builder as the delegate
+                        // let's register the builder as the delegate
                         getProxyBuilder().setClosureDelegate(closure, node);
                         closure.call();
                     } finally {
@@ -1168,7 +1168,7 @@ public abstract class FactoryBuilderSupport extends Binding {
     public Object build(Script script) {
         // this used to be synchronized, but we also used to remove the
         // metaclass.  Since adding the metaclass is now a side effect, we
-        // don't need to ensure the meta-class won't be observed and don't
+        // don't need to ensure the metaclass won't be observed and don't
         // need to hide the side effect.
         MetaClass scriptMetaClass = script.getMetaClass();
         script.setMetaClass(new FactoryInterceptorMetaClass(scriptMetaClass, this));

--- a/src/main/java/groovy/util/Node.java
+++ b/src/main/java/groovy/util/Node.java
@@ -788,7 +788,7 @@ public class Node implements Serializable, Cloneable {
 
 
     /**
-     * Converts the text of this GPathResult to a Integer object.
+     * Converts the text of this GPathResult to an Integer object.
      *
      * @return the GPathResult, converted to a <code>Integer</code>
      */

--- a/src/main/java/groovy/util/PermutationGenerator.java
+++ b/src/main/java/groovy/util/PermutationGenerator.java
@@ -107,13 +107,13 @@ public class PermutationGenerator<E> implements Iterator<List<E>> {
 
         int temp;
 
-        // Find largest index j with a[j] < a[j+1]
+        // Find the largest index j with a[j] < a[j+1]
         int j = a.length - 2;
         while (a[j] > a[j + 1]) {
             j--;
         }
 
-        // Find index k such that a[k] is smallest integer
+        // Find index k such that a[k] is the smallest integer
         // greater than a[j] to the right of a[j]
         int k = a.length - 1;
         while (a[j] > a[k]) {


### PR DESCRIPTION
Fix typos and improve documentation (javadoc, comments) in the groovy package.

Note that the following words / expressions were preferred :

- sub-class -> subclass (more common, see https://docs.oracle.com/javase/tutorial/java/IandI/subclasses.html),
- meta class -> metaclass (incorrect, see https://en.wikipedia.org/wiki/Metaclass).