### PR TITLE
Refactor assertFalse(equals()) with assertNotEquals

### DIFF
--- a/src/test/groovy/GStringTest.groovy
+++ b/src/test/groovy/GStringTest.groovy
@@ -21,6 +21,8 @@ package groovy
 import groovy.test.GroovyTestCase
 import groovy.transform.Pure
 
+import static org.junit.Assert.assertNotEquals;
+
 class GStringTest extends GroovyTestCase {
 
     void check(template, teststr) {
@@ -265,8 +267,8 @@ class GStringTest extends GroovyTestCase {
         assertTrue("literal == template false", literal == template)
 
         // these fail
-        assertFalse("literal not equal to template", literal.equals(template))
-        assertFalse("template not equal to literal", template.equals(literal))
+        assertNotEquals("literal not equal to template", literal, template)
+        assertNotEquals("template not equal to literal", template, literal)
         assertTrue("hash codes not equal", literal.hashCode() != template.hashCode())
     }
 

--- a/src/test/groovy/lang/GStringTest.java
+++ b/src/test/groovy/lang/GStringTest.java
@@ -21,6 +21,8 @@ package groovy.lang;
 import groovy.test.GroovyTestCase;
 import org.codehaus.groovy.runtime.FormatHelper;
 
+import static org.junit.Assert.assertNotEquals;
+
 /**
  * Tests the use of the structured Attribute type
  */
@@ -70,7 +72,7 @@ public class GStringTest extends GroovyTestCase {
 
         assertTrue("a == b", a.equals(b));
         assertEquals("hashcode a == b", a.hashCode(), b.hashCode());
-        assertFalse("a != c", a.equals(c));
+        assertNotEquals("a != c", a, c);
         assertTrue("hashcode a != c", a.hashCode() != c.hashCode());
         assertEquals("a <=> b", 0, a.compareTo(b));
         assertEquals("a <=> b", -1, a.compareTo(c));

--- a/src/test/groovy/lang/NumberRangeTestCase.java
+++ b/src/test/groovy/lang/NumberRangeTestCase.java
@@ -26,6 +26,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import static org.junit.Assert.assertNotEquals;
+
 /**
  * Provides unit tests for ranges of numbers.
  */
@@ -91,7 +93,7 @@ public abstract class NumberRangeTestCase extends TestCase {
         assertTrue("hashcode", a.hashCode() != c.hashCode());
 
         assertEquals("a and b", a, b);
-        assertFalse("a != c", a.equals(c));
+        assertNotEquals("a != c", a, c);
     }
 
     /**
@@ -523,22 +525,22 @@ public abstract class NumberRangeTestCase extends TestCase {
 
         // compare lists that are the same size but contain different elements
         list.set(0, createValue(3));
-        assertFalse("range equals list", range.equals(list));
-        assertFalse("list equals range", list.equals(range));
+        assertNotEquals("range equals list", range, list);
+        assertNotEquals("list equals range", list, range);
         assertFalse("hash codes are equal", range.hashCode() == list.hashCode());
 
         // compare a list longer than the range
         list.set(0, createValue(1));
         list.add(createValue(3));
-        assertFalse("range equals list", range.equals(list));
-        assertFalse("list equals range", list.equals(range));
+        assertNotEquals("range equals list", range, list);
+        assertNotEquals("list equals range", list, range);
         assertFalse("hash are equal", range.hashCode() == list.hashCode());
 
         // compare a list shorter than the range
         list.remove(2);
         list.remove(1);
-        assertFalse("range equals list", range.equals(list));
-        assertFalse("list equals range", list.equals(range));
+        assertNotEquals("range equals list", range, list);
+        assertNotEquals("list equals range", list, range);
         assertFalse("hash are equal", range.hashCode() == list.hashCode());
     }
 
@@ -547,7 +549,7 @@ public abstract class NumberRangeTestCase extends TestCase {
      */
     public void testEqualsNonRange() {
         final Range range = createRange(1, 5);
-        assertFalse("range equal to string", range.equals("hello"));
+        assertNotEquals("range equal to string", range, "hello");
     }
 
     /**
@@ -570,28 +572,28 @@ public abstract class NumberRangeTestCase extends TestCase {
         assertEquals("hash codes not equal", range1.hashCode(), range2.hashCode());
 
         range2 = createRange(0, 5);
-        assertFalse("ranges equal", range1.equals((Object) range2));
-        assertFalse("ranges equal", range2.equals((Object) range1));
+        assertNotEquals("ranges equal", range1, (Object) range2);
+        assertNotEquals("ranges equal", range2, (Object) range1);
         assertFalse("hash codes equal", range1.hashCode() == range2.hashCode());
 
         range2 = createRange(1, 6);
-        assertFalse("ranges equal", range1.equals((Object) range2));
-        assertFalse("ranges equal", range2.equals((Object) range1));
+        assertNotEquals("ranges equal", range1, (Object) range2);
+        assertNotEquals("ranges equal", range2, (Object) range1);
         assertFalse("hash codes equal", range1.hashCode() == range2.hashCode());
 
         range2 = createRange(0, 6);
-        assertFalse("ranges equal", range1.equals((Object) range2));
-        assertFalse("ranges equal", range2.equals((Object) range1));
+        assertNotEquals("ranges equal", range1, (Object) range2);
+        assertNotEquals("ranges equal", range2, (Object) range1);
         assertFalse("hash codes equal", range1.hashCode() == range2.hashCode());
 
         range2 = createRange(2, 4);
-        assertFalse("ranges equal", range1.equals((Object) range2));
-        assertFalse("ranges equal", range2.equals((Object) range1));
+        assertNotEquals("ranges equal", range1, (Object) range2);
+        assertNotEquals("ranges equal", range2, (Object) range1);
         assertFalse("hash codes equal", range1.hashCode() == range2.hashCode());
 
         range2 = createRange(5, 1);
-        assertFalse("ranges equal", range1.equals((Object) range2));
-        assertFalse("ranges equal", range2.equals((Object) range1));
+        assertNotEquals("ranges equal", range1, (Object) range2);
+        assertNotEquals("ranges equal", range2, (Object) range1);
         assertFalse("hash codes equal", range1.hashCode() == range2.hashCode());
     }
 
@@ -626,10 +628,10 @@ public abstract class NumberRangeTestCase extends TestCase {
      */
     public void testEqualsNull() {
         final Range range = createRange(1, 5);
-        assertFalse("range equal to null", range.equals(null));
-        assertFalse("range equal to null Object", range.equals((Object) null));
-        assertFalse("range equal to null Range", range.equals((Range) null));
-        assertFalse("range equal to null List", range.equals((List) null));
+        assertNotEquals("range equal to null", range, null);
+        assertNotEquals("range equal to null Object", range, (Object) null);
+        assertNotEquals("range equal to null Range", range, (Range) null);
+        assertNotEquals("range equal to null List", range, (List) null);
     }
 
     /**

--- a/src/test/groovy/lang/ObjectRangeTest.java
+++ b/src/test/groovy/lang/ObjectRangeTest.java
@@ -27,6 +27,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import static org.junit.Assert.assertNotEquals;
+
 /**
  * Provides unit tests for the <code>ObjectRange</code> class.
  */
@@ -306,7 +308,7 @@ public class ObjectRangeTest extends TestCase {
         assertTrue("hashcode", a.hashCode() != c.hashCode());
 
         assertEquals("a and b", a, b);
-        assertFalse("a != c", a.equals(c));
+        assertNotEquals("a != c", a, c);
     }
 
     public void testIteratorException() {


### PR DESCRIPTION
I am working on research investigating test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

This smell occurs when inappropriate assertions are used, while there exist better alternatives. For example, in [GStringTest.java](https://github.com/apache/groovy/commit/f0bfe65ed5ae2b223b189ee600afc948af125fe4#diff-a8a3008dfada3fafce795f2a075bdbec7b14e24856857129ae21d24869ed083b), I refactored `assertFalse("a != c", a.equals(c));` with `assertNotEquals("a != c", a, c);`.

I would like to get your feedback on this particular test smell and its refactoring. Thanks in advance for your input.