### PR TITLE
GROOVY-10813: Fix NullPointerException for lambdas with raw types

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -855,10 +855,21 @@ public class GenericsUtils {
             GenericsType[] targetGenericsTypes = parameterizedType.redirect().getGenericsTypes();
             if (targetGenericsTypes != null) {
                 GenericsType[] sourceGenericsTypes = parameterizedType.getGenericsTypes();
-                if (sourceGenericsTypes == null) sourceGenericsTypes = EMPTY_GENERICS_ARRAY;
                 map = new LinkedHashMap<>();
-                for (int i = 0, m = sourceGenericsTypes.length, n = targetGenericsTypes.length; i < n; i += 1) {
-                    map.put(targetGenericsTypes[i], i < m ? sourceGenericsTypes[i] : targetGenericsTypes[i]);
+                if (sourceGenericsTypes == null) {
+                    //We have no sourceGenerics, so we need to return the erasures for the raw types.
+                    // If the generic has upper bounds use the first one, else use Object (Groovy-10813)
+                    for (GenericsType targetGenericsType : targetGenericsTypes) {
+                        map.put(targetGenericsType,
+                                targetGenericsType.getUpperBounds() != null ?
+                                    targetGenericsType.getUpperBounds()[0].asGenericsType() :
+                                    ClassHelper.OBJECT_TYPE.asGenericsType()
+                        );
+                    }
+                } else {
+                    for (int i = 0, m = sourceGenericsTypes.length, n = targetGenericsTypes.length; i < n; i += 1) {
+                        map.put(targetGenericsTypes[i], i < m ? sourceGenericsTypes[i] : targetGenericsTypes[i]);
+                    }
                 }
             }
         }

--- a/src/test/groovy/transform/stc/ClosureParamTypeInferenceSTCTest.groovy
+++ b/src/test/groovy/transform/stc/ClosureParamTypeInferenceSTCTest.groovy
@@ -1709,4 +1709,24 @@ class ClosureParamTypeInferenceSTCTest extends StaticTypeCheckingTestCase {
             assert i == 1
         '''
     }
+
+    void testGroovy10813() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            void testClosure(){
+                java.util.function.Consumer c = x -> print(x)
+                c.accept('hello world!')
+            }
+            testClosure()
+        '''
+        assertScript '''
+            interface A<T extends String>{void accept(T input);}
+            @groovy.transform.CompileStatic
+            void testClosure(){
+                A c = x -> print(x)
+                c.accept('hello world!')
+            }
+            testClosure()
+        '''
+    }
 }

--- a/src/test/org/codehaus/groovy/ast/tools/GenericsUtilsTest.groovy
+++ b/src/test/org/codehaus/groovy/ast/tools/GenericsUtilsTest.groovy
@@ -275,4 +275,61 @@ final class GenericsUtilsTest {
 
         assert ClassHelper.Integer_TYPE == typeInfo[1]
     }
+
+    @Test
+    void testParameterizeSAMWithRawType() {
+        def classNodeList = compile '''
+            import java.util.function.*
+            interface T extends BinaryOperator {}
+        '''
+        ClassNode samType = findClassNode('T', classNodeList).interfaces.find { it.name == 'java.util.function.BinaryOperator' }
+
+        def typeInfo = GenericsUtils.parameterizeSAM(samType)
+
+        assert 2 == typeInfo.v1.length
+        assert ClassHelper.OBJECT_TYPE == typeInfo.v1[0]
+        assert ClassHelper.OBJECT_TYPE == typeInfo.v1[1]
+
+        assert ClassHelper.OBJECT_TYPE == typeInfo.v2
+    }
+
+    @Test
+    void testParameterizeSAMWithRawTypeWithUpperBound() {
+        def classNodeList = compile '''
+            interface A<T extends String> {
+                T apply(T input);
+            }
+            class B implements A{
+                @Override
+                String apply(String input) {
+                    return null
+                }
+            }
+        '''
+        ClassNode samType = findClassNode('B', classNodeList).interfaces.find { it.name == 'A' }
+
+        def typeInfo = GenericsUtils.parameterizeSAM(samType)
+
+        assert 1 == typeInfo.v1.length
+        assert ClassHelper.STRING_TYPE == typeInfo.v1[0]
+        assert ClassHelper.STRING_TYPE == typeInfo.v2
+    }
+
+    @Test
+    void testParameterizeSAMWithRawTypeWithUpperBounds() {
+        def classNodeList = compile '''
+            interface A<T extends String, Object> {
+                T apply(T input);
+            }
+            interface B extends A{
+            }
+        '''
+        ClassNode samType = findClassNode('B', classNodeList).interfaces.find { it.name == 'A' }
+
+        def typeInfo = GenericsUtils.parameterizeSAM(samType)
+
+        assert 1 == typeInfo.v1.length
+        assert ClassHelper.STRING_TYPE == typeInfo.v1[0]
+        assert ClassHelper.STRING_TYPE == typeInfo.v2
+    }
 }


### PR DESCRIPTION
I've added a test case and a fix for the bug reported in GROOVY-10813. 
I'm not sure if there are any other edge cases that will now break because of this change, but one [test](https://github.com/apache/groovy/blob/9210cfab6aac681a865c57dd97e96aac73f38fd4/src/test/groovy/transform/stc/GenericsSTCTest.groovy#L740), that failed with another solution that I tried, passes with this solution.