### PR TITLE
Change GROOVY-9962 test to be compatible with Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,12 +211,6 @@ tasks.named('test') {
     dependsOn testExtensionModuleJar
 }
 
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_8)) {
-    sourceSets {
-        test.groovy.filter.exclude '**/Groovy9962.groovy'
-    }
-}
-
 if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
     logger.lifecycle '''
 ************************************* WARNING ***********************************************

--- a/src/test/org/codehaus/groovy/tools/stubgenerator/Groovy9962.groovy
+++ b/src/test/org/codehaus/groovy/tools/stubgenerator/Groovy9962.groovy
@@ -27,7 +27,7 @@ final class Groovy9962 extends StringSourcesStubTestCase {
                 public class Foo {}
             ''',
             'Groovy9962.groovy': '''
-                @Deprecated(since = '${name} paid $7') // value with $
+                @SuppressWarnings('${name} paid $7') // value with $
                 class Groovy9962 {}
             '''
         ]


### PR DESCRIPTION
Instead of skipping the GROOVY-9962 test (as introduced in #1995), we can use a different annotation that accepts a value in Java 8.