### PR TITLE
Fix JMH Benchmarks

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.jfrog.buildinfo:build-info-extractor-gradle:4.31.0'
     implementation 'org.nosphere.apache:creadur-rat-gradle:0.8.0'
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.13'
-    implementation 'me.champeau.gradle:jmh-gradle-plugin:0.5.3'
+    implementation 'me.champeau.jmh:jmh-gradle-plugin:0.6.8'
 }
 
 tasks.withType(Jar).configureEach {

--- a/build-logic/src/main/groovy/org.apache.groovy-performance.gradle
+++ b/build-logic/src/main/groovy/org.apache.groovy-performance.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'groovy'
     id 'org.apache.groovy-common'
     id 'org.apache.groovy-internal'
-    id 'me.champeau.gradle.jmh'
+    id 'me.champeau.jmh'
 }
 
 project.extensions.create("performanceTests", PerformanceTestsExtension, objects, tasks, configurations, dependencies, sourceSets)
@@ -50,10 +50,10 @@ dependencies {
 jmh {
     jmhVersion = versions.jmh
     if (project.hasProperty('benchInclude')) {
-        include = ['.*' + project.benchInclude + '.*']
+        includes = ['.*' + project.benchInclude + '.*']
     }
     includeTests = true
-    duplicateClassesStrategy = 'WARN'
+    duplicateClassesStrategy = DuplicatesStrategy.WARN
 }
 
 tasks.named('jmhClasses') {


### PR DESCRIPTION
This small PR fixes the following error when trying to run the Groovy runtime benchmarks (`./gradlew -PbenchInclude=CallsiteBench :perf:jmh`):
```
Execution failed for task ':performance:jmh'.
> A failure occurred while executing me.champeau.gradle.IsolatedRunner
   > Error while instantiating tests: unable to set 'list' on Runner. This plugin version doesn't seem to be compatible with JMH 1.35. Please report to the plugin authors at https://github.com/melix/jmh-gradle-plugin/.
```

I did look into fixing `./gradlew :perf:performanceTests` as well but unfortunately couldn't figure that one out, sorry about that.