### PR TITLE
GROOVY-11563: STC: check compound assignment `x op= y` like `x = x op y`

### DIFF
--- a/src/main/groovy/groovy/grape/GrapeIvy.groovy
+++ b/src/main/groovy/groovy/grape/GrapeIvy.groovy
@@ -589,7 +589,7 @@ class GrapeIvy implements GrapeEngine {
                 List<String> versions = []
                 moduleDir.eachFileMatch(ivyFilePattern) { File ivyFile ->
                     def m = ivyFilePattern.matcher(ivyFile.getName())
-                    if (m.matches()) versions += m.group(1)
+                    if (m.matches()) versions.add(m.group(1))
                 }
                 grapes[moduleDir.getName()] = versions
             }
@@ -655,8 +655,9 @@ class GrapeIvy implements GrapeEngine {
         List<URI> results = []
         for (ArtifactDownloadReport adl : report.getAllArtifactsReports()) {
             // TODO: check artifact type, jar vs library, etc.
-            if (adl.getLocalFile()) {
-                results += adl.getLocalFile().toURI()
+            def adlLocalFile = adl.getLocalFile()
+            if (adlLocalFile) {
+                results.add(adlLocalFile.toURI())
             }
         }
 

--- a/src/main/java/org/codehaus/groovy/ast/expr/ExpressionTransformer.java
+++ b/src/main/java/org/codehaus/groovy/ast/expr/ExpressionTransformer.java
@@ -18,14 +18,10 @@
  */
 package org.codehaus.groovy.ast.expr;
 
-
 /**
- * Provides a way to transform expressions
+ * Provides a way to transform expressions.
  */
+@FunctionalInterface
 public interface ExpressionTransformer {
-
-    /** 
-     * Transforms the given expression into another expression
-     */
     Expression transform(Expression expression);
 }

--- a/src/test/groovy/transform/stc/STCAssignmentTest.groovy
+++ b/src/test/groovy/transform/stc/STCAssignmentTest.groovy
@@ -341,10 +341,19 @@ class STCAssignmentTest extends StaticTypeCheckingTestCase {
         'Cannot find matching method java.lang.Integer#minus(java.lang.Object)'
     }
 
+    // GROOVY-11563
+    void testNumberPlusEqualsString() {
+        shouldFailWithMessages '''
+        Number n = 0
+        n += "no"
+    ''',
+        'Cannot assign value of type java.lang.String to variable of type java.lang.Number'
+    }
+
     void testStringPlusEqualsString() {
         assertScript '''
-            String str = 'test'
-            str += 'test2'
+            String s = 'prefix'
+            s += 'suffix'
         '''
     }
 

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
@@ -222,10 +222,9 @@ final class BugsStaticCompileTest extends BugsSTCTest implements StaticCompilati
             @CompileStatic
             class Tool {
                 @CompileStatic // annotated too, even if class is already annotated
-                String relativePath(File relbase, File file) {
-                    def pathParts = []
-                    def currentFile = file
-                    while (currentFile != null && currentFile != relbase) {
+                String relativePath(File base, File file) {
+                    List<String> pathParts = []; File currentFile = file
+                    while (currentFile != null && currentFile != base) {
                         pathParts += currentFile.name
                         currentFile = currentFile.parentFile
                     }
@@ -243,10 +242,9 @@ final class BugsStaticCompileTest extends BugsSTCTest implements StaticCompilati
             @CompileStatic
             class Tool {
                 @CompileStatic // annotated too, even if class is already annotated
-                String relativePath(File relbase, File file) {
-                    def pathParts = []
-                    def currentFile = file
-                    while (currentFile != null && currentFile != relbase) {
+                String relativePath(File base, File file) {
+                    List<String> pathParts = []; File currentFile = file
+                    while (currentFile != null && currentFile != base) {
                         pathParts += currentFile.name
                         currentFile = currentFile.parentFile
                     }

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/StaticCompileMathTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/StaticCompileMathTest.groovy
@@ -20,10 +20,13 @@ package org.codehaus.groovy.classgen.asm.sc
 
 import org.codehaus.groovy.classgen.asm.AbstractBytecodeTestCase
 
+import static groovy.test.GroovyAssert.shouldFail
+
 /**
  * Unit tests for static compilation: basic math operations.
  */
-class StaticCompileMathTest extends AbstractBytecodeTestCase {
+final class StaticCompileMathTest extends AbstractBytecodeTestCase {
+
     void testIntSum() {
         assertScript '''
             @groovy.transform.CompileStatic
@@ -243,13 +246,22 @@ class StaticCompileMathTest extends AbstractBytecodeTestCase {
     void testStaticCompileDivideEquals() {
         assertScript '''
             @groovy.transform.CompileStatic
-            int foo() {
-                int i = 4
+            def foo() {
+                def i = 4
                 i /= 2
                 i
             }
             assert foo()==2
         '''
+
+        def err = shouldFail '''
+            @groovy.transform.CompileStatic
+            int foo() {
+                int i = 4
+                i /= 2
+            }
+        '''
+        assert err =~ /Cannot assign value of type java.math.BigDecimal to variable of type int/
     }
 
     void testStaticCompileMultiplyEquals() {


### PR DESCRIPTION
This is a work-in-progress to visit the implied binary expression from a compound assignment to get type-checking similar to the explicit long form.  The GROOVY-10628 elvis assignment special-case approach is extended and moved up a bit earlier.

There are still several test case failures to investigate and deal with.