### PR TITLE
Allow test task to be cache relocateable

### DIFF
--- a/build-logic/src/main/groovy/org.apache.groovy-tested.gradle
+++ b/build-logic/src/main/groovy/org.apache.groovy-tested.gradle
@@ -50,10 +50,13 @@ tasks.withType(Test).configureEach {
         systemProperties 'java.awt.headless': 'true'
     }
     systemProperties 'apple.awt.UIElement': 'true',
-            'javadocAssertion.src.dir': './src/main',
-            'grape.root': grapeDirectory.absolutePath,
-            'gradle.home': gradle.gradleHomeDir, // this is needed by the security.policy
-            'user.home': temporaryDir.absolutePath // make sure tests are isolated from real user home or tests using Grape may fail
+            'javadocAssertion.src.dir': './src/main'
+
+    jvmArgumentProviders.add(new TestCommandLineArgumentProvider(
+            grapeRoot: grapeDirectory,
+            gradleHome: gradle.gradleHomeDir, // this is needed by the security.policy
+            userHome: temporaryDir // make sure tests are isolated from real user home or tests using Grape may fail
+    ))
 
     if (rootProject.hasProperty('target.java.home')) {
         String targetJavaHome = rootProject.property('target.java.home')?.trim()
@@ -91,6 +94,25 @@ tasks.withType(Test).configureEach {
         fs.delete {
             delete(files(".").filter { it.name.endsWith '.class' })
         }
+    }
+}
+
+class TestCommandLineArgumentProvider implements CommandLineArgumentProvider {
+
+    @Internal
+    File grapeRoot
+
+    @Internal
+    File gradleHome
+
+    @Internal
+    File userHome
+
+    @Override
+    Iterable<String> asArguments() {
+        ["-Dgrape.root=${grapeRoot.absolutePath}".toString(),
+         "-Dgradle.home=${gradleHome.absolutePath}".toString(),
+         "-Duser.home=${userHome.absolutePath}".toString()]
     }
 }
 


### PR DESCRIPTION
This will allow test tasks to be cache-relocateable since they inputs to the test task will no longer consider the fully qualified paths of these directories.
