### PR TITLE
Partial cleanup of ReflectionCache

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -117,7 +117,6 @@ import static groovy.lang.Tuple.tuple;
 import static java.lang.Character.isUpperCase;
 import static org.apache.groovy.util.Arrays.concat;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.inSamePackage;
-import static org.codehaus.groovy.reflection.ReflectionCache.isAssignableFrom;
 import static org.codehaus.groovy.reflection.ReflectionUtils.checkAccessible;
 
 /**
@@ -597,7 +596,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
                 boolean skip = false;
                 // skip DGM methods on an interface if the class already has the method
                 // but don't skip for GroovyObject-related methods as it breaks things :-(
-                if (method instanceof GeneratedMetaMethod && !isAssignableFrom(GroovyObject.class, method.getDeclaringClass().getTheClass())) {
+                if (method instanceof GeneratedMetaMethod && !GroovyObject.class.isAssignableFrom(method.getDeclaringClass().getTheClass())) {
                     final String generatedMethodName = method.getName();
                     final CachedClass[] generatedMethodParameterTypes = method.getParameterTypes();
                     for (Method m : (null == theClassMethods ? theClassMethods = theClass.getMethods() : theClassMethods)) {

--- a/src/main/java/org/codehaus/groovy/reflection/ParameterTypes.java
+++ b/src/main/java/org/codehaus/groovy/reflection/ParameterTypes.java
@@ -19,6 +19,7 @@
 package org.codehaus.groovy.reflection;
 
 import org.codehaus.groovy.GroovyBugError;
+import org.codehaus.groovy.classgen.asm.util.TypeUtil;
 import org.codehaus.groovy.runtime.MetaClassHelper;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 import org.codehaus.groovy.runtime.wrappers.Wrapper;
@@ -181,7 +182,7 @@ public class ParameterTypes {
         MetaClassHelper.unwrap(unwrappedArguments);
 
         // get type of each vargs element -- arguments are not primitive
-        vaType = ReflectionCache.autoboxType(vaType.getComponentType());
+        vaType = TypeUtil.autoboxType(vaType.getComponentType());
 
         if (aCount == pCount - 1) {
             // one argument is missing, so fill it with an empty array

--- a/src/main/java/org/codehaus/groovy/reflection/ReflectionCache.java
+++ b/src/main/java/org/codehaus/groovy/reflection/ReflectionCache.java
@@ -18,73 +18,7 @@
  */
 package org.codehaus.groovy.reflection;
 
-import org.codehaus.groovy.classgen.asm.util.TypeUtil;
-import org.codehaus.groovy.util.TripleKeyHashMap;
-
 public class ReflectionCache {
-    public static Class autoboxType(Class type) {
-        return TypeUtil.autoboxType(type);
-    }
-
-    @Deprecated
-    static TripleKeyHashMap mopNames = new TripleKeyHashMap();
-
-    @Deprecated // the method is never called
-    public static String getMOPMethodName(CachedClass declaringClass, String name, boolean useThis) {
-        TripleKeyHashMap.Entry mopNameEntry = mopNames.getOrPut(declaringClass, name, useThis);
-        if (mopNameEntry.value == null) {
-            mopNameEntry.value = (useThis ? "this$" : "super$") + declaringClass.getSuperClassDistance() + "$" + name;
-        }
-        return (String) mopNameEntry.value;
-    }
-
-    static final CachedClass STRING_CLASS = getCachedClass(String.class);
-
-    public static boolean isArray(Class klazz) {
-      return klazz.isArray();
-    }
-
-    static void setAssignableFrom(Class klazz, Class aClass) {
-        // FIXME no implementation?
-//        SoftDoubleKeyMap.Entry val = (SoftDoubleKeyMap.Entry) assignableMap.getOrPut(klazz, aClass, null);
-//        if (val.getValue() == null) {
-//            val.setValue(Boolean.TRUE);
-//        }
-    }
-
-    public static boolean isAssignableFrom(Class klazz, Class aClass) {
-        if (klazz == aClass)
-          return true;
-
-//        SoftDoubleKeyMap.Entry val = (SoftDoubleKeyMap.Entry) assignableMap.getOrPut(klazz, aClass, null);
-//        if (val.getValue() == null) {
-//            val.setValue(Boolean.valueOf(klazz.isAssignableFrom(aClass)));
-//        }
-//        return ((Boolean)val.getValue()).booleanValue();
-        return klazz.isAssignableFrom(aClass);
-    }
-
-    static boolean arrayContentsEq(Object[] a1, Object[] a2) {
-        if (a1 == null) {
-            return a2 == null || a2.length == 0;
-        }
-
-        if (a2 == null) {
-            return a1.length == 0;
-        }
-
-        if (a1.length != a2.length) {
-            return false;
-        }
-
-        for (int i = 0; i < a1.length; i++) {
-            if (a1[i] != a2[i]) {
-                return false;
-            }
-        }
-
-        return true;
-    }
 
     public static final CachedClass OBJECT_CLASS = getCachedClass(Object.class);
 
@@ -96,5 +30,4 @@ public class ReflectionCache {
 
         return ClassInfo.getClassInfo(klazz).getCachedClass();
     }
-
 }

