### PR TITLE
Update SDKMAN install URL

### DIFF
--- a/src/spec/doc/core-getting-started.adoc
+++ b/src/spec/doc/core-getting-started.adoc
@@ -73,7 +73,7 @@ Simply open a new terminal and enter:
 
 [source,shell]
 ----
-$ curl -s get.sdkman.io | bash
+$ curl -s "https://get.sdkman.io" | bash
 ----
 
 Follow the instructions on-screen to complete installation.


### PR DESCRIPTION
Update SDKMAN URL to include `"https://get.sdkman.io"` as the old link does not work.