### PR TITLE
update tools-ide.adoc and fix dead link to IntelliJ IDEA's groovy docs

### DIFF
--- a/src/spec/doc/tools-ide.adoc
+++ b/src/spec/doc/tools-ide.adoc
@@ -27,7 +27,7 @@ Many IDEs and text editors support the Groovy programming language.
 |===============================================================
 |Editor|Syntax highlighting|Code completion|Refactoring
 |https://github.com/groovy/groovy-eclipse[Groovy Eclipse Plugin]|Yes|Yes|Yes
-|http://www.jetbrains.com/idea/features/groovy.html[IntelliJ IDEA]|Yes|Yes|Yes
+|https://www.jetbrains.com/help/idea/groovy.html[IntelliJ IDEA]|Yes|Yes|Yes
 |https://netbeans.org/features/groovy/[Netbeans]|Yes|Yes|Yes
 |https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes[Groovy Emacs Modes]|Yes|No|No
 |https://github.com/textmate/groovy.tmbundle[TextMate]|Yes|No|No


### PR DESCRIPTION
Fixed dead link to IntelliJ IDEA > Groovy docs
![obraz](https://github.com/user-attachments/assets/22292044-e2a1-499d-9621-7b1e53c4a0ef)
