### PR TITLE
Make `Console.prefs` public accessible 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-groovyVersion=4.0.21-SNAPSHOT
+groovyVersion=4.0.21
 # bundle version format: major('.'minor('.'micro('.'qualifier)?)?)? (first 3 only digits)
-groovyBundleVersion=4.0.21.SNAPSHOT
+groovyBundleVersion=4.0.21
 
 groovyTargetBytecodeVersion=1.8
 targetJavaVersion=8

--- a/subprojects/groovy-console/src/main/groovy/groovy/console/ui/Console.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/console/ui/Console.groovy
@@ -108,7 +108,7 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
 
     static final String DEFAULT_SCRIPT_NAME_START = 'ConsoleScript'
 
-    static private prefs = Preferences.userNodeForPackage(Console)
+    static prefs = Preferences.userNodeForPackage(Console)
 
     // Whether or not std output should be captured to the console
     static boolean captureStdOut = prefs.getBoolean('captureStdOut', true)


### PR DESCRIPTION
The [Console.prefs](https://github.com/apache/groovy/blob/GROOVY_4_0_21/subprojects/groovy-console/src/main/groovy/groovy/console/ui/Console.groovy#L111) property is declared private, however, it's accessed by ConsolePreference object, for example [here](https://github.com/apache/groovy/blob/GROOVY_4_0_21/subprojects/groovy-console/src/main/groovy/groovy/console/ui/ConsolePreferences.groovy#L52-L52), causing an error to be reported when the Console class is extended by a subclass 

