### PR TITLE
GROOVY-11566: Bump asm to 9.7.1 in Groovy 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ configurations {
 
 ext {
     antVersion = '1.10.14'
-    asmVersion = '9.7'
+    asmVersion = '9.7.1'
     antlrVersion = '2.7.7'
     antlr4Version = '4.9.0'
     bridgerVersion = '1.6.Final'


### PR DESCRIPTION
Gradle still depends on Groovy 3, and for Java 24 support we need this ASM upgrade in Groovy 3.

