### PR TITLE
GROOVY-11743: super trait may not be transformed when creating helper

### DIFF
--- a/build-logic/src/main/groovy/org/apache/groovy/gradle/DocGDK.groovy
+++ b/build-logic/src/main/groovy/org/apache/groovy/gradle/DocGDK.groovy
@@ -78,7 +78,7 @@ class DocGDK extends DefaultTask {
                      '-link',
                      'groovy,org.codehaus.groovy,org.apache.groovy=https://docs.groovy-lang.org/latest/html/gapi/',
                      '-link',
-                     'java,org.xml,javax,org.w3c=https://docs.oracle.com/en/java/javase/11/docs/api/java.base/'] + classes.get()
+                     'java,org.xml,javax,org.w3c=https://docs.oracle.com/en/java/javase/17/docs/api/java.base/'] + classes.get()
             )
         }
         fs.copy {

--- a/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/ASTTransformationVisitor.java
@@ -143,15 +143,15 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
 
             // second pass, call visit on all the collected nodes
             List<Tuple2<ASTTransformation, ASTNode[]>> tuples = new ArrayList<>();
-            for (ASTNode[] node : targetNodes) {
-                for (ASTTransformation snt : transforms.get(node[0])) {
-                    tuples.add(new Tuple2<>(snt, node));
+            for (ASTNode[] nodes : targetNodes) {
+                for (ASTTransformation xform : transforms.get(nodes[0])) {
+                    tuples.add(new Tuple2<>(xform, nodes));
                 }
             }
-            tuples.sort(priorityComparator);
+            if (tuples.size() > 1) tuples.sort(priorityComparator);
             for (Tuple2<ASTTransformation, ASTNode[]> tuple : tuples) {
-                if (tuple.getV1() instanceof CompilationUnitAware) {
-                    ((CompilationUnitAware)tuple.getV1()).setCompilationUnit(context.getCompilationUnit());
+                if (tuple.getV1() instanceof CompilationUnitAware unitAware) {
+                    unitAware.setCompilationUnit(context.getCompilationUnit());
                 }
                 tuple.getV1().visit(tuple.getV2(), source);
             }
@@ -237,8 +237,6 @@ public final class ASTTransformationVisitor extends ClassCodeVisitorSupport {
                         visitor.source = source;
                         visitor.visitClass(classNode);
                     }, phase.getPhaseNumber());
-                    break;
-
             }
         }
     }

--- a/src/main/java/org/codehaus/groovy/transform/trait/TraitReceiverTransformer.java
+++ b/src/main/java/org/codehaus/groovy/transform/trait/TraitReceiverTransformer.java
@@ -320,7 +320,9 @@ class TraitReceiverTransformer extends ClassCodeExpressionTransformer {
         var traits = Traits.findTraits(traitClass); traits.remove(traitClass);
 
         for (ClassNode superTrait : traits) {
-            for (MethodNode methodNode : Traits.findHelper(superTrait).getDeclaredMethods(methodName)) {
+            ClassNode traitHelper = Traits.findHelper(superTrait);
+            if (traitHelper == null) continue; // GROOVY-11743: order issue
+            for (MethodNode methodNode : traitHelper.getDeclaredMethods(methodName)) {
                 if (methodNode.isPublic() && methodNode.isStatic()
                         // exclude public method with body as it's included in trait interface
                         && ClassHelper.isClassType(methodNode.getParameters()[0].getType())) {

--- a/src/main/java/org/codehaus/groovy/transform/trait/Traits.java
+++ b/src/main/java/org/codehaus/groovy/transform/trait/Traits.java
@@ -142,7 +142,7 @@ public abstract class Traits {
                     staticFieldHelperClassNode = icn;
                 }
             } while (innerClasses.hasNext());
-        } else {
+        } else if (!trait.isPrimaryClassNode()) { // GROOVY-11743
             // precompiled trait
             try {
                 String helperClassName = Traits.helperClassName(trait);
@@ -159,7 +159,9 @@ public abstract class Traits {
             }
         }
         GenericsType[] typeArguments = trait.getGenericsTypes();
-        helperClassNode = GenericsUtils.makeClassSafe0(helperClassNode, typeArguments);
+        if (helperClassNode != null) {
+            helperClassNode = GenericsUtils.makeClassSafe0(helperClassNode, typeArguments);
+        }
         if (fieldHelperClassNode != null) {
             fieldHelperClassNode = GenericsUtils.makeClassSafe0(fieldHelperClassNode, typeArguments);
         }

--- a/src/test/groovy/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
@@ -568,7 +568,7 @@ final class TraitASTTransformationTest {
         assertScript shell, """
             $mode
             trait Impl<T> implements Api<T> {
-                @Override T fun() { null }
+                @Override T fun() { print("") }
             }
             $mode
             trait Api<RT> {


### PR DESCRIPTION
If a super trait is declared later in a unit, it will not have helper classes to perform certain lookups required by helper class creation.