### PR TITLE
GROOVY-11719 - Fix generics handling error

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/java/org/codehaus/groovy/control/ResolveVisitor.java
@@ -1279,7 +1279,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
             if (!Modifier.isStatic(node.getModifiers()))
                 genericParameterNames.putAll(outerNames); // outer names visible
         } else {
-            genericParameterNames.clear(); // outer class: new generic namespace
+            genericParameterNames = new HashMap<>(); // outer class: new generic namespace
         }
         resolveGenericsHeader(node.getGenericsTypes());
         switch (phase) { // GROOVY-9866, GROOVY-10466


### PR DESCRIPTION
It looks like a subtle compilation bug was introduced in 33064484cc043bfb7c2ad75ee8fccbcbc6329b76.

Under the hood, the root cause seemed to be this:

Caused by: java.lang.UnsupportedOperationException
	at java.base/java.util.AbstractMap.put(AbstractMap.java:209)
	at org.codehaus.groovy.control.ResolveVisitor.resolveGenericsHeader(ResolveVisitor.java:1452)
	at org.codehaus.groovy.control.ResolveVisitor.resolveGenericsHeader(ResolveVisitor.java:1409)

Based on a look in the debugger, without the change in this PR, the genericParameterNames field will be a Collections$EmptyMap, which is immutable and therefore doesn't support PUT operations, leading to the above exception.

This is the same issue I raised on the [release thread for 4.0.28](https://lists.apache.org/thread/3srdsx4q3ktmxq5rb3t6jhon7qdfvcwb).