### PR TITLE
Use Thread subclass instead of Closure in Console

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-groovyVersion=4.0.21-SNAPSHOT
+groovyVersion=4.0.21
 # bundle version format: major('.'minor('.'micro('.'qualifier)?)?)? (first 3 only digits)
-groovyBundleVersion=4.0.21.SNAPSHOT
+groovyBundleVersion=4.0.21
 
 groovyTargetBytecodeVersion=1.8
 targetJavaVersion=8


### PR DESCRIPTION
The use of closure to run the method `doRun` in the Groovy `Console` class makes impossible to extend the `Console` in custom code due to this [Groovy issue](https://issues.apache.org/jira/browse/GROOVY-2433). 

This PR solves the problem creating running thread using a `Thread` subclass instead of a Closure 