### PR TITLE
GROOVY-7439: allow logging transform on trait class

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
@@ -280,21 +280,24 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
         if (!ASTTransformation.class.isAssignableFrom(transformClass)) {
             String error = "Not an ASTTransformation: " + transformClass.getName() + " declared by " + annotation.getClassNode().getName();
             source.getErrorCollector().addError(new SimpleMessage(error, source));
+            return;
         }
 
         GroovyASTTransformation transformationClass = transformClass.getAnnotation(GroovyASTTransformation.class);
         if (transformationClass == null) {
             String error = "AST transformation implementation classes must be annotated with " + GroovyASTTransformation.class.getName() + ". " + transformClass.getName() + " lacks this annotation.";
             source.getErrorCollector().addError(new SimpleMessage(error, source));
+            return;
         }
 
         CompilePhase specifiedCompilePhase = transformationClass.phase();
         if (specifiedCompilePhase.getPhaseNumber() < CompilePhase.SEMANTIC_ANALYSIS.getPhaseNumber()) {
             String error = annotation.getClassNode().getName() + " is defined to be run in compile phase " + specifiedCompilePhase + ". Local AST transformations must run in SEMANTIC_ANALYSIS or later!";
             source.getErrorCollector().addError(new SimpleMessage(error, source));
+            return;
         }
 
-        if (!Traits.isTrait(classNode) || transformClass == TraitASTTransformation.class || transformClass == SealedASTTransformation.class) {
+        if (!Traits.isTrait(classNode) || transformClass == TraitASTTransformation.class || transformClass == SealedASTTransformation.class || transformClass == LogASTTransformation.class) {
             classNode.addTransform((Class<? extends ASTTransformation>) transformClass, annotation);
         }
     }

--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -113,7 +113,7 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
         // only descend if we have annotations to look for
         Map<Class<? extends ASTTransformation>, Set<ASTNode>> baseTransforms = classNode.getTransforms(phase);
         if (!baseTransforms.isEmpty()) {
-            final Map<Class<? extends ASTTransformation>, ASTTransformation> transformInstances = new HashMap<Class<? extends ASTTransformation>, ASTTransformation>();
+            final Map<Class<? extends ASTTransformation>, ASTTransformation> transformInstances = new HashMap<>();
             for (Class<? extends ASTTransformation> transformClass : baseTransforms.keySet()) {
                 try {
                     transformInstances.put(transformClass, transformClass.getDeclaredConstructor().newInstance());
@@ -121,13 +121,13 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
                     source.getErrorCollector().addError(
                             new SimpleMessage(
                                     "Could not instantiate Transformation Processor " + transformClass
-                                    , //+ " declared by " + annotation.getClassNode().getName(),
+                                    /*+ " declared by " + annotation.getClassNode().getName()*/,
                                     source));
                 }
             }
 
             // invert the map, is now one to many
-            transforms = new HashMap<ASTNode, List<ASTTransformation>>();
+            transforms = new HashMap<>();
             for (Map.Entry<Class<? extends ASTTransformation>, Set<ASTNode>> entry : baseTransforms.entrySet()) {
                 for (ASTNode node : entry.getValue()) {
                     List<ASTTransformation> list = transforms.computeIfAbsent(node, k -> new ArrayList<>());
@@ -136,7 +136,7 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
                 }
             }
 
-            targetNodes = new LinkedList<ASTNode[]>();
+            targetNodes = new LinkedList<>();
 
             // first pass, collect nodes
             super.visitClass(classNode);
@@ -395,15 +395,15 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
     private static class PriorityComparator implements Comparator<Tuple2<ASTTransformation, ASTNode[]>> {
         @Override
         public int compare(Tuple2<ASTTransformation, ASTNode[]> o1, Tuple2<ASTTransformation, ASTNode[]> o2) {
-            Integer i1 = 0;
-            Integer i2 = 0;
+            int i1 = 0;
+            int i2 = 0;
             if (o1.getV1() instanceof TransformWithPriority) {
                 i1 = ((TransformWithPriority) o1.getV1()).priority();
             }
             if (o2.getV1() instanceof TransformWithPriority) {
                 i2 = ((TransformWithPriority) o2.getV1()).priority();
             }
-            return i2.compareTo(i1);
+            return Integer.compare(i2, i1);
         }
     }
 }

--- a/src/main/java/org/codehaus/groovy/transform/BuilderASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/BuilderASTTransformation.java
@@ -56,14 +56,24 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.param;
 @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
 public class BuilderASTTransformation extends AbstractASTTransformation implements CompilationUnitAware, TransformWithPriority {
 
-    private static final Class MY_CLASS = Builder.class;
+    private static final Class<?> MY_CLASS = Builder.class;
     private static final ClassNode MY_TYPE = make(MY_CLASS);
     public static final String MY_TYPE_NAME = "@" + MY_TYPE.getNameWithoutPackage();
     private static final ClassNode RECORD_TYPE = make(RecordBase.class, false);
     public static final ClassNode[] NO_EXCEPTIONS = ClassNode.EMPTY_ARRAY;
     public static final Parameter[] NO_PARAMS = Parameter.EMPTY_ARRAY;
 
+    @Override
+    public int priority() {
+        return -5;
+    }
+
     private CompilationUnit compilationUnit;
+
+    @Override
+    public void setCompilationUnit(final CompilationUnit unit) {
+        this.compilationUnit = unit;
+    }
 
     @Override
     public void visit(ASTNode[] nodes, SourceUnit source) {
@@ -99,11 +109,6 @@ public class BuilderASTTransformation extends AbstractASTTransformation implemen
             if (strategy == null) return;
             strategy.build(this, parent, anno);
         }
-    }
-
-    @Override
-    public int priority() {
-        return -5;
     }
 
     public interface BuilderStrategy {
@@ -294,10 +299,5 @@ public class BuilderASTTransformation extends AbstractASTTransformation implemen
             addError("Can't load builderStrategy '" + className + "' " + e, anno);
             return null;
         }
