### PR TITLE
use Locale.ROOT in CharSequenceValue.toEnum case fallback

### DIFF
--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharSequenceValue.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharSequenceValue.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Objects;
 
 import static org.apache.groovy.json.internal.CharScanner.isInteger;
@@ -131,7 +132,7 @@ public class CharSequenceValue implements Value, CharSequence {
         try {
             return (T) Enum.valueOf(cls, value);
         } catch (Exception ex) {
-            return (T) Enum.valueOf(cls, value.toUpperCase().replace('-', '_'));
+            return (T) Enum.valueOf(cls, value.toUpperCase(Locale.ROOT).replace('-', '_'));
         }
     }
 


### PR DESCRIPTION
Hit this running JSON binding under a tr_TR default locale. toEnum's case-insensitive fallback uppercases the value with the JVM default locale, so `"high"` folds to `HİGH` (dotted I) and `Enum.valueOf` throws even though `HIGH` exists. The exact-match path and the lowercase fallback (testStaticToEnumByValueWithDash) work everywhere except locales with special case rules. Use Locale.ROOT.