### PR TITLE
Remove redundant `gradle_version` property

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -107,8 +107,8 @@ As mentioned in the previous paragraph, if you download the source distribution
 you need to bootstrap Gradle. This isn't needed if you clone from the GitHub repo.
 
 Each version of Groovy is built and tested using a specific version of Gradle.
-That version is specified by the `gradle_version` property defined in the `gradle.properties`
-file within the root directory. Luckily you shouldn't need to know that version and,
+That version is defined in the `gradle/wrapper/gradle-wrapper.properties` file.
+Luckily you shouldn't need to know that version and,
 after bootstrapping, you should use the `gradlew` command which will ensure the
 correct version is always used.
 

--- a/bootstrap/build.gradle
+++ b/bootstrap/build.gradle
@@ -24,10 +24,6 @@ file("$projectDir/../gradle.properties").withInputStream {
 
 defaultTasks 'bootstrap'
 
-tasks.withType(Wrapper).configureEach {
-    gradleVersion = props.gradle_version
-}
-
 tasks.register('bootstrap') {
     dependsOn 'wrapper'
     doLast {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,6 @@ groovyTargetBytecodeVersion=11
 targetJavaVersion=11
 
 binaryCompatibilityBaseline=4.0.11
-gradle_version=8.5
 
 groovyJUnit_ms=512m
 groovyJUnit_mx=2g


### PR DESCRIPTION
It's easy to forget to modify this property, and we have no much necessary to input it for Wrapper tasks.