### PR TITLE
[GROOVY-7407] Compilation not thread safe if Grape / Ivy is used in Groovy scripts

### DIFF
--- a/src/resources/groovy/grape/defaultGrapeConfig.xml
+++ b/src/resources/groovy/grape/defaultGrapeConfig.xml
@@ -20,6 +20,7 @@
 -->
 <ivysettings>
   <settings defaultResolver="downloadGrapes"/>
+  <caches lockStrategy="artifact-lock-nio"/>
   <resolvers>
     <chain name="downloadGrapes" returnFirst="true">
       <filesystem name="cachedGrapes">


### PR DESCRIPTION
See [GROOVY-7407 (comment)](https://issues.apache.org/jira/browse/GROOVY-7407?focusedCommentId=17913089&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17913089). Implements the same high-level solution used in the workaround tested and delivered to Jenkins users in https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/148. Not tested directly, but the high-level solution was tested indirectly via [JENKINS-72050 (comment)](https://issues.jenkins.io/browse/JENKINS-72050?focusedId=451809&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-451809) and https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/148 by two separate people.