### PR TITLE
misc: minor documentation edits

### DIFF
--- a/src/spec/doc/_type-checking-extensions.adoc
+++ b/src/spec/doc/_type-checking-extensions.adoc
@@ -1062,14 +1062,14 @@ type of the dynamic call is a `Robot`, subsequent calls will be done statically!
 
 Some would wonder why the static compiler doesn't do this by default without an extension. It is a design decision:
 
-* if the code is statically compiled, we normally want type safety and best performance
-* so if unrecognized variables/method calls are made dynamic, you loose type safety, but also all support for typos at
-compile time!
+* if the code is statically compiled, we normally want type safety and the best performance
+* if unrecognized variables/method calls are made dynamic, you lose type safety, but also all support for catching typos
+at compile time!
 
 In short, if you want to have mixed mode compilation, it *has* to be explicit, through a type checking extension, so
 that the compiler, and the designer of the DSL, are totally aware of what they are doing.
 
-`makeDynamic` can be used on 3 kind of AST nodes:
+`makeDynamic` can be used on 3 kinds of AST nodes:
 
 * a method node (`MethodNode`)
 * a variable (`VariableExpression`)


### PR DESCRIPTION
Was reading through [the guide on Type Checking Extensions](https://docs.groovy-lang.org/docs/latest/html/documentation/#_type_checking_extensions) today and my picky brain tripped over what seemed like a few typos. Figured I'd put up a small PR to fix them while I was here.

There is one spot where I've inferred a meaning that may be incorrect. I rewrote

> but also all support for typos at compile time!

to be

> but also all support for catching typos at compile time!

I think that's right, but am sophomoric at best when it comes to understanding type checking extensions. Just @me if that's wrong and I'll put it back.