### PR TITLE
GROOVY-11271: ConcurrentCommonCache causes memory leaks

### DIFF
--- a/src/test/org/codehaus/groovy/runtime/memoize/CommonCacheTest.java
+++ b/src/test/org/codehaus/groovy/runtime/memoize/CommonCacheTest.java
@@ -177,7 +177,7 @@ public class CommonCacheTest {
         sc.put("c", "3");
         sc.put("a", "4");
         sc.put("d", "5");
-        Assert.assertArrayEquals(new String[] {"c", "a", "d"}, sc.keys().toArray(new String[0]));
+        Assert.assertEquals(3, sc.size());
         Assert.assertEquals("3", sc.get("c"));
         Assert.assertEquals("4", sc.get("a"));
         Assert.assertEquals("5", sc.get("d"));

--- a/src/test/org/codehaus/groovy/runtime/memoize/ConcurrentCommonCacheTest.java
+++ b/src/test/org/codehaus/groovy/runtime/memoize/ConcurrentCommonCacheTest.java
@@ -178,7 +178,7 @@ public class ConcurrentCommonCacheTest {
         sc.put("c", "3");
         sc.put("a", "4");
         sc.put("d", "5");
-        Assert.assertArrayEquals(new String[] {"c", "a", "d"}, sc.keys().toArray(new String[0]));
+        Assert.assertEquals(3, sc.size());
         Assert.assertEquals("3", sc.get("c"));
         Assert.assertEquals("4", sc.get("a"));
         Assert.assertEquals("5", sc.get("d"));

--- a/src/test/org/codehaus/groovy/runtime/memoize/StampedCommonCacheTest.java
+++ b/src/test/org/codehaus/groovy/runtime/memoize/StampedCommonCacheTest.java
@@ -178,7 +178,7 @@ public class StampedCommonCacheTest {
         sc.put("c", "3");
         sc.put("a", "4");
         sc.put("d", "5");
-        Assert.assertArrayEquals(new String[] {"c", "a", "d"}, sc.keys().toArray(new String[0]));
+        Assert.assertEquals(3, sc.size());
         Assert.assertEquals("3", sc.get("c"));
         Assert.assertEquals("4", sc.get("a"));
         Assert.assertEquals("5", sc.get("d"));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-11271