### PR TITLE
GROOVY-9530: use parsed static field value for constant inlining

### DIFF
--- a/src/main/java/org/apache/groovy/ast/tools/ExpressionUtils.java
+++ b/src/main/java/org/apache/groovy/ast/tools/ExpressionUtils.java
@@ -278,7 +278,7 @@ public final class ExpressionUtils {
                     if (e instanceof ConstantExpression) {
                         return e;
                     }
-                } else if (cn.isResolved()) {
+                }/* else if (cn.isResolved()) { // GROOVY-9530
                     try {
                         var field = cn.getTypeClass().getField(pe.getPropertyAsString());
                         if (field != null) {
@@ -287,7 +287,7 @@ public final class ExpressionUtils {
                     } catch (Exception | LinkageError ignore) {
                         // leave property expression and we will report later
                     }
-                }
+                }*/
             }
         } else if (exp instanceof VariableExpression) {
             VariableExpression ve = (VariableExpression) exp;

--- a/src/main/java/org/codehaus/groovy/ast/decompiled/MemberSignatureParser.java
+++ b/src/main/java/org/codehaus/groovy/ast/decompiled/MemberSignatureParser.java
@@ -53,7 +53,7 @@ class MemberSignatureParser {
             // ex: java.util.Collections#EMPTY_LIST/EMPTY_MAP/EMPTY_SET
             type[0] = GenericsUtils.nonGeneric(type[0]);
         }
-        return new FieldNode(field.fieldName, field.accessModifiers, type[0], owner, field.value != null ? new ConstantExpression(field.value) : null);
+        return new FieldNode(field.fieldName, field.accessModifiers, type[0], owner, field.value != null ? new ConstantExpression(field.value, true) : null);
     }
 
     static MethodNode createMethodNode(final AsmReferenceResolver resolver, final MethodStub method) {

--- a/src/test/groovy/bugs/Groovy9530.groovy
+++ b/src/test/groovy/bugs/Groovy9530.groovy
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bugs
+
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+final class Groovy9530 {
+
+    static class StaticClass {
+        public static final int STATIC_VALUE = getStaticValue()
+
+        private static int getStaticValue() {
+            return 'resource from classpath'.length()
+        }
+    }
+
+    @Test
+    void testConstantInlining() {
+        assertScript """import bugs.Groovy9530.StaticClass
+            class C {
+                public static final int VALUE = StaticClass.STATIC_VALUE
+            }
+
+            assert C.VALUE == 23
+        """
+    }
+}


### PR DESCRIPTION
Step 1: use field value if given by class decompiler
Step 2: move load field value from `transformInlineConstants` to `configureClassNode` -- `ClassNode(Class)` drives the latter for things like `ClassNode CLOSURE_TYPE = ClassHelper.makeCached(Closure.class)`

The field value loading could be limited to fields with a `ConstantValue` attribute.  However this is not available through the Reflection API.  Maybe it will be available in a JVM newer than 21.  In any case, fewer class nodes are created through this path than the wide open constant inlining.  So this does address the test case for user code.