### PR TITLE
GROOVY-11308: Restore compatibility of Collection#unique

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -14580,10 +14580,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.8.1
      */
     public static <T> Collection<T> unique(Collection<T> self, boolean mutate) {
-        Collection<T> answer = null;
-        if (mutate || (self != null && self.size() > 1)) {
-            answer = uniqueItems(self);
-        }
+        Collection<T> answer = uniqueItems(self);
         if (mutate) {
             self.clear();
             self.addAll(answer);

--- a/src/test/groovy/UniqueOnCollectionTest.groovy
+++ b/src/test/groovy/UniqueOnCollectionTest.groovy
@@ -112,4 +112,22 @@ class UniqueOnCollectionTest extends GroovyTestCase {
         assert orig == [1, 3, 2, 3]
         assert uniq == [1, 3, 2]
     }
+
+    /** GROOVY-11308 */
+    void testNonMutatingEmpty() {
+        def it = []
+        def uniq = it.unique( false )
+        assert uniq !== it : "Must be a different instance to preserve documented behavior"
+        assert uniq == []
+        assert it == []
+    }
+
+    /** GROOVY-11308 */
+    void testNonMutatingSingleElement() {
+        def it = [1]
+        def uniq = it.unique( false )
+        assert uniq !== it : "Must be a different instance to preserve documented behavior"
+        assert uniq == [1]
+        assert it == [1]
+    }
 }


### PR DESCRIPTION
The documentation for this method states that when `mutate` is false, a new collection is _always_ returned. The previous code only did so when `self.size()` was greater than 1, and otherwise returned null.