### PR TITLE
Use the tap() method instead of with(), as tap() returns the object instead of returning the last expression of the closure like with with().

### DIFF
--- a/src/spec/test/CodeGenerationASTTransformsTest.groovy
+++ b/src/spec/test/CodeGenerationASTTransformsTest.groovy
@@ -1313,7 +1313,7 @@ assert "$p1.first $p1.last" == 'Johnny Depp'
 // end::builder_simple_usage[]
 // tag::builder_simple_alternatives[]
 def p2 = new Person(first: 'Keira', last: 'Knightley', born: 1985)
-def p3 = new Person().with {
+def p3 = new Person().tap {
     first = 'Geoffrey'
     last = 'Rush'
     born = 1951


### PR DESCRIPTION
Without this change, variable p3 actually contained the int 1951