### PR TITLE
escape namespace uri in XmlNodePrinter.printNamespace

### DIFF
--- a/subprojects/groovy-xml/src/main/java/groovy/xml/XmlNodePrinter.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/xml/XmlNodePrinter.java
@@ -396,7 +396,7 @@ public class XmlNodePrinter {
                             out.print(prefix);
                         }
                         out.print("=" + quote);
-                        out.print(namespaceUri);
+                        printEscaped(namespaceUri, true);
                         out.print(quote);
                     }
                 }

--- a/subprojects/groovy-xml/src/test/groovy/groovy/xml/XmlNodePrinterTest.groovy
+++ b/subprojects/groovy-xml/src/test/groovy/groovy/xml/XmlNodePrinterTest.groovy
@@ -55,6 +55,20 @@ class XmlNodePrinterTest {
 </soap:Envelope>
 """
 
+    def namespaceWithSpecialUriInput = """\
+<foo:Envelope xmlns:foo="http://x/a?b=1&amp;c=2&lt;d">
+  <foo:Body>text</foo:Body>
+</foo:Envelope>
+"""
+
+    def namespaceWithSpecialUriOutput = """\
+<foo:Envelope xmlns:foo="http://x/a?b=1&amp;c=2&lt;d">
+  <foo:Body>
+    text
+  </foo:Body>
+</foo:Envelope>
+"""
+
     def noNamespaceInputVerbose = """\
 <Envelope>
   <Body>
@@ -202,6 +216,11 @@ class XmlNodePrinterTest {
     @Test
     void attributeWithNamespaceInput() {
         checkRoundtrip attributeWithNamespaceInput, attributeWithNamespaceInput
+    }
+
+    @Test
+    void namespaceUriWithSpecialCharsEscaped() {
+        checkRoundtrip namespaceWithSpecialUriInput, namespaceWithSpecialUriOutput
     }
 
     private checkRoundtrip(String intext, String outtext) {


### PR DESCRIPTION
XmlNodePrinter escapes element text and ordinary attribute values, but printNamespace writes the namespace URI straight to the output. When a parsed node carries a namespace URI containing an XML metacharacter such as & or < (for example xmlns:foo="http://example.com/ns?a=1&amp;b=2"), the printer emits the literal character and the result is no longer well formed, so re-parsing the output fails. The URI is an attribute value, so route it through the existing printEscaped path used for other attribute values; a round-trip test covers & and < in a declared namespace.