### PR TITLE
GROOVY-11600: no implicit outer class argument on inner record ctor call

### DIFF
--- a/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -1255,8 +1255,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
                     null,
                     outerClass
             );
-        } else if (asBoolean(outerClass)) {
-            if (outerClass.isInterface()) modifiers |= Opcodes.ACC_STATIC;
+        } else if (outerClass != null) {
             classNode = new InnerClassNode(
                     outerClass,
                     outerClass.getName() + "$" + className,
@@ -1317,20 +1316,18 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
             this.checkUsingGenerics(classNode);
 
         } else if (isInterface) {
-            classNode.setModifiers(classNode.getModifiers() | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT);
+            classNode.setModifiers(classNode.getModifiers() | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT | (outerClass != null ? Opcodes.ACC_STATIC : 0));
             classNode.setInterfaces(this.visitTypeList(ctx.scs));
             this.checkUsingGenerics(classNode);
             this.hackMixins(classNode);
 
         } else if (isEnum || isRecord) {
+            if (isRecord) this.transformRecordHeaderToProperties(ctx, classNode);
             classNode.setInterfaces(this.visitTypeList(ctx.is));
             this.checkUsingGenerics(classNode);
-            if (isRecord) {
-                this.transformRecordHeaderToProperties(ctx, classNode);
-            }
 
         } else if (isAnnotation) {
-            classNode.setModifiers(classNode.getModifiers() | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT | Opcodes.ACC_ANNOTATION);
+            classNode.setModifiers(classNode.getModifiers() | Opcodes.ACC_ANNOTATION | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT | (outerClass != null ? Opcodes.ACC_STATIC : 0));
             classNode.addInterface(ClassHelper.Annotation_TYPE);
             this.hackMixins(classNode);
 

--- a/src/main/java/org/codehaus/groovy/antlr/EnumHelper.java
+++ b/src/main/java/org/codehaus/groovy/antlr/EnumHelper.java
@@ -35,7 +35,7 @@ public class EnumHelper {
         if (outerClass == null) {
             enumClass = new ClassNode(name, modifiers | Opcodes.ACC_ENUM, null, interfaces, MixinNode.EMPTY_ARRAY);
         } else {
-            enumClass = new InnerClassNode(outerClass, outerClass.getName() + "$" + name, modifiers | Opcodes.ACC_ENUM, null, interfaces, MixinNode.EMPTY_ARRAY);
+            enumClass = new InnerClassNode(outerClass, outerClass.getName() + "$" + name, modifiers | Opcodes.ACC_ENUM | Opcodes.ACC_STATIC, null, interfaces, MixinNode.EMPTY_ARRAY);
         }
 
         // enum E extends java.lang.Enum<E>

--- a/src/main/java/org/codehaus/groovy/ast/InnerClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/InnerClassNode.java
@@ -18,6 +18,8 @@
  */
 package org.codehaus.groovy.ast;
 
+import org.objectweb.asm.Opcodes;
+
 /**
  * Represents an inner class definition.
  */
@@ -30,7 +32,7 @@ public class InnerClassNode extends ClassNode {
     /**
      * @param name is the full name of the class
      * @param modifiers the modifiers, @see org.objectweb.asm.Opcodes
-     * @param superClass the base class name - use "java.lang.Object" if no direct base class
+     * @param superClass the base class name; use "java.lang.Object" if no direct base class
      */
     public InnerClassNode(ClassNode outerClass, String name, int modifiers, ClassNode superClass) {
         this(outerClass, name, modifiers, superClass, ClassNode.EMPTY_ARRAY, MixinNode.EMPTY_ARRAY);
@@ -39,10 +41,10 @@ public class InnerClassNode extends ClassNode {
     /**
      * @param name is the full name of the class
      * @param modifiers the modifiers, @see org.objectweb.asm.Opcodes
-     * @param superClass the base class name - use "java.lang.Object" if no direct base class
+     * @param superClass the base class name; use "java.lang.Object" if no direct base class
      */
     public InnerClassNode(ClassNode outerClass, String name, int modifiers, ClassNode superClass, ClassNode[] interfaces, MixinNode[] mixins) {
-        super(name, modifiers, superClass, interfaces, mixins);
+        super(name, modifiers | (outerClass != null && outerClass.isInterface() ? Opcodes.ACC_STATIC : 0), superClass, interfaces, mixins);
         if (outerClass != null) outerClass.addInnerClass(this);
         this.outerClass = outerClass;
     }

--- a/src/main/java/org/codehaus/groovy/classgen/EnumVisitor.java
+++ b/src/main/java/org/codehaus/groovy/classgen/EnumVisitor.java
@@ -141,8 +141,6 @@ public class EnumVisitor extends ClassCodeVisitorSupport {
 
             addMethods(enumClass, values, minValue, maxValue);
 
-            // for now, inner enum is always static
-            if (isInnerClass) enumClass.setModifiers(enumClass.getModifiers() | ACC_STATIC);
             if (isAnyAbstract(enumClass)) enumClass.setModifiers(enumClass.getModifiers() | ACC_ABSTRACT);
             else if (isNotExtended(enumClass)) enumClass.setModifiers(enumClass.getModifiers() | ACC_FINAL);
         }

--- a/src/main/java/org/codehaus/groovy/classgen/InnerClassVisitorHelper.java
+++ b/src/main/java/org/codehaus/groovy/classgen/InnerClassVisitorHelper.java
@@ -96,7 +96,8 @@ public abstract class InnerClassVisitorHelper extends ClassCodeVisitorSupport {
     }
 
     protected static boolean shouldHandleImplicitThisForInnerClass(final ClassNode cn) {
-        final int explicitOrImplicitStatic = Opcodes.ACC_STATIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ENUM;
-        return (cn.getModifiers() & explicitOrImplicitStatic) == 0 && (cn instanceof InnerClassNode && !((InnerClassNode) cn).isAnonymous());
+        final int explicitOrImplicitStatic = Opcodes.ACC_ENUM | Opcodes.ACC_INTERFACE | Opcodes.ACC_RECORD | Opcodes.ACC_STATIC;
+        return (cn.getModifiers() & explicitOrImplicitStatic) == 0 && (cn instanceof InnerClassNode && !((InnerClassNode) cn).isAnonymous())
+                && cn.getAnnotations().stream().noneMatch(aNode -> "groovy.transform.RecordType".equals(aNode.getClassNode().getName())); // GROOVY-11600
     }
 }

--- a/src/main/java/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
@@ -184,7 +184,8 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
     }
 
     private ClassNode createHelperClass(final ClassNode cNode) {
-        cNode.setModifiers(ACC_PUBLIC | ACC_ABSTRACT | ACC_INTERFACE);
+        cNode.setModifiers(ACC_PUBLIC | ACC_ABSTRACT | ACC_INTERFACE
+                | (cNode.getOuterClass() != null ? ACC_STATIC : 0)); // GROOVY-11600
 
         ClassNode helper = new InnerClassNode(
                 cNode,

--- a/src/test/gls/innerClass/InnerClassTest.groovy
+++ b/src/test/gls/innerClass/InnerClassTest.groovy
@@ -341,6 +341,31 @@ final class InnerClassTest {
         '''
     }
 
+    // GROOVY-11600
+    @Test
+    void testInnerEnumOrRecordOrInterfaceHasStaticModifier() {
+        assertScript '''
+            import static java.lang.reflect.Modifier.*
+
+            class C {
+                enum E {}
+                class C {}
+                trait T {}
+                record R() {}
+                interface I {}
+                @interface A {}
+            }
+
+            assert  isStatic(C.E.modifiers)
+            assert !isStatic(C.C.modifiers)
+            assert  isStatic(C.T.modifiers)
+            assert  isStatic(C.R.modifiers)
+            assert  isFinal (C.R.modifiers)
+            assert  isStatic(C.I.modifiers)
+            assert  isStatic(C.A.modifiers)
+        '''
+    }
+
     @Test
     void testStaticInnerClass() {
         assertScript '''

--- a/src/test/groovy/transform/stc/ConstructorsSTCTest.groovy
+++ b/src/test/groovy/transform/stc/ConstructorsSTCTest.groovy
@@ -603,6 +603,22 @@ class ConstructorsSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-11600
+    void testInnerRecordConstructorCall() {
+        assertScript '''
+            class C {
+                record R(int i, Number n) {
+                }
+                void test() {
+                    def r = new C.R(1,2)
+                    assert r.i() == 1
+                    assert r.n() == 2
+                }
+            }
+            new C().test()
+        '''
+    }
+
     // GROOVY-11274
     void testPrivateDefaultConstructor() {
         shouldFailWithMessages '''


### PR DESCRIPTION
also static modifier for inner `enum`, `trait`, `interface` or `annotation` -- I checked this behavior against `javac`