### PR TITLE
GROOVY-11987: groovydoc CLI fails with "Unsupported Java Version: fal…

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/groovy/org/codehaus/groovy/tools/groovydoc/Main.groovy
+++ b/subprojects/groovy-groovydoc/src/main/groovy/org/codehaus/groovy/tools/groovydoc/Main.groovy
@@ -160,7 +160,7 @@ class Main {
             sourcepath = list.toArray()
         }
 
-        javaVersion = options.javaVersion
+        javaVersion = options.javaVersion ?: null
         author = Boolean.valueOf(options.author) ?: false
         noScripts = Boolean.valueOf(options.noscripts) ?: false
         noMainForScripts = Boolean.valueOf(options.nomainforscripts) ?: false


### PR DESCRIPTION
…se" when --javaVersion omitted