### PR TITLE
GROOVY-12080: RegexChecker crashes on inline pattern (~/.../) as .mat…

### DIFF
--- a/subprojects/groovy-typecheckers/src/main/groovy/groovy/typecheckers/RegexChecker.groovy
+++ b/subprojects/groovy-typecheckers/src/main/groovy/groovy/typecheckers/RegexChecker.groovy
@@ -149,8 +149,8 @@ class RegexChecker extends GroovyTypeCheckingExtensionSupport.TypeCheckingDSL {
                     if (call.objectExpression instanceof ClassExpression) {
                         checkPatternMethod(call, call.objectExpression.type)
                     } else if (isPattern(call.receiver) && call.methodAsString == 'matcher') {
-                        def var = findTargetVariable(call.receiver)
-                        def groupCount = var?.getNodeMetaData(REGEX_GROUP_COUNT)
+                        def source = call.receiver instanceof VariableExpression ? findTargetVariable(call.receiver) : call.receiver
+                        def groupCount = source?.getNodeMetaData(REGEX_GROUP_COUNT)
                         if (groupCount != null) {
                             call.putNodeMetaData(REGEX_GROUP_COUNT, groupCount)
                         }
@@ -233,8 +233,8 @@ class RegexChecker extends GroovyTypeCheckingExtensionSupport.TypeCheckingDSL {
                 @Override
                 void visitMethodCallExpression(MethodCallExpression call) {
                     if (isPattern(call.receiver) && call.methodAsString == 'matcher') {
-                        def var = findTargetVariable(call.receiver)
-                        def groupCount = var?.getNodeMetaData(REGEX_GROUP_COUNT)
+                        def source = call.receiver instanceof VariableExpression ? findTargetVariable(call.receiver) : call.receiver
+                        def groupCount = source?.getNodeMetaData(REGEX_GROUP_COUNT)
                         if (groupCount != null) {
                             call.putNodeMetaData(REGEX_GROUP_COUNT, groupCount)
                         }

--- a/subprojects/groovy-typecheckers/src/test/groovy/groovy/typecheckers/RegexCheckerTest.groovy
+++ b/subprojects/groovy-typecheckers/src/test/groovy/groovy/typecheckers/RegexCheckerTest.groovy
@@ -272,6 +272,29 @@ final class RegexCheckerTest {
     }
 
     @Test
+    void testInlinePatternAsMatcherReceiver() {
+        // GROOVY-12080: pattern operator result used directly as a matcher() receiver
+        // used to crash the compiler ("No signature of method: findTargetVariable")
+        assertScript shell, '''
+            Matcher m = (~/(...)(...)/).matcher('foobar')
+            assert m.find()
+            assert m.group(1) == 'foo'
+            assert m.group(2) == 'bar'
+        '''
+    }
+
+    @Test
+    void testBadRegexGroupCountForInlinePattern() {
+        // GROOVY-12080: group count is now inferred for inline patterns too
+        def err = shouldFail shell, '''
+            Matcher m = (~/(...)(...)/).matcher('foobar')
+            assert m.find()
+            assert m.group(3)
+        '''
+        assert err.message =~ /Invalid group count 3 for regex with 2 groups/
+    }
+
+    @Test
     void testGoodRegexGroupCount() {
         assertScript shell, '''
             def m = 'foobaz' =~ /(...)(...)/


### PR DESCRIPTION
…cher() receiver