### PR TITLE
GROOVY-11758: detect final super method that shadows interface or trait method

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/trait/TraitASTTransformation.java
@@ -507,13 +507,7 @@ public class TraitASTTransformation extends AbstractASTTransformation implements
     }
 
     private static boolean methodNeedsReplacement(final ClassNode cNode, final MethodNode mNode) {
-        // no method found, we need to replace
-        if (mNode == null) return true;
-        // method is in current class, nothing to be done
-        if (mNode.getDeclaringClass() == cNode) return false;
-        // do not overwrite final
-        if ((mNode.getModifiers() & ACC_FINAL) != 0) return false;
-        return true;
+        return mNode == null || mNode.getDeclaringClass() != cNode; // do not replace trait method
     }
 
     private void processField(final FieldNode field, final MethodNode initializer, final MethodNode staticInitializer,

--- a/src/test/groovy/groovy/InterfaceTest.groovy
+++ b/src/test/groovy/groovy/InterfaceTest.groovy
@@ -135,6 +135,22 @@ final class InterfaceTest extends CompilableTestSupport {
         '''
     }
 
+    // GROOVY-11758
+    void testSuperClassFinalMethodAndInterfaceMethod() {
+        def err = shouldNotCompile '''
+            interface A {
+                def m()
+            }
+            class B {
+                protected final m() {
+                }
+            }
+            class C extends B implements A {
+            }
+        '''
+        assert err =~ /inherited final method m\(\) from B cannot shadow the public method in A/
+    }
+
     // GROOVY-11753
     void testSuperClassCovariantOfParameterizedInterface() {
         assertScript '''

--- a/src/test/groovy/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/transform/traitx/TraitASTTransformationTest.groovy
@@ -441,7 +441,7 @@ final class TraitASTTransformationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings=['public',/*TODO:'protected',*/'private'])
+    @ValueSource(strings=['public','private'])
     void testFinalPropertyGetterDefinedInSuperClass(String modifier) {
         assertScript shell, """
             trait Foo {


### PR DESCRIPTION
Given:
```java
  interface A {
    Object getFoo();
  }
  class B {
    protected final Object getFoo() { return null; }
  }
  class C extends B implements A {
  }
```

The eclipse java compiler says: The inherited method `B.getFoo()` cannot hide the public abstract method in `A`