### PR TITLE
build(console): move `groovy-swing` to API scope

### DIFF
--- a/subprojects/groovy-console/build.gradle
+++ b/subprojects/groovy-console/build.gradle
@@ -22,9 +22,9 @@ plugins {
 
 dependencies {
     api rootProject // AstBrowser has methods with Closure params...
+    api projects.groovySwing // SwingBuilder is used in public API
     implementation "com.github.javaparser:javaparser-core:${versions.javaParser}"
     implementation "org.ow2.asm:asm-util:${versions.asm}"
-    implementation projects.groovySwing
     implementation projects.groovyTemplates
     implementation ("org.apache.ivy:ivy:${versions.ivy}") {
         transitive = false


### PR DESCRIPTION
`SwingBuilder` is part of `groovy-console`'s public API, so it must be in the `api` configuration scope. This prevents a downstream `NoClassDefFoundError: groovy.swing.SwingBuilder` at compile time.