### PR TITLE
use Locale.ROOT in CharSequenceValue.toEnum

### DIFF
--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharSequenceValue.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharSequenceValue.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Objects;
 
 import static org.apache.groovy.json.internal.CharScanner.isInteger;
@@ -131,7 +132,7 @@ public class CharSequenceValue implements Value, CharSequence {
         try {
             return (T) Enum.valueOf(cls, value);
         } catch (Exception ex) {
-            return (T) Enum.valueOf(cls, value.toUpperCase().replace('-', '_'));
+            return (T) Enum.valueOf(cls, value.toUpperCase(Locale.ROOT).replace('-', '_'));
         }
     }
 


### PR DESCRIPTION
Noticed the fallback in `CharSequenceValue.toEnum` uppercases the token text with the JVM default locale before matching the enum constant. Under tr_TR a value like `id` folds to `İD`, so `Enum.valueOf` throws and a valid JSON value never resolves. Fold with Locale.ROOT so the lookup stays locale-independent.