### PR TITLE
GROOVY-11973: Allow ASTTransformationCustomizer to support annotation…

### DIFF
--- a/src/main/groovy/org/codehaus/groovy/control/customizers/ASTTransformationCustomizer.groovy
+++ b/src/main/groovy/org/codehaus/groovy/control/customizers/ASTTransformationCustomizer.groovy
@@ -18,6 +18,7 @@
  */
 package org.codehaus.groovy.control.customizers
 
+import groovy.transform.AnnotationCollector
 import groovy.transform.AutoFinal
 import groovy.transform.CompilationUnitAware
 import groovy.transform.CompileStatic
@@ -195,20 +196,85 @@ class ASTTransformationCustomizer extends CompilationCustomizer implements Compi
 
     @SuppressWarnings('ClassForName')
     private static Class<ASTTransformation> findASTTransformationClass(Class<? extends Annotation> anAnnotationClass, ClassLoader transformationClassLoader) {
+        List<Class<ASTTransformation>> classes = findASTTransformationClasses(anAnnotationClass, transformationClassLoader)
+        if (classes.size() > 1) {
+            throw new IllegalArgumentException("AST transformation customizer doesn't support AST transforms with multiple classes; use ASTTransformationCustomizer.forAnnotation(...) to obtain one customizer per transform class")
+        }
+        classes[0]
+    }
+
+    @SuppressWarnings('ClassForName')
+    private static List<Class<ASTTransformation>> findASTTransformationClasses(Class<? extends Annotation> anAnnotationClass, ClassLoader transformationClassLoader) {
         GroovyASTTransformationClass annotation = anAnnotationClass.getAnnotation(GroovyASTTransformationClass)
         if (annotation == null) throw new IllegalArgumentException("Provided class doesn't look like an AST @interface")
 
-        Class[] classes = annotation.classes()
-        String[] classesAsStrings = annotation.value()
-        if (classes.length + classesAsStrings.length > 1) {
-            throw new IllegalArgumentException("AST transformation customizer doesn't support AST transforms with multiple classes")
+        ClassLoader loader = transformationClassLoader ?: anAnnotationClass.classLoader
+        List<Class<ASTTransformation>> result = []
+        annotation.classes().each { Class c -> result << (c as Class<ASTTransformation>) }
+        annotation.value().each { String name -> result << (Class.forName(name, true, loader) as Class<ASTTransformation>) }
+        if (result.isEmpty()) {
+            throw new IllegalArgumentException("No AST transformation class found for ${anAnnotationClass.name}")
         }
-        classes ? classes[0] : (Class) Class.forName(classesAsStrings[0], true, transformationClassLoader ?: anAnnotationClass.classLoader)
+        result
     }
 
     @SuppressWarnings('ClassForName')
     private static Class<ASTTransformation> findASTTransformationClass(Class<? extends Annotation> anAnnotationClass, String astTransformationClassName, ClassLoader transformationClassLoader) {
         Class.forName(astTransformationClassName, true, transformationClassLoader ?: anAnnotationClass.classLoader) as Class<ASTTransformation>
+    }
+
+    /**
+     * Creates one {@link ASTTransformationCustomizer} per AST transformation class declared by the
+     * given annotation's {@link GroovyASTTransformationClass} list. This is the way to use the
+     * customizer with annotations whose implementation is split across multiple transforms running
+     * at different compile phases (e.g. {@link groovy.transform.Sealed}, {@link groovy.transform.RecordBase}).
+     * <p>
+     * Spread the result into {@link org.codehaus.groovy.control.CompilerConfiguration#addCompilationCustomizers}:
+     * <pre>
+     *     configuration.addCompilationCustomizers(*ASTTransformationCustomizer.forAnnotation(Sealed))
+     * </pre>
+     *
+     * @since 6.0.0
+     */
+    static List<ASTTransformationCustomizer> forAnnotation(Class<? extends Annotation> transformationAnnotation) {
+        forAnnotation([:], transformationAnnotation, transformationAnnotation.classLoader)
+    }
+
+    /**
+     * @see #forAnnotation(Class)
+     * @since 6.0.0
+     */
+    static List<ASTTransformationCustomizer> forAnnotation(Class<? extends Annotation> transformationAnnotation, ClassLoader transformationClassLoader) {
+        forAnnotation([:], transformationAnnotation, transformationClassLoader)
+    }
+
+    /**
+     * @see #forAnnotation(Class)
+     * @since 6.0.0
+     */
+    static List<ASTTransformationCustomizer> forAnnotation(Map annotationParams, Class<? extends Annotation> transformationAnnotation) {
+        forAnnotation(annotationParams, transformationAnnotation, transformationAnnotation.classLoader)
+    }
+
+    /**
+     * @see #forAnnotation(Class)
+     * @since 6.0.0
+     */
+    static List<ASTTransformationCustomizer> forAnnotation(Map annotationParams, Class<? extends Annotation> transformationAnnotation, ClassLoader transformationClassLoader) {
+        // expand @AnnotationCollector aliases (e.g. @AutoExternalize -> @ExternalizeMethods + @ExternalizeVerifier)
+        AnnotationCollector collector = transformationAnnotation.getAnnotation(AnnotationCollector)
+        if (collector != null) {
+            List<ASTTransformationCustomizer> result = []
+            for (Class<? extends Annotation> aliased : collector.value()) {
+                result.addAll(forAnnotation(annotationParams, aliased, transformationClassLoader))
+            }
+            return result
+        }
+        findASTTransformationClasses(transformationAnnotation, transformationClassLoader).collect { Class<ASTTransformation> txClass ->
+            annotationParams
+                ? new ASTTransformationCustomizer(annotationParams, transformationAnnotation, txClass.name, transformationClassLoader)
+                : new ASTTransformationCustomizer(transformationAnnotation, txClass.name, transformationClassLoader)
+        }
     }
 
     private static CompilePhase findPhase(ASTTransformation transformation) {

--- a/src/main/java/org/codehaus/groovy/transform/SealedCompletionASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/SealedCompletionASTTransformation.java
@@ -52,11 +52,11 @@ public class SealedCompletionASTTransformation extends AbstractASTTransformation
         if (!SEALED_TYPE.equals(anno.getClassNode())) return;
 
         if (parent instanceof ClassNode) {
-            addDetectedSealedClasses((ClassNode) parent);
+            addDetectedSealedClasses((ClassNode) parent, anno);
         }
     }
 
-    private void addDetectedSealedClasses(ClassNode node) {
+    private void addDetectedSealedClasses(ClassNode node, AnnotationNode anno) {
         boolean sealed = Boolean.TRUE.equals(node.getNodeMetaData(SEALED_CLASS));
         List<ClassNode> permitted = node.getPermittedSubclasses();
         if (!sealed || !permitted.isEmpty() || node.getModule() == null) return;
@@ -70,11 +70,11 @@ public class SealedCompletionASTTransformation extends AbstractASTTransformation
                 }
             }
         }
