### PR TITLE
Update osgi plugin to avoid deprecated convention usage

### DIFF
--- a/build-logic/src/main/groovy/org/apache/groovy/gradle/JarJarTask.groovy
+++ b/build-logic/src/main/groovy/org/apache/groovy/gradle/JarJarTask.groovy
@@ -146,7 +146,7 @@ class JarJarTask extends DefaultTask {
 
             if (createManifest) {
                 // next step is to generate an OSGI manifest using the newly repackaged classes
-                def mf = project.rootProject.convention.plugins.osgi.osgiManifest {
+                def mf = project.rootProject.extensions.osgi.osgiManifest {
                     symbolicName = project.name
                     instruction 'Import-Package', '*;resolution:=optional'
                     classesDir = tmpJar

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
 plugins {
     id 'me.champeau.buildscan-recipes' version '0.2.3'
     id 'com.github.ben-manes.versions' version '0.47.0'
-    id 'com.github.blindpirate.osgi' version '0.0.6'
+    id 'com.github.blindpirate.osgi' version '0.0.7'
     id "com.github.jk1.dependency-license-report" version "2.4"
     id 'org.sonarqube' version '4.2.1.3168'
     id 'org.apache.groovy-core'


### PR DESCRIPTION
https://plugins.gradle.org/plugin/com.github.blindpirate.osgi/0.0.7