### PR TITLE
GROOVY-11644: check for `namedVariant` constructor duplication

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/RecordTypeASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/RecordTypeASTTransformation.java
@@ -39,6 +39,7 @@ import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.RecordComponentNode;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.ClassExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MapEntryExpression;
 import org.codehaus.groovy.ast.expr.PropertyExpression;
@@ -283,6 +284,10 @@ public class RecordTypeASTTransformation extends AbstractASTTransformation imple
 
         if (hasAnnotation(cNode, TupleConstructorASTTransformation.MY_TYPE)) {
             AnnotationNode tupleConstructor = cNode.getAnnotations(TupleConstructorASTTransformation.MY_TYPE).get(0);
+            if (pList.size() == 1 && pList.get(0).getType().equals(MAP_TYPE)
+                    && memberHasValue(tupleConstructor, "namedVariant", Boolean.TRUE)) {
+                tupleConstructor.setMember("namedVariant", ConstantExpression.PRIM_FALSE); // GROOVY-11644: conflicts
+            }
             if (unsupportedTupleAttribute(tupleConstructor, "excludes")) return;
             if (unsupportedTupleAttribute(tupleConstructor, "includes")) return;
             if (unsupportedTupleAttribute(tupleConstructor, "includeProperties")) return;

--- a/src/main/java/org/codehaus/groovy/transform/TupleConstructorASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/TupleConstructorASTTransformation.java
@@ -208,8 +208,7 @@ public class TupleConstructorASTTransformation extends AbstractASTTransformation
         if (pre != null) {
             superInPre = copyStatementsWithSuperAdjustment(pre, preBody);
             if (superInPre && callSuper) {
-                xform.addError("Error during " + MY_TYPE_NAME + " processing, can't have a super call in 'pre' " +
-                        "closure and also 'callSuper' enabled", cNode);
+                xform.addError("Error during " + MY_TYPE_NAME + " processing, can't have a super call in 'pre' closure and also 'callSuper' enabled", cNode);
             }
         }
 
@@ -268,7 +267,7 @@ public class TupleConstructorASTTransformation extends AbstractASTTransformation
         }
 
         int modifiers = getVisibility(anno, cNode, ConstructorNode.class, ACC_PUBLIC);
-        Parameter[] signature = params.toArray(Parameter.EMPTY_ARRAY);
+        Parameter[] signature = params.toArray(Parameter[]::new);
         if (cNode.getDeclaredConstructor(signature) != null) {
             if (sourceUnit != null) {
                 String warning = String.format(
@@ -287,15 +286,13 @@ public class TupleConstructorASTTransformation extends AbstractASTTransformation
             if (namedVariant) {
                 BlockStatement inner = new BlockStatement();
                 Parameter mapParam = param(ClassHelper.MAP_TYPE.getPlainNodeReference(), NAMED_ARGS);
-                List<Parameter> genParams = new ArrayList<>();
-                genParams.add(mapParam);
                 ArgumentListExpression args = new ArgumentListExpression();
                 List<String> propNames = new ArrayList<>();
                 Map<Parameter, Expression> seen = new HashMap<>();
                 for (Parameter p : params) {
                     if (!processImplicitNamedParam(xform, tupleCtor, mapParam, inner, args, propNames, p, false, seen)) return;
                 }
-                NamedVariantASTTransformation.createMapVariant(xform, tupleCtor, anno, mapParam, genParams, cNode, inner, args, propNames);
+                NamedVariantASTTransformation.createMapVariant(xform, tupleCtor, anno, mapParam, List.of(mapParam), cNode, inner, args, propNames);
             }
 
             if (sourceUnit != null && !body.isEmpty()) {

--- a/src/test/groovy/org/codehaus/groovy/classgen/RecordTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/classgen/RecordTest.groovy
@@ -591,6 +591,28 @@ final class RecordTest {
                 new Person(name:'John Doe')
             }
         '''
+
+        // GROOVY-11644
+        assertScript shell, '''
+            record Person(@NamedParam(value='name', required=true) Map map) {
+                Person {
+                    assert map.name instanceof String
+                        && map.name.trim().size() > 1
+                }
+                String getName() {
+                    return map.get('name')
+                }
+            }
+
+            def person = new Person(name:'Frank Grimes', hair:'brown')
+            assert person.name == 'Frank Grimes'
+            shouldFail {
+                new Person([:])
+            }
+            shouldFail {
+                new Person()
+            }
+        '''
     }
 
     @Test


### PR DESCRIPTION
`@RecordType` should not set `namedVariant=true` when only record component is a `Map`.