### PR TITLE
GROOVY-11508: change exception to detailed warning

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/Verifier.java
@@ -367,7 +367,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                                 if (t.equals(in)) {
                                     String one = in.toString(false), two = t.toString(false);
                                     if (!one.equals(two))
-                                        LOG.warning("Warning: " + " on " + cn.getName() + " the interface " + in.getNameWithoutPackage() +
+                                        LOG.warning("Warning: " + "on " + cn.getName() + " the interface " + in.getNameWithoutPackage() +
                                             " was implemented more than once with different arguments: " + one + " and " + two + ",  " +
                                             cn.getName() + " will only implement the lowest level " + in.getNameWithoutPackage());
                                 }

--- a/src/main/java/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/Verifier.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import static java.lang.reflect.Modifier.isFinal;
 import static java.lang.reflect.Modifier.isPrivate;
@@ -148,6 +149,8 @@ import static org.codehaus.groovy.ast.tools.PropertyNodeUtils.adjustPropertyModi
  * </ul>
  */
 public class Verifier implements GroovyClassVisitor, Opcodes {
+
+    private static final Logger LOG = Logger.getLogger(Verifier.class.getName());
 
     public static final String SWAP_INIT = "__$swapInit";
     public static final String STATIC_METACLASS_BOOL = "__$stMC";
@@ -364,9 +367,9 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                                 if (t.equals(in)) {
                                     String one = in.toString(false), two = t.toString(false);
                                     if (!one.equals(two))
-                                        throw new RuntimeParserException("The interface " + in.getNameWithoutPackage() +
-                                            " cannot be implemented more than once with different arguments: " + one + " and " + two, cn);
-                                    break;
+                                        LOG.warning("Warning: " + " on " + cn.getName() + " the interface " + in.getNameWithoutPackage() +
+                                            " was implemented more than once with different arguments: " + one + " and " + two + ",  " +
+                                            cn.getName() + " will only implement the lowest level " + in.getNameWithoutPackage());
                                 }
                             }
                         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-11508

This PR converts the `RuntimeParserException`, which stops compilation, to a more detailed warning about using a `Trait` or `Interface` with more than one generic type parameter via inheritance.  

Resolves https://github.com/grails/grails-data-mapping/issues/1811 which is a significant open issue for the Groovy 3.0.x to 4.0.x upgrade in preparation for Grails 7.  Grails 6 and lower were still on Groovy 3.0.x.

Precise simplified example of the code which results in the exception with Groovy 4.0.x compiler:  https://github.com/grails/grails-data-mapping/issues/1811#issue-2481317054

https://github.com/grails/grails-data-mapping/issues/1811#issuecomment-2419515195 - the decompiled Grails Domain Classes, compiled with Groovy 4.0.23, after changing the exception to a warning.   These Grails Domains, with inheritance, compile and run without issue once the exception is removed during pre-compilation verification.   

In each instance the `Trait` or `Interface` which is implemented with 2+ generic types via inheritance, have generic types which are compatible and extend in a lineage hierarchy.  

The Groovy 4 compiler only copies the lowest level Trait or Interface methods into the class, before compiling, which was the approach in Groovy 3 and same and expected approach in Groovy 4.

Example output after restoring Domain Inheritance and Inheritance tests on https://github.com/grails/grails-data-mapping/

```
> Task :grails-datastore-gorm-tck:compileGroovy
Warning:  on grails.gorm.tests.City the interface GormEntity was implemented more than once with different arguments: org.grails.datastore.gorm.GormEntity<grails.gorm.tests.City> and org.grails.datastore.gorm.GormEntity<grails.gorm.tests.Location>,  grails.gorm.tests.City will only implement the lowest level GormEntity
Warning:  on grails.gorm.tests.City the interface GormEntityApi was implemented more than once with different arguments: org.grails.datastore.gorm.GormEntityApi<grails.gorm.tests.City> and org.grails.datastore.gorm.GormEntityApi<grails.gorm.tests.Location>,  grails.gorm.tests.City will only implement the lowest level GormEntityApi
Warning:  on grails.gorm.tests.City the interface Entity was implemented more than once with different arguments: grails.gorm.Entity<grails.gorm.tests.City> and grails.gorm.Entity<grails.gorm.tests.Location>,  grails.gorm.tests.City will only implement the lowest level Entity
Warning:  on grails.gorm.tests.Country the interface GormEntity was implemented more than once with different arguments: org.grails.datastore.gorm.GormEntity<grails.gorm.tests.Country> and org.grails.datastore.gorm.GormEntity<grails.gorm.tests.Location>,  grails.gorm.tests.Country will only implement the lowest level GormEntity
Warning:  on grails.gorm.tests.Country the interface GormEntityApi was implemented more than once with different arguments: org.grails.datastore.gorm.GormEntityApi<grails.gorm.tests.Country> and org.grails.datastore.gorm.GormEntityApi<grails.gorm.tests.Location>,  grails.gorm.tests.Country will only implement the lowest level GormEntityApi
Warning:  on grails.gorm.tests.Country the interface Entity was implemented more than once with different arguments: grails.gorm.Entity<grails.gorm.tests.Country> and grails.gorm.Entity<grails.gorm.tests.Location>,  grails.gorm.tests.Country will only implement the lowest level Entity
```
