### PR TITLE
GROOVY-12089: Groovy 5 ClassNode.getGetterMethod() can clone a getter…

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/MethodNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/MethodNode.java
@@ -59,7 +59,7 @@ public class MethodNode extends AnnotatedNode {
 
     protected MethodNode() {
         this.name = null;
-        this.exceptions = null;
+        this.exceptions = ClassNode.EMPTY_ARRAY;
     }
 
     /**
@@ -77,7 +77,7 @@ public class MethodNode extends AnnotatedNode {
     public MethodNode(final String name, final int modifiers, final ClassNode returnType, final Parameter[] parameters, final ClassNode[] exceptions, final Statement code) {
         this.name = name;
         this.modifiers = modifiers;
-        this.exceptions = exceptions;
+        this.exceptions = exceptions != null ? exceptions : ClassNode.EMPTY_ARRAY;
         this.code = code;
         setReturnType(returnType);
         setParameters(parameters);

--- a/src/test/groovy/org/codehaus/groovy/ast/MethodNodeTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/ast/MethodNodeTest.groovy
@@ -96,4 +96,18 @@ final class MethodNodeTest {
         assert !methodNode.isDynamicReturnType()
         assert methodNode.returnType != null
     }
+
+    @Test // GROOVY-12089
+    void testExceptionsNeverNull() {
+        // a null exceptions argument must be normalized to an empty array so that
+        // getExceptions() honours its contract and callers (e.g. VariableScopeVisitor,
+        // and getter synthesis in ClassNode.getGetterMethod) never hit a NullPointerException
+        def methodNode = new MethodNode('foo', 0, ClassHelper.OBJECT_TYPE, Parameter.EMPTY_ARRAY, null, null)
+        assert methodNode.exceptions != null
+        assert methodNode.exceptions.length == 0
+
+        // the no-arg constructor used by subclasses must likewise expose an empty array
+        assert new MethodNode().exceptions != null
+        assert new MethodNode().exceptions.length == 0
+    }
 }


### PR DESCRIPTION
… with a null exceptions array when @Entity and @Sortable are combined