### PR TITLE
GROOVY-10060: Support static & private interface methods

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -187,8 +187,9 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
     private void checkInterfaceMethodVisibility(final ClassNode node) {
         if (!node.isInterface()) return;
         for (MethodNode method : node.getMethods()) {
-            if (method.isPrivate()) {
-                addError("Method '" + method.getName() + "' is private but should be public in " + getDescription(currentClass) + ".", method);
+            if (method.isPrivate() && method.isAbstract()) {
+                addError("Method '" + method.getName() + "' from " + getDescription(node) +
+                    " must not be private as it is declared as an abstract method.", method);
             } else if (method.isProtected()) {
                 addError("Method '" + method.getName() + "' is protected but should be public in " + getDescription(currentClass) + ".", method);
             }

--- a/src/main/java/org/codehaus/groovy/classgen/asm/indy/InvokeDynamicWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/indy/InvokeDynamicWriter.java
@@ -171,6 +171,11 @@ public class InvokeDynamicWriter extends InvocationWriter {
             PropertyExpression pexp = (PropertyExpression) exp;
             if (pexp.getObjectExpression() instanceof ClassExpression && "super".equals(pexp.getPropertyAsString())) {
                 return bytecodeX(pexp.getObjectExpression().getType(), mv -> mv.visitIntInsn(Opcodes.ALOAD, 0));
+            } else if (pexp.getObjectExpression() instanceof ClassExpression && "this".equals(pexp.getPropertyAsString())) {
+                ClassExpression ce = (ClassExpression) pexp.getObjectExpression();
+                if (ce.getType().isInterface()) {
+                    return bytecodeX(pexp.getObjectExpression().getType(), mv -> mv.visitIntInsn(Opcodes.ALOAD, 0));
+                }
             }
         }
         return exp;

--- a/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
@@ -964,7 +964,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         if (!prop.equals("this") && !prop.equals("super")) return;
 
         ClassNode type = expression.getObjectExpression().getType();
-        if (expression.getObjectExpression() instanceof ClassExpression && !isSuperCallToDefaultMethod(expression)) {
+        if (expression.getObjectExpression() instanceof ClassExpression && !isSuperCallToDefaultMethod(expression) && !isThisCallToPrivateInterfaceMethod(expression)) {
             if (!(currentClass instanceof InnerClassNode) && !Traits.isTrait(type)) {
                 addError("The usage of 'Class.this' and 'Class.super' is only allowed in nested/inner classes.", expression);
                 return;
@@ -992,6 +992,12 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
         // a more sophisticated check might be required in the future
         ClassExpression clazzExpression = (ClassExpression) expression.getObjectExpression();
         return clazzExpression.getType().isInterface() && expression.getPropertyAsString().equals("super");
+    }
+
+    private boolean isThisCallToPrivateInterfaceMethod(PropertyExpression expression) {
+        // a more sophisticated check might be required in the future
+        ClassExpression clazzExpression = (ClassExpression) expression.getObjectExpression();
+        return clazzExpression.getType().isInterface() && expression.getPropertyAsString().equals("this");
     }
 
     protected Expression transformVariableExpression(final VariableExpression ve) {

--- a/src/spec/test/ClassTest.groovy
+++ b/src/spec/test/ClassTest.groovy
@@ -233,18 +233,6 @@ class ClassTest extends GroovyTestCase {
             '''
         }
         assert err.contains("Method 'greet' is protected but should be public in interface 'Greeter'")
-
-        err = shouldFail {
-            assertScript '''
-                // tag::private_forbidden[]
-                interface Greeter {
-                    private void greet(String name)
-                }
-                // end::private_forbidden[]
-                1
-            '''
-        }
-        assert err.contains("Method 'greet' is private but should be public in interface 'Greeter'")
     }
 
 

--- a/src/test/groovy/AbstractClassAndInterfaceTest.groovy
+++ b/src/test/groovy/AbstractClassAndInterfaceTest.groovy
@@ -110,7 +110,7 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
             """
         def retVal = shell.evaluate(text)
         assert retVal.class == Object
-    }    
+    }
 
     void testClassExtendingAnAbstractClassButMissesMethod() {
         shouldNotCompile """
@@ -132,7 +132,7 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
 
             def b = new C();
             return b.methodTwo()
-            """    
+            """
 
        shouldNotCompile """
             abstract class A {
@@ -321,6 +321,6 @@ class AbstractClassAndInterfaceTest extends CompilableTestSupport {
                 private abstract void y()
             }
         """
-        assert msg.contains("Method 'y' is private but should be public in interface 'X'.")
+        assert msg.contains("Method 'y' from interface 'X' must not be private as it is declared as an abstract method.")
     }
 }

--- a/src/test/org/codehaus/groovy/classgen/ClassCompletionVerifierTest.java
+++ b/src/test/org/codehaus/groovy/classgen/ClassCompletionVerifierTest.java
@@ -156,17 +156,15 @@ public class ClassCompletionVerifierTest extends TestSupport {
 
     public void testDetectsIncorrectMemberVisibilityInInterface() throws Exception {
         ClassNode node = new ClassNode("zzz", ACC_ABSTRACT | ACC_INTERFACE, ClassHelper.OBJECT_TYPE);
-        node.addMethod(new MethodNode("prim", ACC_PRIVATE, ClassHelper.OBJECT_TYPE, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, null));
         node.addMethod(new MethodNode("prom", ACC_PROTECTED, ClassHelper.OBJECT_TYPE, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, null));
         node.addField("prif", ACC_PRIVATE, ClassHelper.OBJECT_TYPE, null);
         node.addField("prof", ACC_PROTECTED, ClassHelper.OBJECT_TYPE, null);
         addDummyConstructor(node);
         verifier.visitClass(node);
-        checkErrorCount(4);
+        checkErrorCount(3);
         checkErrorMessage(EXPECTED_PROTECTED_FIELD_ERROR_MESSAGE);
         checkErrorMessage(EXPECTED_PRIVATE_FIELD_ERROR_MESSAGE);
         checkErrorMessage(EXPECTED_PROTECTED_METHOD_ERROR_MESSAGE);
-        checkErrorMessage(EXPECTED_PRIVATE_METHOD_ERROR_MESSAGE);
     }
 
     public void testDetectsCorrectMethodModifiersInClass() throws Exception {


### PR DESCRIPTION
Currently for dynamic dispatch, default interface methods which access private methods must use the syntax `InterfaceName.this.privateMethod(args)`. We might be able to remove that limitation with further work. The qualification is not needed for static compilation.