### PR TITLE
GROOVY-12073: reject dot-dot segments in grape coordinate validation

### DIFF
--- a/subprojects/groovy-grape-ivy/src/main/groovy/groovy/grape/ivy/GrapeIvy.groovy
+++ b/subprojects/groovy-grape-ivy/src/main/groovy/groovy/grape/ivy/GrapeIvy.groovy
@@ -401,6 +401,9 @@ class GrapeIvy implements GrapeEngine {
                         throw new RuntimeException("Grab: invalid value of '$v' for $k: should only contain - . _ a-z A-Z 0-9")
                     }
                 }
+                if (v.toString().contains('..')) {
+                    throw new RuntimeException("Grab: invalid value of '$v' for $k: should not contain '..'")
+                }
             }
         }
 

--- a/subprojects/groovy-grape-ivy/src/test/groovy/groovy/grape/ivy/GrapeIvyTest.groovy
+++ b/subprojects/groovy-grape-ivy/src/test/groovy/groovy/grape/ivy/GrapeIvyTest.groovy
@@ -427,6 +427,33 @@ final class GrapeIvyTest {
     }
 
     @Test
+    void testInvalidVersionDotDot() {
+        def ex = shouldFail '''
+            groovy.grape.Grape.grab(group: 'org.ejml', module: 'ejml-simple', version: '..')
+        '''
+        assert ex.message.contains('for version')
+        assert ex.message.contains("should not contain '..'")
+    }
+
+    @Test
+    void testInvalidGroupDotDot() {
+        def ex = shouldFail '''
+            groovy.grape.Grape.grab(group: '..', module: 'ejml-simple', version: '0.41')
+        '''
+        assert ex.message.contains('for group')
+        assert ex.message.contains("should not contain '..'")
+    }
+
+    @Test
+    void testInvalidModuleDotDot() {
+        def ex = shouldFail '''
+            groovy.grape.Grape.grab(group: 'org.ejml', module: '..', version: '0.41')
+        '''
+        assert ex.message.contains('for module')
+        assert ex.message.contains("should not contain '..'")
+    }
+
+    @Test
     void testInvalidMutuallyExclusiveArgs() {
         def ex = shouldFail '''
             groovy.grape.Grape.grab(group: 'org.ejml', groupId: 'org.ejml', module: 'ejml-simple', version: '0.41')

--- a/subprojects/groovy-grape-maven/build.gradle
+++ b/subprojects/groovy-grape-maven/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     // NoClassDefFoundError: javax/inject/Provider. The supplier's POM doesn't declare this
     // transitively as of 2.0.17, so we provide it explicitly.
     implementation "javax.inject:javax.inject:${versions.javaxInject}"
+    testImplementation projects.groovyTest
 }
 
 tasks.withType(Javadoc).configureEach {

--- a/subprojects/groovy-grape-maven/src/main/groovy/groovy/grape/maven/GrapeMaven.groovy
+++ b/subprojects/groovy-grape-maven/src/main/groovy/groovy/grape/maven/GrapeMaven.groovy
@@ -586,6 +586,9 @@ class GrapeMaven implements GrapeEngine {
                         throw new RuntimeException("Grab: invalid value of '$v' for $k: should only contain - . _ a-z A-Z 0-9")
                     }
                 }
+                if (v.toString().contains('..')) {
+                    throw new RuntimeException("Grab: invalid value of '$v' for $k: should not contain '..'")
+                }
             }
         }
 

--- a/subprojects/groovy-grape-maven/src/test/groovy/groovy/grape/maven/GrapeMavenTest.groovy
+++ b/subprojects/groovy-grape-maven/src/test/groovy/groovy/grape/maven/GrapeMavenTest.groovy
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.util.jar.JarOutputStream
 
+import static groovy.test.GroovyAssert.shouldFail
+
 final class GrapeMavenTest {
     private static File writeEmptyJar(File jarFile) {
         jarFile.parentFile.mkdirs()
@@ -146,5 +148,32 @@ ${depsXml}
         assert uris.any { it.toString().contains('root-artifact-1.0.0.jar') }
         assert uris.any { it.toString().contains('dep-required-1.0.0.jar') }
         assert !uris.any { it.toString().contains('dep-optional-1.0.0.jar') }
+    }
+
+    @Test
+    void testInvalidVersionDotDot() {
+        def ex = shouldFail '''
+            groovy.grape.Grape.grab(group: 'org.ejml', module: 'ejml-simple', version: '..')
+        '''
+        assert ex.message.contains('for version')
+        assert ex.message.contains("should not contain '..'")
+    }
+
+    @Test
+    void testInvalidGroupDotDot() {
+        def ex = shouldFail '''
+            groovy.grape.Grape.grab(group: '..', module: 'ejml-simple', version: '0.41')
+        '''
+        assert ex.message.contains('for group')
+        assert ex.message.contains("should not contain '..'")
+    }
+
+    @Test
+    void testInvalidModuleDotDot() {
+        def ex = shouldFail '''
+            groovy.grape.Grape.grab(group: 'org.ejml', module: '..', version: '0.41')
+        '''
+        assert ex.message.contains('for module')
+        assert ex.message.contains("should not contain '..'")
     }
 }


### PR DESCRIPTION
createGrabRecord rejects path separators and shell metacharacters in coordinate values, but a value made only of dot segments still passes both the version blacklist and the group/module whitelist, so a version or group of '..' survives and is later interpolated into the ivy/maven cache file paths as a parent-directory hop. This adds a contains('..') guard next to the existing checks, after the backslash fix, and applies it to GrapeMaven too since it shares the same validation.