### PR TITLE
GROOVY-11621: STC: fix for `list[idx] = null` and `map[key] = null`

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -882,12 +882,13 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                         && enclosingBinaryExpression != null
                         && enclosingBinaryExpression.getLeftExpression() == expression
                         && isAssignment(enclosingBinaryExpression.getOperation().getType())) {
-                    // left hand side of a subscript assignment: map['foo'] = ...
+                    // left hand side of a subscript assignment: map['key'] = ...
                     Expression enclosingExpressionRHS = enclosingBinaryExpression.getRightExpression();
                     if (!(enclosingExpressionRHS instanceof ClosureExpression)) {
                         enclosingExpressionRHS.visit(this);
                     }
-                    ClassNode[] arguments = {rType, getType(enclosingExpressionRHS)};
+                    ClassNode[] arguments = {rType, isNullConstant(enclosingExpressionRHS) // GROOVY-11621
+                                ? UNKNOWN_PARAMETER_TYPE : getType(enclosingExpressionRHS)};
                     List<MethodNode> methods = findMethod(lType, "putAt", arguments);
                     if (methods.isEmpty()) {
                         addNoMatchingMethodError(lType, "putAt", arguments, enclosingBinaryExpression);

--- a/src/test/groovy/groovy/transform/stc/ArraysAndCollectionsSTCTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/ArraysAndCollectionsSTCTest.groovy
@@ -945,6 +945,45 @@ class ArraysAndCollectionsSTCTest extends StaticTypeCheckingTestCase {
         'Cannot find matching method java.util.Collection#putAt(int, java.lang.Object)'
     }
 
+    // GROOVY-11621
+    void testListPutAt() {
+        assertScript '''
+            def list = ['a', 'b', 'c']
+            list[0] = 'aa'
+            assert list[0] == 'aa'
+
+            list.set(2, null)
+            assert list[2] == null
+
+            list.putAt(0, null)
+            assert list[0] == null
+
+            list[1] = null
+            assert list[1] == null
+        '''
+    }
+
+    // GROOVY-11621
+    void testMapPutAt() {
+        assertScript '''
+            def map = [a: 'foo', b: 'bar', c: 'baz']
+            map['a'] = 'aa'
+            assert map['a'] == 'aa'
+
+            map.put('c', null)
+            assert map['c'] == null
+
+            map.putAt('a', null)
+            assert map['a'] == null
+
+            map.d = null
+            assert map['d'] == null
+
+            map['b'] = null
+            assert map['b'] == null
+        '''
+    }
+
     // GROOVY-6266
     void testMapGenerics() {
         assertScript '''


### PR DESCRIPTION
Special checks for `putAt` lack `null` handling.  Adding "isNullConstant(enclosingExpressionRHS) ? UNKNOWN_PARAMETER_TYPE :" to `getType` would expose to all STC users/scripts.