### PR TITLE
GROOVY-11664: STC: combine generics of same-type witnesses

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingSupport.java
@@ -1537,6 +1537,14 @@ public abstract class StaticTypeCheckingSupport {
                 }
                 return true; // incompatible
             }
+            if (!fixedPlaceHolders.contains(entry.getKey())
+                    && !resolved.isPlaceholder() && !resolved.isWildcard()
+                    && !candidate.isPlaceholder() && !candidate.isWildcard()) {
+                // resolved "T=Object" and candidate "T=Object" or "T=String"; or
+                // GROOVY-11664: resolved "T=Class<A>" and candidate "T=Class<B>"
+                ClassNode oldT = resolved.getType(), newT = candidate.getType();
+                resolvedMethodGenerics.put(entry.getKey(), new GenericsType(lowestUpperBound(oldT, newT)));
+            }
         }
 
         connections.keySet().removeAll(fixedPlaceHolders); // GROOVY-10337

--- a/src/test/groovy/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/GenericsSTCTest.groovy
@@ -263,6 +263,19 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
             def list = Arrays.asList(new A(), new B(), new C())
             assert list.size() == 3
         '''
+
+        // GROOVY-11664:
+        assertScript '''
+            class A {}
+            class B extends A {}
+            class C extends B {}
+            @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                def type = node.getNodeMetaData(INFERRED_TYPE)
+                assert type.toString(false) == 'java.util.List<java.lang.Class<? extends A>>'
+            })
+            def list = Arrays.asList(A.class, B.class, C.class)
+            assert list.size() == 3
+        '''
     }
 
     // GROOVY-10062


### PR DESCRIPTION
Merging of type witness data -- see GROOVY-5692 and GROOVY-10006 -- was not applied to equal/compatible type case.