### PR TITLE
GROOVY-11582: remove excess manifest attributes

### DIFF
--- a/build-logic/src/main/groovy/org.apache.groovy-core.gradle
+++ b/build-logic/src/main/groovy/org.apache.groovy-core.gradle
@@ -119,7 +119,7 @@ tasks.named('jarjar') { JarJarTask jjt ->
     jjt.withManifest {
         instruction '-nouses', 'true'
         instruction 'Export-Package', "*;version=${groovyBundleVersion}"
-        instruction 'Eclipse-ExtensibleAPI', 'true'
+        instruction 'Eclipse-ExtensibleAPI', 'true' // GROOVY-8713, GROOVY-11582
     }
 }
 

--- a/build-logic/src/main/groovy/org/apache/groovy/gradle/GroovyLibraryExtension.groovy
+++ b/build-logic/src/main/groovy/org/apache/groovy/gradle/GroovyLibraryExtension.groovy
@@ -211,8 +211,6 @@ class GroovyLibraryExtension {
                 'Bundle-Vendor'         : 'The Apache Software Foundation',
                 'Bundle-Version'        : groovyBundleVersion,
                 'Bundle-License'        : 'Apache-2.0',
-                'DynamicImport-Package' : '*',
-                'Eclipse-BuddyPolicy'   : 'dependent',
                 'Specification-Title'   : 'Groovy: a powerful, multi-faceted language for the JVM',
                 'Specification-Vendor'  : 'The Apache Software Foundation',
                 'Specification-Version' : groovyBundleVersion,
@@ -221,7 +219,11 @@ class GroovyLibraryExtension {
                 'Implementation-Version': groovyBundleVersion
             )
             if (projectName == 'groovy') {
-                attributes('Main-Class': 'groovy.ui.GroovyMain')
+                attributes(
+                    'DynamicImport-Package': '*', // GROOVY-3192
+                    'Eclipse-BuddyPolicy'  : 'dependent', // GROOVY-5571
+                    'Main-Class'           : 'groovy.ui.GroovyMain'
+                )
             }
         }
     }


### PR DESCRIPTION
I suspect not all of these are still required.  This is a draft to explore removing all or some.  And for any kept, adding some docs and tests.

* `Ant-Version`
* `Bundle-ClassPath`
* `Created-By`
* `DynamicImport-Package`
* `Eclipse-BuddyPolicy`
* `Eclipse-ExtensibleAPI`
* `Extension-Name`
* `Tool`