+        if (permitted.isEmpty()) return;
         List<Expression> names = new ArrayList<>();
         for (ClassNode next : permitted) {
             names.add(classX(ClassHelper.make(next.getName())));
         }
-        AnnotationNode an = node.getAnnotations(SEALED_TYPE).get(0);
-        an.addMember("permittedSubclasses", new ListExpression(names));
+        anno.addMember("permittedSubclasses", new ListExpression(names));
     }
 }

--- a/src/test/groovy/org/codehaus/groovy/control/customizers/ASTTransformationCustomizerTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/control/customizers/ASTTransformationCustomizerTest.groovy
@@ -177,6 +177,60 @@ final class ASTTransformationCustomizerTest {
         '''
     }
 
+    @Test
+    void testForAnnotationSealed() {
+        def config = new CompilerConfiguration()
+        config.addCompilationCustomizers(*ASTTransformationCustomizer.forAnnotation(Sealed))
+        def shell = new GroovyShell(config)
+        def result = shell.evaluate '''
+            class Shape { }
+            class Circle extends Shape { }
+            class Square extends Shape { }
+            [Shape, Circle, Square]
+        '''
+        assert result[0].permittedSubclasses*.simpleName.toSet() == ['Circle', 'Square'] as Set
+    }
+
+    @Test
+    void testForAnnotationWithSingleTransform() {
+        // single-transform annotations should also work via the factory
+        def config = new CompilerConfiguration()
+        config.addCompilationCustomizers(*ASTTransformationCustomizer.forAnnotation(Log))
+        def shell = new GroovyShell(config)
+        def result = shell.evaluate '''
+            class MyClass { }
+            new MyClass()
+        '''
+        assert result.log.class == java.util.logging.Logger
+    }
+
+    @Test
+    void testForAnnotationCollector() {
+        // @AutoExternalize is an @AnnotationCollector bundling @ExternalizeMethods + @ExternalizeVerifier
+        def config = new CompilerConfiguration()
+        config.addCompilationCustomizers(*ASTTransformationCustomizer.forAnnotation(AutoExternalize))
+        def shell = new GroovyShell(config)
+        def result = shell.evaluate '''
+            class Person {
+                String first, last
+            }
+            new Person(first: 'a', last: 'b')
+        '''
+        assert result instanceof Externalizable
+    }
+
+    @Test
+    void testForAnnotationWithParams() {
+        def config = new CompilerConfiguration()
+        config.addCompilationCustomizers(*ASTTransformationCustomizer.forAnnotation([value: 'logger'], Log))
+        def shell = new GroovyShell(config)
+        def result = shell.evaluate '''
+            class MyClass { }
+            new MyClass()
+        '''
+        assert result.logger.class == java.util.logging.Logger
+    }
+
     //--------------------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
…s with multiple AST transforms (e.g. @Sealed, @RecordBase) and @AnnotationCollector aliases (e.g. @AutoExternalize) via a new forAnnotation factory method.

This doesn't represent new functionality in that there are long-hand ways to achieve the same result - it's just that we have the short-hand way for all of the other transforms, so having the short-hand for these cases aids consistency.