### PR TITLE
GROOVY-11753: covariant method of super class parameterized interface

### DIFF
--- a/src/test/groovy/groovy/InterfaceTest.groovy
+++ b/src/test/groovy/groovy/InterfaceTest.groovy
@@ -134,4 +134,25 @@ final class InterfaceTest extends CompilableTestSupport {
             }
         '''
     }
+
+    // GROOVY-11753
+    void testSuperClassCovariantOfParameterizedInterface() {
+        assertScript '''
+            class A extends B {
+            }
+            class B implements C<String> {
+                static class NestMate {
+                }
+                @Override
+                void p(String s) {
+                    print(s)
+                }
+            }
+            interface C<T> {
+                void p(T t)
+            }
+
+            new A().p("")
+        '''
+    }
 }


### PR DESCRIPTION
An empty generics specification was used when trying to see if super interface methods might require a covariant addition to a super class.  If the super class is processed after the subclass, missing the covariant can result in abstract method in non-abstract class error.