### PR TITLE
Default MarkdownSlurper stream decoding to UTF-8

### DIFF
--- a/subprojects/groovy-markdown/src/main/java/groovy/markdown/MarkdownSlurper.java
+++ b/subprojects/groovy-markdown/src/main/java/groovy/markdown/MarkdownSlurper.java
@@ -47,6 +47,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -135,7 +136,7 @@ public class MarkdownSlurper {
      * @return the parsed document
      */
     public MarkdownDocument parse(InputStream stream) {
-        return parse(new InputStreamReader(stream));
+        return parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
     }
 
     /**
@@ -158,7 +159,7 @@ public class MarkdownSlurper {
      */
     public MarkdownDocument parse(Path path) throws IOException {
         try (InputStream stream = Files.newInputStream(path)) {
-            return parse(new InputStreamReader(stream));
+            return parse(new InputStreamReader(stream, StandardCharsets.UTF_8));
         }
     }
 


### PR DESCRIPTION
MarkdownSlurper.parse decodes InputStream and Path input through a plain InputStreamReader, so it picks up Charset.defaultCharset() instead of UTF-8. On a JVM whose default isn't UTF-8 this looks like it would corrupt any multibyte content in an otherwise valid UTF-8 document. The sibling YamlSlurper, TomlSlurper, CsvSlurper and JsonSlurper already default stream input to UTF-8, so this passes StandardCharsets.UTF_8 at both reader sites to match.