### PR TITLE
reject ?> and -- in markup builder pi and comment output

### DIFF
--- a/subprojects/groovy-xml/src/main/groovy/groovy/xml/streamingmarkupsupport/AbstractStreamingBuilder.groovy
+++ b/subprojects/groovy-xml/src/main/groovy/groovy/xml/streamingmarkupsupport/AbstractStreamingBuilder.groovy
@@ -77,6 +77,9 @@ class AbstractStreamingBuilder {
     def toMapStringClosure = { Map instruction, checkDoubleQuotationMarks={ value -> !value.toString().contains('"') } ->
         def buf = new StringBuilder()
         instruction.each { name, value ->
+            if (name.toString().contains('?>') || value.toString().contains('?>')) {
+                throw new GroovyRuntimeException("Processing instruction data must not contain '?>': ${name}=${value}")
+            }
             if (checkDoubleQuotationMarks(value)) {
                 buf.append(" $name=\"$value\"")
             } else {

--- a/subprojects/groovy-xml/src/main/java/groovy/xml/MarkupBuilderHelper.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/xml/MarkupBuilderHelper.java
@@ -104,6 +104,9 @@ public class MarkupBuilderHelper {
      * @param value the text within the comment.
      */
     public void comment(String value) {
+        if (value != null && value.contains("--")) {
+            throw new IllegalArgumentException("XML comment text must not contain '--': " + value);
+        }
         yieldUnescaped("<!-- " + value + " -->");
     }
 

--- a/subprojects/groovy-xml/src/test/groovy/groovy/xml/MarkupBuilderInjectionTest.groovy
+++ b/subprojects/groovy-xml/src/test/groovy/groovy/xml/MarkupBuilderInjectionTest.groovy
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.xml
+
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * The markup builders escape element text and attribute values, but
+ * processing-instruction and comment bodies cannot use entity escaping.
+ * These tests check that content which would close such a construct early
+ * (and inject sibling markup) is rejected instead of emitted.
+ */
+final class MarkupBuilderInjectionTest {
+
+    @Test
+    void commentRejectsCommentTerminator() {
+        assertThrows(IllegalArgumentException) {
+            new MarkupBuilder(new StringWriter()).root { mkp.comment('legit --> <injected/>') }
+        }
+        assertThrows(IllegalArgumentException) {
+            new MarkupBuilder(new StringWriter()).root { mkp.comment('a -- b') }
+        }
+    }
+
+    @Test
+    void commentKeepsPlainTextLiteral() {
+        def writer = new StringWriter()
+        new MarkupBuilder(writer).root { mkp.comment('plain > & < text') }
+        assertTrue(writer.toString().contains('<!-- plain > & < text -->'))
+    }
+
+    @Test
+    void streamingProcessingInstructionRejectsTerminator() {
+        def smb = new StreamingMarkupBuilder()
+        assertThrows(GroovyRuntimeException) {
+            smb.bind { mkp.pi('xml-stylesheet': [href: 'a', type: 'b?><injected/>']); root('x') }.toString()
+        }
+    }
+
+    @Test
+    void streamingProcessingInstructionKeepsPlainData() {
+        def smb = new StreamingMarkupBuilder()
+        def result = smb.bind { mkp.pi('xml-stylesheet': [href: 'style.css', type: 'text/css']); root('x') }.toString()
+        assertTrue(result.contains('<?xml-stylesheet') && result.contains('style.css') && result.contains('?>'))
+    }
+}


### PR DESCRIPTION
1. AbstractStreamingBuilder.toMapStringClosure builds processing-instruction pseudo-attributes by writing each name and value straight into the `<?...?>` body, so a value holding `?>` closes the PI early and injects sibling markup. This closure backs both StreamingMarkupBuilder and StreamingDOMBuilder.
2. MarkupBuilderHelper.comment wraps its text in `<!-- ... -->` through yieldUnescaped, so text holding `--` closes the comment early the same way.

Entity escaping is not legal inside a processing instruction or comment, so the terminating sequence is rejected (`?>` for the PI data, `--` for the comment text) rather than escaped. The builders already escape element text and attribute values, these two bodies were the gap. Regression test added for both, plus a check that ordinary PI/comment content still round-trips.
