### PR TITLE
Replace usages of `path.toFile().exists()` in `NioExtensions` with `Files#exists`

### DIFF
--- a/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
+++ b/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
@@ -701,7 +701,7 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
         Writer writer = null;
         try {
             Charset resolvedCharset = Charset.forName(charset);
-            boolean shouldWriteBom = writeBom && !self.toFile().exists();
+            boolean shouldWriteBom = writeBom && !Files.exists(self);
             OutputStream out = Files.newOutputStream(self, CREATE, APPEND);
             if (shouldWriteBom) {
                 writeUTF16BomIfRequired(out, resolvedCharset);
@@ -819,7 +819,7 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
     private static void appendBuffered(Path file, Object text, String charset, boolean writeBom) throws IOException {
         BufferedWriter writer = null;
         try {
-            boolean shouldWriteBom = writeBom && !file.toFile().exists();
+            boolean shouldWriteBom = writeBom && !Files.exists(file);
             writer = newWriter(file, charset, true);
             if (shouldWriteBom) {
                 writeUTF16BomIfRequired(writer, charset);
@@ -1627,7 +1627,7 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
      * @since 2.5.0
      */
     public static BufferedWriter newWriter(Path self, String charset, boolean append, boolean writeBom) throws IOException {
-        boolean shouldWriteBom = writeBom && !self.toFile().exists();
+        boolean shouldWriteBom = writeBom && !Files.exists(self);
         if (append) {
             BufferedWriter writer = Files.newBufferedWriter(self, Charset.forName(charset), CREATE, APPEND);
             if (shouldWriteBom) {


### PR DESCRIPTION
This PR replaces the different usages of `Path#toFile` in `NioExtensions` with the equivalent methods in the NIO API (`Files`). This change is done because there is no guarantee a `Path` can always be converted to a `File`, even if you can open a stream to it:
> Throws: UnsupportedOperationException – if this Path is not associated with the default provider