### PR TITLE
GROOVY-11601: restore support for expression list in `for` statement initializer

### DIFF
--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -704,6 +704,7 @@ originalForControl
 
 forInit
     :   localVariableDeclaration
+    |   expressionList[false]
     ;
 
 forUpdate

--- a/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -545,6 +545,10 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
             }
         }
 
+        if (asBoolean(ctx.expressionList())) {
+            return this.translateExpressionList(ctx.expressionList());
+        }
+
         throw createParsingFailedException("Unsupported for init: " + ctx.getText(), ctx);
     }
 
@@ -554,9 +558,14 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
             return EmptyExpression.INSTANCE;
         }
 
-        var expressionList = this.visitExpressionList(ctx.expressionList());
+        return this.translateExpressionList(ctx.expressionList());
+    }
+
+    private Expression translateExpressionList(final ExpressionListContext ctx) {
+        List<Expression> expressionList = this.visitExpressionList(ctx);
+
         if (expressionList.size() == 1) {
-            return configureAST(expressionList.get(0), ctx); // one Expression
+            return configureAST(expressionList.get(0), ctx);
         } else {
             return configureAST(new ClosureListExpression(expressionList), ctx);
         }

--- a/src/test/groovy/groovy/ForLoopTest.groovy
+++ b/src/test/groovy/groovy/ForLoopTest.groovy
@@ -157,14 +157,19 @@ final class ForLoopTest {
 
     @Test
     void testClassicFor() {
-        for (int i = 0; i < 10; i++) {
-            x++
+        for (x = 0; x < 10; x += 2) {
         }
         assert x == 10
 
-        def list = [1, 2]
         x = 0
-        for (Iterator i = list.iterator(); i.hasNext();) {
+        for (int i = 0; i < 10; i++) {
+            x += 1
+        }
+        assert x == 10
+
+        x = 0
+        def list = [1, 2]
+        for (Iterator i = list.iterator(); i.hasNext(); ) {
             x += i.next()
         }
         assert x == 3
@@ -212,6 +217,15 @@ final class ForLoopTest {
             result += i + j
         }
         assert result == 7 // 1 + 2 + 4
+    }
+
+    // GROOVY-11601
+    void testClassicForWithMultiAssignment2() {
+        int foo, bar, baz = 0
+        for (foo = 1, bar = 2; foo < 10; foo += 1, bar += 2) {
+            baz += bar
+        }
+        assert baz == (2 + 4 + 6 + 8 + 10 + 12 + 14 + 16 + 18)
     }
 
     @Test


### PR DESCRIPTION
revert commit 7f6720b17cd81ba62f82a71d6353963ac31fc7d4

see #2174