### PR TITLE
GROOVY-12085: SourceText slices UTF-16 with code-point AST columns, t…

### DIFF
--- a/src/main/java/org/apache/groovy/parser/antlr4/util/PositionConfigureUtils.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/util/PositionConfigureUtils.java
@@ -61,9 +61,14 @@ public class PositionConfigureUtils {
         }
 
         if (0 == newLineCnt) {
-            return tuple(token.getLine(), token.getCharPositionInLine() + 1 + token.getText().length());
+            // column numbers are code-point based (the lexer reads a CodePointCharStream), so
+            // measure the token text in code points too -- otherwise supplementary characters
+            // (e.g. emoji) make lastColumnNumber over-count by one UTF-16 unit each (GROOVY-12085)
+            return tuple(token.getLine(), token.getCharPositionInLine() + 1 + stopText.codePointCount(0, stopTextLength));
         } else { // e.g. GStringEnd contains newlines, we should fix the location info
-            return tuple(token.getLine() + newLineCnt, stopTextLength - stopText.lastIndexOf('\n'));
+            // measure the trailing line in code points too, so supplementary characters after
+            // the last newline don't make lastColumnNumber over-count by a UTF-16 unit each (GROOVY-12085)
+            return tuple(token.getLine() + newLineCnt, stopText.codePointCount(stopText.lastIndexOf('\n'), stopTextLength));
         }
     }
 
@@ -75,7 +80,9 @@ public class PositionConfigureUtils {
         astNode.setLineNumber(token.getLine());
         astNode.setColumnNumber(token.getCharPositionInLine() + 1);
         astNode.setLastLineNumber(token.getLine());
-        astNode.setLastColumnNumber(token.getCharPositionInLine() + 1 + token.getText().length());
+        // measure the token text in code points to keep lastColumnNumber code-point based (GROOVY-12085)
+        String text = token.getText();
+        astNode.setLastColumnNumber(token.getCharPositionInLine() + 1 + text.codePointCount(0, text.length()));
 
         return astNode;
     }

--- a/src/main/java/org/codehaus/groovy/runtime/powerassert/SourceText.java
+++ b/src/main/java/org/codehaus/groovy/runtime/powerassert/SourceText.java
@@ -59,10 +59,14 @@ public class SourceText {
             if (lineText == null)
                 throw new SourceTextNotAvailableException(stat, sourceUnit, "SourceUnit.getSample() returned null");
 
+            // AST column numbers are code-point based, but lineText is a UTF-16 String;
+            // convert before slicing so supplementary characters (e.g. emoji) don't shift
+            // the cut by one UTF-16 unit each (GROOVY-12085). lineOffsets stays code-point
+            // based to match the (code-point) columns passed to getNormalizedColumn().
             if (line == stat.getLastLineNumber())
-                lineText = lineText.substring(0, stat.getLastColumnNumber() - 1);
+                lineText = lineText.substring(0, codePointToIndex(lineText, stat.getLastColumnNumber() - 1));
             if (line == stat.getLineNumber()) {
-                lineText = lineText.substring(stat.getColumnNumber() - 1);
+                lineText = lineText.substring(codePointToIndex(lineText, stat.getColumnNumber() - 1));
                 lineOffsets.add(stat.getColumnNumber() - 1);
             } else
                 lineOffsets.add(countLeadingWhitespace(lineText));
@@ -114,6 +118,20 @@ public class SourceText {
                 && node.getLastLineNumber() >= node.getLineNumber()
                 && node.getLastColumnNumber() >
                 (node.getLineNumber() == node.getLastLineNumber() ? node.getColumnNumber() : 0);
+    }
+
+    /**
+     * Translates a 0-based code-point offset into a UTF-16 {@code String} index,
+     * clamping to the bounds of {@code text}. AST column numbers are code-point
+     * based (the lexer reads a code-point stream), whereas the sampled source line
+     * is a UTF-16 {@code String}; the two differ once supplementary characters are
+     * present.
+     */
+    private static int codePointToIndex(String text, int codePointOffset) {
+        if (codePointOffset <= 0) return 0;
+        int length = text.length();
+        if (codePointOffset >= text.codePointCount(0, length)) return length;
+        return text.offsetByCodePoints(0, codePointOffset);
     }
 
     private static int countLeadingWhitespace(String lineText) {

--- a/src/test/groovy/org/apache/groovy/parser/antlr4/Groovy12085Test.groovy
+++ b/src/test/groovy/org/apache/groovy/parser/antlr4/Groovy12085Test.groovy
@@ -1,0 +1,53 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.parser.antlr4
+
+import org.codehaus.groovy.ast.builder.AstBuilder
+import org.codehaus.groovy.ast.expr.Expression
+import org.codehaus.groovy.control.CompilePhase
+import org.junit.jupiter.api.Test
+
+/**
+ * GROOVY-12085: AST column numbers are code-point based (the lexer reads an ANTLR
+ * CodePointCharStream), so a supplementary character (e.g. an emoji) must advance
+ * the column by one code point, not by its two UTF-16 units. This covers the
+ * multi-line-token path in {@code PositionConfigureUtils.endPosition}, whose end
+ * column is computed from the text after the last newline.
+ */
+final class Groovy12085Test {
+
+    @Test
+    void testMultiLineTokenEndColumnIsCodePointBased() {
+        // last line is: end🥤"""  -- 7 code points, so the literal ends at column 8
+        Expression withEmoji = literalOf('def a = """line1\nend🥤"""')
+        // control without the supplementary character: endz"""
+        Expression withAscii = literalOf('def a = """line1\nendz"""')
+
+        assert [withEmoji.lastLineNumber, withEmoji.lastColumnNumber] == [2, 8]
+        assert [withAscii.lastLineNumber, withAscii.lastColumnNumber] == [2, 8]
+
+        // the emoji (1 code point) must occupy the same column span as a single ASCII char
+        assert withEmoji.lastColumnNumber == withAscii.lastColumnNumber
+    }
+
+    private static Expression literalOf(String src) {
+        def nodes = new AstBuilder().buildFromString(CompilePhase.CONVERSION, false, src)
+        nodes[0].statements[0].expression.rightExpression
+    }
+}

--- a/src/test/groovy/org/codehaus/groovy/runtime/powerassert/AssertionRenderingTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/runtime/powerassert/AssertionRenderingTest.groovy
@@ -67,6 +67,30 @@ assert 1 + 2 == 4 - 2
     }
 
     @Test
+    void testFullSourceCapturedWithSupplementaryCharacters() {
+        // GROOVY-12085: AST column numbers are code-point based, but SourceText sliced
+        // the UTF-16 source line with them, dropping one trailing char per astral-plane
+        // character (e.g. emoji) appearing before the cut. Verify the captured source
+        // line is now complete in both compilation modes.
+        def captured = []
+        try {
+            assert '🥤🐝'.length() == 999
+        } catch (PowerAssertionError e) {
+            captured << e.message.readLines().first()
+        }
+        try {
+            def n = true
+            assert (n ? '🥤🐝' : 'z').length() == 999
+        } catch (PowerAssertionError e) {
+            captured << e.message.readLines().first()
+        }
+        assert captured == [
+            "assert '🥤🐝'.length() == 999",
+            "assert (n ? '🥤🐝' : 'z').length() == 999",
+        ]
+    }
+
+    @Test
     void testMethodCallExpressionWithImplicitTarget() {
         isRendered '''
 assert one(a)


### PR DESCRIPTION
…runcating source for supplementary characters