### PR TITLE
decode yaml/toml/csv input streams as utf-8

### DIFF
--- a/subprojects/groovy-csv/src/main/java/groovy/csv/CsvSlurper.java
+++ b/subprojects/groovy-csv/src/main/java/groovy/csv/CsvSlurper.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -155,7 +156,7 @@ public class CsvSlurper {
      * @return a list of maps (one per row)
      */
     public List<Map<String, String>> parse(InputStream stream) {
-        return parse(new InputStreamReader(stream));
+        return parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
     }
 
     /**
@@ -176,7 +177,7 @@ public class CsvSlurper {
      */
     public List<Map<String, String>> parse(Path path) throws IOException {
         try (InputStream stream = Files.newInputStream(path)) {
-            return parse(new InputStreamReader(stream));
+            return parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
         }
     }
 
@@ -246,7 +247,7 @@ public class CsvSlurper {
      */
     public <T> List<T> parseAs(Class<T> type, Path path) throws IOException {
         try (InputStream stream = Files.newInputStream(path)) {
-            return parseAs(type, new InputStreamReader(stream));
+            return parseAs(type, new InputStreamReader(stream, StandardCharsets.UTF_8));
         }
     }
 

--- a/subprojects/groovy-toml/src/main/java/groovy/toml/TomlSlurper.java
+++ b/subprojects/groovy-toml/src/main/java/groovy/toml/TomlSlurper.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -78,7 +79,7 @@ public class TomlSlurper {
      * @return the root node of the parsed tree of Nodes
      */
     public Object parse(InputStream stream) {
-        return parse(new InputStreamReader(stream));
+        return parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
     }
 
     /**
@@ -99,7 +100,7 @@ public class TomlSlurper {
      */
     public Object parse(Path path) throws IOException {
         try (InputStream stream = Files.newInputStream(path)) {
-            return parse(new InputStreamReader(stream));
+            return parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
         }
     }
 
@@ -156,7 +157,7 @@ public class TomlSlurper {
      * @since 6.0.0
      */
     public <T> T parseAs(Class<T> type, InputStream stream) {
-        return parseAs(type, new InputStreamReader(stream));
+        return parseAs(type, new InputStreamReader(stream, StandardCharsets.UTF_8));
     }
 
     /**
@@ -183,7 +184,7 @@ public class TomlSlurper {
      */
     public <T> T parseAs(Class<T> type, Path path) throws IOException {
         try (InputStream stream = Files.newInputStream(path)) {
-            return parseAs(type, new InputStreamReader(stream));
+            return parseAs(type, new InputStreamReader(stream, StandardCharsets.UTF_8));
         }
     }
 }

--- a/subprojects/groovy-yaml/src/main/java/groovy/yaml/YamlSlurper.java
+++ b/subprojects/groovy-yaml/src/main/java/groovy/yaml/YamlSlurper.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -77,7 +78,7 @@ public class YamlSlurper {
      * @return the root node of the parsed tree of Nodes
      */
     public Object parse(InputStream stream) {
-        return parse(new InputStreamReader(stream));
+        return parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
     }
 
     /**
@@ -98,7 +99,7 @@ public class YamlSlurper {
      */
     public Object parse(Path path) throws IOException {
         try (InputStream stream = Files.newInputStream(path)) {
-            return parse(new InputStreamReader(stream));
+            return parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
         }
     }
 
@@ -151,7 +152,7 @@ public class YamlSlurper {
      * @since 6.0.0
      */
     public <T> T parseAs(Class<T> type, InputStream stream) {
-        return parseAs(type, new InputStreamReader(stream));
+        return parseAs(type, new InputStreamReader(stream, StandardCharsets.UTF_8));
     }
 
     /**
@@ -178,7 +179,7 @@ public class YamlSlurper {
      */
     public <T> T parseAs(Class<T> type, Path path) throws IOException {
         try (InputStream stream = Files.newInputStream(path)) {
-            return parseAs(type, new InputStreamReader(stream));
+            return parseAs(type, new InputStreamReader(stream, StandardCharsets.UTF_8));
         }
     }
 }


### PR DESCRIPTION
YamlSlurper, TomlSlurper and CsvSlurper wrap their stream and path inputs in `new InputStreamReader(stream)`, so bytes are decoded with the JVM default charset. Under a non-UTF-8 default (Windows-1252, Shift_JIS, or a JVM started with `-Dfile.encoding`), UTF-8 `0xC3 0xA9` reads back as `U+00C3 U+00A9` instead of `U+00E9`. YAML and TOML mandate UTF-8 and JsonSlurper already defaults byte/stream input to it, so pin these readers to UTF-8.