### PR TITLE
fix for NPE

### DIFF
--- a/src/main/java/org/codehaus/groovy/util/ListHashMap.java
+++ b/src/main/java/org/codehaus/groovy/util/ListHashMap.java
@@ -114,15 +114,15 @@ public class ListHashMap<K,V> implements Map<K,V> {
 
     @Override
     public V get(Object key) {
-        if(size==0) return null;
-        if (innerMap==null) {
-            for (int i=0; i<size; i++) {
-                if (listKeys[i].equals(key)) return (V) listValues[i];
-            }
+        if (size == 0)
             return null;
-        } else {
+        if (innerMap != null)
             return innerMap.get(key);
+        for (int i = 0; i < size; ++i) {
+            if (key.equals(listKeys[i]))
+                return (V) listValues[i];
         }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
java.lang.NullPointerException
	at org.codehaus.groovy.util.ListHashMap.get(ListHashMap.java:120)
	at org.codehaus.groovy.ast.NodeMetaDataHandler.getNodeMetaData(NodeMetaDataHandler.java:44)