### PR TITLE
GROOVY-11559: fix `addAllInterfaces` for `UnionTypeClassNode`

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
+++ b/src/main/java/org/codehaus/groovy/ast/tools/GenericsUtils.java
@@ -290,7 +290,7 @@ public class GenericsUtils {
         Map<String, ClassNode> gt;
 
         // relationship may be reversed for cases like "Iterable<String> x = []"
-        if (!cn.equals(hint) && implementsInterfaceOrIsSubclassOf(target, hint)) {
+        if (!cn.equals(hint) && (hint.isInterface() ? cn.implementsInterface(hint) : cn.isDerivedFrom(hint))) { // GROOVY-11559
             do { // walk target type hierarchy towards hint
                 cn = ClassHelper.getNextSuperClass(cn, hint);
                 if (hasUnresolvedGenerics(cn)) {

--- a/src/test/groovy/transform/stc/TypeInferenceSTCTest.groovy
+++ b/src/test/groovy/transform/stc/TypeInferenceSTCTest.groovy
@@ -412,11 +412,11 @@ class TypeInferenceSTCTest extends StaticTypeCheckingTestCase {
 
     // GROOVY-8965
     void testMultipleInstanceOf4() {
-        ['o', '((Number) o)'].each {
+        for (o in ['o', '((Number) o)']) {
             assertScript """
                 def foo(o) {
                     if (o instanceof Integer || o instanceof Double) {
-                        ${it}.floatValue() // ClassCastException
+                        ${o}.floatValue() // ClassCastException
                     }
                 }
                 def bar = foo(1.1d)
@@ -427,7 +427,20 @@ class TypeInferenceSTCTest extends StaticTypeCheckingTestCase {
         }
     }
 
+    // GROOVY-11559
     void testMultipleInstanceOf5() {
+        assertScript '''
+            def foo(o) {
+                if (o instanceof Set || o instanceof List) {
+                    o = "" // NullPointerException
+                }
+            }
+            foo("")
+            foo([])
+        '''
+    }
+
+    void testMultipleInstanceOf6() {
         assertScript '''
             void test(thing) {
                 if (thing instanceof Deque) {
@@ -445,8 +458,8 @@ class TypeInferenceSTCTest extends StaticTypeCheckingTestCase {
     }
 
     // GROOVY-10668
-    void testMultipleInstanceOf6() {
-        ['(value as String)', 'value.toString()'].each { string ->
+    void testMultipleInstanceOf7() {
+        for (string in ['(value as String)', 'value.toString()']) {
             assertScript """
                 def toArray(Object value) {
                     def array
@@ -466,7 +479,7 @@ class TypeInferenceSTCTest extends StaticTypeCheckingTestCase {
     }
 
     // GROOVY-8828
-    void testMultipleInstanceOf7() {
+    void testMultipleInstanceOf8() {
         assertScript '''
             interface Foo { }
             interface Bar { String name() }


### PR DESCRIPTION
In the multiple `instanceof` case, a `UnionTypeClassNode` is created.  A call to `addAllInterfaces` triggers a call to `parameterizeType` with the union type as the hint and each of the `instanceof` types as the target.  The walk type hierarchy should not be entered for a union type.

https://issues.apache.org/jira/browse/GROOVY-11559