### PR TITLE
GROOVY-11649: add partitionPoint to Groovy Array and List(missed in java and groovy)

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/ArrayGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ArrayGroovyMethods.java
@@ -87,6 +87,9 @@ import java.util.function.IntConsumer;
 import java.util.function.IntUnaryOperator;
 import java.util.function.LongConsumer;
 import java.util.function.LongUnaryOperator;
+import java.util.function.IntPredicate;
+import java.util.function.LongPredicate;
+import java.util.function.DoublePredicate;
 
 /**
  * Defines new groovy methods which appear on arrays inside the Groovy environment.
@@ -6574,6 +6577,521 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
             result = Arrays.copyOfRange(result, 0, i);
         }
         return result;
+    }
+
+    //--------------------------------------------------------------------------
+    // partition_point
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as Integer[];
+     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param intRange  the range [l,r) to find data match the condition
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static <T> int partitionPoint(T[] self, IntRange intRange, @ClosureParams(FirstParam.FirstGenericType.class) Closure<?> condition) {
+        int result = intRange.getFromInt();
+        BooleanClosureWrapper bcw = new BooleanClosureWrapper(condition);
+        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (bcw.call(self[mid])) {
+                result = mid + 1;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as Integer[];
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint{ it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint{ it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 0 } == 0
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static <T> int partitionPoint(T[] self, @ClosureParams(FirstParam.FirstGenericType.class) Closure<?> condition) {
+        return partitionPoint(self, new IntRange(0, self.length), condition);
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as char[];
+     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as char[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param intRange  the range [l,r) to find data match the condition
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(char[] self, IntRange intRange, IntPredicate condition) {
+        int result = intRange.getFromInt();
+        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (condition.test(self[mid])) {
+                result = mid + 1;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as char[];
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as char[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint{ it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint{ it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 0 } == 0
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(char[] self, IntPredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length), condition);
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as short[];
+     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as short[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param intRange  the range [l,r) to find data match the condition
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(short[] self, IntRange intRange, IntPredicate condition) {
+        int result = intRange.getFromInt();
+        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (condition.test(self[mid])) {
+                result = mid + 1;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as short[];
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as short[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint{ it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint{ it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 0 } == 0
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(short[] self, IntPredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length), condition);
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as int[];
+     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as int[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param intRange  the range [l,r) to find data match the condition
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(int[] self, IntRange intRange, IntPredicate condition) {
+        int result = intRange.getFromInt();
+        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (condition.test(self[mid])) {
+                result = mid + 1;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as int[];
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as int[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint{ it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint{ it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 0 } == 0
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(int[] self, IntPredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length), condition);
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as long[];
+     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param intRange  the range [l,r) to find data match the condition
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(long[] self, IntRange intRange, LongPredicate condition) {
+        int result = intRange.getFromInt();
+        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (condition.test(self[mid])) {
+                result = mid + 1;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as long[];
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint{ it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint{ it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 0 } == 0
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(long[] self, LongPredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length), condition);
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as float[];
+     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as float[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param intRange  the range [l,r) to find data match the condition
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(float[] self, IntRange intRange, DoublePredicate condition) {
+        int result = intRange.getFromInt();
+        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (condition.test(self[mid])) {
+                result = mid + 1;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as float[];
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as float[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint{ it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint{ it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 0 } == 0
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(float[] self, DoublePredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length), condition);
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as double[];
+     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as double[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param intRange  the range [l,r) to find data match the condition
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(double[] self, IntRange intRange, DoublePredicate condition) {
+        int result = intRange.getFromInt();
+        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (condition.test(self[mid])) {
+                result = mid + 1;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The arr is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as long[];
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert arr.partitionPoint{ it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert arr.partitionPoint{ it <= 4 } == 6
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * //for all match condition
+     * assert arr.partitionPoint{ it <= 0 } == 0
+     * </pre>
+     *
+     * @param self      a groovy arr
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static int partitionPoint(double[] self, DoublePredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length), condition);
     }
 
     //--------------------------------------------------------------------------

--- a/src/main/java/org/codehaus/groovy/runtime/ArrayGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ArrayGroovyMethods.java
@@ -6580,41 +6580,44 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     //--------------------------------------------------------------------------
-    // partition_point
+    // binaryPartitionPoint
 
     /**
      * Returns the index of the partition point according to the given predicate
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as Integer[];
-     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as Integer[]
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
-     * @param intRange  the range [l,r) to find data match the condition
+     * @param intRange  the range [l,r] to find data match the condition
      * @param condition the matching condition
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static <T> int partitionPoint(T[] self, IntRange intRange, @ClosureParams(FirstParam.FirstGenericType.class) Closure<?> condition) {
+    public static <T> int binaryPartitionPoint(T[] self, IntRange intRange, @ClosureParams(FirstParam.FirstGenericType.class) Closure<?> condition) {
+        Objects.requireNonNull(self);
+        assert !intRange.isReverse();
+        Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
         int result = intRange.getFromInt();
         BooleanClosureWrapper bcw = new BooleanClosureWrapper(condition);
-        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        int left = intRange.getFromInt(), right = intRange.getToInt();
         while (left <= right) {
             int mid = left + (right - left) / 2;
             if (bcw.call(self[mid])) {
@@ -6632,20 +6635,20 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as Integer[];
-     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as Integer[]
+     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint{ it < 4 } == 4
+     * assert arr.binaryPartitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint{ it <= 4 } == 6
+     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6653,8 +6656,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static <T> int partitionPoint(T[] self, @ClosureParams(FirstParam.FirstGenericType.class) Closure<?> condition) {
-        return partitionPoint(self, new IntRange(0, self.length), condition);
+    public static <T> int binaryPartitionPoint(T[] self, @ClosureParams(FirstParam.FirstGenericType.class) Closure<?> condition) {
+        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6662,33 +6665,37 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as char[];
-     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as char[]
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as char[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as char[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
-     * @param intRange  the range [l,r) to find data match the condition
+     * @param intRange  the range [l,r] to find data match the condition
      * @param condition the matching condition
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(char[] self, IntRange intRange, IntPredicate condition) {
+    public static int binaryPartitionPoint(char[] self, IntRange intRange, IntPredicate condition) {
+        Objects.requireNonNull(self);
+        assert !intRange.isReverse();
+        Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
+
         int result = intRange.getFromInt();
-        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        int left = intRange.getFromInt(), right = intRange.getToInt();
         while (left <= right) {
             int mid = left + (right - left) / 2;
             if (condition.test(self[mid])) {
@@ -6706,20 +6713,20 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as char[];
-     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as char[]
+     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as char[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as char[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint{ it < 4 } == 4
+     * assert arr.binaryPartitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint{ it <= 4 } == 6
+     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint{ it <= 0 } == 0
+     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6727,8 +6734,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(char[] self, IntPredicate condition) {
-        return partitionPoint(self, new IntRange(0, self.length), condition);
+    public static int binaryPartitionPoint(char[] self, IntPredicate condition) {
+        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6736,33 +6743,37 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as short[];
-     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as short[]
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as short[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as short[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
-     * @param intRange  the range [l,r) to find data match the condition
+     * @param intRange  the range [l,r] to find data match the condition
      * @param condition the matching condition
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(short[] self, IntRange intRange, IntPredicate condition) {
+    public static int binaryPartitionPoint(short[] self, IntRange intRange, IntPredicate condition) {
+        Objects.requireNonNull(self);
+        assert !intRange.isReverse();
+        Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
+
         int result = intRange.getFromInt();
-        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        int left = intRange.getFromInt(), right = intRange.getToInt();
         while (left <= right) {
             int mid = left + (right - left) / 2;
             if (condition.test(self[mid])) {
@@ -6780,20 +6791,20 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as short[];
-     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as short[]
+     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as short[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as short[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint{ it < 4 } == 4
+     * assert arr.binaryPartitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint{ it <= 4 } == 6
+     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint{ it <= 0 } == 0
+     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6801,8 +6812,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(short[] self, IntPredicate condition) {
-        return partitionPoint(self, new IntRange(0, self.length), condition);
+    public static int binaryPartitionPoint(short[] self, IntPredicate condition) {
+        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6810,33 +6821,37 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as int[];
-     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as int[]
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as int[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as int[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
-     * @param intRange  the range [l,r) to find data match the condition
+     * @param intRange  the range [l,r] to find data match the condition
      * @param condition the matching condition
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(int[] self, IntRange intRange, IntPredicate condition) {
+    public static int binaryPartitionPoint(int[] self, IntRange intRange, IntPredicate condition) {
+        Objects.requireNonNull(self);
+        assert !intRange.isReverse();
+        Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
+
         int result = intRange.getFromInt();
-        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        int left = intRange.getFromInt(), right = intRange.getToInt();
         while (left <= right) {
             int mid = left + (right - left) / 2;
             if (condition.test(self[mid])) {
@@ -6854,20 +6869,20 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as int[];
-     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as int[]
+     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as int[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as int[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint{ it < 4 } == 4
+     * assert arr.binaryPartitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint{ it <= 4 } == 6
+     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint{ it <= 0 } == 0
+     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6875,8 +6890,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(int[] self, IntPredicate condition) {
-        return partitionPoint(self, new IntRange(0, self.length), condition);
+    public static int binaryPartitionPoint(int[] self, IntPredicate condition) {
+        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6884,33 +6899,37 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as long[];
-     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as long[]
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
-     * @param intRange  the range [l,r) to find data match the condition
+     * @param intRange  the range [l,r] to find data match the condition
      * @param condition the matching condition
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(long[] self, IntRange intRange, LongPredicate condition) {
+    public static int binaryPartitionPoint(long[] self, IntRange intRange, LongPredicate condition) {
+        Objects.requireNonNull(self);
+        assert !intRange.isReverse();
+        Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
+
         int result = intRange.getFromInt();
-        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        int left = intRange.getFromInt(), right = intRange.getToInt();
         while (left <= right) {
             int mid = left + (right - left) / 2;
             if (condition.test(self[mid])) {
@@ -6928,20 +6947,20 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as long[];
-     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as long[]
+     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint{ it < 4 } == 4
+     * assert arr.binaryPartitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint{ it <= 4 } == 6
+     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint{ it <= 0 } == 0
+     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6949,8 +6968,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(long[] self, LongPredicate condition) {
-        return partitionPoint(self, new IntRange(0, self.length), condition);
+    public static int binaryPartitionPoint(long[] self, LongPredicate condition) {
+        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6958,33 +6977,37 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as float[];
-     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as float[]
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as float[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as float[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
-     * @param intRange  the range [l,r) to find data match the condition
+     * @param intRange  the range [l,r] to find data match the condition
      * @param condition the matching condition
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(float[] self, IntRange intRange, DoublePredicate condition) {
+    public static int binaryPartitionPoint(float[] self, IntRange intRange, DoublePredicate condition) {
+        Objects.requireNonNull(self);
+        assert !intRange.isReverse();
+        Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
+
         int result = intRange.getFromInt();
-        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        int left = intRange.getFromInt(), right = intRange.getToInt();
         while (left <= right) {
             int mid = left + (right - left) / 2;
             if (condition.test(self[mid])) {
@@ -7002,20 +7025,20 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as float[];
-     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as float[]
+     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as float[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as float[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint{ it < 4 } == 4
+     * assert arr.binaryPartitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint{ it <= 4 } == 6
+     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint{ it <= 0 } == 0
+     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -7023,8 +7046,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(float[] self, DoublePredicate condition) {
-        return partitionPoint(self, new IntRange(0, self.length), condition);
+    public static int binaryPartitionPoint(float[] self, DoublePredicate condition) {
+        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -7032,33 +7055,37 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as double[];
-     * assert arr.partitionPoint(0..arr.size()) { it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as double[]
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as double[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as double[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint(0..arr.size()) { it < 4 } == 4
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for all match condition
-     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
+     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
-     * @param self      a groovy arr
-     * @param intRange  the range [l,r) to find data match the condition
+     * @param self      a groovy array
+     * @param intRange  the range [l,r] to find data match the condition
      * @param condition the matching condition
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(double[] self, IntRange intRange, DoublePredicate condition) {
+    public static int binaryPartitionPoint(double[] self, IntRange intRange, DoublePredicate condition) {
+        Objects.requireNonNull(self);
+        assert !intRange.isReverse();
+        Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
+
         int result = intRange.getFromInt();
-        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        int left = intRange.getFromInt(), right = intRange.getToInt() ;
         while (left <= right) {
             int mid = left + (right - left) / 2;
             if (condition.test(self[mid])) {
@@ -7076,20 +7103,20 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def arr = [7, 15, 3, 5, 4, 12, 6] as long[];
-     * assert arr.partitionPoint{ it%2 != 0 } == 4
+     * def arr = [7, 15, 3, 5, 4, 12, 6] as double[]
+     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[];
+     * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as double[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.partitionPoint{ it < 4 } == 4
+     * assert arr.binaryPartitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.partitionPoint{ it <= 4 } == 6
+     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint{ it <= 100 } == arr.size()
+     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.partitionPoint{ it <= 0 } == 0
+     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -7097,8 +7124,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int partitionPoint(double[] self, DoublePredicate condition) {
-        return partitionPoint(self, new IntRange(0, self.length), condition);
+    public static int binaryPartitionPoint(double[] self, DoublePredicate condition) {
+        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     //--------------------------------------------------------------------------

--- a/src/main/java/org/codehaus/groovy/runtime/ArrayGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ArrayGroovyMethods.java
@@ -6599,8 +6599,9 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * //for none match condition with range
      * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
      * </pre>
      *
@@ -6642,9 +6643,9 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * //usage case as upperBound(cpp), bisect_right(python)
      * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.partitionPoint{ it <= 100 } == arr.size()
-     * //for all match condition
-     * assert arr.partitionPoint{ it <= 0 } == 0
+     * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
+     * //for none match condition
+     * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6673,8 +6674,9 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * //for none match condition with range
      * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
      * </pre>
      *
@@ -6716,7 +6718,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint{ it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
@@ -6746,8 +6748,9 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * //for none match condition with range
      * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
      * </pre>
      *
@@ -6789,7 +6792,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint{ it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
@@ -6821,6 +6824,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
      * //for all match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * //for none match condition with range
      * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
      * </pre>
      *
@@ -6862,7 +6866,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint{ it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
@@ -6892,8 +6896,9 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * //for none match condition with range
      * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
      * </pre>
      *
@@ -6935,7 +6940,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint{ it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
@@ -6965,8 +6970,9 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint(0..arr.size()) { it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * //for none match condition with range
      * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
      * </pre>
      *
@@ -7008,7 +7014,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint{ it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
@@ -7040,6 +7046,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint(0..arr.size()) { it <= 100 } == arr.size()
      * //for all match condition
      * assert arr.partitionPoint(0..arr.size()) { it <= 0 } == 0
+     * //for none match condition with range
      * assert arr.partitionPoint(2..arr.size()) { it <= 0 } == 2
      * </pre>
      *
@@ -7081,7 +7088,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
      * assert arr.partitionPoint{ it <= 100 } == arr.size()
-     * //for all match condition
+     * //for none match condition
      * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *

--- a/src/main/java/org/codehaus/groovy/runtime/ArrayGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ArrayGroovyMethods.java
@@ -87,6 +87,7 @@ import java.util.function.IntConsumer;
 import java.util.function.IntUnaryOperator;
 import java.util.function.LongConsumer;
 import java.util.function.LongUnaryOperator;
+import java.util.function.Predicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.DoublePredicate;
@@ -6580,7 +6581,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     //--------------------------------------------------------------------------
-    // binaryPartitionPoint
+    // partitionPoint
 
     /**
      * Returns the index of the partition point according to the given predicate
@@ -6588,21 +6589,21 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as Integer[]
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
+     * assert arr.partitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
@@ -6611,16 +6612,16 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static <T> int binaryPartitionPoint(T[] self, IntRange intRange, @ClosureParams(FirstParam.FirstGenericType.class) Closure<?> condition) {
+    public static <T> int partitionPoint(T[] self, IntRange intRange, Predicate<T> condition) {
         Objects.requireNonNull(self);
         assert !intRange.isReverse();
         Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
+
         int result = intRange.getFromInt();
-        BooleanClosureWrapper bcw = new BooleanClosureWrapper(condition);
         int left = intRange.getFromInt(), right = intRange.getToInt();
         while (left <= right) {
             int mid = left + (right - left) / 2;
-            if (bcw.call(self[mid])) {
+            if (condition.test(self[mid])) {
                 result = mid + 1;
                 left = mid + 1;
             } else {
@@ -6636,19 +6637,19 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as Integer[]
-     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint{ it < 4 } == 4
+     * assert arr.partitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
+     * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
+     * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6656,8 +6657,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static <T> int binaryPartitionPoint(T[] self, @ClosureParams(FirstParam.FirstGenericType.class) Closure<?> condition) {
-        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
+    public static <T> int partitionPoint(T[] self, Predicate<T> condition) {
+        return partitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6666,21 +6667,21 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as char[]
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as char[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
+     * assert arr.partitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
@@ -6689,7 +6690,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(char[] self, IntRange intRange, IntPredicate condition) {
+    public static int partitionPoint(char[] self, IntRange intRange, IntPredicate condition) {
         Objects.requireNonNull(self);
         assert !intRange.isReverse();
         Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
@@ -6714,19 +6715,19 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as char[]
-     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as char[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint{ it < 4 } == 4
+     * assert arr.partitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
+     * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
+     * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6734,8 +6735,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(char[] self, IntPredicate condition) {
-        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
+    public static int partitionPoint(char[] self, IntPredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6744,21 +6745,21 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as short[]
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as short[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
+     * assert arr.partitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
@@ -6767,7 +6768,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(short[] self, IntRange intRange, IntPredicate condition) {
+    public static int partitionPoint(short[] self, IntRange intRange, IntPredicate condition) {
         Objects.requireNonNull(self);
         assert !intRange.isReverse();
         Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
@@ -6792,19 +6793,19 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as short[]
-     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as short[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint{ it < 4 } == 4
+     * assert arr.partitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
+     * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
+     * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6812,8 +6813,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(short[] self, IntPredicate condition) {
-        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
+    public static int partitionPoint(short[] self, IntPredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6822,21 +6823,21 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as int[]
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as int[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
+     * assert arr.partitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
@@ -6845,7 +6846,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(int[] self, IntRange intRange, IntPredicate condition) {
+    public static int partitionPoint(int[] self, IntRange intRange, IntPredicate condition) {
         Objects.requireNonNull(self);
         assert !intRange.isReverse();
         Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
@@ -6870,19 +6871,19 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as int[]
-     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as int[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint{ it < 4 } == 4
+     * assert arr.partitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
+     * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
+     * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6890,8 +6891,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(int[] self, IntPredicate condition) {
-        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
+    public static int partitionPoint(int[] self, IntPredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6900,21 +6901,21 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as long[]
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
+     * assert arr.partitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
@@ -6923,7 +6924,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(long[] self, IntRange intRange, LongPredicate condition) {
+    public static int partitionPoint(long[] self, IntRange intRange, LongPredicate condition) {
         Objects.requireNonNull(self);
         assert !intRange.isReverse();
         Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
@@ -6948,19 +6949,19 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as long[]
-     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as long[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint{ it < 4 } == 4
+     * assert arr.partitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
+     * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
+     * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -6968,8 +6969,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(long[] self, LongPredicate condition) {
-        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
+    public static int partitionPoint(long[] self, LongPredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -6978,21 +6979,21 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as float[]
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as float[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
+     * assert arr.partitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy arr
@@ -7001,7 +7002,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(float[] self, IntRange intRange, DoublePredicate condition) {
+    public static int partitionPoint(float[] self, IntRange intRange, DoublePredicate condition) {
         Objects.requireNonNull(self);
         assert !intRange.isReverse();
         Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
@@ -7026,19 +7027,19 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as float[]
-     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as float[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint{ it < 4 } == 4
+     * assert arr.partitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
+     * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
+     * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -7046,8 +7047,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(float[] self, DoublePredicate condition) {
-        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
+    public static int partitionPoint(float[] self, DoublePredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     /**
@@ -7056,21 +7057,21 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as double[]
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it%2 != 0 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as double[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it < 4 } == 4
+     * assert arr.partitionPoint(0..<arr.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 4 } == 6
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 100 } == arr.size()
      * //for all match condition
-     * assert arr.binaryPartitionPoint(0..<arr.size()) { it <= 0 } == 0
+     * assert arr.partitionPoint(0..<arr.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert arr.binaryPartitionPoint(2..<arr.size()) { it <= 0 } == 2
+     * assert arr.partitionPoint(2..<arr.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy array
@@ -7079,7 +7080,7 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(double[] self, IntRange intRange, DoublePredicate condition) {
+    public static int partitionPoint(double[] self, IntRange intRange, DoublePredicate condition) {
         Objects.requireNonNull(self);
         assert !intRange.isReverse();
         Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.length);
@@ -7104,19 +7105,19 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * The arr is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def arr = [7, 15, 3, 5, 4, 12, 6] as double[]
-     * assert arr.binaryPartitionPoint{ it%2 != 0 } == 4
+     * assert arr.partitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def arr = [1, 2, 3, 3, 4, 4, 5, 6, 7] as double[]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert arr.binaryPartitionPoint{ it < 4 } == 4
+     * assert arr.partitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert arr.binaryPartitionPoint{ it <= 4 } == 6
+     * assert arr.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert arr.binaryPartitionPoint{ it <= 100 } == arr.size()
+     * assert arr.partitionPoint{ it <= 100 } == arr.size()
      * //for none match condition
-     * assert arr.binaryPartitionPoint{ it <= 0 } == 0
+     * assert arr.partitionPoint{ it <= 0 } == 0
      * </pre>
      *
      * @param self      a groovy arr
@@ -7124,8 +7125,8 @@ public class ArrayGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static int binaryPartitionPoint(double[] self, DoublePredicate condition) {
-        return binaryPartitionPoint(self, new IntRange(0, self.length - 1), condition);
+    public static int partitionPoint(double[] self, DoublePredicate condition) {
+        return partitionPoint(self, new IntRange(0, self.length - 1), condition);
     }
 
     //--------------------------------------------------------------------------

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -153,6 +153,7 @@ import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static groovy.lang.groovydoc.Groovydoc.EMPTY_GROOVYDOC;
 
@@ -11045,6 +11046,82 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      */
     public static <T> SortedSet<T> or(SortedSet<T> left, Iterable<T> right) {
         return plus(left, right);
+    }
+
+    //--------------------------------------------------------------------------
+    // partition_point
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The list is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def list = [7, 15, 3, 5, 4, 12, 6];
+     * assert list.partitionPoint(0..list.size()) { it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def list = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert list.partitionPoint(0..list.size()) { it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert list.partitionPoint(0..list.size()) { it <= 4 } == 6
+     * //for all match condition
+     * assert list.partitionPoint(0..list.size()) { it <= 100 } == list.size()
+     * //for all match condition
+     * assert list.partitionPoint(0..list.size()) { it <= 0 } == 0
+     * assert list.partitionPoint(2..list.size()) { it <= 0 } == 2
+     * </pre>
+     *
+     * @param self      a groovy list
+     * @param intRange  the range [l,r) to find data match the condition
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static <T> int partitionPoint(List<T> self, IntRange intRange, Predicate<T> condition) {
+        int result = intRange.getFromInt();
+        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            if (condition.test(self.get(mid))) {
+                result = mid + 1;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the index of the partition point according to the given predicate
+     * (the index of the first element of the second partition).
+     * The list is assumed to be partitioned according to the given predicate.
+     * <pre class="groovyTestCase">
+     * def list = [7, 15, 3, 5, 4, 12, 6];
+     * assert list.partitionPoint{ it%2 != 0 } == 4
+     * </pre>
+     *
+     * <pre class="groovyTestCase">
+     * def list = [1, 2, 3, 3, 4, 4, 5, 6, 7];
+     * //usage case as lowerBound(cpp), bisect_left(python)
+     * assert list.partitionPoint{ it < 4 } == 4
+     * //usage case as upperBound(cpp), bisect_right(python)
+     * assert list.partitionPoint{ it <= 4 } == 6
+     * //for all match condition
+     * assert list.partitionPoint{ it <= 100 } == list.size()
+     * //for all match condition
+     * assert list.partitionPoint{ it <= 0 } == 0
+     * </pre>
+     *
+     * @param self      a groovy list
+     * @param condition the matching condition
+     * @return an integer that is the index of the first element of the second partition
+     * @since 5.0
+     */
+    public static <T> int partitionPoint(List<T> self, Predicate<T> condition) {
+        return partitionPoint(self, new IntRange(0, self.size()), condition);
     }
 
     //--------------------------------------------------------------------------

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -132,7 +132,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.AbstractList;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -11050,7 +11049,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     //--------------------------------------------------------------------------
-    // binaryPartitionPoint
+    // partitionPoint
 
     /**
      * Returns the index of the partition point according to the given predicate
@@ -11058,21 +11057,21 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * The list is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def list = [7, 15, 3, 5, 4, 12, 6]
-     * assert list.binaryPartitionPoint(0..<list.size()) { it%2 != 0 } == 4
+     * assert list.partitionPoint(0..<list.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def list = [1, 2, 3, 3, 4, 4, 5, 6, 7]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert list.binaryPartitionPoint(0..<list.size()) { it < 4 } == 4
+     * assert list.partitionPoint(0..<list.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert list.binaryPartitionPoint(0..<list.size()) { it <= 4 } == 6
+     * assert list.partitionPoint(0..<list.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert list.binaryPartitionPoint(0..<list.size()) { it <= 100 } == list.size()
+     * assert list.partitionPoint(0..<list.size()) { it <= 100 } == list.size()
      * //for none match condition
-     * assert list.binaryPartitionPoint(0..<list.size()) { it <= 0 } == 0
+     * assert list.partitionPoint(0..<list.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert list.binaryPartitionPoint(2..<list.size()) { it <= 0 } == 2
+     * assert list.partitionPoint(2..<list.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy list
@@ -11081,7 +11080,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static <T> int binaryPartitionPoint(AbstractList<T> self, IntRange intRange, Predicate<T> condition) {
+    public static <T> int partitionPoint(List<T> self, IntRange intRange, Predicate<T> condition) {
         Objects.requireNonNull(self);
         assert !intRange.isReverse();
         Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.size());
@@ -11105,22 +11104,22 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * The list is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
      * def list = [7, 15, 3, 5, 4, 12, 6]
-     * assert list.binaryPartitionPoint{ it%2 != 0 } == 4
+     * assert list.partitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
      * def list = [1, 2, 3, 3, 4, 4, 5, 6, 7]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert list.binaryPartitionPoint{ it < 4 } == 4
+     * assert list.partitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert list.binaryPartitionPoint{ it <= 4 } == 6
+     * assert list.partitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert list.binaryPartitionPoint{ it <= 100 } == list.size()
+     * assert list.partitionPoint{ it <= 100 } == list.size()
      * //for none match condition
-     * assert list.binaryPartitionPoint{ it <= 0 } == 0
-     * //reverse logic test:
-     * assert [7, 6, 5, 4, 4, 3, 3, 2, 1].binaryPartitionPoint{ it > 4 } == 3
-     * assert [7, 6, 5, 4, 4, 3, 3, 2, 1].binaryPartitionPoint{ it >= 4 } == 5
+     * assert list.partitionPoint{ it <= 0 } == 0
+     * //predicate of reverse logic examples:
+     * assert [7, 6, 5, 4, 4, 3, 3, 2, 1].partitionPoint{ it > 4 } == 3
+     * assert [7, 6, 5, 4, 4, 3, 3, 2, 1].partitionPoint{ it >= 4 } == 5
      * </pre>
      *
      * @param self      a groovy list
@@ -11128,8 +11127,8 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static <T> int binaryPartitionPoint(AbstractList<T> self, Predicate<T> condition) {
-        return binaryPartitionPoint(self, new IntRange(0, self.size() - 1), condition);
+    public static <T> int partitionPoint(List<T> self, Predicate<T> condition) {
+        return partitionPoint(self, new IntRange(0, self.size() - 1), condition);
     }
 
     //--------------------------------------------------------------------------

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -132,6 +132,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.AbstractList;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -11049,40 +11050,43 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     //--------------------------------------------------------------------------
-    // partition_point
+    // binaryPartitionPoint
 
     /**
      * Returns the index of the partition point according to the given predicate
      * (the index of the first element of the second partition).
      * The list is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def list = [7, 15, 3, 5, 4, 12, 6];
-     * assert list.partitionPoint(0..list.size()) { it%2 != 0 } == 4
+     * def list = [7, 15, 3, 5, 4, 12, 6]
+     * assert list.binaryPartitionPoint(0..<list.size()) { it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def list = [1, 2, 3, 3, 4, 4, 5, 6, 7] as Integer[];
+     * def list = [1, 2, 3, 3, 4, 4, 5, 6, 7]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert list.partitionPoint(0..list.size()) { it < 4 } == 4
+     * assert list.binaryPartitionPoint(0..<list.size()) { it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert list.partitionPoint(0..list.size()) { it <= 4 } == 6
+     * assert list.binaryPartitionPoint(0..<list.size()) { it <= 4 } == 6
      * //for all match condition
-     * assert list.partitionPoint(0..list.size()) { it <= 100 } == list.size()
+     * assert list.binaryPartitionPoint(0..<list.size()) { it <= 100 } == list.size()
      * //for none match condition
-     * assert list.partitionPoint(0..list.size()) { it <= 0 } == 0
+     * assert list.binaryPartitionPoint(0..<list.size()) { it <= 0 } == 0
      * //for none match condition with range
-     * assert list.partitionPoint(2..list.size()) { it <= 0 } == 2
+     * assert list.binaryPartitionPoint(2..<list.size()) { it <= 0 } == 2
      * </pre>
      *
      * @param self      a groovy list
-     * @param intRange  the range [l,r) to find data match the condition
+     * @param intRange  the range [l,r] to find data match the condition
      * @param condition the matching condition
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static <T> int partitionPoint(List<T> self, IntRange intRange, Predicate<T> condition) {
+    public static <T> int binaryPartitionPoint(AbstractList<T> self, IntRange intRange, Predicate<T> condition) {
+        Objects.requireNonNull(self);
+        assert !intRange.isReverse();
+        Objects.checkFromToIndex(intRange.getFromInt(),intRange.getToInt(), self.size());
         int result = intRange.getFromInt();
-        int left = intRange.getFromInt(), right = intRange.getToInt() - 1;
+        int left = intRange.getFromInt(), right = intRange.getToInt();
         while (left <= right) {
             int mid = left + (right - left) / 2;
             if (condition.test(self.get(mid))) {
@@ -11100,20 +11104,23 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * (the index of the first element of the second partition).
      * The list is assumed to be partitioned according to the given predicate.
      * <pre class="groovyTestCase">
-     * def list = [7, 15, 3, 5, 4, 12, 6];
-     * assert list.partitionPoint{ it%2 != 0 } == 4
+     * def list = [7, 15, 3, 5, 4, 12, 6]
+     * assert list.binaryPartitionPoint{ it%2 != 0 } == 4
      * </pre>
      *
      * <pre class="groovyTestCase">
-     * def list = [1, 2, 3, 3, 4, 4, 5, 6, 7];
+     * def list = [1, 2, 3, 3, 4, 4, 5, 6, 7]
      * //usage case as lowerBound(cpp), bisect_left(python)
-     * assert list.partitionPoint{ it < 4 } == 4
+     * assert list.binaryPartitionPoint{ it < 4 } == 4
      * //usage case as upperBound(cpp), bisect_right(python)
-     * assert list.partitionPoint{ it <= 4 } == 6
+     * assert list.binaryPartitionPoint{ it <= 4 } == 6
      * //for all match condition
-     * assert list.partitionPoint{ it <= 100 } == list.size()
+     * assert list.binaryPartitionPoint{ it <= 100 } == list.size()
      * //for none match condition
-     * assert list.partitionPoint{ it <= 0 } == 0
+     * assert list.binaryPartitionPoint{ it <= 0 } == 0
+     * //reverse logic test:
+     * assert [7, 6, 5, 4, 4, 3, 3, 2, 1].binaryPartitionPoint{ it > 4 } == 3
+     * assert [7, 6, 5, 4, 4, 3, 3, 2, 1].binaryPartitionPoint{ it >= 4 } == 5
      * </pre>
      *
      * @param self      a groovy list
@@ -11121,8 +11128,8 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @return an integer that is the index of the first element of the second partition
      * @since 5.0
      */
-    public static <T> int partitionPoint(List<T> self, Predicate<T> condition) {
-        return partitionPoint(self, new IntRange(0, self.size()), condition);
+    public static <T> int binaryPartitionPoint(AbstractList<T> self, Predicate<T> condition) {
+        return binaryPartitionPoint(self, new IntRange(0, self.size() - 1), condition);
     }
 
     //--------------------------------------------------------------------------

--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -11068,8 +11068,9 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert list.partitionPoint(0..list.size()) { it <= 4 } == 6
      * //for all match condition
      * assert list.partitionPoint(0..list.size()) { it <= 100 } == list.size()
-     * //for all match condition
+     * //for none match condition
      * assert list.partitionPoint(0..list.size()) { it <= 0 } == 0
+     * //for none match condition with range
      * assert list.partitionPoint(2..list.size()) { it <= 0 } == 2
      * </pre>
      *
@@ -11111,7 +11112,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * assert list.partitionPoint{ it <= 4 } == 6
      * //for all match condition
      * assert list.partitionPoint{ it <= 100 } == list.size()
-     * //for all match condition
+     * //for none match condition
      * assert list.partitionPoint{ it <= 0 } == 0
      * </pre>
      *


### PR DESCRIPTION
partition_point missed in java and groovy like in
* rust: https://doc.rust-lang.org/std/primitive.slice.html#method.partition_point
* c++:  https://en.cppreference.com/w/cpp/algorithm/ranges/partition_point
