### PR TITLE
Bugfix/groovy 9541 respect parent classloader

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/ExtendedVerifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/ExtendedVerifier.java
@@ -220,7 +220,7 @@ public class ExtendedVerifier extends ClassCodeVisitorSupport {
                         for (AnnotationNode annotation : repeatable.getAnnotations()) {
                             if (annotation.getClassNode().getName().equals("java.lang.annotation.Retention")) {
                                 Expression value = annotation.getMember("value"); assert value != null;
-                                Object retention = evaluateExpression(value, source.getConfiguration());
+                                Object retention = evaluateExpression(value, source.getConfiguration(), source.getClassLoader());
                                 collector.setRuntimeRetention(retention != null && retention.toString().equals("RUNTIME"));
                                 break;
                             }

--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
@@ -184,7 +184,7 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
                 Expression mode = annotation.getMember("mode");
                 modes.put(index, Optional.ofNullable(mode)
                     .map(exp -> evaluateExpression(exp, source.getConfiguration(), source.getClassLoader()))
-                    .map(val -> (AnnotationCollectorMode) val)
+                    .map(val -> AnnotationCollectorMode.valueOf(val.toString()))
                     .orElse(AnnotationCollectorMode.DUPLICATE)
                 );
 

--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
@@ -183,7 +183,7 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
             if (annotation.getClassNode().getName().equals(AnnotationCollector.class.getName())) {
                 Expression mode = annotation.getMember("mode");
                 modes.put(index, Optional.ofNullable(mode)
-                    .map(exp -> evaluateExpression(exp, source.getConfiguration()))
+                    .map(exp -> evaluateExpression(exp, source.getConfiguration(), source.getClassLoader()))
                     .map(val -> (AnnotationCollectorMode) val)
                     .orElse(AnnotationCollectorMode.DUPLICATE)
                 );
@@ -191,7 +191,7 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
                 Expression processor = annotation.getMember("processor");
                 AnnotationCollectorTransform act = null;
                 if (processor != null) {
-                    String className = (String) evaluateExpression(processor, source.getConfiguration());
+                    String className = (String) evaluateExpression(processor, source.getConfiguration(), source.getClassLoader());
                     Class<?> klass = loadTransformClass(className, alias);
                     if (klass != null) {
                         try {

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -18,6 +18,7 @@
  */
 package org.codehaus.groovy.transform.stc;
 
+import groovy.lang.GroovyClassLoader;
 import org.apache.groovy.util.Maps;
 import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.ast.ClassNode;
@@ -2136,6 +2137,13 @@ public abstract class StaticTypeCheckingSupport {
     }
 
     /**
+     * @deprecated Use {@link #evaluateExpression(Expression, CompilerConfiguration, GroovyClassLoader)} instead
+     */
+    public static Object evaluateExpression(final Expression expr, final CompilerConfiguration config) {
+        return evaluateExpression(expr, config, null);
+    }
+
+    /**
      * A helper method that can be used to evaluate expressions as found in annotation
      * parameters. For example, it will evaluate a constant, be it referenced directly as
      * an integer or as a reference to a field.
@@ -2146,8 +2154,8 @@ public abstract class StaticTypeCheckingSupport {
      * @param config the compiler configuration
      * @return the result of the expression
      */
-    public static Object evaluateExpression(final Expression expr, final CompilerConfiguration config) {
-        String className = "Expression$"+UUID.randomUUID().toString().replace('-', '$');
+    public static Object evaluateExpression(final Expression expr, final CompilerConfiguration config, GroovyClassLoader groovyClassLoader) {
+        String className = "Expression$" + UUID.randomUUID().toString().replace('-', '$');
         ClassNode classNode = new ClassNode(className, Opcodes.ACC_PUBLIC, OBJECT_TYPE);
         addGeneratedMethod(classNode, "eval", Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, OBJECT_TYPE, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, new ReturnStatement(expr));
 
@@ -2157,7 +2165,7 @@ public abstract class StaticTypeCheckingSupport {
         copyConf.setScriptBaseClass(null);
         copyConf.setTargetBytecode(CompilerConfiguration.DEFAULT.getTargetBytecode());
 
-        CompilationUnit cu = new CompilationUnit(copyConf);
+        CompilationUnit cu = new CompilationUnit(copyConf, null, groovyClassLoader);
         try {
             cu.addClassNode(classNode);
             cu.compile(Phases.CLASS_GENERATION);

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -3211,7 +3211,8 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                 Expression type = annotation.getMember("type");
                 Integer stInt = Closure.OWNER_FIRST;
                 if (strategy != null) {
-                    stInt = (Integer) evaluateExpression(castX(Integer_TYPE, strategy), getSourceUnit().getConfiguration());
+                    SourceUnit sourceUnit = getSourceUnit();
+                    stInt = (Integer) evaluateExpression(castX(Integer_TYPE, strategy), sourceUnit.getConfiguration(), sourceUnit.getClassLoader());
                 }
                 if (value instanceof ClassExpression && !value.getType().equals(DELEGATES_TO_TARGET)) {
                     if (genericTypeIndex != null) {
@@ -3634,7 +3635,8 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         if (annotations != null && !annotations.isEmpty()) {
             Expression strategy = annotations.get(0).getMember("strategy");
             if (strategy != null) {
-                return (Integer) evaluateExpression(castX(Integer_TYPE, strategy), getSourceUnit().getConfiguration());
+                SourceUnit sourceUnit = getSourceUnit();
+                return (Integer) evaluateExpression(castX(Integer_TYPE, strategy), sourceUnit.getConfiguration(), sourceUnit.getClassLoader());
             }
         }
         return Closure.OWNER_FIRST;


### PR DESCRIPTION
Helpful background may be found in the comments of https://issues.apache.org/jira/browse/GROOVY-9541.

As @eric-milles noted there, we may need to do a more careful consideration of each consumer of `StaticTypeCheckingSupport#evaluateExpression`, since the `source` object's classloader may not actually be correct in every case.

I can attest that letting `org.codehaus.groovy.transform.ASTTransformationCollectorCodeVisitor#findCollectedAnnotations` use the context classloader will result in difficult-to-resolve cases of GROOVY-9541. 

A word about 4616fc8: without that, you'll get a [cast_failure](https://github.com/apache/groovy/files/9864104/cast_failure.txt) when trying to compile the groovy-macro module. I was a bit nervous about it, but I think `java.util.Optional#map` provides enough null safety that it should work.

My local test suite is still finishing execution, but I thought a concrete diff & a PR would be helpful for the discussion.