### PR TITLE
Move JDK 18 into groovy-build-test-aux matrix

### DIFF
--- a/.github/workflows/groovy-build-test-aux.yml
+++ b/.github/workflows/groovy-build-test-aux.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        java: [12, 13, 14, 15, 16]
+        java: [12, 13, 14, 15, 16, 18]
     runs-on: ${{ matrix.os }}
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}

--- a/.github/workflows/groovy-build-test-main.yml
+++ b/.github/workflows/groovy-build-test-main.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        java: [11, 17, 18]
+        java: [11, 17]
     runs-on: ${{ matrix.os }}
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}


### PR DESCRIPTION
Seems JDK 18 should be seated at `Build and test additional JDK versions`.