### PR TITLE
Add `groovy.io.fileLegacyTruthy` system property to opt out of new File/Path truthy semantics

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -31,6 +31,7 @@ import groovy.transform.stc.FromString;
 import groovy.transform.stc.PickFirstResolver;
 import groovy.transform.stc.SimpleType;
 import groovy.util.CharsetToolkit;
+import org.apache.groovy.util.SystemUtil;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 import java.io.BufferedInputStream;
@@ -153,14 +154,22 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
 
     /**
      * Coerce the file to a {@code boolean} value.
+     * <p>
+     * By default this returns whether the file exists. Set the system property
+     * {@code groovy.io.fileLegacyTruthy} to {@code true} to restore the
+     * pre-Groovy-5 behavior where any non-{@code null} {@code File} is truthy
+     * regardless of whether the underlying file exists.
      *
      * @param file a {@code File}
      * @return {@code true} if the file exists, {@code false} otherwise
      * @since 5.0.0
      */
     public static boolean asBoolean(final File file) {
+        if (LEGACY_TRUTHY) return file != null;
         return file.exists();
     }
+
+    private static final boolean LEGACY_TRUTHY = SystemUtil.getBooleanSafe("groovy.io.fileLegacyTruthy");
 
     /**
      * Create an object output stream for this file.

--- a/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -156,7 +156,7 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
      * Coerce the file to a {@code boolean} value.
      * <p>
      * By default this returns whether the file exists. Set the system property
-     * {@code groovy.io.fileLegacyTruthy} to {@code true} to restore the
+     * {@code groovy.truth.file.exists.enabled} to {@code false} to restore the
      * pre-Groovy-5 behavior where any non-{@code null} {@code File} is truthy
      * regardless of whether the underlying file exists.
      *
@@ -165,11 +165,18 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 5.0.0
      */
     public static boolean asBoolean(final File file) {
-        if (LEGACY_TRUTHY) return file != null;
+        if (!FILE_EXISTS_ENABLED) return file != null;
         return file.exists();
     }
 
-    private static final boolean LEGACY_TRUTHY = SystemUtil.getBooleanSafe("groovy.io.fileLegacyTruthy");
+    /**
+     * When {@code true} (the default), coercing a {@link File} or {@link java.nio.file.Path}
+     * to a {@code boolean} returns whether the underlying file exists. Set the system property
+     * {@code groovy.truth.file.exists.enabled} to {@code false} to restore the pre-Groovy-5
+     * behavior where any non-{@code null} reference is truthy.
+     */
+    public static final boolean FILE_EXISTS_ENABLED = Boolean.parseBoolean(
+            SystemUtil.getSystemPropertySafe("groovy.truth.file.exists.enabled", "true"));
 
     /**
      * Create an object output stream for this file.

--- a/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
+++ b/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
@@ -30,6 +30,7 @@ import groovy.transform.stc.FromString;
 import groovy.transform.stc.PickFirstResolver;
 import groovy.transform.stc.SimpleType;
 import org.apache.groovy.nio.runtime.WritablePath;
+import org.apache.groovy.util.SystemUtil;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport;
 import org.codehaus.groovy.runtime.FormatHelper;
@@ -147,6 +148,11 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
 
     /**
      * Coerce the path to a {@code boolean} value.
+     * <p>
+     * By default this returns whether the file at the path exists. Set the
+     * system property {@code groovy.io.fileLegacyTruthy} to {@code true} to
+     * restore the pre-Groovy-5 behavior where any non-{@code null} {@code Path}
+     * is truthy regardless of whether the underlying file exists.
      *
      * @param path a {@code Path} object
      * @return {@code true} if the file at the path exists, {@code false} otherwise
@@ -154,8 +160,11 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
      * @since 5.0.0
      */
     public static boolean asBoolean(final Path path) {
+        if (LEGACY_TRUTHY) return path != null;
         return Files.exists(path);
     }
