### PR TITLE
GROOVY-11745: check for null sender

### DIFF
--- a/src/main/java/groovy/lang/MetaClassImpl.java
+++ b/src/main/java/groovy/lang/MetaClassImpl.java
@@ -2095,11 +2095,12 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
     }
 
     private boolean isVisibleProperty(final MetaProperty field, final MetaMethod method, final Class<?> sender) {
-        if (!(field instanceof CachedField)) return false;
+        if (field == null
+            || sender == null // GROOVY-11745
+            || field.isPrivate()
+            || !(field instanceof CachedField cachedField)) return false;
 
-        if (field.isPrivate()) return false;
-
-        Class<?> owner = ((CachedField) field).getDeclaringClass();
+        Class<?> owner = cachedField.getDeclaringClass();
         // ensure access originates within the type hierarchy of the field owner
         if (owner.equals(sender) || !owner.isAssignableFrom(sender)) return false;
 


### PR DESCRIPTION
I looked into adding `if (senderClass == null) senderClass = metaClass.getTheClass();` to `ScriptBytecodeAdapter` `getProperty` and `setProperty`.  From what I can gather, the old behavior -- before any of the "propagate sender class" changes went in -- passed along the null sender.  So I opted for a null test within `isVisibleProperty`.