### PR TITLE
use Locale.ROOT in StringGroovyMethods.containsIgnoreCase

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/StringGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/StringGroovyMethods.java
@@ -44,6 +44,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -4339,6 +4340,6 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
         if (searchString == null || searchString.length() == 0 || self.length() < searchString.length())
             return false;
 
-        return self.toString().toLowerCase().contains(searchString.toString().toLowerCase());
+        return self.toString().toLowerCase(Locale.ROOT).contains(searchString.toString().toLowerCase(Locale.ROOT));
     }
 }


### PR DESCRIPTION
`containsIgnoreCase` lowercases both arguments with the JVM default locale, so
under `tr_TR` `"ADMIN".containsIgnoreCase("admin")` returns false — `I` folds
to dotless `ı`. Switch to `Locale.ROOT`, matching the sibling
`startsWithIgnoreCase`/`endsWithIgnoreCase` which already fold locale-independently via `equalsIgnoreCase`.