+
+    private static final boolean LEGACY_TRUTHY = SystemUtil.getBooleanSafe("groovy.io.fileLegacyTruthy");
 
     /**
      * Tests whether the file at the path exists.

--- a/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
+++ b/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
@@ -30,12 +30,12 @@ import groovy.transform.stc.FromString;
 import groovy.transform.stc.PickFirstResolver;
 import groovy.transform.stc.SimpleType;
 import org.apache.groovy.nio.runtime.WritablePath;
-import org.apache.groovy.util.SystemUtil;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport;
 import org.codehaus.groovy.runtime.FormatHelper;
 import org.codehaus.groovy.runtime.IOGroovyMethods;
 import org.codehaus.groovy.runtime.InvokerHelper;
+import org.codehaus.groovy.runtime.ResourceGroovyMethods;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 import java.io.BufferedInputStream;
@@ -150,8 +150,8 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
      * Coerce the path to a {@code boolean} value.
      * <p>
      * By default this returns whether the file at the path exists. Set the
-     * system property {@code groovy.io.fileLegacyTruthy} to {@code true} to
-     * restore the pre-Groovy-5 behavior where any non-{@code null} {@code Path}
+     * system property {@code groovy.truth.file.exists.enabled} to {@code false}
+     * to restore the pre-Groovy-5 behavior where any non-{@code null} {@code Path}
      * is truthy regardless of whether the underlying file exists.
      *
      * @param path a {@code Path} object
@@ -160,11 +160,9 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
      * @since 5.0.0
      */
     public static boolean asBoolean(final Path path) {
-        if (LEGACY_TRUTHY) return path != null;
+        if (!ResourceGroovyMethods.FILE_EXISTS_ENABLED) return path != null;
         return Files.exists(path);
     }
-
-    private static final boolean LEGACY_TRUTHY = SystemUtil.getBooleanSafe("groovy.io.fileLegacyTruthy");
 
     /**
      * Tests whether the file at the path exists.


### PR DESCRIPTION
## Summary

Adds an opt-out system property that restores the pre-Groovy-5 truthy semantics for `java.io.File` and `java.nio.file.Path`: when `-Dgroovy.io.fileLegacyTruthy=true` is set, any non-`null` reference is truthy, regardless of whether the underlying file exists.

The new default behaviour introduced in 5.0 (delegating to `File.exists()` / `Files.exists()`) is preserved when the property is absent or false.

## Why

The new truthy semantics for `File`/`Path` introduced in Groovy 5 are a useful upgrade for greenfield code, but they silently change the behaviour of any existing code that uses `if (path) { … }` or `path ? a : b` to mean **"the reference is set"**. The release notes call this out and recommend rewriting affected sites to use explicit `!= null`.

That recommendation is reasonable for code authors who control the codebase, but it does not generalise. In platforms that **execute user-supplied Groovy code** — Nextflow being one example, but the same applies to Gradle build scripts, Jenkins pipelines, and many other Groovy-based DSLs — the upgrade does not just affect the platform itself. Every existing user pipeline written against earlier Groovy versions can be silently affected, and there is no realistic path to audit and rewrite all of them. The end-user authoring those pipelines may have no idea Groovy was upgraded under them, and a previously-working `if(file)` may now silently skip a branch when the referenced file happens not to exist yet at evaluation time.

A toggle flag here lets such platforms upgrade to Groovy 5 without forcing a coordinated rewrite of an unbounded set of downstream user code. Greenfield Groovy 5 users continue to get the new default; platform integrators have an explicit, well-named knob to preserve compatibility for their users.

## Implementation

- New system property: `groovy.io.fileLegacyTruthy` (single shared flag covering both `File` and `Path`, named per Groovy's existing convention — see `groovy.compiler.strictNames`, `groovy.json.internKeys`, etc.).
- Two changes:
  - `ResourceGroovyMethods.asBoolean(File)` — opt-out branch returns `file != null`.
  - `NioExtensions.asBoolean(Path)` — opt-out branch returns `path != null`.
- Read once at class load via `SystemUtil.getBooleanSafe(...)` to match the pattern used elsewhere (`StaticTypeCheckingVisitor.DEBUG_GENERATED_CODE`, `CompilerConfiguration.parameters`, …).
- Javadoc updated on both methods.

The default path is unchanged (no behaviour change, no perf impact beyond a single boolean read at JVM start).

## Test plan

- [ ] Verify default behaviour (property absent) still calls `File.exists()` / `Files.exists()` — covered by the existing `ResourceGroovyMethodsTest.test_asBoolean`.
- [ ] Add a test exercising the opt-out path. Note: because the constant is initialised at class load, this test needs to set the system property before the class is loaded (forked JVM, or junit-pioneer `@SetSystemProperty`). Happy to add the test in this PR if a particular fixture style is preferred — let me know.

## Notes

- Single property covers both `File` and `Path` because the breaking change is conceptually the same; users are likely to want to flip both together.
- No CHANGELOG / release-note entry yet — happy to add one in the form preferred by the project.
