### PR TITLE
GROOVY-11192: Diamond inference should work on subclasses with less generic parameters

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -1192,7 +1192,7 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
     }
 
     private void adjustGenerics(final ClassNode source, final ClassNode target) {
-        GenericsType[] genericsTypes = source.getGenericsTypes();
+        GenericsType[] genericsTypes = source.getGenericsTypes(), targetRedirectGenericsTypes = target.redirect().getGenericsTypes();
         if (genericsTypes == null) { // Map foo = new HashMap<>()
             genericsTypes = target.redirect().getGenericsTypes().clone();
             for (int i = 0, n = genericsTypes.length; i < n; i += 1) {
@@ -1202,7 +1202,21 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
                         ? gt.getUpperBounds()[0] : gt.getType().redirect();
                 genericsTypes[i] = cn.getPlainNodeReference().asGenericsType();
             }
-        } else {
+        } else if (targetRedirectGenericsTypes != null && genericsTypes.length > targetRedirectGenericsTypes.length) {
+            GenericsType[] genericsRedirectTypes = source.redirect().getGenericsTypes(), out = new GenericsType[targetRedirectGenericsTypes.length];
+            for (int i = 0; i < targetRedirectGenericsTypes.length; i++) {
+                for (int j = 0; j < genericsRedirectTypes.length; j++) {
+                    if (targetRedirectGenericsTypes[i].getName().equals(genericsRedirectTypes[j].getName())) {
+                        GenericsType gt = genericsTypes[j];
+                        out[i] = new GenericsType(gt.getType(),
+                            gt.getUpperBounds(), gt.getLowerBound());
+                        out[i].setWildcard(gt.isWildcard());
+                        break;
+                    }
+                }
+            }
+        }
+        else {
             genericsTypes = genericsTypes.clone();
             for (int i = 0, n = genericsTypes.length; i < n; i += 1) {
                 GenericsType gt = genericsTypes[i];

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -1215,6 +1215,8 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
                     }
                 }
             }
+            target.setGenericsTypes(out);
+            return;
         }
         else {
             genericsTypes = genericsTypes.clone();

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -1721,7 +1721,16 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
             test([(A.X): B.Y])
         '''
     }
-
+    // GROOVY-11193
+    void testDiamondInferenceFromConstructor38() {
+        assertScript '''
+            interface A<K, V> {
+            }
+            class B<V> implements A<Long, V>{
+            }
+            A<Long, String> a = new B<>()
+        '''
+    }
     // GROOVY-10280
     void testTypeArgumentPropagation() {
         assertScript '''

--- a/src/test/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/GenericsSTCTest.groovy
@@ -1721,7 +1721,7 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
             test([(A.X): B.Y])
         '''
     }
-    // GROOVY-11193
+    // GROOVY-11192
     void testDiamondInferenceFromConstructor38() {
         assertScript '''
             interface A<K, V> {


### PR DESCRIPTION
# Bug Description
Something like
```
            interface A<K, V> {
            }
            class B<V> implements A<Long, V>{
            }
            A<Long, String> a = new B<>()
```
would cause groovyc to fail.

# Analysis
https://issues.apache.org/jira/browse/GROOVY-11192

There is a bug in `org.codehaus.groovy.transform.stc.StaticTypeCheckingVisitor#inferDiamondType`.

The `inferredType` is `java.util.Map<java.lang.Long, java.lang.String> -> java.util.Map<K, V> `and `cceType` is `MapLong<> -> MapLong<V>`.

After `adjustGenerics()` on line 1124, `cceType` becomes `MapLong<java.lang.Long, java.lang.String> -> MapLong<V>`, which is incorrect. It should be `MapLong<java.lang.String> -> MapLong<V>`.

# Fix
If we see (# of generic types for A) > (# of generic types for B's redirect), then only keep the generic types that correspond to B's redirect generic types.

A.genericTypes = [Long, String]
B.genericTypes = []
A.redirect().genericTypes = [K, V]
B.redirect().genericTypes = [V]

In this case, find the index of `V` in A.redirect().genericTypes, then find the corresponding type in A.genericTypes, which is String.