### PR TITLE
GROOVY-11736: propagate missing type arguments to super interface(s)

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/java/org/codehaus/groovy/classgen/Verifier.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
 import static java.lang.reflect.Modifier.isFinal;
@@ -402,6 +403,18 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                                 if (t.equals(in)) {
                                     String one = in.toString(false), two = t.toString(false);
                                     if (!one.equals(two)) {
+                                        IntFunction<String> via = (n) -> {
+                                            ClassNode from;
+                                            if (n < nInterfaces) {
+                                                from = interfaces[n];
+                                                if (from.equals(in)) from = cn;
+                                            } else {
+                                                from = cn.getUnresolvedSuperClass();
+                                            }
+                                            return " (via " + from.getNameWithoutPackage() + ")";
+                                        };
+                                        one += via.apply(i);
+                                        two += via.apply(j);
                                         if (Traits.isTrait(in)) { // GROOVY-11508
                                             cn.getModule().getContext().addWarning("The trait " + in.getNameWithoutPackage() +
                                                 " is implemented more than once with different arguments: " + one + " and " + two, cn);

--- a/src/test/groovy/bugs/Groovy7722.groovy
+++ b/src/test/groovy/bugs/Groovy7722.groovy
@@ -19,7 +19,7 @@
 package bugs
 
 import groovy.transform.CompileStatic
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import static groovy.test.GroovyAssert.assertScript
 
@@ -46,7 +46,8 @@ final class Groovy7722 {
         '''
     }
 
-    @Test // GROOVY-7864
+    // GROOVY-7864
+    @Test
     void testGenericsStackOverflow2() {
         assertScript '''
             // from RxJava 1.x
@@ -54,12 +55,12 @@ final class Groovy7722 {
                 interface OnSubscribe<T> extends Action1<Subscriber<? super T>> {
                 }
                 static <T> Observable<T> create(OnSubscribe<T> f) {
-                    return new Observable<T>(/*RxJavaHooks.onCreate(f)*/);
+                    new Observable<T>(/*RxJavaHooks.onCreate(f)*/)
                 }
             }
             abstract class Subscriber<T> implements Observer<T>, Subscription {
             }
-            interface Action1<T> /*extends Action*/ {
+            interface Action1<T> {
                 void call(T t)
             }
             interface Observer<T> {
@@ -67,7 +68,7 @@ final class Groovy7722 {
                 void onCompleted()
                 void onError(Throwable t)
             }
-            public interface Subscription {
+            interface Subscription {
                 void unsubscribe()
                 boolean isUnsubscribed()
             }

--- a/src/test/groovy/groovy/InterfaceTest.groovy
+++ b/src/test/groovy/groovy/InterfaceTest.groovy
@@ -44,7 +44,7 @@ final class InterfaceTest extends CompilableTestSupport {
             interface J<T> extends I<T> {}
             class X implements I<String>, J<Number> {}
         '''
-        assert err.contains('The interface I cannot be implemented more than once with different arguments: I<java.lang.String> and I<java.lang.Number>')
+        assert err.contains('The interface I cannot be implemented more than once with different arguments: I<java.lang.String> (via X) and I<java.lang.Number> (via J)')
     }
 
     // GROOVY-5106
@@ -54,7 +54,7 @@ final class InterfaceTest extends CompilableTestSupport {
             class X implements I<Number> {}
             class Y extends X implements I<String> {}
         '''
-        assert err.contains('The interface I cannot be implemented more than once with different arguments: I<java.lang.String> and I<java.lang.Number>')
+        assert err.contains('The interface I cannot be implemented more than once with different arguments: I<java.lang.String> (via Y) and I<java.lang.Number> (via X)')
     }
 
     // GROOVY-11707
@@ -65,6 +65,17 @@ final class InterfaceTest extends CompilableTestSupport {
             abstract class B extends A implements Comparable {
             }
         '''
+    }
+
+    // GROOVY-11736
+    void testReImplementsInterface4() {
+        def err = shouldFail '''
+            abstract class A implements Comparable<Object> {
+            }
+            abstract class B extends A implements Comparable {
+            }
+        '''
+        assert err.contains('The interface Comparable cannot be implemented more than once with different arguments: java.lang.Comparable (via B) and java.lang.Comparable<java.lang.Object> (via A)')
     }
 
     // GROOVY-10060

--- a/src/test/groovy/org/codehaus/groovy/transform/DelegateTransformTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/transform/DelegateTransformTest.groovy
@@ -21,7 +21,7 @@ package org.codehaus.groovy.transform
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 import org.codehaus.groovy.tools.javac.JavaAwareCompilationUnit
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.util.concurrent.Callable
 import java.util.concurrent.locks.Lock
@@ -37,7 +37,8 @@ import static org.junit.Assert.assertTrue
  */
 final class DelegateTransformTest {
 
-    @Test // GROOVY-3380
+    // GROOVY-3380
+    @Test
     void testDelegateImplementingNonPublicInterface() {
         assertScript '''
             import org.codehaus.groovy.transform.ClassImplementingANonPublicInterface
@@ -51,7 +52,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-3380
+    // GROOVY-3380
+    @Test
     void testDelegateImplementingNonPublicInterfaceWithZipFileConcreteCase() {
         assertScript '''
             import java.util.zip.*
@@ -64,7 +66,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-10439
+    // GROOVY-10439
+    @Test
     void testDelegateImplementingInterfaceWithDifferentTypeArgumentThanOwner() {
         def err = shouldFail '''
             class C extends ArrayList<String> {
@@ -79,10 +82,11 @@ final class DelegateTransformTest {
                 @Delegate HashSet<Number> numbers // Set<Number> added; Verifier checks
             }
         '''
-        assert err =~ /The interface Collection cannot be implemented more than once with different arguments: java.util.Collection<java.lang.Number> and java.util.Collection<java.lang.String>/
+        assert err =~ /The interface Collection cannot be implemented more than once with different arguments: java.util.Collection<java.lang.Number> \(via Set\) and java.util.Collection<java.lang.String> \(via ArrayList\)/
     }
 
-    @Test // GROOVY-5974
+    // GROOVY-5974
+    @Test
     void testDelegateExcludes() {
         assertScript '''
             class MapSet {
@@ -198,7 +202,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-3471
+    // GROOVY-3471
+    @Test
     void testDelegateOnAMapTypeFieldWithInitializationUsingConstructorProperties() {
         assertScript '''
             class Test3471 { @Delegate Map mp }
@@ -207,13 +212,15 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-3323
+    // GROOVY-3323
+    @Test
     void testDelegateTransformCorrectlyDelegatesMethodsFromSuperInterfaces() {
         assert new DelegateBarImpl(new DelegateFooImpl()).bar() == 'bar impl'
         assert new DelegateBarImpl(new DelegateFooImpl()).foo() == 'foo impl'
     }
 
-    @Test // GROOVY-3555
+    // GROOVY-3555
+    @Test
     void testDelegateTransformIgnoresDeprecatedMethodsByDefault() {
         def b1 = new DelegateBarForcingDeprecated(baz: new BazWithDeprecatedFoo())
         def b2 = new DelegateBarWithoutDeprecated(baz: new BazWithDeprecatedFoo())
@@ -225,7 +232,8 @@ final class DelegateTransformTest {
         }
     }
 
-    @Test // GROOVY-4163
+    // GROOVY-4163
+    @Test
     void testDelegateTransformAllowsInterfacesAndDelegation() {
         assertScript '''
             class Temp implements Runnable {
@@ -258,7 +266,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-4265
+    // GROOVY-4265
+    @Test
     void testShouldPreferDelegatedOverStaticSuperMethod() {
         assertScript '''
             class A {
@@ -274,7 +283,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-4244
+    // GROOVY-4244
+    @Test
     void testSetPropertiesThroughDelegate() {
         def foo = new Foo4244()
 
@@ -288,12 +298,14 @@ final class DelegateTransformTest {
         }
     }
 
+    // GROOVY-4619
     @Test
-    void testDelegateSuperInterfaces_Groovy4619() {
+    void testDelegateSuperInterfaces() {
         assert 'doSomething' in SomeClass4619.class.methods*.name
     }
 
-    @Test // GROOVY-5112
+    // GROOVY-5112
+    @Test
     void testGenericsOnArray() {
         assertScript '''
             class ListWrapper {
@@ -307,7 +319,41 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-5732
+    // GROOVY-11736
+    @Test
+    void testRawTypeInterfaces() {
+        assertScript '''
+            class C implements Collection {
+                @Delegate Collection collection
+                C(Collection collection) {
+                    this.collection = collection
+                }
+            }
+
+            class D extends C implements Set {
+                @Delegate Set set
+                D(Set set) {
+                    super(set)
+                    this.set = set
+                }
+            }
+
+            def c = new C(new HashSet<>())
+            assert c instanceof Collection
+            assert c !instanceof Set
+            assert c.isEmpty()
+
+            def d = new D(new HashSet<>())
+            assert d instanceof Collection
+            assert d.collection.isEmpty()
+            assert d instanceof Set
+            assert d.set.isEmpty()
+            assert d.isEmpty()
+        '''
+    }
+
+    // GROOVY-5732
+    @Test
     void testInterfacesFromSuperClasses() {
         assertScript '''
             interface I5732 {
@@ -328,7 +374,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-5729
+    // GROOVY-5729
+    @Test
     void testDeprecationWithInterfaces() {
         assertScript '''
             interface I5729 {
@@ -356,7 +403,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-5446
+    // GROOVY-5446
+    @Test
     void testDelegateWithParameterAnnotations() {
         assertScript '''
             import java.lang.annotation.*
@@ -503,7 +551,8 @@ final class DelegateTransformTest {
         assert err.message.contains('@Delegate does not support keeping Closure annotation members.')
     }
 
-    @Test // GROOVY-5445
+    // GROOVY-5445
+    @Test
     void testDelegateToSuperProperties() {
         assertScript '''
             class Foo {
@@ -523,7 +572,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-7243
+    // GROOVY-7243
+    @Test
     void testInclude() {
         assertScript '''
             class Book {
@@ -568,7 +618,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-6329
+    // GROOVY-6329
+    @Test
     void testIncludeAndExcludeByType() {
         assertScript '''
             interface OddInclusionsTU<T, U> {
@@ -609,7 +660,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-5211
+    // GROOVY-5211
+    @Test
     void testAvoidFieldNameClashWithParameterName() {
         assertScript '''
             class A {
@@ -638,7 +690,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-6542
+    // GROOVY-6542
+    @Test
     void testLineNumberInStackTrace() {
         def err = shouldFail '''\
             @groovy.transform.ASTTest(phase=CANONICALIZATION, value={
@@ -692,7 +745,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-7118
+    // GROOVY-7118
+    @Test
     void testDelegateOfMethodHavingPlaceholder() {
         assertScript '''
             interface FooInt {
@@ -725,7 +779,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-7261
+    // GROOVY-7261
+    @Test
     void testShouldWorkWithLazyTransform() {
         assertScript '''
             class Foo {
@@ -741,7 +796,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-6454
+    // GROOVY-6454
+    @Test
     void testMethodsWithInternalNameShouldNotBeDelegatedTo() {
         assertScript '''
             class HasMethodWithInternalName {
@@ -758,7 +814,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-6454
+    // GROOVY-6454
+    @Test
     void testMethodsWithInternalNameShouldBeDelegatedToIfRequested() {
         assertScript '''
             interface HasMethodWithInternalName {
@@ -774,7 +831,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-6454
+    // GROOVY-6454
+    @Test
     void testProperitesWithInternalNameShouldBeDelegatedToIfRequested() {
         assertScript '''
             class HasPropertyWithInternalName {
@@ -794,15 +852,15 @@ final class DelegateTransformTest {
 
     @Test
     void testDelegateToGetterMethod() {
-        // given:
         def delegate = { new DelegateFooImpl() }
-        // when:
+
         def foo = new FooToMethod(delegate)
-        // then:
+
         assert foo.foo() == delegate().foo()
     }
 
-    @Test // GROOVY-5752
+    // GROOVY-5752
+    @Test
     void testDelegationShouldAccountForPrimitiveBooleanProperties() {
         assertScript '''
             class A {
@@ -831,7 +889,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test //GROOVY-8132
+    //GROOVY-8132
+    @Test
     void testOwnerPropertyPreferredToDelegateProperty() {
         assertScript '''
             class Foo {
@@ -863,7 +922,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-8204
+    // GROOVY-8204
+    @Test
     void testDelegateToArray() {
         assertScript '''
             class BugsMe {
@@ -877,7 +937,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-9289
+    // GROOVY-9289
+    @Test
     void testExcludesWithInvalidPropertyNameResultsInError() {
         def err = shouldFail '''
             class WMap {
@@ -897,7 +958,8 @@ final class DelegateTransformTest {
         assert err.message.contains("Error during @Delegate processing: 'excludes' property or method 'name' does not exist.")
     }
 
-    @Test // GROOVY-8825
+    // GROOVY-8825
+    @Test
     void testDelegateToPrecompiledGroovyGeneratedMethod() {
         assertScript '''
             import org.codehaus.groovy.transform.CompiledClass8825
@@ -909,7 +971,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-9414
+    // GROOVY-9414
+    @Test
     void testDelegateToPropertyViaGetter() {
         assertScript '''
             class Bar {
@@ -922,7 +985,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-4516
+    // GROOVY-4516
+    @Test
     void testParameterWithDefaultArgument1() {
         assertScript '''
             class C {
@@ -939,7 +1003,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-4516
+    // GROOVY-4516
+    @Test
     void testParameterWithDefaultArgument2() {
         assertScript '''
             class C {
@@ -978,7 +1043,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-4320
+    // GROOVY-4320
+    @Test
     void testParameterWithDefaultArgument4() {
         assertScript '''
             interface I {
@@ -999,7 +1065,8 @@ final class DelegateTransformTest {
         '''
     }
 
-    @Test // GROOVY-4320
+    // GROOVY-4320
+    @Test
     void testParameterWithDefaultArgument5() {
         def config = new CompilerConfiguration(
             targetDirectory: File.createTempDir(),
@@ -1055,7 +1122,8 @@ final class DelegateTransformTest {
         }
     }
 
-    @Test // GROOVY-5204
+    // GROOVY-5204
+    @Test
     void testParameterWithDefaultArgument6() {
         assertScript '''
             class C {


### PR DESCRIPTION
The interfaces of `Set` are `Collection` and `Iterable` -- not `Collection<Object>` and `Iterable<Object>`.

Added some provenance information to error for re-implementing interface with different type arguments.

`Delegate` does not need to add the super interface(s) to the enclosing class; they are implemented transitively.