### PR TITLE
return BigInteger for json integers beyond long range

### DIFF
--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharScanner.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharScanner.java
@@ -19,6 +19,7 @@
 package org.apache.groovy.json.internal;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import static org.apache.groovy.json.internal.Exceptions.die;
 import static org.apache.groovy.json.internal.Exceptions.handle;
@@ -501,8 +502,10 @@ public class CharScanner {
         if (!foundDot && simple) {
             if (isInteger(buffer, from, length)) {
                 value = parseIntFromTo(buffer, from, index);
-            } else {
+            } else if (isLong(buffer, from, length)) {
                 value = parseLongFromTo(buffer, from, index);
+            } else {
+                value = new BigInteger(new String(buffer, from, length));
             }
         } else {
             value = new BigDecimal(buffer, from, length);

--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserUsingCharacterSource.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserUsingCharacterSource.java
@@ -22,6 +22,7 @@ import groovy.json.JsonException;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -155,6 +156,8 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
             value = CharScanner.parseInt(chars);
         } else if (CharScanner.isLong(chars)) {
             value = CharScanner.parseLong(chars);
+        } else {
+            value = new BigInteger(new String(chars));
         }
 
         return value;

--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/NumberValue.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/NumberValue.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 
 import static java.lang.Boolean.parseBoolean;
 import static org.apache.groovy.json.internal.CharScanner.isInteger;
+import static org.apache.groovy.json.internal.CharScanner.isLong;
 import static org.apache.groovy.json.internal.CharScanner.parseDouble;
 import static org.apache.groovy.json.internal.CharScanner.parseFloat;
 import static org.apache.groovy.json.internal.CharScanner.parseIntFromTo;
@@ -161,8 +162,10 @@ public class NumberValue extends java.lang.Number implements Value {
             case INTEGER:
                 if (isInteger(buffer, startIndex, endIndex - startIndex)) {
                     return intValue();
-                } else {
+                } else if (isLong(buffer, startIndex, endIndex - startIndex)) {
                     return longValue();
+                } else {
+                    return bigIntegerValue();
                 }
         }
         die();

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -742,6 +742,16 @@ class JsonSlurperTest {
     }
 
     @Test
+    void testParseIntegerBeyondLongRange() {
+        // 9999999999999999999 exceeds Long.MAX_VALUE; it must round-trip as a
+        // BigInteger rather than silently overflowing to a wrong (negative) long.
+        def raw = parser.parseText('9999999999999999999')
+        def value = raw instanceof Value ? raw.toValue() : raw
+        assertTrue(value instanceof BigInteger)
+        assertEquals(new BigInteger('9999999999999999999'), value)
+    }
+
+    @Test
     void testParseNegativeNumber() {
         def slurper = new JsonSlurper()
         def result = slurper.parseText('{"negative":-42}')

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -745,6 +745,8 @@ class JsonSlurperTest {
     void testParseIntegerBeyondLongRange() {
         // 9999999999999999999 exceeds Long.MAX_VALUE; it must round-trip as a
         // BigInteger rather than silently overflowing to a wrong (negative) long.
+        // The IndexOverlay/Lax/CharSource subclasses inherit this test and rerun
+        // it with their own parser.type, so all four parser types are covered.
         def raw = parser.parseText('9999999999999999999')
         def value = raw instanceof Value ? raw.toValue() : raw
         assertTrue(value instanceof BigInteger)


### PR DESCRIPTION
1. JsonSlurper's default CHAR_BUFFER parser, the INDEX_OVERLAY and LAX overlay parsers, and the CHARACTER_SOURCE parser each pick a JSON integer's Java type with only an int-or-long check, so a value past Long.MAX_VALUE is never promoted to BigInteger.
2. CHAR_BUFFER (CharScanner.parseJsonNumber) and the overlay parsers (NumberValue.doToValue) fall through to parseLongFromTo, which wraps silently, so parsing 9999999999999999999 yields -8446744073709551617. CHARACTER_SOURCE (JsonParserUsingCharacterSource.decodeNumber) has no branch past isLong and returns null instead.
3. The lexer-based path (JsonToken.getValue) already returns Integer, Long, or BigInteger, so the parser types disagree on the same input.

Added the missing BigInteger branch at the three decode sites so every parser type matches the JsonToken contract. The new regression test runs across all four parser types and fails before the change.