### PR TITLE
ci: Fix problem locating build component

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         maven { url 'https://plugins.gradle.org/m2/' }
         // uncomment next repo if jcenter isn't available
         // we have some build components mirrored there
-//        maven { url 'https://groovy.jfrog.io/artifactory/libs-release-local/' }
+        maven { url 'https://groovy.jfrog.io/artifactory/libs-release-local/' }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven { url 'https://jitpack.io' }
     }


### PR DESCRIPTION
The transitive build script dependency `org.jfrog.buildinfo:build-info-extractor:2.3.2` cannot be found.

This commit adds Groovy's artifactory repo to the build script repositories, to make the build find the missing dependency.

The problem started occurring in Grails `groovy-joint-workflow` Github action.
Error message is:
```
:buildSrc:compileJava NO-SOURCE
:buildSrc:compileGroovy FROM-CACHE
:buildSrc:processResources NO-SOURCE
:buildSrc:classes UP-TO-DATE
:buildSrc:jar
:buildSrc:assemble
:buildSrc:compileTestJava NO-SOURCE
:buildSrc:compileTestGroovy NO-SOURCE
:buildSrc:processTestResources NO-SOURCE
:buildSrc:testClasses UP-TO-DATE
:buildSrc:test NO-SOURCE
:buildSrc:check UP-TO-DATE
:buildSrc:build

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'groovy'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find org.jfrog.buildinfo:build-info-extractor:2.3.2.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/jfrog/buildinfo/build-info-extractor/2.3.2/build-info-extractor-2.3.2.pom
       - https://plugins.gradle.org/m2/org/jfrog/buildinfo/build-info-extractor/2.3.2/build-info-extractor-2.3.2.pom
       - https://oss.sonatype.org/content/repositories/snapshots/org/jfrog/buildinfo/build-info-extractor/2.3.2/build-info-extractor-2.3.2.pom
       - https://jitpack.io/org/jfrog/buildinfo/build-info-extractor/2.3.2/build-info-extractor-2.3.2.pom
     Required by:
         project : > org.jfrog.buildinfo:build-info-extractor-gradle:3.0.3

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 20s
```