### PR TITLE
GROOVY-11200: (Second Approach) JsonSlurper should throw exception when parsing invalid String ended with a right curly brace

### DIFF
--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserCharArray.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserCharArray.java
@@ -35,12 +35,18 @@ public class JsonParserCharArray extends BaseJsonParser {
     protected char __currentChar;
 
     private int lastIndex;
+    private int openLeftCurlyBraces;
 
     protected Object decodeFromChars(char[] cs) {
         __index = 0;
         charArray = cs;
         lastIndex = cs.length - 1;
-        return decodeValue();
+        openLeftCurlyBraces = 0;
+        Object result = decodeValue();
+        if (openLeftCurlyBraces != 0) {
+            complain("Curly braces do not match");
+        }
+        return result;
     }
 
     protected final boolean hasMore() {
@@ -95,6 +101,9 @@ public class JsonParserCharArray extends BaseJsonParser {
 
     protected final Object decodeJsonObject() {
         if (__currentChar == '{') {
+            if (hasCurrent()) {
+                openLeftCurlyBraces++;
+            }
             __index++;
         }
 
@@ -132,6 +141,9 @@ public class JsonParserCharArray extends BaseJsonParser {
             }
 
             if (__currentChar == '}') {
+                if (hasCurrent()) {
+                    openLeftCurlyBraces--;
+                }
                 __index++;
                 break;
             } else if (__currentChar == ',') {
@@ -202,6 +214,8 @@ public class JsonParserCharArray extends BaseJsonParser {
                 throw new JsonException(exceptionDetails("Unable to determine the " +
                         "current character, it is not a string, number, array, or object"));
         }
+
+
 
         return value;
     }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -386,7 +386,12 @@ class JsonSlurperTest extends GroovyTestCase {
 
     void testParseStringEndedWithRightCurlyBrace() {
         def jsonSlurper = new JsonSlurper()
-        def inValid = """{"a":1,"b": {"c":2}"""
+        def inValid = """
+                            {
+                            "a":1,
+                            "b": {
+                                "c":2
+                            }"""
         shouldFail (JsonException) { jsonSlurper.parseText(inValid) }
 
         def valid = """

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -384,4 +384,18 @@ class JsonSlurperTest extends GroovyTestCase {
 
     }
 
+    void testParseStringEndedWithRightCurlyBrace() {
+        def jsonSlurper = new JsonSlurper()
+        def inValid = """{"a":1,"b": {"c":2}"""
+        shouldFail (JsonException) { jsonSlurper.parseText(inValid) }
+
+        def valid = """
+                            {
+                            "a":1,
+                            "b": {
+                                "c":2
+                            }}"""
+        assert jsonSlurper.parseText(valid) == [a: 1, b:[c:2]]
+    }
+
 }


### PR DESCRIPTION
This approach avoids array copy as in https://github.com/apache/groovy/pull/1972 by using a simple counter.