### PR TITLE
GROOVY-12062: OptimizingStatementWriter __$stMC slow branch resolves …

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/CompileStack.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/CompileStack.java
@@ -1001,6 +1001,31 @@ public class CompileStack {
     }
 
     /**
+     * Inlines an excluded finally block via {@code visit} while hiding the
+     * variables of the current (try) scope, then fully restores that scope —
+     * including its variables.
+     * <p>
+     * Popping the current scope keeps try-block locals out of scope in the
+     * finally body (GROOVY-4721); restoring the saved variables afterwards
+     * ensures any subsequent re-emission of the same statement (e.g. the
+     * {@link OptimizingStatementWriter} fast/slow fork) still resolves those
+     * locals rather than falling back to property access (GROOVY-12062).
+     *
+     * @param recorder the block recorder being visited
+     * @param visit    emits the finally body
+     */
+    public void visitExcludedFinally(final BlockRecorder recorder, final Runnable visit) {
+        VariableScope originalScope = scope;
+        Map<String, BytecodeVariable> savedVariables = stackVariables;
+        pop();
+        pushBlockRecorderVisit(recorder);
+        visit.run();
+        popBlockRecorderVisit(recorder);
+        pushVariableScope(originalScope);
+        stackVariables = savedVariables;
+    }
+
+    /**
      * Writes the exception-table entries for all label ranges recorded in {@code block}.
      *
      * @param block the block recorder containing the try-range labels

--- a/src/main/java/org/codehaus/groovy/classgen/asm/StatementWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/StatementWriter.java
@@ -557,13 +557,9 @@ public class StatementWriter {
 
         recorder.excludedStatement = () -> {
             if (isEmptyStatement(finallyStatement)) return;
-
-            final VariableScope originalScope = compileStack.getScope();
-            compileStack.pop();
-            compileStack.pushBlockRecorderVisit(recorder);
-            finallyStatement.visit(controller.getAcg());
-            compileStack.popBlockRecorderVisit(recorder);
-            compileStack.pushVariableScope(originalScope);
+            // GROOVY-4721, GROOVY-12062: emit the finally with the try-block locals
+            // hidden, then restore the try scope (and its variables) afterwards.
+            compileStack.visitExcludedFinally(recorder, () -> finallyStatement.visit(controller.getAcg()));
         };
 
         compileStack.pushBlockRecorder(recorder);

--- a/src/test/groovy/bugs/Groovy12062.groovy
+++ b/src/test/groovy/bugs/Groovy12062.groovy
@@ -1,0 +1,123 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bugs
+
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.shouldFail
+
+/**
+ * Under classic (non-indy) codegen, {@link org.codehaus.groovy.classgen.asm.OptimizingStatementWriter}
+ * emits an optimizable statement twice behind a {@code __$stMC} fast/slow guard.
+ * When the method has a non-empty (and non-optimizable) {@code finally} block,
+ * inlining that block used to unwind the {@code CompileStack} scope permanently,
+ * so the second emission resolved a try-block local as {@code this.getProperty(name)}
+ * and threw {@code MissingPropertyException} at runtime (only the fast path was
+ * correct). This was a regression introduced with GROOVY-4721.
+ */
+final class Groovy12062 {
+
+    private static CompilerConfiguration nonIndy() {
+        def config = new CompilerConfiguration()
+        config.optimizationOptions.put('indy', false)
+        return config
+    }
+
+    @Test
+    void testTryLocalAsMethodArgWithNonEmptyFinally() {
+        new GroovyShell(nonIndy()).evaluate '''
+            class C {
+                String helper(String s) { 'got:' + s }
+                def action() {
+                    try {
+                        String x = 'VALUE'   // local declared in try block
+                        return helper(x)     // optimizable this-call; x passed as argument
+                    } finally {
+                        Math.random()        // non-empty, non-optimizable finally
+                    }
+                }
+            }
+            assert new C().action() == 'got:VALUE'
+        '''
+    }
+
+    // The faulty fast/slow fork means both branches must be exercised: the slow
+    // branch is taken once the static metaclass guard (__$stMC) is set, which is
+    // what a metaclass mutation (e.g. Grails interception) does.
+    @Test
+    void testTryLocalAsMethodArgBothBranches() {
+        new GroovyShell(nonIndy()).evaluate '''
+            class C {
+                String helper(String s) { 'got:' + s }
+                def action() {
+                    try {
+                        String x = 'VALUE'
+                        return helper(x)
+                    } finally {
+                        Math.random()
+                    }
+                }
+            }
+            assert new C().action() == 'got:VALUE'   // fast branch (default metaclass)
+            C.metaClass.ping = { -> 'pong' }         // flip __$stMC -> slow branch
+            assert new C().action() == 'got:VALUE'   // slow branch
+        '''
+    }
+
+    @Test
+    void testTryLocalAsMethodArgImplicitReturn() {
+        new GroovyShell(nonIndy()).evaluate '''
+            class C {
+                String helper(String s) { 'got:' + s }
+                def action() {
+                    try {
+                        String x = 'VALUE'
+                        helper(x)            // implicit return
+                    } finally {
+                        Math.random()
+                    }
+                }
+            }
+            assert new C().action() == 'got:VALUE'
+        '''
+    }
+
+    // GROOVY-4721 must remain in force: a try-block local is out of scope in the
+    // finally block, so referencing it there falls back to (failing) property access.
+    @Test
+    void testTryLocalNotVisibleInFinallyStillHolds() {
+        def err = shouldFail {
+            new GroovyShell(nonIndy()).evaluate '''
+                class C {
+                    def action() {
+                        try {
+                            String x = 'VALUE'
+                            return x
+                        } finally {
+                            println 'x: ' + x
+                        }
+                    }
+                }
+                new C().action()
+            '''
+        }
+        assert err.message =~ /No such property: x for class: C/
+    }
+}


### PR DESCRIPTION
…a try-block local as getProperty when the method has a non-empty finally (classic non-indy codegen) - regression in 5.0.x