### PR TITLE
Add Bundle-License to the generated jars

### DIFF
--- a/build-logic/src/main/groovy/org/apache/groovy/gradle/GroovyLibraryExtension.groovy
+++ b/build-logic/src/main/groovy/org/apache/groovy/gradle/GroovyLibraryExtension.groovy
@@ -209,6 +209,7 @@ class GroovyLibraryExtension {
                     'Implementation-Vendor': 'The Apache Software Foundation',
                     'Bundle-ManifestVersion': '2',
                     'Bundle-Description': 'Groovy Runtime',
+                    'Bundle-License': 'Apache-2.0',
                     'Bundle-Version': groovyBundleVersion,
                     'Bundle-Vendor': 'The Apache Software Foundation',
                     'Bundle-ClassPath': '.',


### PR DESCRIPTION
SBOM tools like Syft rely on the Bundle-License in the Manifest to detect licenses when generating SBOMs. Please backport to all active branches if/when applied.