### PR TITLE
GROOVY-11933: Mesh async and http builder via Flow.Publisher

### DIFF
--- a/src/main/java/groovy/concurrent/AwaitableAdapterRegistry.java
+++ b/src/main/java/groovy/concurrent/AwaitableAdapterRegistry.java
@@ -19,6 +19,7 @@
 package groovy.concurrent;
 
 import org.apache.groovy.runtime.async.AsyncSupport;
+import org.apache.groovy.runtime.async.FlowPublisherAdapter;
 import org.apache.groovy.runtime.async.GroovyPromise;
 
 import java.util.Iterator;
@@ -34,11 +35,13 @@ import java.util.concurrent.Future;
  * Central registry for {@link AwaitableAdapter} instances.
  * <p>
  * On class-load, adapters are discovered via {@link ServiceLoader} from
- * {@code META-INF/services/groovy.concurrent.AwaitableAdapter}. A built-in
- * adapter is always present as the lowest-priority fallback, handling:
+ * {@code META-INF/services/groovy.concurrent.AwaitableAdapter}. Two built-in
+ * adapters are always present after SPI-loaded ones:
  * <ul>
- *   <li>{@link CompletableFuture} and {@link CompletionStage}</li>
- *   <li>{@link Future} (adapted via a blocking wrapper)</li>
+ *   <li>{@link FlowPublisherAdapter} for {@link java.util.concurrent.Flow.Publisher}
+ *       (single-value {@code await} and multi-value {@code for await}).</li>
+ *   <li>A {@code Future} fallback handling {@link CompletableFuture},
+ *       {@link CompletionStage}, and {@link Future} (via a blocking wrapper).</li>
  * </ul>
  *
  * @since 6.0.0
@@ -64,6 +67,9 @@ public final class AwaitableAdapterRegistry {
         } catch (Throwable ignored) {
             // ServiceLoader failure — continue with built-in adapter only
         }
+        // Built-in JDK Flow.Publisher adapter (after SPI, before Future fallback).
+        // SPI adapters take precedence so framework-specific types resolve first.
+        adapters.add(new FlowPublisherAdapter());
         // Built-in fallback adapter (lowest priority)
         adapters.add(new BuiltInAdapter());
     }

