### PR TITLE
GROOVY-11513: include `import java.time.*` by default

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
@@ -95,9 +95,9 @@ import static org.codehaus.groovy.ast.tools.ClosureUtils.getParametersSafe;
  */
 public class ResolveVisitor extends ClassCodeExpressionTransformer {
     // note: BigInteger and BigDecimal are also imported by default
-    // `java.util` is used much frequently than other two java packages(`java.io` and `java.net`), so place java.util before the two packages
-    public static final String[] DEFAULT_IMPORTS = {"java.lang.", "java.util.", "java.io.", "java.net.", "groovy.lang.", "groovy.util."};
-    public static final String[] EMPTY_STRING_ARRAY = new String[0];
+    // `java.util` is used much frequently, so place it before `java.io`, et al.
+    public static final String[] DEFAULT_IMPORTS = {"java.lang.", "java.util.", "java.io.", "java.net.", "java.time.", "groovy.lang.", "groovy.util."};
+    public static final String[] EMPTY_STRING_ARRAY = {};
     public static final String QUESTION_MARK = "?";
 
     private final CompilationUnit compilationUnit;

--- a/src/spec/doc/core-differences-java.adoc
+++ b/src/spec/doc/core-differences-java.adoc
@@ -45,6 +45,7 @@ have to use an explicit `import` statement to use them:
 * java.math.BigDecimal
 * java.math.BigInteger
 * java.net.*
+* java.time.*
 * java.util.*
 * groovy.lang.*
 * groovy.util.*

--- a/src/spec/doc/core-program-structure.adoc
+++ b/src/spec/doc/core-program-structure.adoc
@@ -72,6 +72,7 @@ import java.lang.*
 import java.util.*
 import java.io.*
 import java.net.*
+import java.time.*
 import groovy.lang.*
 import groovy.util.*
 import java.math.BigInteger

--- a/src/spec/test/PackageTest.groovy
+++ b/src/spec/test/PackageTest.groovy
@@ -17,7 +17,7 @@
  *  under the License.
  */
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import static groovy.test.GroovyAssert.assertScript
 
@@ -55,7 +55,8 @@ final class PackageTest {
     void testDefaultImports() {
         assertScript '''
             // tag::default_import[]
-            new Date()
+            long time = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+            Date date = new Date(time)
             // end::default_import[]
         '''
     }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/apache/groovy/groovysh/completion/ImportsSyntaxCompleterTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/apache/groovy/groovysh/completion/ImportsSyntaxCompleterTest.groovy
@@ -24,7 +24,9 @@ import org.apache.groovy.groovysh.completion.antlr4.ImportsSyntaxCompleter
 
 import static org.apache.groovy.groovysh.completion.TokenUtilTest.tokenList
 
-class ImportsSyntaxCompleterTest extends CompleterTestSupport {
+final class ImportsSyntaxCompleterTest extends CompleterTestSupport {
+
+    private static final int DEFAULT_IMPORT_COUNT = org.codehaus.groovy.control.ResolveVisitor.DEFAULT_IMPORTS.size()
 
     void testPackagePattern() {
         assert 'static java.lang.Math'.matches(ImportsSyntaxCompleter.STATIC_IMPORT_PATTERN)
@@ -36,19 +38,19 @@ class ImportsSyntaxCompleterTest extends CompleterTestSupport {
     }
 
     void testPreImported() {
-        groovyshMocker.demand.getPackageHelper(6) { [getContents: {['Foo']}] }
+        groovyshMocker.demand.getPackageHelper(DEFAULT_IMPORT_COUNT) { [getContents: {['Foo']}] }
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
             ImportsSyntaxCompleter completer = new ImportsSyntaxCompleter(groovyshMock)
             def candidates = ['prefill']
             assert completer.findMatchingPreImportedClasses('Foo', candidates)
             // once for each standard package
-            assert ['prefill', 'Foo', 'Foo', 'Foo', 'Foo', 'Foo', 'Foo'] == candidates
+            assert ['prefill', *Collections.nCopies(DEFAULT_IMPORT_COUNT, 'Foo')] == candidates
         }
     }
 
     void testPreImportedBigs() {
-        groovyshMocker.demand.getPackageHelper(6) { [getContents: {[]}] }
+        groovyshMocker.demand.getPackageHelper(DEFAULT_IMPORT_COUNT) { [getContents: {[]}] }
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
             ImportsSyntaxCompleter completer = new ImportsSyntaxCompleter(groovyshMock)
@@ -178,7 +180,7 @@ class ImportsSyntaxCompleterTest extends CompleterTestSupport {
 
     // Integration tests over all methods
     void testNoImports() {
-        groovyshMocker.demand.getPackageHelper(6) { [getContents: {[]}] }
+        groovyshMocker.demand.getPackageHelper(DEFAULT_IMPORT_COUNT) { [getContents: {[]}] }
         groovyshMocker.demand.getImports(1) { [] }
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
@@ -190,7 +192,7 @@ class ImportsSyntaxCompleterTest extends CompleterTestSupport {
     }
 
     void testSimpleImport() {
-        groovyshMocker.demand.getPackageHelper(6) { [getContents: {[]}] }
+        groovyshMocker.demand.getPackageHelper(DEFAULT_IMPORT_COUNT) { [getContents: {[]}] }
         groovyshMocker.demand.getImports(1) { ['xyzabc.*', 'xxxx.*'] }
         groovyshMocker.demand.getPackageHelper(1) { [getContents: { ['Xyzabc']}] }
         groovyshMocker.demand.getPackageHelper(1) { [getContents: { ['Xyz123']}] }
@@ -211,7 +213,7 @@ class ImportsSyntaxCompleterTest extends CompleterTestSupport {
     }
 
     void testUnknownImport() {
-        groovyshMocker.demand.getPackageHelper(6) { [getContents: {[]}] }
+        groovyshMocker.demand.getPackageHelper(DEFAULT_IMPORT_COUNT) { [getContents: {[]}] }
         groovyshMocker.demand.getImports(1) { ['xxxx'] }
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()


### PR DESCRIPTION
For your consideration.  Here are the types in `java.time` package:

![image](https://github.com/user-attachments/assets/c483ea98-ad59-43fd-8a95-632ee898a7d1)
