### PR TITLE
GROOVY-10993: Add CycloneDX SBOM files

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.nosphere.apache:creadur-rat-gradle:0.8.1'
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.7'
     implementation 'me.champeau.jmh:jmh-gradle-plugin:0.7.2'
+    implementation 'org.cyclonedx:cyclonedx-gradle-plugin:1.8.2'
 }
 
 tasks.withType(Jar).configureEach {

--- a/build-logic/src/main/groovy/org.apache.groovy-published-library.gradle
+++ b/build-logic/src/main/groovy/org.apache.groovy-published-library.gradle
@@ -1,10 +1,12 @@
 import groovy.swing.SwingBuilder
+import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
     id 'maven-publish'
     id 'signing'
     id 'org.apache.groovy-publish-validation'
     id 'org.apache.groovy-artifactory'
+    id 'org.cyclonedx.bom'
 }
 
 def componentName
@@ -14,6 +16,16 @@ if (pluginManager.hasPlugin('java-platform')) {
     componentName = 'groovyDistribution'
 } else {
     componentName = 'groovyLibrary'
+}
+
+afterEvaluate {
+    def bomTask = tasks.cyclonedxBom
+    def bomFile = new File(bomTask.outputs.files.singleFile, "${bomTask.outputName.get()}.${bomTask.outputFormat.get()}")
+    def mavenPublish = extensions.findByName(PublishingExtension.NAME) as PublishingExtension
+    mavenPublish?.publications.each {
+        it.artifact(bomFile) { classifier = "cyclonedx" }
+    }
+    tasks.matching { it.group == PublishingExtension.NAME }.configureEach { dependsOn(bomTask) }
 }
 
 publishing {
@@ -855,4 +867,12 @@ def promptUser(String prompt) {
         throw new InvalidUserDataException("Null response detected!")
     }
     response
+}
+
+cyclonedxBom {
+    includeConfigs = ['runtimeClasspath']
+    skipConfigs = ['compileClasspath', 'testCompileClasspath', 'detached.*']
+    outputName = "cyclonedx"
+    outputFormat = 'json'
+    includeLicenseText = false
 }


### PR DESCRIPTION
This creates and publishes the cyclonedx sbom files but there are essentially empty ones for groovy-all, groovy-bom and groovy-binary. I don't know if that is a bug or feature. I.e. I don't know whether security scanning tools follow the transitive dependencies and merged to sbom data. If not we might have to do some aggregation like we do for groovy-all docs.