### PR TITLE
reject non-hex characters in decodeHex

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/EncodingGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/EncodingGroovyMethods.java
@@ -372,10 +372,17 @@ public class EncodingGroovyMethods {
 
         byte[] bytes = new byte[value.length() / 2];
         for (int i = 0; i < value.length(); i += 2) {
-            bytes[i / 2] = (byte) Integer.parseInt(value.substring(i, i + 2), 16);
+            bytes[i / 2] = (byte) ((hexToNibble(value.charAt(i)) << 4) | hexToNibble(value.charAt(i + 1)));
         }
 
         return bytes;
+    }
+
+    private static int hexToNibble(final char c) {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        throw new NumberFormatException("illegal hexadecimal character " + c + " in hex string");
     }
 
     /**

--- a/src/test/groovy/groovy/HexTest.groovy
+++ b/src/test/groovy/groovy/HexTest.groovy
@@ -67,6 +67,19 @@ class HexTest {
             "1g".decodeHex()
         }
 
+        // a leading sign is not a valid hexadecimal character and must be rejected
+        // (Integer.parseInt would otherwise accept it and decode a wrong byte)
+        ["-1", "+a", "-f", "+0"].each { bad ->
+            shouldFail(NumberFormatException) {
+                bad.decodeHex()
+            }
+        }
+
+        // non-ASCII digit characters are not valid hexadecimal either
+        shouldFail(NumberFormatException) {
+            "１１".decodeHex()
+        }
+
         // test to make sure a leading zero is handled correctly
         bytes = "0a".decodeHex()
         assert bytes.length == 1


### PR DESCRIPTION
1. decodeHex decodes each two-character group with Integer.parseInt(value.substring(i, i + 2), 16), which accepts a leading + or - sign and non-ASCII Unicode digit characters.
2. so malformed input such as "-1", "+a" or "-f" decodes to a byte (0xff, 0x0a, 0xf1) instead of throwing NumberFormatException, which the method javadoc documents for characters that are not valid hexadecimal values.

Replaced the per-group parseInt with a strict per-nibble decode over the ASCII ranges 0-9/a-f/A-F. Valid hex decodes to the same bytes (checked against the old path for every byte value in both letter cases); the rejected inputs are covered by new cases in HexTest. Happy to file a Jira and link it.