### PR TITLE
Update style-guide.adoc with 4 proper rendering of "`" character

### DIFF
--- a/src/spec/doc/style-guide.adoc
+++ b/src/spec/doc/style-guide.adoc
@@ -622,7 +622,7 @@ and the resulting value will be null if something's `null`.
 
 To check your parameters, your return values, and more, you can use the `assert` statement.
 
-Contrary to Java's `assert`, `assert`s don't need to be activated to be working, so `assert`s are always checked.
+Contrary to Java's `assert`, ``assert``s don't need to be activated to be working, so ``assert``s are always checked.
 
 [source,groovy]
 ----
@@ -685,8 +685,8 @@ try {
 ----
 
 [NOTE]
-Note that it's catching all Exceptions, not `Throwable`s. If you need to really catch "everything",
-you'll have to be explicit and say you want to catch `Throwable`s.
+Note that it's catching all Exceptions, not ``Throwable``s. If you need to really catch "everything",
+you'll have to be explicit and say you want to catch ``Throwable``s.
 
 == Optional typing advice
 


### PR DESCRIPTION
As mentioned in Example 6 in https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#text-formatting, 
two consecutive "`" character can be used to render unconstrained italic (I think it means italic that are not constrained to boundary of words)
<img width="837" alt="assert" src="https://github.com/user-attachments/assets/95e8b340-334e-42ba-b27f-664a77bce68b">
<img width="838" alt="Throwable" src="https://github.com/user-attachments/assets/430c836f-ca5b-422d-b55b-f331c8f5dc53">

There are four places that "`" is not rendered as expected in this adoc file (as shown above), I tried to fix all of them.
Please help review. Thanks
