### PR TITLE
Sort element value pairs in `AstBuilder` for reproducibility

### DIFF
--- a/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -139,6 +139,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -4231,6 +4232,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     public Map<String, Expression> visitElementValuePairs(final ElementValuePairsContext ctx) {
         return ctx.elementValuePair().stream()
                 .map(this::visitElementValuePair)
+                .sorted(Comparator.comparing(Tuple2::getV1)) // GROOVY-11715, sort for reproducible builds
                 .collect(Collectors.toMap(
                         Tuple2::getV1,
                         Tuple2::getV2,

--- a/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -127,12 +127,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 
 import static org.apache.groovy.ast.tools.ClassNodeUtils.getField;
@@ -2222,11 +2222,10 @@ public class AsmClassGenerator extends ClassGenerator {
      * @param av the visitor to use
      */
     public void visitAnnotationAttributes(final AnnotationNode an, final AnnotationVisitor av) {
-        // GROOVY-11715 TODO If we can determine what was causing the issues mentioned on that ticket, we should change these back to LinkedHashMap
-        Map<String, Object> constantAttrs = new TreeMap<>();
-        Map<String, PropertyExpression> enumAttrs = new TreeMap<>();
-        Map<String, Object> atAttrs = new TreeMap<>();
-        Map<String, ListExpression> arrayAttrs = new TreeMap<>();
+        Map<String, Object> constantAttrs = new LinkedHashMap<>();
+        Map<String, PropertyExpression> enumAttrs = new LinkedHashMap<>();
+        Map<String, Object> atAttrs = new LinkedHashMap<>();
+        Map<String, ListExpression> arrayAttrs = new LinkedHashMap<>();
 
         for (Map.Entry<String, Expression> member : an.getMembers().entrySet()) {
             String name = member.getKey();


### PR DESCRIPTION
Sort element value pairs by key before collecting them into a `LinkedHashMap` to ensure consistent iteration order across builds.

This change addresses GROOVY-11715 without requiring `TreeMap` usage downstream, contributing to more reproducible build outputs.

I'm not sure if this is better than #2267, but perhaps it moves the solution one step closer to the source of the problem.