--- a/src/main/java/org/codehaus/groovy/reflection/stdclasses/CachedSAMClass.java
+++ b/src/main/java/org/codehaus/groovy/reflection/stdclasses/CachedSAMClass.java
@@ -20,13 +20,6 @@ package org.codehaus.groovy.reflection.stdclasses;
 
 import groovy.lang.Closure;
 import groovy.util.ProxyGenerator;
-import org.codehaus.groovy.GroovyBugError;
-import org.codehaus.groovy.reflection.CachedClass;
-import org.codehaus.groovy.reflection.ClassInfo;
-import org.codehaus.groovy.reflection.ReflectionCache;
-import org.codehaus.groovy.runtime.ConvertedClosure;
-import org.codehaus.groovy.transform.trait.Traits;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
@@ -40,6 +33,11 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.codehaus.groovy.GroovyBugError;
+import org.codehaus.groovy.reflection.CachedClass;
+import org.codehaus.groovy.reflection.ClassInfo;
+import org.codehaus.groovy.runtime.ConvertedClosure;
+import org.codehaus.groovy.transform.trait.Traits;
 
 public class CachedSAMClass extends CachedClass {
 
@@ -55,7 +53,7 @@ public class CachedSAMClass extends CachedClass {
     public boolean isAssignableFrom(Class argument) {
         return argument == null
             || Closure.class.isAssignableFrom(argument)
-            || ReflectionCache.isAssignableFrom(getTheClass(), argument);
+            || getTheClass().isAssignableFrom(argument);
     }
 
     @Override

--- a/src/main/java/org/codehaus/groovy/reflection/stdclasses/StringCachedClass.java
+++ b/src/main/java/org/codehaus/groovy/reflection/stdclasses/StringCachedClass.java
@@ -21,7 +21,6 @@ package org.codehaus.groovy.reflection.stdclasses;
 import groovy.lang.GString;
 import org.codehaus.groovy.reflection.CachedClass;
 import org.codehaus.groovy.reflection.ClassInfo;
-import org.codehaus.groovy.reflection.ReflectionCache;
 
 public class StringCachedClass extends CachedClass {
     private static final Class STRING_CLASS = String.class;
@@ -40,7 +39,7 @@ public class StringCachedClass extends CachedClass {
     public boolean isAssignableFrom(Class classToTransformFrom) {
         return  classToTransformFrom == null
               || classToTransformFrom == STRING_CLASS
-              || ReflectionCache.isAssignableFrom(GSTRING_CLASS,classToTransformFrom);
+              || GSTRING_CLASS.isAssignableFrom(classToTransformFrom);
     }
 
     @Override

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -1258,7 +1258,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
             return (T) stack;
         }
 
-        if (clazz!=String[].class && ReflectionCache.isArray(clazz)) {
+        if (clazz!=String[].class && clazz.isArray()) {
             try {
                 return (T) asArrayType(col, clazz);
             } catch (GroovyCastException e) {

--- a/src/main/java/org/codehaus/groovy/runtime/MetaClassHelper.java
+++ b/src/main/java/org/codehaus/groovy/runtime/MetaClassHelper.java
@@ -25,6 +25,7 @@ import groovy.lang.GroovyRuntimeException;
 import groovy.lang.MetaClass;
 import groovy.lang.MetaMethod;
 import org.apache.groovy.util.BeanUtils;
+import org.codehaus.groovy.classgen.asm.util.TypeUtil;
 import org.codehaus.groovy.reflection.CachedClass;
 import org.codehaus.groovy.reflection.ParameterTypes;
 import org.codehaus.groovy.reflection.ReflectionCache;
@@ -344,7 +345,7 @@ public class MetaClassHelper {
             }
 
             Method sam;
-            for (Class<?> c = ReflectionCache.autoboxType(argument); c != null && c != parameterClass; c = c.getSuperclass()) {
+            for (Class<?> c = TypeUtil.autoboxType(argument); c != null && c != parameterClass; c = c.getSuperclass()) {
                 if (c == Closure.class && parameterClass.isInterface() && (sam = getSAMMethod(parameterClass)) != null) {
                     // In the case of multiple overloads, give preference to equal parameter count
                     // with fuzzy matching of length for implicit arg Closures
@@ -745,8 +746,8 @@ public class MetaClassHelper {
             return true;
         }
 
-        classToTransformTo = ReflectionCache.autoboxType(classToTransformTo);
-        classToTransformFrom = ReflectionCache.autoboxType(classToTransformFrom);
+        classToTransformTo = TypeUtil.autoboxType(classToTransformTo);
+        classToTransformFrom = TypeUtil.autoboxType(classToTransformFrom);
         if (classToTransformTo == classToTransformFrom) return true;
 
         // note: there is no coercion for boolean and char. Range matters, precision doesn't
@@ -793,7 +794,7 @@ public class MetaClassHelper {
             }
         }
 
-        return ReflectionCache.isAssignableFrom(classToTransformTo, classToTransformFrom);
+        return classToTransformTo.isAssignableFrom(classToTransformFrom);
     }
 
     private static boolean isIntegerLongShortByte(Class classToTransformFrom) {

--- a/src/main/java/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
+++ b/src/main/java/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
@@ -21,6 +21,7 @@ package org.codehaus.groovy.runtime.typehandling;
 import groovy.lang.Closure;
 import groovy.lang.GString;
 import groovy.lang.GroovyRuntimeException;
+import org.codehaus.groovy.classgen.asm.util.TypeUtil;
 import org.codehaus.groovy.reflection.ReflectionCache;
 import org.codehaus.groovy.reflection.stdclasses.CachedSAMClass;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
@@ -59,8 +60,6 @@ import java.util.stream.BaseStream;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-
-import static org.codehaus.groovy.reflection.ReflectionCache.isArray;
 
 /**
  * Class providing various type conversions, coercions and boxing/unboxing operations.
@@ -235,7 +234,7 @@ public class DefaultTypeTransformation {
             return object;
         }
 
-        if (isArray(type)) {
+        if (type.isArray()) {
             return asArray(object, type);
         } else if (type.isEnum()) {
             return ShortTypeHandling.castToEnum(object, type);
@@ -743,7 +742,7 @@ public class DefaultTypeTransformation {
 
     public static Object[] primitiveArrayBox(Object array) {
         int size = Array.getLength(array);
-        Object[] ret = (Object[]) Array.newInstance(ReflectionCache.autoboxType(array.getClass().getComponentType()), size);
+        Object[] ret = (Object[]) Array.newInstance(TypeUtil.autoboxType(array.getClass().getComponentType()), size);
         for (int i = 0; i < size; i++) {
             ret[i] = Array.get(array, i);
         }


### PR DESCRIPTION
A bit refactoring of ReflectionCache
I think we should actually completely get rid of this class. The leftovers could go to CachedClass. And actually this searchMethods method in CachedClass https://github.com/apache/groovy/blob/94c7b6c2bbc8c7ddfbb7c83cac71a0a4348fca47/src/main/java/org/codehaus/groovy/reflection/CachedClass.java#L271 should also go away.