### PR TITLE
make use of Runtime.version().feature()

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java
+++ b/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java
@@ -257,7 +257,7 @@ public class ClassNodeResolver {
                     // this may happen under Windows because getResource is case-insensitive under that OS!
                     asmClass = null;
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 // fall through and attempt other search strategies
             }
         }

--- a/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java
+++ b/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java
@@ -188,15 +188,16 @@ public class ClassNodeResolver {
     private LookupResult tryAsLoaderClassOrScript(final String name, final CompilationUnit compilationUnit) {
         GroovyClassLoader loader = compilationUnit.getClassLoader();
         Map<String, Boolean> options = compilationUnit.configuration.getOptimizationOptions();
+        boolean noClassLoaderResolving = Boolean.FALSE.equals(options.get("classLoaderResolving"));
 
         if (!Boolean.FALSE.equals(options.get("asmResolving"))) {
-            LookupResult result = findDecompiled(name, compilationUnit, loader);
+            LookupResult result = findDecompiled(name, compilationUnit, loader, noClassLoaderResolving);
             if (result != null) {
                 return result;
             }
         }
 
-        if (!Boolean.FALSE.equals(options.get("classLoaderResolving"))) {
+        if (!noClassLoaderResolving) {
             return findByClassLoading(name, compilationUnit, loader);
         }
 
@@ -241,7 +242,7 @@ public class ClassNodeResolver {
     /**
      * Search for classes using ASM decompiler
      */
-    private LookupResult findDecompiled(final String name, final CompilationUnit compilationUnit, final GroovyClassLoader loader) {
+    private LookupResult findDecompiled(final String name, final CompilationUnit compilationUnit, final GroovyClassLoader loader, boolean failOnIllegalArguentException) {
         ClassNode node = ClassHelper.make(name);
         if (node.isResolved()) {
             return new LookupResult(null, node);
@@ -257,8 +258,14 @@ public class ClassNodeResolver {
                     // this may happen under Windows because getResource is case-insensitive under that OS!
                     asmClass = null;
                 }
-            } catch (Exception e) {
+            } catch (IOException e) {
                 // fall through and attempt other search strategies
+            } catch (IllegalArgumentException e) {
+                // very likely resolving failed here due to a class format error or similar
+                // if we do not try other means we should report this error to the user
+                if (failOnIllegalArguentException) {
+                    throw e;
+                }
             }
         }
 

--- a/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java
+++ b/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java
@@ -242,7 +242,7 @@ public class ClassNodeResolver {
     /**
      * Search for classes using ASM decompiler
      */
-    private LookupResult findDecompiled(final String name, final CompilationUnit compilationUnit, final GroovyClassLoader loader, boolean failOnIllegalArguentException) {
+    private LookupResult findDecompiled(final String name, final CompilationUnit compilationUnit, final GroovyClassLoader loader, boolean failOnUnexpectedParseClassException) {
         ClassNode node = ClassHelper.make(name);
         if (node.isResolved()) {
             return new LookupResult(null, node);
@@ -263,7 +263,7 @@ public class ClassNodeResolver {
             } catch (IllegalArgumentException e) {
                 // very likely resolving failed here due to a class format error or similar
                 // if we do not try other means we should report this error to the user
-                if (failOnIllegalArguentException) {
+                if (failOnUnexpectedParseClassException) {
                     throw e;
                 }
             }

--- a/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -23,7 +23,6 @@ import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.control.customizers.CompilationCustomizer;
 import org.codehaus.groovy.control.io.NullWriter;
 import org.codehaus.groovy.control.messages.WarningMessage;
-import org.codehaus.groovy.vmplugin.VMPlugin;
 import org.objectweb.asm.Opcodes;
 
 import java.io.File;
@@ -1115,7 +1114,7 @@ public class CompilerConfiguration {
      * @since 4.0.0
      */
     private static String defaultTargetBytecode() {
-        final String javaVersion = VMPlugin.getJavaVersion();
+        String javaVersion = Integer.toString(Runtime.version().feature());
         if (JDK_TO_BYTECODE_VERSION_MAP.containsKey(javaVersion)) {
             return javaVersion;
         }

--- a/src/main/java/org/codehaus/groovy/vmplugin/VMPlugin.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/VMPlugin.java
@@ -76,7 +76,9 @@ public interface VMPlugin {
      *
      * @return java version
      * @since 4.0.0
+     * @deprecated
      */
+    @Deprecated
     static String getJavaVersion() {
         try {
             return System.getProperty("java.specification.version");

--- a/src/main/java/org/codehaus/groovy/vmplugin/VMPluginFactory.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/VMPluginFactory.java
@@ -21,7 +21,6 @@ package org.codehaus.groovy.vmplugin;
 import org.apache.groovy.util.Maps;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
-import java.math.BigDecimal;
 import java.util.Map;
 
 /**
@@ -31,12 +30,10 @@ import java.util.Map;
  */
 public class VMPluginFactory {
 
-    private static final Map<BigDecimal,String> PLUGIN_MAP = Maps.of(
+    private static final Map<Integer,String> PLUGIN_MAP = Maps.of(
         // NOTE: Declare the vm plugin entries in *descending* order!
-        new BigDecimal( "16"), "org.codehaus.groovy.vmplugin.v16.Java16",
-        new BigDecimal( "10"), "org.codehaus.groovy.vmplugin.v10.Java10",
-        new BigDecimal(  "9"), "org.codehaus.groovy.vmplugin.v9.Java9",
-        new BigDecimal("1.8"), "org.codehaus.groovy.vmplugin.v8.Java8"
+        16, "org.codehaus.groovy.vmplugin.v16.Java16",
+        10, "org.codehaus.groovy.vmplugin.v10.Java10"
     );
 
     private static final VMPlugin PLUGIN = createPlugin();
@@ -44,9 +41,9 @@ public class VMPluginFactory {
     private static VMPlugin createPlugin() {
         return doPrivileged(() -> {
             ClassLoader loader = VMPluginFactory.class.getClassLoader();
-            BigDecimal specVer = new BigDecimal(VMPlugin.getJavaVersion());
-            for (Map.Entry<BigDecimal,String> entry : PLUGIN_MAP.entrySet()) {
-                if (DefaultGroovyMethods.isAtLeast(specVer, entry.getKey())) {
+            int specVer = Runtime.version().feature();
+            for (Map.Entry<Integer,String> entry : PLUGIN_MAP.entrySet()) {
+                if (specVer >= entry.getKey()) {
                     String fullName = entry.getValue();
                     try {
                         return (VMPlugin) loader.loadClass(fullName).getDeclaredConstructor().newInstance();

--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/util/SecurityManagerUtil.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/util/SecurityManagerUtil.groovy
@@ -18,9 +18,6 @@
  */
 package org.apache.groovy.groovysh.util
 
-import org.codehaus.groovy.control.CompilerConfiguration
-import org.codehaus.groovy.vmplugin.VMPlugin
-
 class SecurityManagerUtil {
     private final SecurityManager saved
 
@@ -28,14 +25,16 @@ class SecurityManagerUtil {
         if (explicitlyEnabled() || autoEnabledUntilJDK17()) {
             saved = System.getSecurityManager()
             System.setSecurityManager(new NoExitSecurityManager())
+        } else {
+            saved = null;
         }
     }
 
-    private boolean autoEnabledUntilJDK17() {
-        !CompilerConfiguration.isPostJDK18(VMPlugin.getJavaVersion())
+    private static boolean autoEnabledUntilJDK17() {
+        return Runtime.version().feature() < 18;
     }
 
-    private boolean explicitlyEnabled() {
+    private static boolean explicitlyEnabled() {
         System.getProperty('java.security.manager', 'disallow') == 'allow'
     }
 


### PR DESCRIPTION
Maybe special attention should be given to the change of ClassNodeResolver. So far whenever Groovy tried to compile on a newer JDK it did fail because it could not read the class file version. This is mostly due to the decompiler (using ASM to read class files).  https://github.com/apache/groovy/blob/60bde29d2d6546d0cf2c4f83a5f2ad9c641710e6/src/main/java/org/codehaus/groovy/control/ClassNodeResolver.java#L260
This would normally throw a IllegalArgumentException, which is by this change now swallowed and Groovy falls back to ClassLoader based reading of the file instead. This is of course slower then, but it will still work.