### PR TITLE
GROOVY-11200: JsonSlurper should throw exception when parsing invalid String ended with a right curly brace

### DIFF
--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserCharArray.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserCharArray.java
@@ -38,8 +38,11 @@ public class JsonParserCharArray extends BaseJsonParser {
 
     protected Object decodeFromChars(char[] cs) {
         __index = 0;
-        charArray = cs;
-        lastIndex = cs.length - 1;
+        char[] newCs = new char[cs.length + 1];
+        System.arraycopy(cs, 0, newCs, 0, cs.length);
+        newCs[newCs.length - 1] = '\n';
+        charArray = newCs;
+        lastIndex = newCs.length - 1;
         return decodeValue();
     }
 

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -384,4 +384,23 @@ class JsonSlurperTest extends GroovyTestCase {
 
     }
 
+    void testParseStringEndedWithRightCurlyBrace() {
+        def jsonSlurper = new JsonSlurper()
+        def inValid = """
+                            {
+                            "a":1,
+                            "b": {
+                                "c":2
+                            }"""
+        shouldFail (JsonException) { jsonSlurper.parseText(inValid) }
+
+        def valid = """
+                            {
+                            "a":1,
+                            "b": {
+                                "c":2
+                            }}"""
+        assert jsonSlurper.parseText(valid) == [a: 1, b:[c:2]]
+    }
+
 }


### PR DESCRIPTION
# Analysis
As mentioned by Paul's comment in the jira, this is a bug in `JsonParserCharArray`. The problem does not exist in `JsonParserUsingCharacterSource`.
After debugging through both classes, both parser methods look exactly the same, except that `CharacterSource` would automatically add a `10`(line feed) char at the end, which triggers an exception. But for `JsonParserCharArray` it ends right at the last curly brace so the exception is overlooked.
# Fix
To keep the behavior consistent across `JsonParserCharArray` and `JsonParserUsingCharacterSource`, a line feed character is added to the end of the char array on initialization of `JsonParserCharArray`.
# Concern
Performance