### PR TITLE
GROOVY-11954: groovydoc: short-name type resolution cache makes doc o…

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
@@ -34,6 +34,7 @@ import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -75,6 +76,7 @@ public class SimpleGroovyClassDoc extends SimpleGroovyAbstractableElementDoc imp
     private final List<GroovyClassDoc> nested;
     private final List<LinkArgument> links;
     private final Map<String, Class<?>> resolvedExternalClassesCache;
+    private final Map<String, GroovyClassDoc> localResolvedClasses = new HashMap<>();
     private GroovyClassDoc superClass;
     private GroovyClassDoc outer;
     private String superClassName;
@@ -549,20 +551,22 @@ public class SimpleGroovyClassDoc extends SimpleGroovyAbstractableElementDoc imp
 
     private GroovyClassDoc resolveClass(GroovyRootDoc rootDoc, String name) {
         if (isPrimitiveType(name)) return null;
-        GroovyClassDoc groovyClassDoc;
-        Map<String, GroovyClassDoc> resolvedClasses = null;
-        if (rootDoc != null) {
-            resolvedClasses = rootDoc.getResolvedClasses();
-            groovyClassDoc = resolvedClasses.get(name);
-            if (groovyClassDoc != null) {
-                return groovyClassDoc;
-            }
-        }
-        groovyClassDoc = doResolveClass(rootDoc, name);
-        if (resolvedClasses != null) {
-            resolvedClasses.put(name, groovyClassDoc);
-        }
-        return groovyClassDoc;
+        if (rootDoc == null) return doResolveClass(rootDoc, name);
+
+        // Short names resolve against this class's imports/aliases/package,
+        // so caching them on the shared root-level map (GROOVY-11954) lets
+        // the first resolver's context poison every later resolver. Fully
+        // qualified names (containing '/') bypass import resolution and are
+        // safe to share globally.
+        Map<String, GroovyClassDoc> cache = name.indexOf('/') >= 0
+                ? rootDoc.getResolvedClasses()
+                : localResolvedClasses;
+        GroovyClassDoc cached = cache.get(name);
+        if (cached != null) return cached;
+
+        GroovyClassDoc resolved = doResolveClass(rootDoc, name);
+        if (resolved != null) cache.put(name, resolved);
+        return resolved;
     }
 
     private GroovyClassDoc doResolveClass(final GroovyRootDoc rootDoc, final String name) {

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -154,6 +154,36 @@ public class GroovyDocToolTest extends GroovyTestCase {
                 doc.contains("{<DL><DT><B>inheritDoc") || doc.contains("inheritDoc:</B>"));
     }
 
+    // GROOVY-11954: resolveClass must not let a shared root-level cache smear
+    // a short-name resolution across classes with different imports. Here two
+    // classes in the same run both use the short name "Date" — one imports
+    // java.util.Date, the other java.sql.Date. Both must render links to their
+    // own import, regardless of which class is resolved first.
+    public void testShortNameResolutionHonoursPerClassImports() throws Exception {
+        String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
+        // Feed both files into the same doc run so they share a GroovyRootDoc.
+        htmlTool.add(List.of(
+                base + "/AmbiguousDateUtil.groovy",
+                base + "/AmbiguousDateSql.groovy"));
+
+        MockOutputTool output = new MockOutputTool();
+        htmlTool.renderToOutput(output, MOCK_DIR);
+
+        String utilDoc = output.getText(MOCK_DIR + "/" + base + "/AmbiguousDateUtil.html");
+        assertNotNull("Expected AmbiguousDateUtil.html in output", utilDoc);
+        assertTrue("AmbiguousDateUtil should link java.util.Date, got:\n" + utilDoc,
+                utilDoc.contains("java/util/Date.html"));
+        assertFalse("AmbiguousDateUtil must not link java.sql.Date:\n" + utilDoc,
+                utilDoc.contains("java/sql/Date.html"));
+
+        String sqlDoc = output.getText(MOCK_DIR + "/" + base + "/AmbiguousDateSql.html");
+        assertNotNull("Expected AmbiguousDateSql.html in output", sqlDoc);
+        assertTrue("AmbiguousDateSql should link java.sql.Date, got:\n" + sqlDoc,
+                sqlDoc.contains("java/sql/Date.html"));
+        assertFalse("AmbiguousDateSql must not link java.util.Date:\n" + sqlDoc,
+                sqlDoc.contains("java/util/Date.html"));
+    }
+
     // GROOVY-11941: additionalStylesheets property causes templates to emit
     // extra <link rel="stylesheet"> tags at the appropriate relative-root path.
     public void testAdditionalStylesheetsInTemplates() throws Exception {

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/AmbiguousDateSql.groovy
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/AmbiguousDateSql.groovy
@@ -1,0 +1,26 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.groovydoc.testfiles
+
+import java.sql.Date
+
+/** GROOVY-11954 fixture — short name "Date" imported from java.sql. */
+class AmbiguousDateSql {
+    Date when() { new Date(0L) }
+}

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/AmbiguousDateUtil.groovy
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/AmbiguousDateUtil.groovy
@@ -1,0 +1,26 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.groovydoc.testfiles
+
+import java.util.Date
+
+/** GROOVY-11954 fixture — short name "Date" imported from java.util. */
+class AmbiguousDateUtil {
+    Date when() { new Date() }
+}


### PR DESCRIPTION
…utput order-dependent and non-reproducible