### PR TITLE
use Locale.ROOT in DataSet table name folding

### DIFF
--- a/subprojects/groovy-sql/src/main/java/groovy/sql/DataSet.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/DataSet.java
@@ -32,6 +32,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -104,7 +105,7 @@ public class DataSet extends Sql {
         if (idx > 0) {
             table = table.substring(idx + 1);
         }
-        this.table = table.toLowerCase();
+        this.table = table.toLowerCase(Locale.ROOT);
     }
 
     /**


### PR DESCRIPTION
DataSet(Sql, Class) lowercases the table name from the type's simple name with the default locale on DataSet.java:107, so under a Turkish locale a class like Item produces the SQL `select * from ıtem`. Pass Locale.ROOT, matching the GROOVY-12055 fixes in Sql and ResultSetMetaDataWrapper.