--- a/src/main/java/org/apache/groovy/runtime/async/FlowPublisherAdapter.java
+++ b/src/main/java/org/apache/groovy/runtime/async/FlowPublisherAdapter.java
@@ -1,0 +1,308 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.runtime.async;
+
+import groovy.concurrent.Awaitable;
+import groovy.concurrent.AwaitableAdapter;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Adapter for {@link java.util.concurrent.Flow.Publisher}, the JDK's built-in
+ * Reactive Streams type. Enables:
+ * <ul>
+ *   <li>{@code await publisher} — completes with the first {@code onNext}
+ *       value, then cancels the subscription. Completes with {@code null} if
+ *       the publisher signals {@code onComplete} without emitting.</li>
+ *   <li>{@code for await (item in publisher)} — iterates over emitted values
+ *       with bounded backpressure (see {@link #DEFAULT_BATCH_SIZE}).</li>
+ * </ul>
+ * <p>
+ * Conformance:
+ * <ul>
+ *   <li>Reactive Streams §2.13: {@code onNext(null)} is treated as a protocol
+ *       violation and surfaced as a {@link NullPointerException}.</li>
+ *   <li>A second {@code onSubscribe} after the first is cancelled.</li>
+ *   <li>Signals after a terminal {@code onError}/{@code onComplete} are ignored.</li>
+ * </ul>
+ * <p>
+ * This adapter is registered as the lowest-priority built-in (after SPI-loaded
+ * adapters) so framework-specific adapters (Reactor, RxJava) take precedence
+ * for their concrete types.
+ *
+ * @since 6.0.0
+ */
+public final class FlowPublisherAdapter implements AwaitableAdapter {
+
+    /**
+     * Default request batch size for {@code for await} iteration. Chosen as a
+     * compromise between throughput (larger = fewer {@code request()} calls)
+     * and memory (larger = bigger in-flight buffer). Override per-call by
+     * wrapping with a custom adapter if needed.
+     */
+    public static final int DEFAULT_BATCH_SIZE = 32;
+
+    @Override
+    public boolean supportsAwaitable(Class<?> type) {
+        return Flow.Publisher.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public boolean supportsIterable(Class<?> type) {
+        return Flow.Publisher.class.isAssignableFrom(type);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Awaitable<T> toAwaitable(Object source) {
+        if (!(source instanceof Flow.Publisher<?>)) {
+            throw new IllegalArgumentException("Cannot convert to Awaitable: " + source.getClass());
+        }
+        return (Awaitable<T>) publisherToAwaitable((Flow.Publisher<Object>) source);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Iterable<T> toBlockingIterable(Object source) {
+        if (!(source instanceof Flow.Publisher<?>)) {
+            throw new IllegalArgumentException("Cannot convert to Iterable: " + source.getClass());
+        }
+        return (Iterable<T>) publisherToBlockingIterable((Flow.Publisher<Object>) source, DEFAULT_BATCH_SIZE);
+    }
+
+    // ---- single-value: first onNext wins ---------------------------------
+
+    private static <T> Awaitable<T> publisherToAwaitable(Flow.Publisher<T> publisher) {
+        CompletableFuture<T> cf = new CompletableFuture<>();
+        AtomicReference<Flow.Subscription> subRef = new AtomicReference<>();
+        publisher.subscribe(new Flow.Subscriber<T>() {
+            @Override
+            public void onSubscribe(Flow.Subscription s) {
+                if (!subRef.compareAndSet(null, s)) {
+                    s.cancel(); // duplicate onSubscribe — cancel the second
+                    return;
+                }
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(T item) {
+                if (cf.isDone()) return;
+                if (item == null) {
+                    cf.completeExceptionally(new NullPointerException(
+                            "Flow.Publisher onNext received null (Reactive Streams §2.13)"));
+                } else {
+                    cf.complete(item);
+                }
+                Flow.Subscription s = subRef.getAndSet(null);
+                if (s != null) s.cancel();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                if (cf.isDone()) return;
+                cf.completeExceptionally(t);
+                subRef.set(null);
+            }
+
+            @Override
+            public void onComplete() {
+                if (cf.isDone()) return;
+                cf.complete(null); // empty publisher → null result
+                subRef.set(null);
+            }
+        });
+        return GroovyPromise.of(cf);
+    }
+
+    // ---- multi-value: blocking iterable with bounded backpressure --------
+
+    private static <T> Iterable<T> publisherToBlockingIterable(Flow.Publisher<T> publisher, int batchSize) {
+        return new PublisherBlockingIterable<>(publisher, batchSize);
+    }
+
+    /**
+     * Blocking {@link Iterable} backed by a {@link Flow.Publisher} with bounded
+     * backpressure. Implements {@link AutoCloseable} so {@code for await}
+     * cleanup (via {@code AsyncSupport.closeIterable}) cancels the subscription
+     * on early break.
+     */
+    private static final class PublisherBlockingIterable<T> implements Iterable<T>, AutoCloseable {
+        private final Flow.Publisher<T> publisher;
+        private final int batchSize;
+        private final AtomicReference<QueueSubscriber<T>> active = new AtomicReference<>();
+
+        PublisherBlockingIterable(Flow.Publisher<T> publisher, int batchSize) {
+            this.publisher = publisher;
+            this.batchSize = Math.max(1, batchSize);
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            QueueSubscriber<T> sub = new QueueSubscriber<>(batchSize);
+            if (!active.compareAndSet(null, sub)) {
+                throw new IllegalStateException(
+                        "PublisherBlockingIterable is single-use; iterator() was already called");
+            }
+            publisher.subscribe(sub);
+            return sub;
+        }
+
+        @Override
+        public void close() {
+            QueueSubscriber<T> sub = active.get();
+            if (sub != null) sub.cancel();
+        }
+    }
+
+    /**
+     * A {@link Flow.Subscriber} that buffers signals into a blocking queue and
+     * exposes them as an {@link Iterator}. Demand is replenished in halves of
+     * the batch size to overlap consumption with production.
+     */
+    private static final class QueueSubscriber<T> implements Flow.Subscriber<T>, Iterator<T> {
+        private static final Object COMPLETE = new Object();
+        private static final Object ERROR = new Object();
+
+        private final LinkedBlockingQueue<Object> queue = new LinkedBlockingQueue<>();
+        private final int batchSize;
+        private final int replenishThreshold;
+        private final AtomicReference<Flow.Subscription> subRef = new AtomicReference<>();
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+
+        private Object next;
+        private boolean hasNext;
+        private boolean terminated;
+        private Throwable error;
+        private int consumedSinceRequest;
+
+        QueueSubscriber(int batchSize) {
+            this.batchSize = batchSize;
+            this.replenishThreshold = Math.max(1, batchSize / 2);
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription s) {
+            if (!subRef.compareAndSet(null, s)) {
+                s.cancel();
+                return;
+            }
+            // Handle cancel-before-subscribe race: cancel() may have already
+            // run and enqueued the sentinel; dispose of this late subscription.
+            if (cancelled.get() && subRef.compareAndSet(s, null)) {
+                s.cancel();
+                return;
+            }
+            s.request(batchSize);
+        }
+
+        @Override
+        public void onNext(T item) {
+            if (cancelled.get()) return;
+            if (item == null) {
+                onError(new NullPointerException(
+                        "Flow.Publisher onNext received null (Reactive Streams §2.13)"));
+                return;
+            }
+            queue.offer(item);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (cancelled.get()) return;
+            this.error = t;
+            queue.offer(ERROR);
+            subRef.set(null);
+        }
+
+        @Override
+        public void onComplete() {
+            if (cancelled.get()) return;
+            queue.offer(COMPLETE);
+            subRef.set(null);
+        }
+
+        void cancel() {
+            if (!cancelled.compareAndSet(false, true)) return;
+            try {
+                Flow.Subscription s = subRef.getAndSet(null);
+                if (s != null) s.cancel();
+            } finally {
+                // Wake any thread blocked in queue.take() inside hasNext().
+                // The queue's happens-before also publishes the cancelled flag.
+                queue.offer(COMPLETE);
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (hasNext) return true;
+            if (terminated) return false;
+            try {
+                Object item = queue.take();
+                if (item == COMPLETE) {
+                    terminated = true;
+                    return false;
+                }
+                if (item == ERROR) {
+                    terminated = true;
+                    if (error instanceof RuntimeException re) throw re;
+                    if (error instanceof Error err) throw err;
+                    throw new RuntimeException(error);
+                }
+                next = item;
+                hasNext = true;
+                replenishIfNeeded();
+                return true;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                cancel();
+                return false;
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public T next() {
+            if (!hasNext()) throw new NoSuchElementException();
+            T value = (T) next;
+            next = null;
+            hasNext = false;
+            return value;
+        }
+
+        private void replenishIfNeeded() {
+            consumedSinceRequest++;
+            if (consumedSinceRequest >= replenishThreshold) {
+                Flow.Subscription s = subRef.get();
+                if (s != null) {
+                    int toRequest = consumedSinceRequest;
+                    consumedSinceRequest = 0;
+                    s.request(toRequest);
+                }
+            }
+        }
+    }
+}

--- a/src/test/groovy/groovy/concurrent/FlowPublisherAdapterTest.groovy
+++ b/src/test/groovy/groovy/concurrent/FlowPublisherAdapterTest.groovy
@@ -1,0 +1,284 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.concurrent
+
+import org.junit.jupiter.api.Test
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Flow
+import java.util.concurrent.SubmissionPublisher
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+import static groovy.test.GroovyAssert.assertScript
+import static groovy.test.GroovyAssert.shouldFail
+
+final class FlowPublisherAdapterTest {
+
+    @Test
+    void testAwaitOnSubmissionPublisherTakesFirstValue() {
+        assertScript '''
+            import java.util.concurrent.SubmissionPublisher
+            import groovy.concurrent.Awaitable
+
+            def publisher = new SubmissionPublisher<String>()
+            // Subscribe before the producer runs — SubmissionPublisher.submit
+            // only delivers to subscribers present at submit-time.
+            def awaitable = Awaitable.from(publisher)
+            async {
+                publisher.submit('first')
+                publisher.submit('second')
+                publisher.close()
+            }
+            def result = await awaitable
+            assert result == 'first'
+        '''
+    }
+
+    @Test
+    void testAwaitOnEmptyPublisherCompletesWithNull() {
+        assertScript '''
+            import java.util.concurrent.SubmissionPublisher
+            import groovy.concurrent.Awaitable
+
+            def publisher = new SubmissionPublisher<String>()
+            def awaitable = Awaitable.from(publisher)
+            async { publisher.close() }
+            def result = await awaitable
+            assert result == null
+        '''
+    }
+
+    @Test
+    void testAwaitOnFailingPublisherRethrows() {
+        def boom = new RuntimeException('boom')
+        Throwable thrown = shouldFail RuntimeException, {
+            def publisher = new SubmissionPublisher<String>()
+            new Thread({
+                publisher.closeExceptionally(boom)
+            }).start()
+            org.apache.groovy.runtime.async.AsyncSupport.await(groovy.concurrent.Awaitable.from(publisher))
+        }
+        assert thrown.message == 'boom'
+    }
+
+    @Test
+    void testForAwaitIteratesAllValues() {
+        assertScript '''
+            import java.util.concurrent.SubmissionPublisher
+
+            def publisher = new SubmissionPublisher<Integer>()
+            async {
+                (1..5).each { publisher.submit(it) }
+                publisher.close()
+            }
+            def results = []
+            for await (item in publisher) {
+                results << item
+            }
+            assert results == [1, 2, 3, 4, 5]
+        '''
+    }
+
+    @Test
+    void testForAwaitOnEmptyPublisher() {
+        assertScript '''
+            import java.util.concurrent.SubmissionPublisher
+
+            def publisher = new SubmissionPublisher<Integer>()
+            async { publisher.close() }
+            def results = []
+            for await (item in publisher) {
+                results << item
+            }
+            assert results == []
+        '''
+    }
+
+    @Test
+    void testForAwaitPropagatesError() {
+        def thrown = shouldFail RuntimeException, '''
+            import java.util.concurrent.SubmissionPublisher
+
+            def publisher = new SubmissionPublisher<Integer>()
+            async {
+                publisher.submit(1)
+                publisher.submit(2)
+                publisher.closeExceptionally(new RuntimeException('mid-stream'))
+            }
+            def results = []
+            for await (item in publisher) {
+                results << item
+            }
+        '''
+        assert thrown.message == 'mid-stream'
+    }
+
+    @Test
+    void testNullOnNextBecomesNpe() {
+        // Custom publisher that violates §2.13
+        def publisher = { Flow.Subscriber<Object> sub ->
+            sub.onSubscribe(new Flow.Subscription() {
+                @Override void request(long n) { sub.onNext(null) }
+                @Override void cancel() {}
+            })
+        } as Flow.Publisher<Object>
+
+        def thrown = shouldFail NullPointerException, {
+            org.apache.groovy.runtime.async.AsyncSupport.await(groovy.concurrent.Awaitable.from(publisher))
+        }
+        assert thrown.message.contains('§2.13')
+    }
+
+    @Test
+    void testEarlyBreakCancelsSubscription() {
+        // Verify the subscription is cancelled when the consumer breaks early.
+        AtomicBoolean cancelled = new AtomicBoolean()
+        AtomicInteger requested = new AtomicInteger()
+        CountDownLatch cancelSignalled = new CountDownLatch(1)
+
+        def publisher = { Flow.Subscriber<Integer> sub ->
+            sub.onSubscribe(new Flow.Subscription() {
+                @Override
+                void request(long n) {
+                    requested.addAndGet((int) n)
+                    // Emit a few values; do not auto-complete
+                    Thread.startDaemon {
+                        for (int i = 0; i < (int) n; i++) {
+                            sub.onNext(i)
+                        }
+                    }
+                }
+                @Override void cancel() { cancelled.set(true); cancelSignalled.countDown() }
+            })
+        } as Flow.Publisher<Integer>
+
+        def shell = new GroovyShell(new Binding(publisher: publisher))
+        shell.evaluate '''
+            int seen = 0
+            for await (item in publisher) {
+                seen++
+                if (seen >= 3) break
+            }
+        '''
+
+        assert cancelSignalled.await(5, TimeUnit.SECONDS), 'Subscription.cancel was never invoked after early break'
+        assert cancelled.get()
+    }
+
+    @Test
+    void testCrossThreadCancelUnblocksIterator() {
+        // A publisher that never emits or completes — hasNext() will park in
+        // queue.take(). Closing the iterable from another thread must unblock it.
+        AtomicBoolean upstreamCancelled = new AtomicBoolean()
+        CountDownLatch requested = new CountDownLatch(1)
+        def publisher = { Flow.Subscriber<Integer> sub ->
+            sub.onSubscribe(new Flow.Subscription() {
+                @Override void request(long n) { requested.countDown() }
+                @Override void cancel() { upstreamCancelled.set(true) }
+            })
+        } as Flow.Publisher<Integer>
+
+        def iterable = AwaitableAdapterRegistry.toBlockingIterable(publisher)
+        assert iterable instanceof AutoCloseable
+        def iter = iterable.iterator()
+        assert requested.await(5, TimeUnit.SECONDS), 'subscriber never asked to request'
+
+        AtomicReference<Boolean> hasNextResult = new AtomicReference<>()
+        CountDownLatch done = new CountDownLatch(1)
+        Thread consumer = new Thread({
+            hasNextResult.set(iter.hasNext())
+            done.countDown()
+        })
+        consumer.start()
+
+        // Close from the main thread — must unblock the parked consumer.
+        ((AutoCloseable) iterable).close()
+
+        assert done.await(5, TimeUnit.SECONDS), 'hasNext() did not unblock after cancel'
+        assert hasNextResult.get() == Boolean.FALSE
+        assert upstreamCancelled.get(), 'upstream subscription should have been cancelled'
+    }
+
+    @Test
+    void testCancelBeforeOnSubscribeCancelsLateSubscription() {
+        // Race: cancel() runs before onSubscribe delivers its Subscription.
+        // The late subscription must still be cancelled.
+        AtomicBoolean upstreamCancelled = new AtomicBoolean()
+        AtomicReference<Flow.Subscriber<Integer>> subscriber = new AtomicReference<>()
+        def publisher = { Flow.Subscriber<Integer> sub ->
+            subscriber.set(sub) // defer onSubscribe
+        } as Flow.Publisher<Integer>
+
+        def iterable = AwaitableAdapterRegistry.toBlockingIterable(publisher)
+        iterable.iterator()
+        assert subscriber.get() != null
+
+        // Cancel *before* delivering onSubscribe.
+        ((AutoCloseable) iterable).close()
+
+        // Now deliver the subscription — adapter must cancel it.
+        subscriber.get().onSubscribe(new Flow.Subscription() {
+            @Override void request(long n) {}
+            @Override void cancel() { upstreamCancelled.set(true) }
+        })
+
+        assert upstreamCancelled.get(), 'late subscription should have been cancelled'
+    }
+
+    @Test
+    void testBlockingIterableIsSingleUseAndCleansUpFirstSubscription() {
+        // Two requirements: (1) calling iterator() twice must fail fast, rather
+        // than silently leak the first subscription; (2) close() must still
+        // cancel the first subscription even after the rejected second call.
+        AtomicBoolean firstCancelled = new AtomicBoolean()
+        def publisher = { Flow.Subscriber<Integer> sub ->
+            sub.onSubscribe(new Flow.Subscription() {
+                @Override void request(long n) {}
+                @Override void cancel() { firstCancelled.set(true) }
+            })
+        } as Flow.Publisher<Integer>
+
+        def iterable = AwaitableAdapterRegistry.toBlockingIterable(publisher)
+        iterable.iterator()
+
+        shouldFail(IllegalStateException) {
+            iterable.iterator()
+        }
+
+        ((AutoCloseable) iterable).close()
+        assert firstCancelled.get(), 'first subscription must be cancelled even after a rejected second iterator()'
+    }
+
+    @Test
+    void testAdapterRegistered() {
+        // The registry resolves Flow.Publisher via the built-in adapter.
+        def publisher = new SubmissionPublisher<String>()
+        try {
+            def awaitable = Awaitable.from(publisher)
+            assert awaitable != null
+            def iter = AwaitableAdapterRegistry.toBlockingIterable(publisher)
+            assert iter != null
+        } finally {
+            publisher.close()
+        }
+    }
+}

--- a/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpBuilder.groovy
+++ b/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpBuilder.groovy
@@ -166,6 +166,65 @@ final class HttpBuilder {
         return requestAsync('PATCH', uri, spec)
     }
 
+    /**
+     * Streams the response body without buffering. Returns an
+     * {@link HttpStreamResult} whose {@code bodyAsPublisher()} delivers
+     * {@code List<ByteBuffer>} chunks as they arrive — enabling
+     * {@code for await (chunk in result.bodyAsPublisher())} via the
+     * {@code FlowPublisherAdapter}.
+     * <p>
+     * Streaming always uses {@code HttpResponse.BodyHandlers.ofPublisher()};
+     * any {@code bodyHandler} configured on the {@code RequestSpec} is ignored.
+     */
+    CompletableFuture<HttpStreamResult> streamAsync(final String method,
+                                                    final Object uri,
+                                                    @DelegatesTo(value = RequestSpec, strategy = Closure.DELEGATE_FIRST)
+                                                    final Closure<?> spec = null) {
+        HttpRequest httpRequest = buildStreamRequest(method, uri, spec)
+        return client.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofPublisher())
+                .thenApply { HttpResponse response -> new HttpStreamResult(response) }
+    }
+
+    CompletableFuture<HttpStreamResult> getStreamAsync(final Object uri = null,
+                                                       @DelegatesTo(value = RequestSpec, strategy = Closure.DELEGATE_FIRST)
+                                                       final Closure<?> spec = null) {
+        return streamAsync('GET', uri, spec)
+    }
+
+    CompletableFuture<HttpStreamResult> postStreamAsync(final Object uri = null,
+                                                        @DelegatesTo(value = RequestSpec, strategy = Closure.DELEGATE_FIRST)
+                                                        final Closure<?> spec = null) {
+        return streamAsync('POST', uri, spec)
+    }
+
+    private HttpRequest buildStreamRequest(final String method, final Object uri, final Closure<?> spec) {
+        RequestSpec requestSpec = new RequestSpec()
+        if (spec != null) {
+            Closure<?> code = (Closure<?>) spec.clone()
+            code.resolveStrategy = Closure.DELEGATE_FIRST
+            code.delegate = requestSpec
+            code.call()
+        }
+
+        URI resolvedUri = resolveUri(uri, requestSpec.queryParameters)
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(resolvedUri)
+
+        Duration timeout = requestSpec.timeout ?: defaultRequestTimeout
+        if (timeout != null) {
+            requestBuilder.timeout(timeout)
+        }
+
+        defaultHeaders.each { String name, String value ->
+            requestBuilder.header(name, value)
+        }
+        requestSpec.headers.each { String name, String value ->
+            requestBuilder.setHeader(name, value)
+        }
+
+        requestBuilder.method(method, bodyPublisher(method, requestSpec.body))
+        return requestBuilder.build()
+    }
+
     private List buildRequest(final String method, final Object uri, final Closure<?> spec) {
         RequestSpec requestSpec = new RequestSpec()
         if (spec != null) {

--- a/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpStreamResult.groovy
+++ b/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpStreamResult.groovy
@@ -1,0 +1,352 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.http
+
+import org.apache.groovy.lang.annotation.Incubating
+
+import java.net.http.HttpHeaders
+import java.net.http.HttpResponse
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Flow
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Streaming response wrapper for {@link HttpBuilder}'s {@code streamAsync} family.
+ * <p>
+ * Unlike {@link HttpResult}, this does not buffer the response body. The body
+ * is exposed as a {@link Flow.Publisher} of byte chunks that can be consumed
+ * incrementally — typically via {@code for await (chunk in result.bodyAsPublisher())}
+ * once the {@code groovy-concurrent-java} {@code FlowPublisherAdapter} is on
+ * the classpath.
+ */
+@Incubating
+record HttpStreamResult(
+        int status,
+        HttpHeaders headers,
+        HttpResponse<Flow.Publisher<List<ByteBuffer>>> raw) {
+
+    HttpStreamResult(HttpResponse<Flow.Publisher<List<ByteBuffer>>> response) {
+        this(response.statusCode(), response.headers(), response)
+    }
+
+    /**
+     * Returns the response body as a publisher of {@code List<ByteBuffer>}
+     * chunks, exactly as JDK {@code HttpResponse.BodyHandlers.ofPublisher()}
+     * provides it.
+     */
+    Flow.Publisher<List<ByteBuffer>> bodyAsPublisher() {
+        return raw.body()
+    }
+
+    /**
+     * Returns the response body as a publisher of decoded strings, one per
+     * arriving chunk. Each emitted string corresponds to one upstream HTTP
+     * frame (often a complete SSE event or a JSON line, but boundaries are
+     * not guaranteed). Use {@link #bodyAsLinePublisher} for line-aligned
+     * delivery.
+     *
+     * @param charset the charset to decode bytes with (defaults to UTF-8)
+     */
+    Flow.Publisher<String> bodyAsTextPublisher(Charset charset = StandardCharsets.UTF_8) {
+        Closure mapper = { chunk ->
+            StringBuilder sb = new StringBuilder()
+            for (ByteBuffer buf : (List<ByteBuffer>) chunk) {
+                sb.append(charset.decode(buf))
+            }
+            sb.toString()
+        }
+        return (Flow.Publisher<String>) new MappedPublisher(raw.body(), mapper)
+    }
+
+    /**
+     * Returns the response body as a publisher of newline-terminated strings.
+     * Useful for line-oriented streaming protocols (NDJSON, SSE without event
+     * framing, log tails). Trailing partial lines are emitted on completion.
+     *
+     * @param charset the charset to decode bytes with (defaults to UTF-8)
+     */
+    Flow.Publisher<String> bodyAsLinePublisher(Charset charset = StandardCharsets.UTF_8) {
+        return new LinePublisher(raw.body(), charset)
+    }
+
+    /**
+     * One-shot mapping {@link Flow.Publisher} that delegates subscription to a
+     * source publisher and applies a transformer per signalled item.
+     */
+    // package-private for same-package unit testing
+    static final class MappedPublisher implements Flow.Publisher<Object> {
+        private final Flow.Publisher source
+        private final Closure mapper
+
+        MappedPublisher(Flow.Publisher source, Closure mapper) {
+            this.source = source
+            this.mapper = mapper
+        }
+
+        @Override
+        void subscribe(Flow.Subscriber<? super Object> downstream) {
+            source.subscribe(new MappingSubscriber(downstream, mapper))
+        }
+    }
+
+    // package-private for same-package unit testing
+    static final class MappingSubscriber implements Flow.Subscriber<Object> {
+        private final Flow.Subscriber<? super Object> downstream
+        private final Closure mapper
+        private volatile Flow.Subscription subscription
+        private volatile boolean done
+
+        MappingSubscriber(Flow.Subscriber<? super Object> downstream, Closure mapper) {
+            this.downstream = downstream
+            this.mapper = mapper
+        }
+
+        @Override
+        void onSubscribe(Flow.Subscription s) {
+            this.subscription = s
+            downstream.onSubscribe(s)
+        }
+
+        @Override
+        void onNext(Object item) {
+            if (done) return
+            Object mapped
+            try {
+                mapped = mapper.call(item)
+            } catch (Throwable t) {
+                done = true
+                Flow.Subscription s = subscription
+                if (s != null) s.cancel()
+                downstream.onError(t)
+                return
+            }
+            downstream.onNext(mapped)
+        }
+
+        @Override
+        void onError(Throwable t) {
+            if (done) return
+            done = true
+            downstream.onError(t)
+        }
+
+        @Override
+        void onComplete() {
+            if (done) return
+            done = true
+            downstream.onComplete()
+        }
+    }
+
+    /**
+     * Adapts a chunked byte publisher into a publisher of complete lines.
+     * Buffers across chunk boundaries so multi-chunk lines emit correctly,
+     * and honours downstream demand — a single upstream chunk containing
+     * many newlines is drip-fed to the downstream one line per {@code request}.
+     */
+    // package-private for same-package unit testing
+    static final class LinePublisher implements Flow.Publisher<String> {
+        private final Flow.Publisher<List<ByteBuffer>> source
+        private final Charset charset
+
+        LinePublisher(Flow.Publisher<List<ByteBuffer>> source, Charset charset) {
+            this.source = source
+            this.charset = charset
+        }
+
+        @Override
+        void subscribe(Flow.Subscriber<? super String> downstream) {
+            source.subscribe(new LineSubscription(downstream, charset))
+        }
+    }
+
+    /**
+     * Flow.Subscription that mediates demand between a chunk publisher and a
+     * line subscriber. Parses decoded bytes on '\n', honours '\r\n', and
+     * flushes any trailing pending text on upstream completion.
+     */
+    private static final class LineSubscription implements Flow.Subscription, Flow.Subscriber<List<ByteBuffer>> {
+
+        // Upstream window: chunks kept in flight, replenished when half consumed.
+        // Tuned for HTTP line-streaming; not exposed — revisit if pathological.
+        private static final int UPSTREAM_BATCH = 8
+        private static final int UPSTREAM_REPLENISH_AT = UPSTREAM_BATCH.intdiv(2)
+
+        private final Flow.Subscriber<? super String> downstream
+        private final Charset charset
+
+        private final AtomicReference<Flow.Subscription> upstreamSubRef = new AtomicReference<>()
+
+        // Parsed lines (cross-thread: upstream onNext writes, drain reads).
+        private final ConcurrentLinkedQueue<String> buffer = new ConcurrentLinkedQueue<>()
+        // Partial trailing line (upstream-thread only per §1.3 serialisation).
+        private final StringBuilder pending = new StringBuilder()
+
+        private final AtomicLong requested = new AtomicLong()
+        private final AtomicBoolean cancelled = new AtomicBoolean()
+        private final AtomicInteger wip = new AtomicInteger()
+        private final AtomicInteger chunksOutstanding = new AtomicInteger()
+
+        private volatile boolean done
+        private volatile Throwable error
+        // Drain-thread only (wip-serialised).
+        private boolean terminated
+
+        LineSubscription(Flow.Subscriber<? super String> downstream, Charset charset) {
+            this.downstream = downstream
+            this.charset = charset
+        }
+
+        // --- Flow.Subscription (downstream-facing) ---
+
+        @Override
+        void request(long n) {
+            if (n <= 0) {
+                if (cancelled.compareAndSet(false, true)) {
+                    Flow.Subscription s = upstreamSubRef.getAndSet(null)
+                    if (s != null) s.cancel()
+                    downstream.onError(new IllegalArgumentException(
+                            "Flow.Subscription.request must be positive (Reactive Streams §3.9): " + n))
+                }
+                return
+            }
+            if (cancelled.get()) return
+            long r, nr
+            do {
+                r = requested.get()
+                if (r == Long.MAX_VALUE) { drain(); return }
+                nr = r + n
+                if (nr < 0) nr = Long.MAX_VALUE
+            } while (!requested.compareAndSet(r, nr))
+            drain()
+        }
+
+        @Override
+        void cancel() {
+            if (cancelled.compareAndSet(false, true)) {
+                Flow.Subscription s = upstreamSubRef.getAndSet(null)
+                if (s != null) s.cancel()
+                drain()
+            }
+        }
+
+        // --- Flow.Subscriber (upstream-facing) ---
+
+        @Override
+        void onSubscribe(Flow.Subscription s) {
+            if (!upstreamSubRef.compareAndSet(null, s)) {
+                s.cancel()
+                return
+            }
+            downstream.onSubscribe(this)
+            // Cancel-before-subscribe race: cancel() may have already flipped
+            // the flag but found a null subRef. Clean up the late subscription.
+            if (cancelled.get()) {
+                Flow.Subscription sub = upstreamSubRef.getAndSet(null)
+                if (sub != null) sub.cancel()
+            }
+        }
+
+        @Override
+        void onNext(List<ByteBuffer> chunk) {
+            if (cancelled.get() || done) return
+            for (ByteBuffer buf : chunk) {
+                pending.append(charset.decode(buf))
+            }
+            int nl
+            while ((nl = pending.indexOf('\n')) != -1) {
+                String line = pending.substring(0, nl)
+                if (line.endsWith('\r')) line = line.substring(0, line.length() - 1)
+                pending.delete(0, nl + 1)
+                buffer.offer(line)
+            }
+            chunksOutstanding.decrementAndGet()
+            drain()
+        }
+
+        @Override
+        void onError(Throwable t) {
+            if (done) return
+            error = t
+            done = true
+            drain()
+        }
+
+        @Override
+        void onComplete() {
+            if (done) return
+            if (pending.length() > 0) {
+                buffer.offer(pending.toString())
+                pending.setLength(0)
+            }
+            done = true
+            drain()
+        }
+
+        // --- drain: emit buffered lines up to downstream demand, serialised by wip ---
+
+        private void drain() {
+            if (wip.getAndIncrement() != 0) return
+            int missed = 1
+            for (;;) {
+                if (cancelled.get()) { buffer.clear(); return }
+                if (terminated) return
+
+                long r = requested.get()
+                long e = 0
+                while (e < r) {
+                    if (cancelled.get()) { buffer.clear(); return }
+                    String line = buffer.poll()
+                    if (line == null) break
+                    downstream.onNext(line)
+                    e++
+                }
+                if (e > 0 && r != Long.MAX_VALUE) requested.addAndGet(-e)
+
+                if (done && buffer.isEmpty()) {
+                    terminated = true
+                    Throwable t = error
+                    if (t != null) downstream.onError(t)
+                    else downstream.onComplete()
+                    return
+                }
+
+                // Keep the upstream window topped up while downstream has demand.
+                if (!done && requested.get() > 0) {
+                    int outstanding = chunksOutstanding.get()
+                    if (outstanding <= UPSTREAM_REPLENISH_AT) {
+                        int deficit = UPSTREAM_BATCH - outstanding
+                        chunksOutstanding.addAndGet(deficit)
+                        Flow.Subscription s = upstreamSubRef.get()
+                        if (s != null) s.request(deficit)
+                    }
+                }
+
+                missed = wip.addAndGet(-missed)
+                if (missed == 0) return
+            }
+        }
+    }
+}

--- a/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpStreamResultTest.groovy
+++ b/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpStreamResultTest.groovy
@@ -1,0 +1,343 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.http
+
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Flow
+import java.util.concurrent.SubmissionPublisher
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+class HttpStreamResultTest {
+
+    private static final long AWAIT_TIMEOUT_SECONDS = 10
+
+    private HttpServer server
+    private URI rootUri
+
+    @BeforeEach
+    void setup() {
+        server = HttpServer.create(new InetSocketAddress('127.0.0.1', 0), 0)
+        server.createContext('/lines') { exchange ->
+            // chunked transfer (size 0)
+            exchange.responseHeaders.add('Content-Type', 'text/plain')
+            exchange.sendResponseHeaders(200, 0)
+            exchange.responseBody.withCloseable { out ->
+                (1..5).each { i ->
+                    out.write("line-${i}\n".getBytes(StandardCharsets.UTF_8))
+                    out.flush()
+                    Thread.sleep(10)
+                }
+            }
+        }
+        server.createContext('/bytes') { exchange ->
+            byte[] body = ('A'..'Z').collect { it.toString() }.join().getBytes(StandardCharsets.UTF_8)
+            exchange.sendResponseHeaders(200, body.length)
+            exchange.responseBody.withCloseable { it.write(body) }
+        }
+        server.start()
+        rootUri = URI.create("http://127.0.0.1:${server.address.port}/")
+    }
+
+    @AfterEach
+    void cleanup() {
+        server?.stop(0)
+    }
+
+    @Test
+    void streamsBytesAsPublisher() {
+        HttpBuilder http = HttpBuilder.http(rootUri.toString())
+        CompletableFuture<HttpStreamResult> future = http.getStreamAsync('/bytes')
+        HttpStreamResult result = future.join()
+        assert result.status() == 200
+
+        // Drain the publisher manually to a collected string
+        StringBuilder collected = new StringBuilder()
+        def latch = new CountDownLatch(1)
+        result.bodyAsPublisher().subscribe(new Flow.Subscriber<List>() {
+            Flow.Subscription sub
+            @Override void onSubscribe(Flow.Subscription s) { sub = s; s.request(Long.MAX_VALUE) }
+            @Override void onNext(List buffers) {
+                buffers.each { collected.append(StandardCharsets.UTF_8.decode(it)) }
+            }
+            @Override void onError(Throwable t) { latch.countDown() }
+            @Override void onComplete() { latch.countDown() }
+        })
+        assert latch.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS), 'publisher did not complete in time'
+        assert collected.toString() == ('A'..'Z').collect { it.toString() }.join()
+    }
+
+    @Test
+    void streamsLinesAsLinePublisher() {
+        HttpBuilder http = HttpBuilder.http(rootUri.toString())
+        HttpStreamResult result = http.getStreamAsync('/lines').join()
+        assert result.status() == 200
+
+        List<String> lines = []
+        def latch = new CountDownLatch(1)
+        result.bodyAsLinePublisher().subscribe(new Flow.Subscriber<String>() {
+            @Override void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE) }
+            @Override void onNext(String line) { lines << line }
+            @Override void onError(Throwable t) { latch.countDown() }
+            @Override void onComplete() { latch.countDown() }
+        })
+        assert latch.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS), 'publisher did not complete in time'
+        assert lines == ['line-1', 'line-2', 'line-3', 'line-4', 'line-5']
+    }
+
+    @Test
+    void mappingSubscriberCancelsUpstreamWhenMapperThrows() {
+        AtomicBoolean upstreamCancelled = new AtomicBoolean()
+        AtomicReference<Throwable> received = new AtomicReference<>()
+        AtomicBoolean completed = new AtomicBoolean()
+        AtomicReference<Flow.Subscription> upstreamSub = new AtomicReference<>()
+
+        Flow.Publisher upstream = { Flow.Subscriber sub ->
+            upstreamSub.set(sub as Flow.Subscriber)
+            sub.onSubscribe(new Flow.Subscription() {
+                @Override void request(long n) {}
+                @Override void cancel() { upstreamCancelled.set(true) }
+            })
+        } as Flow.Publisher
+
+        Flow.Subscriber downstream = new Flow.Subscriber<Object>() {
+            @Override void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE) }
+            @Override void onNext(Object o) {}
+            @Override void onError(Throwable t) { received.set(t) }
+            @Override void onComplete() { completed.set(true) }
+        }
+
+        def mapping = new HttpStreamResult.MappingSubscriber(downstream, { throw new RuntimeException('boom') } as Closure)
+        upstream.subscribe(mapping)
+
+        mapping.onNext('item-1')
+        assert upstreamCancelled.get(), 'upstream must be cancelled when mapper throws'
+        assert received.get()?.message == 'boom'
+
+        // Subsequent signals must be dropped (§1.7).
+        mapping.onNext('item-2')
+        mapping.onError(new RuntimeException('second'))
+        mapping.onComplete()
+
+        assert received.get().message == 'boom', 'onError must not be signalled twice'
+        assert !completed.get(), 'onComplete must not fire after onError'
+    }
+
+    @Test
+    void mappingSubscriberIgnoresSignalsAfterComplete() {
+        AtomicReference<Throwable> received = new AtomicReference<>()
+        int completions = 0
+        int items = 0
+
+        Flow.Subscriber downstream = new Flow.Subscriber<Object>() {
+            @Override void onSubscribe(Flow.Subscription s) {}
+            @Override void onNext(Object o) { items++ }
+            @Override void onError(Throwable t) { received.set(t) }
+            @Override void onComplete() { completions++ }
+        }
+
+        def mapping = new HttpStreamResult.MappingSubscriber(downstream, { it } as Closure)
+        mapping.onSubscribe(new Flow.Subscription() {
+            @Override void request(long n) {}
+            @Override void cancel() {}
+        })
+        mapping.onNext('a')
+        mapping.onComplete()
+        // Misbehaving upstream keeps signalling past terminal — we must ignore.
+        mapping.onNext('b')
+        mapping.onComplete()
+        mapping.onError(new RuntimeException('late'))
+
+        assert items == 1
+        assert completions == 1
+        assert received.get() == null
+    }
+
+    @Test
+    void linePublisherHonoursBoundedDownstreamDemand() {
+        // One chunk with three lines; downstream requests only one — exactly
+        // one onNext must fire, even though upstream delivered enough for three.
+        def source = new SubmissionPublisher<List<ByteBuffer>>()
+        def lp = new HttpStreamResult.LinePublisher(source, StandardCharsets.UTF_8)
+
+        List<String> received = Collections.synchronizedList([])
+        AtomicReference<Flow.Subscription> sub = new AtomicReference<>()
+        CountDownLatch subscribed = new CountDownLatch(1)
+        lp.subscribe(new Flow.Subscriber<String>() {
+            @Override void onSubscribe(Flow.Subscription s) { sub.set(s); subscribed.countDown() }
+            @Override void onNext(String line) { received << line }
+            @Override void onError(Throwable t) {}
+            @Override void onComplete() {}
+        })
+        assert subscribed.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+        source.submit([ByteBuffer.wrap("one\ntwo\nthree\n".getBytes(StandardCharsets.UTF_8))])
+        sub.get().request(1)
+
+        waitUntil { received.size() >= 1 }
+        assert received == ['one']
+
+        sub.get().request(1)
+        waitUntil { received.size() >= 2 }
+        assert received == ['one', 'two']
+
+        // No further signals without more demand.
+        Thread.sleep(50)
+        assert received == ['one', 'two']
+
+        source.close()
+    }
+
+    private static void waitUntil(Closure<Boolean> condition) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(AWAIT_TIMEOUT_SECONDS)
+        while (!condition.call() && System.nanoTime() < deadline) {
+            Thread.sleep(5)
+        }
+    }
+
+    @Test
+    void linePublisherJoinsLineAcrossChunks() {
+        def source = new SubmissionPublisher<List<ByteBuffer>>()
+        def lp = new HttpStreamResult.LinePublisher(source, StandardCharsets.UTF_8)
+
+        List<String> received = []
+        CountDownLatch completed = new CountDownLatch(1)
+        lp.subscribe(new Flow.Subscriber<String>() {
+            @Override void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE) }
+            @Override void onNext(String line) { received << line }
+            @Override void onError(Throwable t) { completed.countDown() }
+            @Override void onComplete() { completed.countDown() }
+        })
+
+        source.submit([ByteBuffer.wrap('hel'.getBytes(StandardCharsets.UTF_8))])
+        source.submit([ByteBuffer.wrap('lo\nwo'.getBytes(StandardCharsets.UTF_8))])
+        source.submit([ByteBuffer.wrap('rld\n'.getBytes(StandardCharsets.UTF_8))])
+        source.close()
+
+        assert completed.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        assert received == ['hello', 'world']
+    }
+
+    @Test
+    void linePublisherFlushesTrailingPartialLineOnComplete() {
+        def source = new SubmissionPublisher<List<ByteBuffer>>()
+        def lp = new HttpStreamResult.LinePublisher(source, StandardCharsets.UTF_8)
+
+        List<String> received = []
+        CountDownLatch completed = new CountDownLatch(1)
+        lp.subscribe(new Flow.Subscriber<String>() {
+            @Override void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE) }
+            @Override void onNext(String line) { received << line }
+            @Override void onError(Throwable t) {}
+            @Override void onComplete() { completed.countDown() }
+        })
+
+        source.submit([ByteBuffer.wrap('a\nb'.getBytes(StandardCharsets.UTF_8))])
+        source.close()
+
+        assert completed.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        assert received == ['a', 'b']
+    }
+
+    @Test
+    void linePublisherRejectsNonPositiveRequest() {
+        def source = new SubmissionPublisher<List<ByteBuffer>>()
+        def lp = new HttpStreamResult.LinePublisher(source, StandardCharsets.UTF_8)
+
+        AtomicReference<Throwable> error = new AtomicReference<>()
+        CountDownLatch signalled = new CountDownLatch(1)
+        lp.subscribe(new Flow.Subscriber<String>() {
+            @Override void onSubscribe(Flow.Subscription s) { s.request(0L) }
+            @Override void onNext(String line) {}
+            @Override void onError(Throwable t) { error.set(t); signalled.countDown() }
+            @Override void onComplete() { signalled.countDown() }
+        })
+
+        assert signalled.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        assert error.get() instanceof IllegalArgumentException
+        assert error.get().message.contains('§3.9')
+        source.close()
+    }
+
+    @Test
+    void linePublisherCancelStopsUpstreamAndDownstream() {
+        AtomicBoolean upstreamCancelled = new AtomicBoolean()
+        AtomicLong chunkRequests = new AtomicLong()
+        AtomicReference<Flow.Subscriber<? super List<ByteBuffer>>> upstreamSub = new AtomicReference<>()
+        Flow.Publisher<List<ByteBuffer>> source = { sub ->
+            upstreamSub.set(sub as Flow.Subscriber)
+            sub.onSubscribe(new Flow.Subscription() {
+                @Override void request(long n) { chunkRequests.addAndGet(n) }
+                @Override void cancel() { upstreamCancelled.set(true) }
+            })
+        } as Flow.Publisher<List<ByteBuffer>>
+
+        def lp = new HttpStreamResult.LinePublisher(source, StandardCharsets.UTF_8)
+
+        int received = 0
+        AtomicReference<Flow.Subscription> sub = new AtomicReference<>()
+        lp.subscribe(new Flow.Subscriber<String>() {
+            @Override void onSubscribe(Flow.Subscription s) { sub.set(s) }
+            @Override void onNext(String line) { received++ }
+            @Override void onError(Throwable t) {}
+            @Override void onComplete() {}
+        })
+
+        sub.get().request(10)
+        assert chunkRequests.get() > 0, 'upstream should have received a request once downstream demanded lines'
+
+        // Deliver one line, then cancel; subsequent onNext signals must be ignored.
+        upstreamSub.get().onNext([ByteBuffer.wrap('only-line\n'.getBytes(StandardCharsets.UTF_8))])
+        Thread.sleep(20)
+        sub.get().cancel()
+        assert upstreamCancelled.get()
+
+        upstreamSub.get().onNext([ByteBuffer.wrap('ignored\n'.getBytes(StandardCharsets.UTF_8))])
+        Thread.sleep(20)
+        assert received == 1
+    }
+
+    @Test
+    void forAwaitOverLinePublisherViaAdapter() {
+        // Drives the FlowPublisherAdapter end-to-end against a real HTTP stream.
+        def shell = new GroovyShell(new Binding(rootUri: rootUri))
+        shell.evaluate '''
+            import groovy.http.HttpBuilder
+
+            def http = HttpBuilder.http(rootUri.toString())
+            def result = http.getStreamAsync('/lines').join()
+
+            def collected = []
+            for await (line in result.bodyAsLinePublisher()) {
+                collected << line
+            }
+            assert collected == ['line-1', 'line-2', 'line-3', 'line-4', 'line-5']
+        '''
+    }
+}


### PR DESCRIPTION
This a piece that ties together http builder and async pieces but is of most value if we proceed with GEP-18. I'll provide a separate PR with a good example showing that but under a separate Jira.