### PR TITLE
GROOVY-11683: STC: transfer generics to extension method return types

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -2675,7 +2675,7 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
 
             if (!candidates.isEmpty()) {
                 ClassNode[] arguments = expression.getNodeMetaData(CLOSURE_ARGUMENTS);
-                if (asBoolean(arguments) && asBoolean(receiverType.redirect().getGenericsTypes())
+                if (asBoolean(arguments) && missesGenericsTypes(receiverType) // GROOVY-10984
                                          && expression.getExpression() instanceof ClassExpression) {
                     receiverType = GenericsUtils.parameterizeType(arguments[0], receiverType); // GROOVY-11241
                 }
@@ -2685,7 +2685,8 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
                         .peek(candidate -> checkOrMarkPrivateAccess(expression, candidate)) // GROOVY-11365
                         .map (candidate -> {
                             ClassNode returnType = candidate.getReturnType();
-                            if (!candidate.isStatic() && GenericsUtils.hasUnresolvedGenerics(returnType)) {
+                            if (!isStaticInContext(candidate) // GROOVY-11683
+                                    && GenericsUtils.hasUnresolvedGenerics(returnType)) {
                                 Map<GenericsTypeName, GenericsType> spec = new HashMap<>(); // GROOVY-11364
                                 extractGenericsConnections(spec, ownerType, candidate.getDeclaringClass());
                                 returnType = applyGenericsContext(spec, returnType);

--- a/src/test/groovy/groovy/transform/stc/MethodReferenceTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/MethodReferenceTest.groovy
@@ -1330,6 +1330,37 @@ final class MethodReferenceTest {
         '''
     }
 
+    // GROOVY-11683
+    @Test // class::instanceGroovyMethod
+    void testFunctionCI_DGM2() {
+        String head = '''\
+            import static org.codehaus.groovy.control.CompilePhase.*
+            import static org.codehaus.groovy.transform.stc.StaticTypesMarker.*
+
+            @CompileStatic
+            void test(Iterable<String> iterable) {
+                @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                    Object type = node.getNodeMetaData(INFERRED_TYPE)
+                    assert type.toString(false) == 'java.util.Optional<java.util.Collection<java.lang.String>>'
+                })
+        '''
+        String tail = '''\
+            }
+
+            test()
+        '''
+
+        assertScript shell, head + '''
+            def optional = Optional.ofNullable(iterable).map(Iterable::asCollection)
+            assert optional.isEmpty()
+        ''' + tail
+
+        assertScript shell, head + '''
+            def optional = Optional.empty().map(Iterable<String>::asCollection)
+            assert optional.isEmpty()
+        ''' + tail
+    }
+
     @Test // class::staticGroovyMethod
     void testFunctionCS_DGSM() {
         assertScript shell, '''


### PR DESCRIPTION
```groovy
@TypeChecked test() {
    def optional = Optional.empty().map(Iterable<String>::asCollection)
    //  ^^^^^^^^ Optional<Collection<String>>
}
```

https://github.com/apache/groovy/blob/55f31a3aec6cdab1f80aa76d27af08e2c621876d/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java#L922

see also GROOVY-10984