### PR TITLE
GROOVY-8499: `combinations` metadata

### DIFF
--- a/src/main/java/groovy/util/GroovyCollections.java
+++ b/src/main/java/groovy/util/GroovyCollections.java
@@ -34,19 +34,83 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-/**
- * A Collections utility class
- */
 public class GroovyCollections {
+
     /**
      * Finds all combinations of items from the given collections.
      *
      * @param collections the given collections
-     * @return a List of the combinations found
+     * @return A list of the combinations found.
      * @see #combinations(Iterable)
      */
-    public static List combinations(Object[] collections) {
+    public static List<List> combinations(Object[]    collections) {
         return combinations(Arrays.asList(collections));
+    }
+
+    /**
+     * Finds all combinations of items from the given collections.
+     * So, <code>combinations([[true, false], [true, false]])</code>
+     * is <code>[[true, true], [false, true], [true, false], [false, false]]</code>
+     * and <code>combinations([['a', 'b'],[1, 2, 3]])</code>
+     * is <code>[['a', 1], ['b', 1], ['a', 2], ['b', 2], ['a', 3], ['b', 3]]</code>.
+     * If a non-collection item is given, it is treated as a singleton collection,
+     * i.e. <code>combinations([[1, 2], 'x'])</code> is <code>[[1, 'x'], [2, 'x']]</code>.
+     * If an empty collection is found within the given collections, the result will be an empty list.
+     *
+     * @param collections the Iterable of given collections
+     * @return A list of the combinations found.
+     * @since 2.2.0
+     */
+    public static List<List> combinations(Iterable<?> collections) {
+        List<List<Object>> combos = new ArrayList<>();
+        for (var collection : collections) {
+            if (combos.isEmpty()) {
+                for (var object : DefaultTypeTransformation.asCollection(collection)) {
+                    List<Object> list = new ArrayList<>();
+                    list.add(object);
+                    combos.add(list);
+                }
+            } else {
+                List<List<Object>> next = new ArrayList<>(); // each list plus each item
+                for (var object : DefaultTypeTransformation.asCollection(collection)) {
+                    for (var combo : combos) {
+                        List<Object> list = new ArrayList<>(combo);
+                        list.add(object);
+                        next.add(list);
+                    }
+                }
+                combos = next;
+            }
+            if (combos.isEmpty())
+                break;
+        }
+        return (List) combos;
+    }
+
+    /**
+     * @since 2.5.0
+     */
+    public static <T> List<List<T>> inits(Iterable<T> collections) {
+        List<T> copy = DefaultGroovyMethods.toList(collections);
+        List<List<T>> result = new ArrayList<>();
+        for (int i = copy.size(); i >= 0; i--) {
+            List<T> next = copy.subList(0, i);
+            result.add(next);
+        }
+        return result;
+    }
+
+    /**
+     * @since 2.5.0
+     */
+    public static <T> List<List<T>> tails(Iterable<T> collections) {
+        List<T> copy = DefaultGroovyMethods.toList(collections);
+        List<List<T>> result = new ArrayList<>();
+        for (int i = 0; i <= copy.size(); i++) {
+            List<T> next = copy.subList(i, copy.size());
+            result.add(next);
+        }
+        return result;
     }
 
     /**
@@ -56,6 +120,7 @@ public class GroovyCollections {
      *
      * @param items the List of items
      * @return the subsequences from items
+     * @since 1.8.0
      */
     public static <T> Set<List<T>> subsequences(List<T> items) {
         // items.inject([]){ ss, h -> ss.collect { it + [h] }  + ss + [[h]] }
@@ -74,69 +139,6 @@ public class GroovyCollections {
             ans = next;
         }
         return ans;
-    }
-
-    /**
-     * Finds all combinations of items from the given Iterable aggregate of collections.
-     * So, <code>combinations([[true, false], [true, false]])</code>
-     * is <code>[[true, true], [false, true], [true, false], [false, false]]</code>
-     * and <code>combinations([['a', 'b'],[1, 2, 3]])</code>
-     * is <code>[['a', 1], ['b', 1], ['a', 2], ['b', 2], ['a', 3], ['b', 3]]</code>.
-     * If a non-collection item is given, it is treated as a singleton collection,
-     * i.e. <code>combinations([[1, 2], 'x'])</code> is <code>[[1, 'x'], [2, 'x']]</code>.
-     * If an empty collection is found within the given collections, the result will be an empty list.
-     *
-     * @param collections the Iterable of given collections
-     * @return a List of the combinations found
-     * @since 2.2.0
-     */
-    public static List combinations(Iterable collections) {
-        List collectedCombos = new ArrayList();
-        for (Object collection : collections) {
-            Iterable items = DefaultTypeTransformation.asCollection(collection);
-            if (collectedCombos.isEmpty()) {
-                for (Object item : items) {
-                    List l = new ArrayList();
-                    l.add(item);
-                    collectedCombos.add(l);
-                }
-            } else {
-                List savedCombos = new ArrayList(collectedCombos);
-                List newCombos = new ArrayList();
-                for (Object value : items) {
-                    for (Object savedCombo : savedCombos) {
-                        List oldList = new ArrayList((List) savedCombo);
-                        oldList.add(value);
-                        newCombos.add(oldList);
-                    }
-                }
-                collectedCombos = newCombos;
-            }
-
-            if (collectedCombos.isEmpty())
-                break;
-        }
-        return collectedCombos;
-    }
-
-    public static <T> List<List<T>> inits(Iterable<T> collections) {
-        List<T> copy = DefaultGroovyMethods.toList(collections);
-        List<List<T>> result = new ArrayList<>();
-        for (int i = copy.size(); i >= 0; i--) {
-            List<T> next = copy.subList(0, i);
-            result.add(next);
-        }
-        return result;
-    }
-
-    public static <T> List<List<T>> tails(Iterable<T> collections) {
-        List<T> copy = DefaultGroovyMethods.toList(collections);
-        List<List<T>> result = new ArrayList<>();
-        for (int i = 0; i <= copy.size(); i++) {
-            List<T> next = copy.subList(i, copy.size());
-            result.add(next);
-        }
-        return result;
     }
 
     /**
@@ -355,5 +357,4 @@ public class GroovyCollections {
                 : new ClosureComparator<>(condition);
         return union(iterables, comparator);
     }
-
 }

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -4982,36 +4982,41 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
-     * Adds GroovyCollections#combinations(Iterable) as a method on Iterables.
+     * Finds all combinations of items from the given aggregate of collections.
      * <p>
      * Example usage:
      * <pre class="groovyTestCase">
-     * assert [['a', 'b'],[1, 2, 3]].combinations() == [['a', 1], ['b', 1], ['a', 2], ['b', 2], ['a', 3], ['b', 3]]
+     * result = [['a', 'b'], [1, 2, 3]].combinations()
+     * assert result == [['a', 1], ['b', 1], ['a', 2], ['b', 2], ['a', 3], ['b', 3]]
      * </pre>
      *
-     * @param self an Iterable of collections
-     * @return a List of the combinations found
-     * @see groovy.util.GroovyCollections#combinations(java.lang.Iterable)
+     * @param self an iterable of collections
+     * @return A list of the combinations (lists).
+     * @see GroovyCollections#combinations(Iterable)
      * @since 2.2.0
      */
-    public static List combinations(Iterable self) {
+    public static List<List> combinations(Iterable self) {
         return GroovyCollections.combinations(self);
     }
 
     /**
-     * Adds GroovyCollections#combinations(Iterable, Closure) as a method on collections.
+     * Finds all combinations of items from the given aggregate of collections,
+     * then returns the results of the supplied transform.
      * <p>
      * Example usage:
-     * <pre class="groovyTestCase">assert [[2, 3],[4, 5, 6]].combinations {x,y {@code ->} x*y } == [8, 12, 10, 15, 12, 18]</pre>
+     * <pre class="groovyTestCase">
+     * result = [[2, 3], [4, 5, 6]].combinations { x,y {@code ->} x*y }
+     * assert result == [8, 12, 10, 15, 12, 18]
+     * </pre>
      *
-     * @param self a Collection of lists
-     * @param function a closure to be called on each combination
-     * @return a List of the results of applying the closure to each combination found
-     * @see groovy.util.GroovyCollections#combinations(Iterable)
+     * @param self an iterable of collections
+     * @param function a closure to be called on each combination (list)
+     * @return A list of the results of applying the closure to each combination.
+     * @see GroovyCollections#combinations(Iterable)
+     * @see #collect(Iterable,Closure)
      * @since 2.2.0
      */
-    @SuppressWarnings("unchecked")
-    public static List combinations(Iterable self, Closure<?> function) {
+    public static <T> List<T> combinations(Iterable self, @ClosureParams(value=FromString.class, options="List") Closure<T> function) {
         return collect(GroovyCollections.combinations(self), function);
     }
 

--- a/src/test/groovy/transform/stc/ClosureParamTypeInferenceSTCTest.groovy
+++ b/src/test/groovy/transform/stc/ClosureParamTypeInferenceSTCTest.groovy
@@ -388,10 +388,15 @@ class ClosureParamTypeInferenceSTCTest extends StaticTypeCheckingTestCase {
 
     // GROOVY-8499
     void testParamCountCheck6() {
-        shouldFailWithMessages '''
-            ['ab'.chars,'12'.chars].combinations().collect((l,n) -> "$l$n")
-        ''',
-        'Incorrect number of parameters. Expected 1 but found 2'
+        assertScript '''
+            def result = ['ab'.chars,'12'.chars].combinations { l,n -> "$l$n" }
+            assert result == ['a1','b1','a2','b2']
+        '''
+        // cannot know in advance how many list elements
+        def err = shouldFail '''
+            ['ab'.chars,'12'.chars].combinations((l,n,x) -> "$l$n")
+        '''
+        assert err =~ /No signature of method.* is applicable for argument types: \(ArrayList\)/
     }
 
     // GROOVY-8816

--- a/src/test/groovy/transform/stc/CoercionSTCTest.groovy
+++ b/src/test/groovy/transform/stc/CoercionSTCTest.groovy
@@ -561,10 +561,14 @@ class CoercionSTCTest extends StaticTypeCheckingTestCase {
 
     // GROOVY-11092, GROOVY-8499
     void testCoerceToFunctionalInterface21() {
-        // TODO: if extension combinations indicates List<List<?>> this can work
-        shouldFailWithMessages '''
-            ['ab'.chars,'12'.chars].combinations().stream().map((l,n) -> "$l$n")
-        ''',
-        'Wrong number of parameters for method target: apply(java.lang.Object)'
+        assertScript '''
+            def result = ['ab'.chars,'12'.chars].combinations().stream().map((l,n) -> "$l$n").toList()
+            assert result == ['a1','b1','a2','b2']
+        '''
+        // cannot know in advance how many list elements
+        def err = shouldFail '''
+            ['ab'.chars,'12'.chars].combinations().stream().map((l,n,x) -> "").toList()
+        '''
+        assert err =~ /No signature of method.* is applicable for argument types: \(ArrayList\)/
     }
 }

--- a/src/test/groovy/util/GroovyCollectionsTest.groovy
+++ b/src/test/groovy/util/GroovyCollectionsTest.groovy
@@ -18,7 +18,7 @@
  */
 package groovy.util
 
-import groovy.test.GroovyTestCase
+import org.junit.Test
 
 import static groovy.util.GroovyCollections.combinations
 import static groovy.util.GroovyCollections.max
@@ -26,34 +26,39 @@ import static groovy.util.GroovyCollections.min
 import static groovy.util.GroovyCollections.sum
 import static groovy.util.GroovyCollections.transpose
 
-final class GroovyCollectionsTest extends GroovyTestCase {
+final class GroovyCollectionsTest {
 
-    void testCombinations() {
-        // use Sets because we don't care about order
-        Set expected = [
-                        ['a', 1], ['a', 2], ['a', 3],
-                        ['b', 1], ['b', 2], ['b', 3]
-                ]
-        Collection input = [['a', 'b'], [1, 2, 3]]
-
-        // normal varargs versions should match Object[]
-        assert GroovyCollections.combinations(['a', 'b'], [1, 2, 3]) as Set == expected
-        assert combinations(['a', 'b'], [1, 2, 3]) as Set == expected
-
-        // spread versions should match Object[]
-        assert GroovyCollections.combinations(*input) as Set == expected
-        assert combinations(*input) as Set == expected
-
-        // collection versions should match Collection
-        assert GroovyCollections.combinations(input) as Set == expected
-        assert combinations(input) as Set == expected
-
-        // an empty iterable should result in no combination
+    @Test
+    void testCombinations0() {
+        // an empty iterable at any stage should result in an empty result
+        def input = [['a', 'b'], [1, 2, 3]]
         assert combinations([[]] + input).isEmpty()
         assert combinations(input + [[]]).isEmpty()
         assert combinations(input + [[]] + input).isEmpty()
     }
 
+    @Test
+    void testCombinations1() {
+        // use Sets because we don't care about order
+        Set expected = [
+            ['a', 1], ['a', 2], ['a', 3], ['b', 1], ['b', 2], ['b', 3]
+        ]
+        def input = [['a', 'b'], [1, 2, 3]]
+
+        // varargs versions should match Object[]
+        assert GroovyCollections.combinations(input[0], input[1]) as Set == expected
+        assert combinations(input[0], input[1]) as Set == expected
+
+        // spread versions should match Object[]
+        assert GroovyCollections.combinations(*input) as Set == expected
+        assert combinations(*input) as Set == expected
+
+        // list versions should match Iterable
+        assert GroovyCollections.combinations(input) as Set == expected
+        assert combinations(input) as Set == expected
+    }
+
+    @Test
     void testTranspose() {
         // normal varargs versions should match Object[]
         assert GroovyCollections.transpose(['a', 'b'], [1, 2, 3]) == [['a', 1], ['b', 2]]
@@ -70,6 +75,7 @@ final class GroovyCollectionsTest extends GroovyTestCase {
         assert transpose([]) == []
     }
 
+    @Test
     void testMin() {
         // normal varargs versions should match Object[]
         assert GroovyCollections.min('a', 'b') == 'a'
@@ -84,6 +90,7 @@ final class GroovyCollectionsTest extends GroovyTestCase {
         assert min([1, 2, 3]) == 1
     }
 
+    @Test
     void testMax() {
         // normal varargs versions should match Object[]
         assert GroovyCollections.max('a', 'b') == 'b'
@@ -98,6 +105,7 @@ final class GroovyCollectionsTest extends GroovyTestCase {
         assert max([1, 2, 3]) == 3
     }
 
+    @Test
     void testSum() {
         // normal varargs versions should match Object[]
         assert GroovyCollections.sum('a', 'b') == 'ab'
@@ -112,7 +120,7 @@ final class GroovyCollectionsTest extends GroovyTestCase {
         assert sum([1, 2, 3]) == 6
     }
 
-    // GROOVY-7267
+    @Test // GROOVY-7267
     void testHashCodeCollisionInMinus() {
         assert ([[1:2],[2:3]]-[["b":"a"]]) == [[1:2],[2:3]]
     }


### PR DESCRIPTION
@paulk-asert Can you have a look at this?  GROOVY-8499 examples can work under STC if `combinations` indicates it returns a list of lists.  It is up to the caller to determine the number of elements in the sub-lists, but this is not unique to use of `combinations`.

https://issues.apache.org/jira/browse/GROOVY-8499
https://issues.apache.org/jira/browse/GROOVY-11092