### PR TITLE
GROOVY-11616: STC: combine multiple type witnesses for type parameter

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1951,7 +1951,14 @@ public abstract class StaticTypeCheckingSupport {
         // GROOVY-11028, et al.: empty list / map for gt1 or gt2?
         if (gt2.isPlaceholder() && gt2.getName().startsWith("#")) return gt1;
         if (gt1.isPlaceholder() && gt1.getName().startsWith("#")) return gt2;
-        // GROOVY-10315, GROOVY-10317, GROOVY-10339, ...
+        // GROOVY-10315, GROOVY-10317, GROOVY-10339, GROOVY-11616
+        if (!gt1.isPlaceholder() && !gt1.isWildcard()
+                && !gt2.isPlaceholder() && !gt2.isWildcard()) {
+            ClassNode lub = lowestUpperBound(gt1.getType(), gt2.getType());
+            if (!(lub instanceof WideningCategories.LowestUpperBoundClassNode)) {
+                return new GenericsType(lub);
+            }
+        }
         ClassNode cn1 = GenericsUtils.makeClassSafe0(CLASS_Type, gt1);
         ClassNode cn2 = GenericsUtils.makeClassSafe0(CLASS_Type, gt2);
         ClassNode lub = lowestUpperBound(cn1, cn2);

--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -5620,7 +5620,7 @@ trying: for (ClassNode[] signature : signatures) {
                         }
 
                         connections.forEach((gtn, gt) -> resolvedPlaceholders.merge(gtn, gt, (gt1, gt2) -> {
-                            // GROOVY-10339: incorporate another witness
+                            // GROOVY-10339, GROOVY-11616: incorporate another type witness
                             return getCombinedGenericsType(gt1, gt2);
                         }));
                     }

--- a/src/test/groovy/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/GenericsSTCTest.groovy
@@ -250,6 +250,19 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
             def list = Arrays.asList()
             assert list.size() == 0
         '''
+
+        // GROOVY-11616:
+        assertScript '''
+            class A {}
+            class B extends A {}
+            class C extends B {}
+            @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                def type = node.getNodeMetaData(INFERRED_TYPE)
+                assert type.toString(false) == 'java.util.List<A>'
+            })
+            def list = Arrays.asList(new A(), new B(), new C())
+            assert list.size() == 3
+        '''
     }
 
     // GROOVY-10062


### PR DESCRIPTION
In simple cases, types can be merged to common super type.