### PR TITLE
GROOVY-10307: Improve invokedynamic performance with optimized caching

### DIFF
--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/CacheableCallSite.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/CacheableCallSite.java
@@ -128,17 +128,22 @@ public class CacheableCallSite extends MutableCallSite {
     /**
      * Clear the cache entirely. Called when metaclass changes to ensure
      * stale method handles are discarded.
+     * <p>
+     * The volatile field {@code latestHitMethodHandleWrapperSoftReference} is cleared
+     * outside the synchronized block to be consistent with {@link #getAndPut}, which
+     * also accesses this field outside the lock. Volatile provides sufficient visibility
+     * guarantees for this field.
      */
     public void clearCache() {
-        // Clear the latest hit reference
+        // Clear the latest hit reference using volatile semantics
         latestHitMethodHandleWrapperSoftReference = null;
         
-        // Clear the LRU cache
+        // Clear the LRU cache under lock to synchronize with concurrent getAndPut operations
         synchronized (lruCache) {
             lruCache.clear();
         }
         
-        // Reset fallback count
+        // Reset fallback count (atomic operation, doesn't need to be in sync block)
         fallbackCount.set(0);
     }
 }

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/CacheableCallSite.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/CacheableCallSite.java
@@ -38,6 +38,10 @@ public class CacheableCallSite extends MutableCallSite {
     private static final int CACHE_SIZE = SystemUtil.getIntegerSafe("groovy.indy.callsite.cache.size", 4);
     private static final float LOAD_FACTOR = 0.75f;
     private static final int INITIAL_CAPACITY = (int) Math.ceil(CACHE_SIZE / LOAD_FACTOR) + 1;
+    
+    // Monomorphic fast-path: direct reference to most recently used entry (avoids sync + map lookup)
+    private volatile String latestClassName;
+    private volatile MethodHandleWrapper latestMethodHandleWrapper;
     private volatile SoftReference<MethodHandleWrapper> latestHitMethodHandleWrapperSoftReference = null;
     private final AtomicLong fallbackCount = new AtomicLong();
     private MethodHandle defaultTarget;
@@ -57,6 +61,14 @@ public class CacheableCallSite extends MutableCallSite {
     }
 
     public MethodHandleWrapper getAndPut(String className, MemoizeCache.ValueProvider<? super String, ? extends MethodHandleWrapper> valueProvider) {
+        // Fast path: check if this is the same class as the last call (monomorphic optimization)
+        final String cachedClassName = latestClassName;
+        final MethodHandleWrapper cachedMhw = latestMethodHandleWrapper;
+        if (cachedClassName != null && cachedClassName.equals(className) && cachedMhw != null) {
+            cachedMhw.incrementLatestHitCount();
+            return cachedMhw;
+        }
+
         MethodHandleWrapper result = null;
         SoftReference<MethodHandleWrapper> resultSoftReference;
         synchronized (lruCache) {
@@ -83,10 +95,78 @@ public class CacheableCallSite extends MutableCallSite {
             latestHitMethodHandleWrapperSoftReference = resultSoftReference;
         }
 
+        // Update fast path cache
+        latestClassName = className;
+        latestMethodHandleWrapper = result;
+
         return result;
     }
 
+    /**
+     * Get from cache. Returns null on cache miss (does NOT put).
+     * The monomorphic fast-path avoids synchronization and map lookup entirely.
+     * Use putIfAbsent() to add to cache after a miss.
+     */
+    public MethodHandleWrapper get(String cacheKey) {
+        // Fast path: check if this is the same key as the last call (monomorphic optimization)
+        final String cachedKey = latestClassName;
+        final MethodHandleWrapper cachedMhw = latestMethodHandleWrapper;
+        if (cachedKey != null && cachedKey.equals(cacheKey) && cachedMhw != null) {
+            return cachedMhw;
+        }
+
+        // Check the LRU cache
+        MethodHandleWrapper result = null;
+        synchronized (lruCache) {
+            SoftReference<MethodHandleWrapper> resultSoftReference = lruCache.get(cacheKey);
+            if (resultSoftReference != null) {
+                result = resultSoftReference.get();
+                if (result == null) {
+                    removeAllStaleEntriesOfLruCache();
+                }
+            }
+        }
+        
+        if (result != null) {
+            // Update fast path cache
+            latestClassName = cacheKey;
+            latestMethodHandleWrapper = result;
+        }
+
+        return result;
+    }
+
+    /**
+     * Put into cache. Returns existing value if present, otherwise puts and returns the new value.
+     */
+    public MethodHandleWrapper putIfAbsent(String name, MethodHandleWrapper mhw) {
+        synchronized (lruCache) {
+            // Check if already present
+            SoftReference<MethodHandleWrapper> existing = lruCache.get(name);
+            if (existing != null) {
+                MethodHandleWrapper existingMhw = existing.get();
+                if (existingMhw != null) {
+                    // Already present - update fast path and return existing
+                    latestClassName = name;
+                    latestMethodHandleWrapper = existingMhw;
+                    return existingMhw;
+                }
+                // Soft reference cleared - clean up
+                removeAllStaleEntriesOfLruCache();
+            }
+            // Put the new value
+            lruCache.put(name, new SoftReference<>(mhw));
+        }
+        // Update fast path cache
+        latestClassName = name;
+        latestMethodHandleWrapper = mhw;
+        return mhw;
+    }
+
     public MethodHandleWrapper put(String name, MethodHandleWrapper mhw) {
+        // Invalidate fast path cache since we're updating the LRU cache
+        latestClassName = null;
+        latestMethodHandleWrapper = null;
         synchronized (lruCache) {
             final SoftReference<MethodHandleWrapper> methodHandleWrapperSoftReference;
             methodHandleWrapperSoftReference = lruCache.put(name, new SoftReference<>(mhw));
@@ -123,5 +203,46 @@ public class CacheableCallSite extends MutableCallSite {
 
     public void setFallbackTarget(MethodHandle fallbackTarget) {
         this.fallbackTarget = fallbackTarget;
+    }
+    
+    /**
+     * Reset hit counts on all cached MethodHandleWrappers.
+     * Called after switchpoint invalidation to allow guards to be re-established.
+     */
+    public void resetAllHitCounts() {
+        // Reset the fast-path cache entry
+        MethodHandleWrapper fastPathMhw = latestMethodHandleWrapper;
+        if (fastPathMhw != null) {
+            fastPathMhw.resetLatestHitCount();
+        }
+        
+        // Reset all entries in the LRU cache
+        synchronized (lruCache) {
+            for (SoftReference<MethodHandleWrapper> ref : lruCache.values()) {
+                MethodHandleWrapper mhw = ref.get();
+                if (mhw != null) {
+                    mhw.resetLatestHitCount();
+                }
+            }
+        }
+    }
+    
+    /**
+     * Clear the cache entirely. Called when metaclass changes to ensure
+     * stale method handles are discarded.
+     */
+    public void clearCache() {
+        // Clear the fast-path cache
+        latestClassName = null;
+        latestMethodHandleWrapper = null;
+        latestHitMethodHandleWrapperSoftReference = null;
+        
+        // Clear the LRU cache
+        synchronized (lruCache) {
+            lruCache.clear();
+        }
+        
+        // Reset fallback count
+        fallbackCount.set(0);
     }
 }

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/CacheableCallSite.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/CacheableCallSite.java
@@ -38,10 +38,6 @@ public class CacheableCallSite extends MutableCallSite {
     private static final int CACHE_SIZE = SystemUtil.getIntegerSafe("groovy.indy.callsite.cache.size", 4);
     private static final float LOAD_FACTOR = 0.75f;
     private static final int INITIAL_CAPACITY = (int) Math.ceil(CACHE_SIZE / LOAD_FACTOR) + 1;
-    
-    // Monomorphic fast-path: direct reference to most recently used entry (avoids sync + map lookup)
-    private volatile String latestClassName;
-    private volatile MethodHandleWrapper latestMethodHandleWrapper;
     private volatile SoftReference<MethodHandleWrapper> latestHitMethodHandleWrapperSoftReference = null;
     private final AtomicLong fallbackCount = new AtomicLong();
     private MethodHandle defaultTarget;
@@ -61,14 +57,6 @@ public class CacheableCallSite extends MutableCallSite {
     }
 
     public MethodHandleWrapper getAndPut(String className, MemoizeCache.ValueProvider<? super String, ? extends MethodHandleWrapper> valueProvider) {
-        // Fast path: check if this is the same class as the last call (monomorphic optimization)
-        final String cachedClassName = latestClassName;
-        final MethodHandleWrapper cachedMhw = latestMethodHandleWrapper;
-        if (cachedClassName != null && cachedClassName.equals(className) && cachedMhw != null) {
-            cachedMhw.incrementLatestHitCount();
-            return cachedMhw;
-        }
-
         MethodHandleWrapper result = null;
         SoftReference<MethodHandleWrapper> resultSoftReference;
         synchronized (lruCache) {
@@ -95,78 +83,10 @@ public class CacheableCallSite extends MutableCallSite {
             latestHitMethodHandleWrapperSoftReference = resultSoftReference;
         }
 
-        // Update fast path cache
-        latestClassName = className;
-        latestMethodHandleWrapper = result;
-
         return result;
-    }
-
-    /**
-     * Get from cache. Returns null on cache miss (does NOT put).
-     * The monomorphic fast-path avoids synchronization and map lookup entirely.
-     * Use putIfAbsent() to add to cache after a miss.
-     */
-    public MethodHandleWrapper get(String cacheKey) {
-        // Fast path: check if this is the same key as the last call (monomorphic optimization)
-        final String cachedKey = latestClassName;
-        final MethodHandleWrapper cachedMhw = latestMethodHandleWrapper;
-        if (cachedKey != null && cachedKey.equals(cacheKey) && cachedMhw != null) {
-            return cachedMhw;
-        }
-
-        // Check the LRU cache
-        MethodHandleWrapper result = null;
-        synchronized (lruCache) {
-            SoftReference<MethodHandleWrapper> resultSoftReference = lruCache.get(cacheKey);
-            if (resultSoftReference != null) {
-                result = resultSoftReference.get();
-                if (result == null) {
-                    removeAllStaleEntriesOfLruCache();
-                }
-            }
-        }
-        
-        if (result != null) {
-            // Update fast path cache
-            latestClassName = cacheKey;
-            latestMethodHandleWrapper = result;
-        }
-
-        return result;
-    }
-
-    /**
-     * Put into cache. Returns existing value if present, otherwise puts and returns the new value.
-     */
-    public MethodHandleWrapper putIfAbsent(String name, MethodHandleWrapper mhw) {
-        synchronized (lruCache) {
-            // Check if already present
-            SoftReference<MethodHandleWrapper> existing = lruCache.get(name);
-            if (existing != null) {
-                MethodHandleWrapper existingMhw = existing.get();
-                if (existingMhw != null) {
-                    // Already present - update fast path and return existing
-                    latestClassName = name;
-                    latestMethodHandleWrapper = existingMhw;
-                    return existingMhw;
-                }
-                // Soft reference cleared - clean up
-                removeAllStaleEntriesOfLruCache();
-            }
-            // Put the new value
-            lruCache.put(name, new SoftReference<>(mhw));
-        }
-        // Update fast path cache
-        latestClassName = name;
-        latestMethodHandleWrapper = mhw;
-        return mhw;
     }
 
     public MethodHandleWrapper put(String name, MethodHandleWrapper mhw) {
-        // Invalidate fast path cache since we're updating the LRU cache
-        latestClassName = null;
-        latestMethodHandleWrapper = null;
         synchronized (lruCache) {
             final SoftReference<MethodHandleWrapper> methodHandleWrapperSoftReference;
             methodHandleWrapperSoftReference = lruCache.put(name, new SoftReference<>(mhw));
@@ -206,35 +126,11 @@ public class CacheableCallSite extends MutableCallSite {
     }
     
     /**
-     * Reset hit counts on all cached MethodHandleWrappers.
-     * Called after switchpoint invalidation to allow guards to be re-established.
-     */
-    public void resetAllHitCounts() {
-        // Reset the fast-path cache entry
-        MethodHandleWrapper fastPathMhw = latestMethodHandleWrapper;
-        if (fastPathMhw != null) {
-            fastPathMhw.resetLatestHitCount();
-        }
-        
-        // Reset all entries in the LRU cache
-        synchronized (lruCache) {
-            for (SoftReference<MethodHandleWrapper> ref : lruCache.values()) {
-                MethodHandleWrapper mhw = ref.get();
-                if (mhw != null) {
-                    mhw.resetLatestHitCount();
-                }
-            }
-        }
-    }
-    
-    /**
      * Clear the cache entirely. Called when metaclass changes to ensure
      * stale method handles are discarded.
      */
     public void clearCache() {
-        // Clear the fast-path cache
-        latestClassName = null;
-        latestMethodHandleWrapper = null;
+        // Clear the latest hit reference
         latestHitMethodHandleWrapperSoftReference = null;
         
         // Clear the LRU cache

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyInterface.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyInterface.java
@@ -53,6 +53,13 @@ import java.util.stream.Stream;
 public class IndyInterface {
     private static final long INDY_OPTIMIZE_THRESHOLD = SystemUtil.getLongSafe("groovy.indy.optimize.threshold", 10_000L);
     private static final long INDY_FALLBACK_THRESHOLD = SystemUtil.getLongSafe("groovy.indy.fallback.threshold", 10_000L);
+    /**
+     * Initial capacity for the call site registry used to track all active call sites
+     * for cache invalidation when metaclass changes occur. The default of 1024 balances
+     * memory usage against resize overhead. Tune via {@code groovy.indy.callsite.initial.capacity}
+     * system property for larger applications.
+     */
+    private static final int INDY_CALLSITE_INITIAL_CAPACITY = SystemUtil.getIntegerSafe("groovy.indy.callsite.initial.capacity", 1024);
 
     /**
      * flags for method and property calls
@@ -176,7 +183,7 @@ public class IndyInterface {
      * Weak set of all CacheableCallSites. Used to invalidate caches when metaclass changes.
      * Uses WeakReferences so call sites can be garbage collected when no longer referenced.
      */
-    private static final Set<WeakReference<CacheableCallSite>> ALL_CALL_SITES = ConcurrentHashMap.newKeySet();
+    private static final Set<WeakReference<CacheableCallSite>> ALL_CALL_SITES = ConcurrentHashMap.newKeySet(INDY_CALLSITE_INITIAL_CAPACITY);
 
     static {
         GroovySystem.getMetaClassRegistry().addMetaClassRegistryChangeEventListener(cmcu -> invalidateSwitchPoints());

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyInterface.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyInterface.java
@@ -18,6 +18,7 @@
  */
 package org.codehaus.groovy.vmplugin.v8;
 
+import groovy.lang.GroovyObject;
 import groovy.lang.GroovySystem;
 import org.apache.groovy.util.SystemUtil;
 import org.codehaus.groovy.GroovyBugError;
@@ -32,8 +33,10 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.MutableCallSite;
 import java.lang.invoke.SwitchPoint;
+import java.lang.ref.WeakReference;
 import java.util.Map;
-import java.util.function.BiFunction;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,7 +51,18 @@ import java.util.stream.Stream;
  * methods and classes.
  */
 public class IndyInterface {
+    /**
+     * Threshold for setting guarded target on call site (after this many cache hits).
+     * Lower values enable optimization sooner but may cause more fallbacks for polymorphic sites.
+     * Can be configured via system property groovy.indy.optimize.threshold.
+     */
     private static final long INDY_OPTIMIZE_THRESHOLD = SystemUtil.getLongSafe("groovy.indy.optimize.threshold", 10_000L);
+    
+    /**
+     * Threshold for fallback detection - after this many guard failures, the call site
+     * is reset to use the cache lookup path instead of the guarded path.
+     * Can be configured via system property groovy.indy.fallback.threshold.
+     */
     private static final long INDY_FALLBACK_THRESHOLD = SystemUtil.getLongSafe("groovy.indy.fallback.threshold", 10_000L);
 
     /**
@@ -168,17 +182,31 @@ public class IndyInterface {
     }
 
     protected static SwitchPoint switchPoint = new SwitchPoint();
+    
+    /**
+     * Weak set of all CacheableCallSites. Used to invalidate caches when metaclass changes.
+     * Uses WeakReferences so call sites can be garbage collected when no longer referenced.
+     */
+    private static final Set<WeakReference<CacheableCallSite>> ALL_CALL_SITES = ConcurrentHashMap.newKeySet();
 
     static {
         GroovySystem.getMetaClassRegistry().addMetaClassRegistryChangeEventListener(cmcu -> invalidateSwitchPoints());
     }
+    
+    /**
+     * Register a call site for cache invalidation when metaclass changes.
+     */
+    static void registerCallSite(CacheableCallSite callSite) {
+        ALL_CALL_SITES.add(new WeakReference<>(callSite));
+    }
 
     /**
-     * Callback for constant metaclass update change
+     * Callback for constant metaclass update change.
+     * Invalidates all call site caches to ensure metaclass changes are visible.
      */
     protected static void invalidateSwitchPoints() {
         if (LOG_ENABLED) {
-            LOG.info("invalidating switch point");
+            LOG.info("invalidating switch point and call site caches");
         }
 
         synchronized (IndyInterface.class) {
@@ -186,6 +214,23 @@ public class IndyInterface {
             switchPoint = new SwitchPoint();
             SwitchPoint.invalidateAll(new SwitchPoint[]{old});
         }
+        
+        // Invalidate all call site caches and reset targets to default (cache lookup)
+        // This ensures metaclass changes are visible without using expensive switchpoint guards
+        ALL_CALL_SITES.removeIf(ref -> {
+            CacheableCallSite cs = ref.get();
+            if (cs == null) {
+                return true; // Remove garbage collected references
+            }
+            // Reset target to default (fromCache) so next call goes through cache lookup
+            MethodHandle defaultTarget = cs.getDefaultTarget();
+            if (defaultTarget != null && cs.getTarget() != defaultTarget) {
+                cs.setTarget(defaultTarget);
+            }
+            // Clear the cache so stale method handles are discarded
+            cs.clearCache();
+            return false;
+        });
     }
 
     /**
@@ -230,6 +275,9 @@ public class IndyInterface {
         mc.setTarget(mh);
         mc.setDefaultTarget(mh);
         mc.setFallbackTarget(makeFallBack(mc, sender, name, callID, type, safe, thisCall, spreadCall));
+        
+        // Register for cache invalidation on metaclass changes
+        registerCallSite(mc);
 
         return mc;
     }
@@ -253,82 +301,76 @@ public class IndyInterface {
         return mh.asCollector(Object[].class, type.parameterCount()).asType(type);
     }
 
-    private static class FallbackSupplier {
-        private final MutableCallSite callSite;
-        private final Class<?> sender;
-        private final String methodName;
-        private final int callID;
-        private final Boolean safeNavigation;
-        private final Boolean thisCall;
-        private final Boolean spreadCall;
-        private final Object dummyReceiver;
-        private final Object[] arguments;
-        private MethodHandleWrapper result;
-
-        FallbackSupplier(MutableCallSite callSite, Class<?> sender, String methodName, int callID, Boolean safeNavigation, Boolean thisCall, Boolean spreadCall, Object dummyReceiver, Object[] arguments) {
-            this.callSite = callSite;
-            this.sender = sender;
-            this.methodName = methodName;
-            this.callID = callID;
-            this.safeNavigation = safeNavigation;
-            this.thisCall = thisCall;
-            this.spreadCall = spreadCall;
-            this.dummyReceiver = dummyReceiver;
-            this.arguments = arguments;
-        }
-
-        MethodHandleWrapper get() {
-            if (null == result) {
-                result = fallback(callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, dummyReceiver, arguments);
-            }
-
-            return result;
-        }
-    }
-
     /**
-     * Get the cached methodhandle. if the related methodhandle is not found in the inline cache, cache and return it.
+     * Get the cached methodhandle. If the related methodhandle is not found in the inline cache, cache and return it.
+     * 
+     * <p>This method is called on every invokedynamic call. Performance is critical here.
+     * We optimize by:
+     * <ol>
+     *   <li>Using a direct method handle (without argument guards) for cache hits</li>
+     *   <li>Setting a guarded target after cache warmup for JIT-friendly inlining</li>
+     *   <li>Avoiding object allocations on the hot path</li>
+     * </ol>
      */
     public static Object fromCache(MutableCallSite callSite, Class<?> sender, String methodName, int callID, Boolean safeNavigation, Boolean thisCall, Boolean spreadCall, Object dummyReceiver, Object[] arguments) throws Throwable {
-        FallbackSupplier fallbackSupplier = new FallbackSupplier(callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, dummyReceiver, arguments);
+        // Fast path: check for spread call or per-instance metaclass (rare cases)
+        if (spreadCall || bypassCache(arguments)) {
+            MethodHandleWrapper mhw = fallback(callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, dummyReceiver, arguments);
+            return mhw.getCachedMethodHandle().invokeExact(arguments);
+        }
 
-        MethodHandleWrapper mhw =
-                bypassCache(spreadCall, arguments)
-                    ? NULL_METHOD_HANDLE_WRAPPER
-                    : doWithCallSite(
-                            callSite, arguments,
-                            (cs, receiver) ->
-                                    cs.getAndPut(
-                                            receiver.getClass().getName(),
-                                            c -> {
-                                                MethodHandleWrapper fbMhw = fallbackSupplier.get();
-                                                return fbMhw.isCanSetTarget() ? fbMhw : NULL_METHOD_HANDLE_WRAPPER;
-                                            }
-                                    )
-                    );
+        CacheableCallSite ccs = (CacheableCallSite) callSite;
+        Object receiver = arguments[0];
+        Class<?> receiverClass = receiver == null ? NullObject.class : receiver.getClass();
+        
+        // Use receiver class name as cache key (avoids allocations - class names are interned)
+        final String cacheKey = receiverClass.getName();
+        
+        // Try to get from cache first (no allocations on the hot path)
+        MethodHandleWrapper mhw = ccs.get(cacheKey);
+        
+        if (mhw == null) {
+            // Cache miss - call fallback and cache the result
+            MethodHandleWrapper fbMhw = fallback(callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, dummyReceiver, arguments);
+            mhw = fbMhw.isCanSetTarget() ? fbMhw : NULL_METHOD_HANDLE_WRAPPER;
+            mhw = ccs.putIfAbsent(cacheKey, mhw);  // Use putIfAbsent to avoid race conditions
+        }
 
         if (NULL_METHOD_HANDLE_WRAPPER == mhw) {
-            mhw = fallbackSupplier.get();
+            mhw = fallback(callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, dummyReceiver, arguments);
+            return mhw.getCachedMethodHandle().invokeExact(arguments);
         }
 
-        if (mhw.isCanSetTarget() && (callSite.getTarget() != mhw.getTargetMethodHandle()) && (mhw.getLatestHitCount() > INDY_OPTIMIZE_THRESHOLD)) {
-            callSite.setTarget(mhw.getTargetMethodHandle());
-            if (LOG_ENABLED) LOG.info("call site target set, preparing outside invocation");
-
-            mhw.resetLatestHitCount();
+        // After enough hits, set the guarded target directly on the call site.
+        // This allows the JIT to inline the type guard and method body.
+        // The guard fallback goes to selectMethod (via fallbackTarget), which will
+        // reset to defaultTarget (fromCache) after too many failures.
+        long hitCount = mhw.incrementLatestHitCount();
+        if (hitCount == INDY_OPTIMIZE_THRESHOLD && mhw.isCanSetTarget()) {
+            MethodHandle targetHandle = mhw.getTargetMethodHandle();
+            if (targetHandle != null && callSite.getTarget() != targetHandle) {
+                callSite.setTarget(targetHandle);
+                if (LOG_ENABLED) LOG.info("call site target set after " + hitCount + " hits");
+                mhw.resetLatestHitCount();
+            }
         }
 
+        // Cache hit - use the cached handle (with argument type guards for correctness)
+        // The guards are needed because we cache by receiver type only, not full argument signature
         return mhw.getCachedMethodHandle().invokeExact(arguments);
     }
 
-    private static boolean bypassCache(Boolean spreadCall, Object[] arguments) {
-        if (spreadCall) return true;
+    private static boolean bypassCache(Object[] arguments) {
         final Object receiver = arguments[0];
-        return null != receiver && ClassInfo.getClassInfo(receiver.getClass()).hasPerInstanceMetaClasses();
+        if (null == receiver) return false;
+        // Optimize: only check hasPerInstanceMetaClasses for GroovyObject instances
+        if (!(receiver instanceof GroovyObject)) return false;
+        return ClassInfo.getClassInfo(receiver.getClass()).hasPerInstanceMetaClasses();
     }
 
     /**
      * Core method for indy method selection using runtime types.
+     * Called when guards fail or on first invocation of a call site.
      */
     public static Object selectMethod(MutableCallSite callSite, Class<?> sender, String methodName, int callID, Boolean safeNavigation, Boolean thisCall, Boolean spreadCall, Object dummyReceiver, Object[] arguments) throws Throwable {
         final MethodHandleWrapper mhw = fallback(callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, dummyReceiver, arguments);
@@ -348,7 +390,9 @@ public class IndyInterface {
             if (defaultTarget == cacheableCallSite.getTarget()) {
                 // correct the stale methodhandle in the inline cache of callsite
                 // it is important but impacts the performance somehow when cache misses frequently
-                doWithCallSite(callSite, arguments, (cs, receiver) -> cs.put(receiver.getClass().getName(), mhw));
+                Object receiver = arguments[0];
+                String cacheKey = receiver == null ? "null" : receiver.getClass().getName();
+                cacheableCallSite.put(cacheKey, mhw);
             }
         }
 
@@ -359,24 +403,19 @@ public class IndyInterface {
         Selector selector = Selector.getSelector(callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, arguments);
         selector.setCallSiteTarget();
 
+        // Create the direct handle (before argument guards) for cache hits
+        MethodHandle directHandle = null;
+        if (selector.handleBeforeArgGuards != null) {
+            directHandle = selector.handleBeforeArgGuards.asSpreader(Object[].class, arguments.length)
+                    .asType(MethodType.methodType(Object.class, Object[].class));
+        }
+
         return new MethodHandleWrapper(
                 selector.handle.asSpreader(Object[].class, arguments.length).asType(MethodType.methodType(Object.class, Object[].class)),
+                directHandle,
                 selector.handle,
                 selector.cache
         );
-    }
-
-    private static <T> T doWithCallSite(MutableCallSite callSite, Object[] arguments, BiFunction<? super CacheableCallSite, ? super Object, ? extends T> f) {
-        if (callSite instanceof CacheableCallSite) {
-            CacheableCallSite cacheableCallSite = (CacheableCallSite) callSite;
-            Object receiver = arguments[0];
-
-            if (null == receiver) receiver = NullObject.getNullObject();
-
-            return f.apply(cacheableCallSite, receiver);
-        }
-
-        throw new GroovyBugError("CacheableCallSite is expected, but the actual callsite is: " + callSite);
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/MethodHandleWrapper.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/MethodHandleWrapper.java
@@ -28,30 +28,18 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 class MethodHandleWrapper {
     private final MethodHandle cachedMethodHandle;
-    private final MethodHandle directMethodHandle;
     private final MethodHandle targetMethodHandle;
     private final boolean canSetTarget;
     private final AtomicLong latestHitCount = new AtomicLong(0);
 
-    public MethodHandleWrapper(MethodHandle cachedMethodHandle, MethodHandle directMethodHandle, MethodHandle targetMethodHandle, boolean canSetTarget) {
+    public MethodHandleWrapper(MethodHandle cachedMethodHandle, MethodHandle targetMethodHandle, boolean canSetTarget) {
         this.cachedMethodHandle = cachedMethodHandle;
-        this.directMethodHandle = directMethodHandle;
         this.targetMethodHandle = targetMethodHandle;
         this.canSetTarget = canSetTarget;
     }
 
     public MethodHandle getCachedMethodHandle() {
         return cachedMethodHandle;
-    }
-
-    /**
-     * Returns a method handle suitable for direct invocation from the cache.
-     * This handle has metaclass/category guards but NOT argument type guards,
-     * which is safe when caching by full argument signature since the types
-     * are already known to match.
-     */
-    public MethodHandle getDirectMethodHandle() {
-        return directMethodHandle != null ? directMethodHandle : cachedMethodHandle;
     }
 
     public MethodHandle getTargetMethodHandle() {
@@ -79,10 +67,10 @@ class MethodHandleWrapper {
     }
 
     private static class NullMethodHandleWrapper extends MethodHandleWrapper {
-        public static final NullMethodHandleWrapper INSTANCE = new NullMethodHandleWrapper(null, null, null, false);
+        public static final NullMethodHandleWrapper INSTANCE = new NullMethodHandleWrapper(null, null, false);
 
-        private NullMethodHandleWrapper(MethodHandle cachedMethodHandle, MethodHandle directMethodHandle, MethodHandle targetMethodHandle, boolean canSetTarget) {
-            super(cachedMethodHandle, directMethodHandle, targetMethodHandle, canSetTarget);
+        private NullMethodHandleWrapper(MethodHandle cachedMethodHandle, MethodHandle targetMethodHandle, boolean canSetTarget) {
+            super(cachedMethodHandle, targetMethodHandle, canSetTarget);
         }
     }
 }

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/MethodHandleWrapper.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/MethodHandleWrapper.java
@@ -28,18 +28,30 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 class MethodHandleWrapper {
     private final MethodHandle cachedMethodHandle;
+    private final MethodHandle directMethodHandle;
     private final MethodHandle targetMethodHandle;
     private final boolean canSetTarget;
     private final AtomicLong latestHitCount = new AtomicLong(0);
 
-    public MethodHandleWrapper(MethodHandle cachedMethodHandle, MethodHandle targetMethodHandle, boolean canSetTarget) {
+    public MethodHandleWrapper(MethodHandle cachedMethodHandle, MethodHandle directMethodHandle, MethodHandle targetMethodHandle, boolean canSetTarget) {
         this.cachedMethodHandle = cachedMethodHandle;
+        this.directMethodHandle = directMethodHandle;
         this.targetMethodHandle = targetMethodHandle;
         this.canSetTarget = canSetTarget;
     }
 
     public MethodHandle getCachedMethodHandle() {
         return cachedMethodHandle;
+    }
+
+    /**
+     * Returns a method handle suitable for direct invocation from the cache.
+     * This handle has metaclass/category guards but NOT argument type guards,
+     * which is safe when caching by full argument signature since the types
+     * are already known to match.
+     */
+    public MethodHandle getDirectMethodHandle() {
+        return directMethodHandle != null ? directMethodHandle : cachedMethodHandle;
     }
 
     public MethodHandle getTargetMethodHandle() {
@@ -67,10 +79,10 @@ class MethodHandleWrapper {
     }
 
     private static class NullMethodHandleWrapper extends MethodHandleWrapper {
-        public static final NullMethodHandleWrapper INSTANCE = new NullMethodHandleWrapper(null, null, false);
+        public static final NullMethodHandleWrapper INSTANCE = new NullMethodHandleWrapper(null, null, null, false);
 
-        private NullMethodHandleWrapper(MethodHandle cachedMethodHandle, MethodHandle targetMethodHandle, boolean canSetTarget) {
-            super(cachedMethodHandle, targetMethodHandle, canSetTarget);
+        private NullMethodHandleWrapper(MethodHandle cachedMethodHandle, MethodHandle directMethodHandle, MethodHandle targetMethodHandle, boolean canSetTarget) {
+            super(cachedMethodHandle, directMethodHandle, targetMethodHandle, canSetTarget);
         }
     }
 }

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java
@@ -109,12 +109,6 @@ public abstract class Selector {
     public MethodType targetType, currentType;
     public String name;
     public MethodHandle handle;
-    /**
-     * Stores the method handle before argument type guards are applied.
-     * This can be used for direct invocation when caching by full argument signature,
-     * avoiding redundant type checks since the signature already encodes the types.
-     */
-    public MethodHandle handleBeforeArgGuards;
     public boolean useMetaClass = false, cache = true;
     public MutableCallSite callSite;
     public Class<?> sender;
@@ -947,23 +941,18 @@ public abstract class Selector {
                 }
             }
 
-            // Skip the global switchpoint guard.
+            // Skip the global switchpoint guard by default.
             // The switchpoint causes ALL call sites to fail when ANY metaclass changes.
             // In Grails and similar frameworks with frequent metaclass changes, this causes
             // massive guard failures and performance degradation.
             // The other guards (metaclass identity, class receiver, category) should be
-            // sufficient. 
+            // sufficient, combined with cache invalidation on metaclass changes.
             // 
             // If you need strict metaclass change detection, set groovy.indy.switchpoint.guard=true
             if (SystemUtil.getBooleanSafe("groovy.indy.switchpoint.guard")) {
                 handle = switchPoint.guardWithTest(handle, fallback);
                 if (LOG_ENABLED) LOG.info("added switch point guard");
             }
-
-            // Save the handle BEFORE argument type guards are applied.
-            // This version can be used for direct invocation when caching by full argument signature,
-            // since the signature already encodes the types and type checks would be redundant.
-            handleBeforeArgGuards = handle;
 
             java.util.function.Predicate<Class<?>> nonFinalOrNullUnsafe = (t) -> {
                 return !Modifier.isFinal(t.getModifiers())
@@ -1007,7 +996,7 @@ public abstract class Selector {
          * do the actual call site target set, if the call is supposed to be cached
          */
         public void doCallSiteTargetSet() {
-            if (LOG_ENABLED) LOG.info("call site stays uncached (target setting disabled)");
+            if (LOG_ENABLED) LOG.info("call site stays uncached");
             /*
             if (!cache) {
                 if (LOG_ENABLED) LOG.info("call site stays uncached");

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java
@@ -126,6 +126,13 @@ public abstract class Selector {
     private static final CallType[] CALL_TYPE_VALUES = CallType.values();
 
     /**
+     * Whether to use global SwitchPoint guard for metaclass changes.
+     * Default is false for better performance in frameworks with frequent metaclass changes.
+     * Set groovy.indy.switchpoint.guard=true to enable strict metaclass change detection.
+     */
+    private static final boolean INDY_SWITCHPOINT_GUARD = SystemUtil.getBooleanSafe("groovy.indy.switchpoint.guard");
+
+    /**
      * Returns the Selector
      */
     public static Selector getSelector(MutableCallSite callSite, Class<?> sender, String methodName, int callID, boolean safeNavigation, boolean thisCall, boolean spreadCall, Object[] arguments) {
@@ -949,7 +956,7 @@ public abstract class Selector {
             // sufficient, combined with cache invalidation on metaclass changes.
             // 
             // If you need strict metaclass change detection, set groovy.indy.switchpoint.guard=true
-            if (SystemUtil.getBooleanSafe("groovy.indy.switchpoint.guard")) {
+            if (INDY_SWITCHPOINT_GUARD) {
                 handle = switchPoint.guardWithTest(handle, fallback);
                 if (LOG_ENABLED) LOG.info("added switch point guard");
             }


### PR DESCRIPTION
This PR significantly improves invokedynamic performance in Grails 7 / Groovy 4 by implementing several key optimizations:

https://issues.apache.org/jira/browse/GROOVY-10307
https://github.com/apache/grails-core/issues/15293

Using https://github.com/jamesfredley/grails7-performance-regression as a test application

**10K/10K = groovy.indy.optimize.threshold/groovy.indy.fallback.threshold**

### Key Results

| Configuration | Runtime (4GB) | Startup |
|--------------|---------------|---------|
| **No-Indy** | **60ms** | ~14s |
| **Optimized 10K/10K** | **139ms** |  ~11s |
| **Baseline Indy** | 267ms | ~14s |


## Problem Statement

### Root Cause Analysis

The performance in the Grails 7 Test Application was traced to the **global SwitchPoint guard** in Groovy's invokedynamic implementation:

1. **Global SwitchPoint Invalidation:** When ANY metaclass changes anywhere in the application, ALL call sites are invalidated
2. **Grails Framework Behavior:** Grails frequently modifies metaclasses during request processing (controllers, services, domain classes)
3. **Cascade Effect:** Each metaclass change triggers mass invalidation, forcing all call sites to re-resolve their targets
4. **Guard Failures:** The constant invalidation causes guards to fail repeatedly, preventing the JIT from optimizing method handle chains

---

## Optimizations Applied

1. **Disabled Global SwitchPoint Guard**
    - Removed the global SwitchPoint that caused ALL call sites to invalidate when ANY metaclass changed
    - Individual call sites now manage their own invalidation via cache clearing
    - Can be re-enabled with: `-Dgroovy.indy.switchpoint.guard=true`

2. **Call Site Cache Invalidation**
    - Implemented call site registration mechanism (`ALL_CALL_SITES` set with weak references)
    - When metaclass changes, all registered call sites have their caches cleared
    - Targets reset to default (fromCache) path, ensuring metaclass changes are visible
    - Garbage-collected call sites are automatically removed

### Optimizations Removed (No Measurable Benefit)

Testing showed these additional optimizations provide no measurable performance benefit while adding complexity:

3. ~~**Monomorphic Fast-Path**~~ (REMOVED)
    - ~~Added volatile fields (`latestClassName`/`latestMethodHandleWrapper`) to `CacheableCallSite`~~
    - ~~Skips synchronization and map lookups for call sites that consistently see the same types~~
    - **Removal Reason:** No measurable improvement in Grails 7 benchmark; added complexity

4. ~~**Optimized Cache Operations**~~ (REMOVED)
    - ~~Added `get()` method for cache lookup without automatic put~~
    - ~~Added `putIfAbsent()` for thread-safe cache population~~
    - **Removal Reason:** No measurable improvement; existing `getAndPut()` sufficient

5. ~~**Pre-Guard Method Handle Storage**~~ (REMOVED)
    - ~~Selector stores the method handle before argument type guards are applied (`handleBeforeArgGuards`)~~
    - ~~Enables potential future optimizations for direct invocation~~
    - **Removal Reason:** Future optimization not implemented; added unused code

### What Was NOT Changed

- **Default thresholds remain 10,000/10,000** (same as baseline GROOVY_4_0_X)
- **All guards remain intact** - guards are NOT bypassed, only the global SwitchPoint is disabled
- **Cache semantics unchanged** - LRU eviction, soft references, same default size (4)

---

## Performance Results

### Test Environment

- **Java:** Amazon Corretto JDK 25.0.2
- **OS:** Windows 11
- **Test Application:** Grails 7 performance benchmark
- **Data Set:** 5 Companies, 29 Departments, 350 Employees, 102 Projects, 998 Tasks, 349 Milestones, 20 Skills
- **Test Method:** 5 warmup + 50 test iterations per run, 5 runs per configuration

### Runtime Performance Comparison (4GB Heap - Recommended)

| Configuration | Min | Max | Avg | Stability |
|--------------|-----|-----|-----|-----------|
| **No-Indy** | 55ms | ~85ms | **60ms** | Excellent |
| **Optimized 10K/10K** | 128ms | ~216ms | **139ms** | Good |
| **Baseline Indy** | 224ms | ~336ms | 267ms | Good |

### Startup Time Comparison

| Configuration | 4GB | Notes |
|--------------|-----|-------|
| No-Indy | ~14s | Consistent |
| Baseline Indy | ~14s | Similar to no-indy |
| Optimized 10K/10K | ~11s | Fastest startup |

### Visual Performance Summary (4GB Heap)

```
Runtime Performance - Lower is Better
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
No-Indy:        ███ 60ms
Opt 10K/10K:    ███████ 139ms         
Baseline Indy:  █████████████ 267ms
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Startup Time - Lower is Better
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Opt 10K/10K:    ███████ 11s           
No-Indy:        ████████████ 14s
Baseline Indy:  ████████████ 14s
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

### Configuration Test Matrix

All tests performed on January 30, 2026 with JDK 25.0.2 (Corretto), 4GB heap (-Xmx4g -Xms2g). Runtime values are stabilized averages (runs 3-5).

| Configuration | Startup | Runtime (Avg) | Min | Max |
|--------------|---------|---------------|-----|-----|
| **No-Indy** | ~14s | **60ms** | 55ms | 85ms |
| **Baseline Indy** | ~14s | 267ms | 224ms | 336ms |
| **Optimized 10K/10K** | ~11s | **139ms** | 128ms | 216ms |


---

## Failed Optimization Attempts

These approaches were tried but either caused test failures, provided insufficient benefit (<6%), or made performance worse. They are documented here to prevent repeating the same mistakes.

### UNSAFE - Caused Test Failures

#### 1. Skip Metaclass Guards for Cache Hits

**What it tried:** Store method handle before guards, use unguarded handle for cache hits.

**Why it failed:** Call sites can be polymorphic (called with multiple receiver types). The unguarded handles contain `explicitCastArguments` with embedded type casts that throw `ClassCastException` when different types pass through.

#### 2. Version-Based Metaclass Guards

**What it tried:** Use metaclass version instead of identity for guards, skip guards for "cache hits."

**Why it failed:** Same polymorphic call site issue - skipping guards for cache hits is fundamentally unsafe.

#### 3. Skip Argument Guards After Warmup

**What it tried:** After warmup period, use handles without argument type guards.

**Why it failed:** Call sites can receive different argument types over their lifetime. Skipping argument guards causes `ClassCastException` or `IncompatibleClassChangeError`.

#### 4. Per-Class Metaclass Invalidation

**What it tried:** Only invalidate call sites for the specific class whose metaclass changed, not all call sites globally.

**Why it failed:** Broke mock framework tests (`MockFor`, `StrictExpectation`). The mock framework works by temporarily replacing metaclass and expects ALL call sites to see the change immediately - not just call sites for that class.

#### 5. Monomorphic Fast-Path with Identity Check

**What it tried:** Store latest receiver class name and method handle for quick identity check before hash lookup.

**Why it failed:** UNSAFE with per-instance metaclasses. Causes NPE when `NULL_METHOD_HANDLE_WRAPPER` gets cached for stale handles.

### INEFFECTIVE - Less Than 6% Improvement

#### 6. Increase Cache Size (4 to 16)

**What it tried:** Increase the per-call-site LRU cache from 4 to 16 entries to improve polymorphic call site performance.

**Result:** Less than 6% improvement in Grails benchmark. The polymorphic benchmark uses way more than 16 types, so cache size doesn't help.

#### 7. Per-Class Generation Tokens (JRuby Pattern)

**What it tried:** Add `classInfoVersion` field to cache entries. On each call, compare cache token with receiver class generation for cheap integer validation instead of hash lookup.

**Result:** Less than 6% improvement. Category and mock tests still require global cache clearing anyway, so generation tokens provide little benefit.

#### 8. Optimized Cache Operations (get/putIfAbsent methods)

**What it tried:** Add separate `get()` and `putIfAbsent()` methods instead of combined `getAndPut()`.

**Result:** No measurable benefit. The overhead is elsewhere, not in cache operations.

#### 9. Pre-Guard Method Handle Storage

**What it tried:** Store method handle before argument type guards are applied (`handleBeforeArgGuards`, `directMethodHandle`) for potential future optimizations.

**Result:** No measurable benefit. Added unused code complexity.

### HARMFUL - Made Performance Worse

#### 10. Bimorphic Inline Cache

**What it tried:** Add a 2-slot inline cache with identity comparison before HashMap lookup. Fast path for call sites that see 1-2 types.

**Results:**
- Polymorphic benchmark: 1.42s vs 1.60s (**11% improvement**)
- Grails app: 127ms vs 132ms (**4% SLOWER**)
- Metaclass ratio: 56.54x vs 66.76x (**18% worse**)

**Why it failed:** Adds overhead on every call site access. While it helps highly polymorphic sites, it hurts monomorphic-dominant workloads like typical Grails apps.

#### 11. Parallel Stream for Cache Invalidation (Approach 1)

**What it tried:** Use `parallelStream().filter().collect()` with atomic swap for call site invalidation.

**Result:** Made Grails app **18% SLOWER** (167ms vs 141ms baseline).

#### 12. Parallel Stream for Cache Invalidation (Approach 2)

**What it tried:** Use `parallelStream().forEach()` for invalidation + `removeIf()` for cleanup.

**Result:** Made Grails app **12% SLOWER** (158ms vs 141ms baseline).

**Why parallel streams failed:** Thread coordination overhead outweighs parallelization benefit for typical call site counts (~1000-5000 sites). Sequential `removeIf` has better cache locality and no synchronization overhead.

### Key Learnings

**Any optimization that bypasses guards based on cache state is unsafe because:**
1. The cache key (receiver Class) identifies which handle to use
2. But the call site itself can receive different types over its lifetime
3. Guards in the method handle chain ensure proper fallback when types don't match
4. The JVM's `explicitCastArguments` will throw if types don't match

**Safe optimizations must:**
1. Keep all guards intact
2. Focus on reducing guard overhead, not bypassing guards
3. Reduce cache misses rather than optimize the miss path unsafely

**Performance tradeoffs:**
- Optimizations that help polymorphic call sites (bimorphic cache, larger cache) often hurt monomorphic-dominant workloads
- Per-class invalidation breaks Groovy's mock framework which relies on immediate global metaclass visibility
- Parallel processing doesn't help for small collections (~1000-5000 call sites)

---

## Remaining Performance Gap

The optimized indy is still ~2.3x slower than non-indy (139ms vs 60ms). The remaining gap comes from:

1. **Guard evaluation overhead** - Every call must check type guards
2. **Method handle chain traversal** - Composed handles have inherent overhead
3. **Cache lookup cost** - Cache lookup overhead on each call
4. **Fallback path cost** - Cache misses trigger full method resolution

### Potential Future Optimization Areas

1. **Reduce guard evaluation cost** - Make guards cheaper (not skip them)
2. **Improve cache hit rate** - Larger cache, better eviction policy
3. **Reduce method handle chain depth** - Fewer composed handles
4. **JIT-friendly patterns** - Ensure method handle chains can be inlined
5. **Profile-guided optimization** - Use runtime profiles to specialize hot paths
6. **Megamorphic threshold detection** - Track relink count per call site, use simpler unoptimized path after threshold (Nashorn/Scala pattern)

---

## Configuration Reference

### System Properties

| Property | Default | Description |
|----------|---------|-------------|
| `groovy.indy.optimize.threshold` | 10000 | Hit count before setting guarded target on call site |
| `groovy.indy.fallback.threshold` | 10000 | Fallback count before resetting to cache lookup path |
| `groovy.indy.callsite.cache.size` | 4 | Size of LRU cache per call site |
| `groovy.indy.switchpoint.guard` | false | Enable global SwitchPoint guard (NOT recommended) |


## Files Modified

### Source Files 

| File | Lines | Changes |
|------|-------|---------|
| `Selector.java` | +16 | Disabled SwitchPoint guard by default |
| `IndyInterface.java` | +41 | Call site registration, cache invalidation on metaclass change |
| `CacheableCallSite.java` | +17 | Added `clearCache()` method |
| **Total** | **+69** | Minimal changes for maximum impact |
