### PR TITLE
reject backslash in grape ivy coordinate validation

### DIFF
--- a/subprojects/groovy-grape-ivy/src/main/groovy/groovy/grape/ivy/GrapeIvy.groovy
+++ b/subprojects/groovy-grape-ivy/src/main/groovy/groovy/grape/ivy/GrapeIvy.groovy
@@ -393,7 +393,7 @@ class GrapeIvy implements GrapeEngine {
         dep.each { k, v ->
             if (v instanceof CharSequence) {
                 if (k.toString().contains('v')) { // revision, version, rev
-                    if (!(v ==~ '[^\\/:"<>|]*')) {
+                    if (!(v ==~ '[^\\\\/:"<>|]*')) {
                         throw new RuntimeException("Grab: invalid value of '$v' for $k: should not contain any of / \\ : \" < > |")
                     }
                 } else {


### PR DESCRIPTION
The coordinate check in createGrabRecord rejects / : " < > | in version and revision values, but the character class leaves out the backslash it claims to forbid, so a value such as ..\..\x slips through on Windows and is later interpolated into grape cache file paths. GrapeMaven already escapes the backslash in the same class; this brings GrapeIvy in line.
