### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/grails-joint-validation.yml
+++ b/.github/workflows/grails-joint-validation.yml
@@ -39,7 +39,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
-        DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/groovy-build-coverage.yml
+++ b/.github/workflows/groovy-build-coverage.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/groovy-build-dist.yml
+++ b/.github/workflows/groovy-build-dist.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Install graphviz
         run: sudo apt-get install -y graphviz

--- a/.github/workflows/groovy-build-test.yml
+++ b/.github/workflows/groovy-build-test.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   lts:

--- a/.github/workflows/groovy-rat-check.yml
+++ b/.github/workflows/groovy-rat-check.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/micronaut-joint-validation.yml
+++ b/.github/workflows/micronaut-joint-validation.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -21,7 +21,7 @@ def env = System.getenv()
 boolean isCI = env.CI || env.TEAMCITY_VERSION || env.GITHUB_ACTIONS
 
 develocity {
-    server = "https://ge.apache.org"
+    server = "https://develocity.apache.org"
     allowUntrustedServer = false
 
     buildScan {

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -22,6 +22,7 @@ boolean isCI = env.CI || env.TEAMCITY_VERSION || env.GITHUB_ACTIONS
 
 develocity {
     server = "https://develocity.apache.org"
+    projectId = "groovy"
     allowUntrustedServer = false
 
     buildScan {

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ pluginManagement {
 
 // check https://gradle.com/enterprise/releases with new versions. GE plugin version should not lag behind Gradle version
 plugins {
-    // Before updating this, please check the compatibility from https://docs.gradle.com/enterprise/compatibility/#develocity_compatibility and https://ge.apache.org/scans.
+    // Before updating this, please check the compatibility from https://docs.gradle.com/enterprise/compatibility/#develocity_compatibility and https://develocity.apache.org/scans.
     id "com.gradle.develocity" version "3.18.2"
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }


### PR DESCRIPTION
This PR migrates the Groovy project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR sets a projectId for use by Develocity.