### PR TITLE
GROOVY-12058: ClassNodeUtils.getPropNameForAccessor should use JavaBe…

### DIFF
--- a/src/main/java/org/apache/groovy/ast/tools/ClassNodeUtils.java
+++ b/src/main/java/org/apache/groovy/ast/tools/ClassNodeUtils.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -338,7 +337,8 @@ public class ClassNodeUtils {
     public static String getPropNameForAccessor(final String accessorName) {
         if (!isValidAccessorName(accessorName)) return accessorName;
         int prefixLength = accessorName.startsWith("is") ? 2 : 3;
-        return String.valueOf(accessorName.charAt(prefixLength)).toLowerCase(Locale.ROOT) + accessorName.substring(prefixLength + 1);
+        // use JavaBean decapitalization so acronyms match the runtime rule, e.g. getURL -> URL (not uRL)
+        return BeanUtils.decapitalize(accessorName.substring(prefixLength));
     }
 
     /**

--- a/src/test/groovy/org/apache/groovy/ast/tools/ClassNodeUtilsTest.groovy
+++ b/src/test/groovy/org/apache/groovy/ast/tools/ClassNodeUtilsTest.groovy
@@ -1,0 +1,54 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.ast.tools
+
+import org.junit.jupiter.api.Test
+
+import static org.apache.groovy.ast.tools.ClassNodeUtils.getPropNameForAccessor
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+/**
+ * Tests for {@link ClassNodeUtils}.
+ */
+final class ClassNodeUtilsTest {
+
+    @Test
+    void 'getPropNameForAccessor strips the accessor prefix'() {
+        assertEquals('age', getPropNameForAccessor('getAge'))
+        assertEquals('age', getPropNameForAccessor('setAge'))
+        assertEquals('active', getPropNameForAccessor('isActive'))
+        assertEquals('x', getPropNameForAccessor('getX'))
+    }
+
+    @Test
+    void 'getPropNameForAccessor uses JavaBean decapitalization for acronyms'() {
+        // GROOVY-12055 follow-up: must match the runtime rule (MetaClassImpl uses
+        // BeanUtils.decapitalize), e.g. getURL -> URL, not uRL
+        assertEquals('URL', getPropNameForAccessor('getURL'))
+        assertEquals('URL', getPropNameForAccessor('setURL'))
+        assertEquals('URLConnection', getPropNameForAccessor('getURLConnection'))
+    }
+
+    @Test
+    void 'getPropNameForAccessor returns the original when not a valid accessor'() {
+        assertEquals('foo', getPropNameForAccessor('foo'))
+        assertEquals('get', getPropNameForAccessor('get'))
+        assertEquals('is', getPropNameForAccessor('is'))
+    }
+}


### PR DESCRIPTION
…ans decapitalization to match runtime property naming