### PR TITLE
`SecureASTCustomizer` can't see types set prior by a type-checking extension

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
+++ b/src/main/java/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
@@ -1251,7 +1251,7 @@ public class SecureASTCustomizer extends CompilationCustomizer {
         public void visitMethodCallExpression(final MethodCallExpression call) {
             assertExpressionAuthorized(call);
             Expression receiver = call.getObjectExpression();
-            final String typeName = receiver.getType().getName();
+            final String typeName = getType(receiver).getName();
             if (allowedReceivers != null && !allowedReceivers.contains(typeName)) {
                 throw new SecurityException("Method calls not allowed on [" + typeName + "]");
             } else if (disallowedReceivers != null && disallowedReceivers.contains(typeName)) {


### PR DESCRIPTION
This is an incorrect, incomplete proposal to suggest that methods such as `SecureASTCustomizer.SecuringCodeVisitor.visitMethodCallExpression()` should probably be using `TypeCheckingExtension.getType()` as opposed to `Expression.getType()`.

This is because, as suggested in the [docs](https://docs.groovy-lang.org/next/html/documentation/#Typecheckingextensions-TheAPI), type-checking extensions (via `ASTTransformationCustomizer` with `CompileStatic`) may be calling `TypeCheckingExtension.storeType()` to dynamically assign a type to a variable, but `SecureASTCustomizer` won't see that type even if run after such type-checking extension.