### PR TITLE
GROOVY-11627: SC: disable mixed public and private overloads checking

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -74,6 +74,7 @@ import static org.codehaus.groovy.ast.tools.GenericsUtils.addMethodGenerics;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.buildWildcardType;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.correctToGenericsSpecRecurse;
 import static org.codehaus.groovy.ast.tools.GenericsUtils.createGenericsSpec;
+import static org.codehaus.groovy.transform.sc.StaticCompilationVisitor.isStaticallyCompiled;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
@@ -538,8 +539,8 @@ out:        for (ClassNode sc : superTypes) {
             checkOverloadingPrivateAndPublic(node);
         }
         checkMethodForIncorrectModifiers(node);
-        checkGenericsUsage(node, node.getParameters());
         checkGenericsUsage(node, node.getReturnType());
+        checkGenericsUsage(node, node.getParameters());
         for (Parameter param : node.getParameters()) {
             if (ClassHelper.isPrimitiveVoid(param.getType())) {
                 addError("The " + getDescription(param) + " in " +  getDescription(node) + " has invalid type void", param);
@@ -588,6 +589,7 @@ out:        for (ClassNode sc : superTypes) {
     }
 
     private void checkOverloadingPrivateAndPublic(final MethodNode node) {
+        if (isStaticallyCompiled(currentClass)) return; // GROOVY-11627
         boolean mixed = false;
         if (node.isPublic()) {
             for (MethodNode mn : currentClass.getDeclaredMethods(node.getName())) {

--- a/src/test/groovy/bugs/Groovy5193.groovy
+++ b/src/test/groovy/bugs/Groovy5193.groovy
@@ -21,6 +21,7 @@ package bugs
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import org.junit.jupiter.api.Test
 
+import static groovy.test.GroovyAssert.assertScript
 import static groovy.test.GroovyAssert.shouldFail
 
 final class Groovy5193 {
@@ -53,5 +54,30 @@ final class Groovy5193 {
             }
         '''
         assert err.message.contains('Mixing private and public/protected methods of the same name causes multimethods to be disabled')
+    }
+
+    @Test
+    void testMixingMethodsWithPrivatePublicAccessInSameClass3() {
+        assertScript '''
+            class A {
+                def f(x) { g(x) }
+                def g(x) {"object case"}
+            }
+            class B extends A {
+                private g(String x) {"string case"}
+            }
+
+            def a = new A()
+            assert a.f(null) == "object case"
+            assert a.g(null) == "object case"
+            assert a.f("xx") == "object case"
+            assert a.g("xx") == "object case"
+
+            def b = new B()
+            assert b.f(null) == "object case"
+            assert b.g(null) == "object case"
+            assert b.f("xx") == "object case"
+            assert b.g("xx") == "string case"
+        '''
     }
 }

--- a/src/test/groovy/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
@@ -1810,21 +1810,24 @@ final class TraitASTTransformationTest {
         """
     }
 
-    // GROOVY-5193
+    // GROOVY-5193, GROOVY-11627
     @Test
     void testMixPrivatePublicMethodsOfSameName() {
-        def err = shouldFail shell, '''
+        assertScript shell, '''
+            @CompileStatic
             trait T {
-                private String secret(String s) { s.toUpperCase() }
-                String secret() { 'public' }
-                String foo() { secret('secret') }
+                private String f(String s) { s.toUpperCase() }
+                public  String f(Object o) { 'default value' }
+                public  String f(        ) { 'unknown value' }
+                def m() {
+                    f('secret')
+                }
             }
             class C implements T {
             }
 
-            assert new C().foo() == 'SECRET'
+            assert new C().m() == 'SECRET'
         '''
-        assert err =~ 'Mixing private and public/protected methods of the same name causes multimethods to be disabled'
     }
 
     @Test


### PR DESCRIPTION
I kept tests for the error and changed the trait test to work.  It looked like the better example of a supported scenario.