### PR TITLE
GROOVY-8668: add property groovysh.disableDocCommand

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/util/DefaultCommandsRegistrar.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/util/DefaultCommandsRegistrar.groovy
@@ -57,31 +57,32 @@ class DefaultCommandsRegistrar {
     }
 
     void register() {
+        def commands = [
+            new HelpCommand(shell),
+            new ExitCommand(shell),
+            new ImportCommand(shell),
+            new DisplayCommand(shell),
+            new ClearCommand(shell),
+            new ShowCommand(shell),
+            new InspectCommand(shell),
+            new PurgeCommand(shell),
+            new EditCommand(shell),
+            new LoadCommand(shell),
+            new SaveCommand(shell),
+            new RecordCommand(shell),
+            new HistoryCommand(shell),
+            new AliasCommand(shell),
+            new SetCommand(shell),
+            new GrabCommand(shell),
+            new RegisterCommand(shell),
+        ]
 
-        for (Command classname in [
-                new HelpCommand(shell),
-                new ExitCommand(shell),
-                new ImportCommand(shell),
-                new DisplayCommand(shell),
-                new ClearCommand(shell),
-                new ShowCommand(shell),
-                new InspectCommand(shell),
-                new PurgeCommand(shell),
-                new EditCommand(shell),
-                new LoadCommand(shell),
-                new SaveCommand(shell),
-                new RecordCommand(shell),
-                new HistoryCommand(shell),
-                new AliasCommand(shell),
-                new SetCommand(shell),
-                new GrabCommand(shell),
-                // does not do anything
-                //new ShadowCommand(shell),
-                new RegisterCommand(shell),
-                new DocCommand(shell)
-        ]) {
-            shell.register(classname)
+        if (!System.getProperty("groovysh.disableDocCommand").toBoolean()) {
+            commands.add(new DocCommand(shell))
         }
 
+        for (Command classname in commands) {
+            shell.register(classname)
+        }
     }
 }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/util/DefaultCommandsRegistrar.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/util/DefaultCommandsRegistrar.groovy
@@ -77,7 +77,7 @@ class DefaultCommandsRegistrar {
             new RegisterCommand(shell),
         ]
 
-        if (!System.getProperty("groovysh.disableDocCommand").toBoolean()) {
+        if (!System.getProperty("groovysh.disableDocCommand")?.toBoolean()) {
             commands.add(new DocCommand(shell))
         }
 


### PR DESCRIPTION
The AWT window is launched by DocCommand. I want to exclude this functionality to avoid opening a new window so I suggest to add an option to disable it.