### PR TITLE
GROOVY-11694: SC: implicit-this call to static method of super class

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/sc/transformers/StaticMethodCallExpressionTransformer.java
+++ b/src/main/java/org/codehaus/groovy/transform/sc/transformers/StaticMethodCallExpressionTransformer.java
@@ -35,10 +35,15 @@ class StaticMethodCallExpressionTransformer {
     }
 
     Expression transformStaticMethodCallExpression(final StaticMethodCallExpression smce) {
-        Object target = smce.getNodeMetaData(DIRECT_METHOD_CALL_TARGET);
+        var target = smce.getNodeMetaData(DIRECT_METHOD_CALL_TARGET);
         if (target instanceof MethodNode) {
-            ClassExpression receiver = new ClassExpression(smce.getOwnerType().getPlainNodeReference());
-            MethodCallExpression mce = new MethodCallExpression(receiver, smce.getMethod(), smce.getArguments());
+            var receiver = new ClassExpression(smce.getOwnerType().getPlainNodeReference());
+            receiver.setLineNumber(smce.getLineNumber());
+            receiver.setColumnNumber(smce.getColumnNumber());
+            receiver.setLastLineNumber(receiver.getLineNumber());
+            receiver.setLastColumnNumber(receiver.getColumnNumber());
+
+            var mce = new MethodCallExpression(receiver, smce.getMethod(), smce.getArguments());
             mce.setMethodTarget((MethodNode) target);
             mce.setSourcePosition(smce);
             mce.copyNodeMetaData(smce);

--- a/src/test/groovy/groovy/transform/stc/MethodCallsSTCTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/MethodCallsSTCTest.groovy
@@ -104,6 +104,14 @@ class MethodCallsSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    void testStaticMethodCallThroughInstance() {
+        assertScript '''
+            A a = new A()
+            String echo = a.echo 'echo'
+            assert echo == 'echo'
+        '''
+    }
+
     void testStaticMethodCallWithInheritance() {
         assertScript '''
             String echo = B.echo 'echo'
@@ -111,11 +119,13 @@ class MethodCallsSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
-    void testStaticMethodCallThroughInstance() {
+    // GROOVY-11694
+    void testStaticMethodCallWithInheritance2() {
         assertScript '''
-            A a = new A()
-            String echo = a.echo 'echo'
-            assert echo == 'echo'
+            class D extends C {
+                def m() { protect() }
+            }
+            assert new D().m() != null
         '''
     }
 
@@ -2067,7 +2077,9 @@ class MethodCallsSTCTest extends StaticTypeCheckingTestCase {
         T[] identity(T... args) { args }
     }
 
-    static class MyMethodCallTestClass3 extends MyMethodCallTestClass2<String> {}
+    static class MyMethodCallTestClass3 extends MyMethodCallTestClass2<String> {
+        protected static String protect() { '' }
+    }
 
     static class GroovyPage {
         final void printHtmlPart(int partNumber) {}


### PR DESCRIPTION
`StaticMethodCallExpressionTransformer` creates "Type.staticMethod(arguments)" and later `StaticInvocationWriter` gets type of receiver expression as `Class<Type>`.  Use `Type` for access checks.