### PR TITLE
Bump version on GROOVY_5_0_X branch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-groovyVersion=5.0.6-SNAPSHOT
+groovyVersion=5.0.7-SNAPSHOT
 # bundle version format: major('.'minor('.'micro('.'qualifier)?)?)? (first 3 only digits)
-groovyBundleVersion=5.0.6.SNAPSHOT
+groovyBundleVersion=5.0.7.SNAPSHOT
 
 groovyTargetBytecodeVersion=11
 targetJavaVersion=11


### PR DESCRIPTION
Groovy 5.0.6 was released on May 4, 2026 (tag `GROOVY_5_0_6`, commit `6c61c378c8`), but the SNAPSHOT on `GROOVY_5_0_X` was not advanced afterwards. This PR bumps `groovyVersion` and `groovyBundleVersion` from `5.0.6-SNAPSHOT` to `5.0.7-SNAPSHOT` so ongoing 5.0.x development resolves under the correct snapshot coordinates.

Matches the historical pattern used for every prior 5.0.x bump:

- `9ac7ff1364` Bump version on GROOVY_5_0_X branch (5.0.5 -> 5.0.6)
- `7dfb204364` Bump version on GROOVY_5_0_X branch (5.0.4 -> 5.0.5)
- `a3c1decd78` Bump version on GROOVY_5_0_X branch (5.0.2 -> 5.0.3)
- `7e7dbb5302` Bump version on GROOVY_5_0_X branch (5.0.1 -> 5.0.2)

Two-line change in `gradle.properties` only.
