### PR TITLE
GROOVY-11639: include super interface fields in face's property index

### DIFF
--- a/src/main/java/org/codehaus/groovy/reflection/CachedClass.java
+++ b/src/main/java/org/codehaus/groovy/reflection/CachedClass.java
@@ -174,7 +174,7 @@ public class CachedClass {
         @Override
         public Set<CachedClass> initValue() {
             Class[] classes = getTheClass().getInterfaces();
-            Set<CachedClass> res = new HashSet<>(classes.length);
+            Set<CachedClass> res = new LinkedHashSet<>(classes.length);
             for (Class cls : classes) {
                 res.add(ReflectionCache.getCachedClass(cls));
             }

--- a/src/test/groovy/groovy/lang/DefaultInterfaceMethodsTest.groovy
+++ b/src/test/groovy/groovy/lang/DefaultInterfaceMethodsTest.groovy
@@ -18,7 +18,7 @@
  */
 package groovy.lang
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import static groovy.test.GroovyAssert.assertScript
 
@@ -56,6 +56,31 @@ final class DefaultInterfaceMethodsTest {
             }
 
             assert new C().m() == 'Bon jour'
+        '''
+    }
+
+    // GROOVY-11639
+    @Test
+    void testDefaultMethodUsesSuperProperty() {
+        assertScript '''
+            interface I {
+                String FOO = 'foo'
+            }
+
+            interface J extends I {
+                default m() {
+                    return FOO + 'bar'
+                }
+            }
+
+            class C implements J {
+                def xx() {
+                    return m() + 'baz'
+                }
+            }
+
+            String result = new C().xx()
+            assert result == 'foobarbaz'
         '''
     }
 }


### PR DESCRIPTION
Support interface default method making reference to super interface constant.