### PR TITLE
GROOVY-11343: Bump asm to 9.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ configurations {
 
 ext {
     antVersion = '1.10.14'
-    asmVersion = '9.6'
+    asmVersion = '9.7'
     antlrVersion = '2.7.7'
     antlr4Version = '4.9.0'
     bridgerVersion = '1.6.Final'


### PR DESCRIPTION
Gradle still uses Groovy 3 and so requires this bump for full 23 support in the future.