### PR TITLE
GROOVY-11965: groovydoc incorrectly includes members declared inside …

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/antlr4/GroovydocJavaVisitor.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/antlr4/GroovydocJavaVisitor.java
@@ -37,6 +37,7 @@ import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
@@ -131,6 +132,8 @@ public class GroovydocJavaVisitor
         currentClassDoc.addEnumConstant(enumConstantDoc);
         processAnnotations(enumConstantDoc, n);
         applyJavadocComment(n.getJavadocComment(), enumConstantDoc);
+        // Per-constant class bodies are anonymous implementation details.
+        if (!n.getClassBody().isEmpty()) return;
         super.visit(n, arg);
     }
 
@@ -437,6 +440,13 @@ public class GroovydocJavaVisitor
         applyJavadocComment(f.getJavadocComment(), field);
         currentClassDoc.add(field);
         super.visit(f, arg);
+    }
+
+    @Override
+    public void visit(ObjectCreationExpr n, Object arg) {
+        // Anonymous class bodies must not contribute members to the enclosing type doc.
+        if (n.getAnonymousClassBody().isPresent()) return;
+        super.visit(n, arg);
     }
 
     public Map<String, GroovyClassDoc> getGroovyClassDocs() {

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -1495,7 +1495,50 @@ public class GroovyDocToolTest extends GroovyTestCase {
         xmlTool.renderToOutput(output, MOCK_DIR);
         String classWithAnonymousInnerClassDoc = output.getText(MOCK_DIR + "/" + base + ".html");
         assertNotNull("No GroovyDoc found for " + base, classWithAnonymousInnerClassDoc);
-        assertFalse("innerClassMethod found in: \"" + classWithAnonymousInnerClassDoc + "\"", classWithAnonymousInnerClassDoc.contains("innerClassMethod"));
+        assertTrue("visibleMethod missing from: \"" + classWithAnonymousInnerClassDoc + "\"",
+                classWithAnonymousInnerClassDoc.contains("name=\"visibleMethod\""));
+        assertEquals("Anonymous class getType() leaked into outer doc:\n" + classWithAnonymousInnerClassDoc,
+                0, StringGroovyMethods.count(classWithAnonymousInnerClassDoc, "name=\"getType\""));
+        assertEquals("Anonymous class getValue() leaked into outer doc:\n" + classWithAnonymousInnerClassDoc,
+                0, StringGroovyMethods.count(classWithAnonymousInnerClassDoc, "name=\"getValue\""));
+        assertFalse("Anonymous field leaked into outer doc:\n" + classWithAnonymousInnerClassDoc,
+                classWithAnonymousInnerClassDoc.contains("hiddenField"));
+        assertFalse("Anonymous-body local type leaked into outer doc:\n" + classWithAnonymousInnerClassDoc,
+                classWithAnonymousInnerClassDoc.contains("HiddenType"));
+
+        String namedNestedDoc = output.getText(MOCK_DIR + "/" + base + ".NamedNested.html");
+        assertNotNull("Expected GroovyDoc for named nested class " + base + ".NamedNested", namedNestedDoc);
+        assertTrue("visibleNestedMethod missing from named nested doc:\n" + namedNestedDoc,
+                namedNestedDoc.contains("name=\"visibleNestedMethod\""));
+    }
+
+    public void testJavaEnumConstantBodyMethodsNotIncluded() throws Exception {
+        List<String> srcList = new ArrayList<>();
+        String base = "org/codehaus/groovy/tools/groovydoc/testfiles/JavaEnumWithConstantBodies";
+        srcList.add(base + ".java");
+        xmlTool.add(srcList);
+        MockOutputTool output = new MockOutputTool();
+        xmlTool.renderToOutput(output, MOCK_DIR);
+        String javaEnumDoc = output.getText(MOCK_DIR + "/" + base + ".html");
+        assertNotNull("No GroovyDoc found for " + base, javaEnumDoc);
+        assertEquals("Per-constant enum class bodies leaked draw() implementations into enum doc:\n" + javaEnumDoc,
+                1, StringGroovyMethods.count(javaEnumDoc, "name=\"draw\""));
+    }
+
+    public void testSqlAnonymousParameterImplementationsDoNotLeakIntoClassDoc() throws Exception {
+        GroovyDocTool sqlXmlTool = makeXmlTool(new ArrayList<>(), new Properties(),
+                new String[]{"subprojects/groovy-sql/src/main/java", "../groovy-sql/src/main/java"});
+        sqlXmlTool.add(List.of("groovy/sql/Sql.java"));
+
+        MockOutputTool output = new MockOutputTool();
+        sqlXmlTool.renderToOutput(output, MOCK_DIR);
+
+        String sqlDoc = output.getText(MOCK_DIR + "/groovy/sql/Sql.html");
+        assertNotNull("Expected GroovyDoc for groovy/sql/Sql", sqlDoc);
+        assertEquals("Sql doc should not expose getType() from anonymous parameter implementations:\n" + sqlDoc,
+                0, StringGroovyMethods.count(sqlDoc, "name=\"getType\""));
+        assertEquals("Sql doc should not expose getValue() from anonymous parameter implementations:\n" + sqlDoc,
+                0, StringGroovyMethods.count(sqlDoc, "name=\"getValue\""));
     }
 
     public void testJavaClassWithDiamondOperator() throws Exception {

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/ClassWithAnonymousInnerClass.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/ClassWithAnonymousInnerClass.java
@@ -19,10 +19,52 @@
 package org.codehaus.groovy.tools.groovydoc.testfiles;
 
 public class ClassWithAnonymousInnerClass {
-}
+    private final Supplier anonymous = new Supplier() {
+        private final String hiddenField = "hidden";
 
-class AnonymusInnerClass  {
+        @Override
+        public int getType() {
+            return hiddenField.length();
+        }
 
-    public void innerClassMethod(){
+        @Override
+        public Object getValue() {
+            return hiddenField;
+        }
+
+        class HiddenType {
+            Object reveal() {
+                return hiddenField;
+            }
+        }
+    };
+
+    public Supplier inout(final Supplier supplier) {
+        return new Supplier() {
+            @Override
+            public int getType() {
+                return supplier.getType();
+            }
+
+            @Override
+            public Object getValue() {
+                return supplier.getValue();
+            }
+        };
+    }
+
+    public int visibleMethod() {
+        return anonymous.getType();
+    }
+
+    public static class NamedNested {
+        public String visibleNestedMethod() {
+            return "visible";
+        }
+    }
+
+    public interface Supplier {
+        int getType();
+        Object getValue();
     }
 }

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaEnumWithConstantBodies.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/testfiles/JavaEnumWithConstantBodies.java
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.tools.groovydoc.testfiles;
+
+public enum JavaEnumWithConstantBodies {
+    FIRST {
+        @Override
+        public String draw() {
+            return "first";
+        }
+    },
+    SECOND {
+        @Override
+        public String draw() {
+            return "second";
+        }
+    };
+
+    public abstract String draw();
+}


### PR DESCRIPTION
…anonymous Java class bodies in the generated documentation of the enclosing class

https://issues.apache.org/jira/browse/GROOVY-11965