### PR TITLE
GROOVY-12024: add `getAt(Map,String)` and `putAt(Map,String,V)`

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -7352,6 +7352,24 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Support the subscript operator for a Map.
+     * <pre class="language-groovy groovyTestCase">def map = [foo:'bar', class:'baz', empty:'nope']
+     * assert map['foo'] == 'bar'
+     * assert map['class'] == 'baz'
+     * assert map['empty'] == 'nope'
+     * assert map['properties'] == null // GROOVY-12024
+     * </pre>
+     *
+     * @param self a Map
+     * @param key  a String as a key for the map
+     * @return the value corresponding to the given key
+     * @since 6.0.0
+     */
+    public static <V> V getAt(Map<? super String,V> self, String key) {
+        return self.get(key);
+    }
+
+    /**
      * Support the subscript operator for a Bitset
      *
      * @param self  a BitSet
@@ -12950,10 +12968,29 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @param self  a Map
      * @param key   an Object as a key for the map
      * @param value the value to put into the map
-     * @return the value corresponding to the given key
+     * @return the value
      * @since 1.0
      */
     public static <K,V> V putAt(Map<K,V> self, K key, V value) {
+        self.put(key, value);
+        return value;
+    }
+
+    /**
+     * A helper method to allow maps to work with subscript operators.
+     * <pre class="language-groovy groovyTestCase">def map = [:]
+     * assert map['properties'] == null
+     * map['properties'] = new Object() // GROOVY-12024
+     * assert map['properties'] != null
+     * </pre>
+     *
+     * @param self  a Map
+     * @param key   an Object as a key for the map
+     * @param value the value to put into the map
+     * @return the value
+     * @since 6.0.0
+     */
+    public static <V> V putAt(Map<? super String,V> self, String key, V value) {
         self.put(key, value);
         return value;
     }

--- a/src/test/groovy/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/FieldsAndPropertiesSTCTest.groovy
@@ -765,7 +765,7 @@ class FieldsAndPropertiesSTCTest extends StaticTypeCheckingTestCase {
         'Cannot set read-only property: properties'
     }
 
-    // GROOVY-8074
+    // GROOVY-8074, GROOVY-12024
     @Test
     void testMapPropertyAccess6() {
         assertScript '''
@@ -775,23 +775,27 @@ class FieldsAndPropertiesSTCTest extends StaticTypeCheckingTestCase {
             def map = new C()
             map.put('foo', 11)
             assert map.foo == 1
-            assert map['foo'] == 1
+            assert map['foo'] == 11
+            assert map.get('foo') == 11
         '''
         assertScript """
             def map = new ${MapType.name}()
             map.put('foo', 11)
             assert map.foo == 1
-            assert map['foo'] == 1
+            assert map['foo'] == 11
+            assert map.get('foo') == 11
             map.put('bar', 22)
             assert map.bar == 22
             assert map['bar'] == 22
+            assert map.get('bar') == 22
             map.put('baz', 33)
             assert map.baz == 33
             assert map['baz'] == 33
+            assert map.get('baz') == 33
         """
     }
 
-    // GROOVY-5001, GROOVY-5491, GROOVY-6144
+    // GROOVY-5001, GROOVY-5491, GROOVY-6144, GROOVY-12024
     @Test
     void testMapPropertyAccess7() {
         String types = '''
@@ -804,23 +808,21 @@ class FieldsAndPropertiesSTCTest extends StaticTypeCheckingTestCase {
         assertScript types + '''
             def map = new C()
             map.put('a', new A())
+            assert map.a != null
+            assert map.b != null
+            assert map['a'] != null
+            assert map['b'] == null
             assert map.get('a') != null
             assert map.get('b') == null
-            A a = map.a
-            B b = map.b
-            a = map['a']
-            b = map['b']
-            assert a instanceof A
-            assert b instanceof B
         '''
         assertScript types + '''
             def test(C map) {
-                A a = map.a
-                B b = map.b
-                a = map['a']
-                b = map['b']
-                assert a instanceof A
-                assert b instanceof B
+                assert map.a != null
+                assert map.b != null
+                assert map['a'] != null
+                assert map['b'] == null
+                assert map.get('a') != null
+                assert map.get('b') == null
             }
             test(new C().tap{ put('a', new A()) })
         '''

--- a/src/test/groovy/groovy/transform/stc/GenericsSTCTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/GenericsSTCTest.groovy
@@ -2575,7 +2575,7 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
             def map = new HashMap<String, Integer>()
             map['x'] = new Object()
         ''',
-            'Cannot assign value of type java.lang.Object to variable of type java.lang.Integer'
+        'Cannot call','putAt','with arguments [java.util.HashMap<java.lang.String, java.lang.Integer>, java.lang.String, java.lang.Object]'
     }
 
     // GROOVY-9069
@@ -2591,8 +2591,8 @@ class GenericsSTCTest extends StaticTypeCheckingTestCase {
                 }
             }
         ''',
-            'Cannot call java.util.Map#put(java.lang.String, java.util.Map<java.lang.String, java.util.List<java.lang.String>>) with arguments [java.lang.String, java.util.LinkedHashMap<java.lang.String, java.util.List<ConfigAttribute>>]',
-            'Cannot assign java.util.LinkedHashMap<java.lang.String, java.util.List<ConfigAttribute>> to: java.util.Map<java.lang.String, java.util.List<java.lang.String>>'
+        'Cannot call java.util.Map#put(java.lang.String, java.util.Map<java.lang.String, java.util.List<java.lang.String>>) with arguments [java.lang.String, java.util.LinkedHashMap<java.lang.String, java.util.List<ConfigAttribute>>]',
+        'Cannot call <V> org.codehaus.groovy.runtime.DefaultGroovyMethods#putAt(java.util.Map<? super java.lang.String, V>, java.lang.String, V) with arguments [java.util.Map<java.lang.String, java.util.Map<java.lang.String, java.util.List<java.lang.String>>>, java.lang.String, java.util.LinkedHashMap<java.lang.String, java.util.List<ConfigAttribute>>]'
 
         assertScript '''
             void test(Map<String, Map<String, List<String>>> maps) {


### PR DESCRIPTION
Should `map['key']` work like `map.key` or `map.get('key')`?  In older Groovy versions, `getAt(Map,Object)` was considered closer than `getAt(Object,String)`.  Adding `getAt(Map,String)` and `putAt(Map,String,V)` restores alignment between `getAt` and `get` at the expense of the public property handling for the subscript syntax.

STC of `map['key'] = value` would indicate "Cannot assign value of type ..." but now reports "Cannot call putAt ... with arguments ..."