-    }
-
-    @Override
-    public void setCompilationUnit(final CompilationUnit unit) {
-        this.compilationUnit = unit;
     }
 }

--- a/src/main/java/org/codehaus/groovy/transform/ExternalizeVerifierASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/ExternalizeVerifierASTTransformation.java
@@ -39,9 +39,10 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.getInstancePropertyFiel
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_TRANSIENT;
 
-@org.codehaus.groovy.transform.GroovyASTTransformation(phase = CompilePhase.CLASS_GENERATION)
-public class ExternalizeVerifierASTTransformation extends org.codehaus.groovy.transform.AbstractASTTransformation {
-    static final Class MY_CLASS = ExternalizeVerifier.class;
+@GroovyASTTransformation(phase = CompilePhase.CLASS_GENERATION)
+public class ExternalizeVerifierASTTransformation extends AbstractASTTransformation {
+
+    static final Class<?> MY_CLASS = ExternalizeVerifier.class;
     static final ClassNode MY_TYPE = make(MY_CLASS);
     static final String MY_TYPE_NAME = "@" + MY_TYPE.getNameWithoutPackage();
     private static final ClassNode EXTERNALIZABLE_TYPE = make(Externalizable.class);

--- a/src/main/java/org/codehaus/groovy/transform/LogASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/LogASTTransformation.java
@@ -56,7 +56,7 @@ import static org.objectweb.asm.Opcodes.ACC_TRANSIENT;
  * This class provides an AST Transformation to add a log field to a class.
  */
 @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
-public class LogASTTransformation extends AbstractASTTransformation implements CompilationUnitAware {
+public class LogASTTransformation extends AbstractASTTransformation implements CompilationUnitAware, TransformWithPriority {
 
     /**
      * This is just a dummy value used because String annotations values can not be null.
@@ -65,6 +65,11 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
     public static final String DEFAULT_CATEGORY_NAME = "##default-category-name##";
 
     public static final String DEFAULT_ACCESS_MODIFIER = "private";
+
+    @Override
+    public int priority() {
+        return 1; // GROOVY-7439
+    }
 
     private CompilationUnit compilationUnit;
 

--- a/src/main/java/org/codehaus/groovy/transform/SortableASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/SortableASTTransformation.java
@@ -84,8 +84,8 @@ import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
  * Injects a set of Comparators and sort methods.
  */
 @GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
-
 public class SortableASTTransformation extends AbstractASTTransformation {
+
     private static final ClassNode MY_TYPE = make(Sortable.class);
     private static final String MY_TYPE_NAME = "@" + MY_TYPE.getNameWithoutPackage();
     private static final ClassNode COMPARABLE_TYPE = makeClassSafe(Comparable.class);

--- a/src/main/java/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
@@ -375,13 +375,13 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
 
     /**
      * Copies annotations from the trait to the helper, excluding non-applicable
-     * items such as {@link Trait @Trait} and {@link Sealed @Sealed}.
+     * items such as {@link Trait @Trait}, {@link Sealed @Sealed} and logging transforms.
      */
     private static void copyClassAnnotations(final ClassNode helper) {
         for (AnnotationNode annotation : helper.getOuterClass().getAnnotations()) {
             ClassNode annotationType = annotation.getClassNode();
-            if (!annotationType.equals(Traits.TRAIT_CLASSNODE)
-                    && !annotationType.equals(SEALED_TYPE)) {
+            if (!annotationType.equals(Traits.TRAIT_CLASSNODE) && !annotationType.equals(SEALED_TYPE)
+                    && !annotationType.getName().startsWith("groovy.util.logging.")) { // GROOVY-7439
                 helper.addAnnotation(annotation);
             }
         }

--- a/src/test/groovy/groovy/util/logging/Slf4jTest.groovy
+++ b/src/test/groovy/groovy/util/logging/Slf4jTest.groovy
@@ -24,7 +24,6 @@ import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.spi.LoggingEvent
 import ch.qos.logback.core.OutputStreamAppender
 import ch.qos.logback.core.layout.EchoLayout
-import groovy.test.NotYetImplemented
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -374,7 +373,6 @@ final class Slf4jTest {
     }
 
     // GROOVY-7439
-    @NotYetImplemented
     @ParameterizedTest
     @ValueSource(strings=[
         'log', // Cannot find matching method Object#debug(String)


### PR DESCRIPTION
Let `@Log`, etc. apply to trait class and run before trait transform.