### PR TITLE
GROOVY-9848: Allow map membership to be key-based via @OperatorRename opt-in

### DIFF
--- a/src/main/java/groovy/transform/OperatorRename.java
+++ b/src/main/java/groovy/transform/OperatorRename.java
@@ -62,4 +62,9 @@ public @interface OperatorRename {
     String or() default Undefined.STRING;
     String xor() default Undefined.STRING;
     String compareTo() default Undefined.STRING;
+    // GROOVY-9848: the membership operators `in` / `!in` (default methods isIn / isNotIn).
+    // Operands are reversed, so `a in b` dispatches to `b.name(a)`. For example
+    // isIn='containsKey' opts a scope into key-based map membership.
+    String isIn() default Undefined.STRING;
+    String isNotIn() default Undefined.STRING;
 }

--- a/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java
@@ -763,6 +763,28 @@ public class ScriptBytecodeAdapter {
         return !isCase(switchValue, caseExpression);
     }
 
+    //isIn  (GROOVY-9848: membership helper. Groovy 5 still compiles `in`/`!in` to isCase/isNotCase;
+    // these are provided so a class compiled by Groovy 6 -- whose `in` codegen targets isIn/isNotIn --
+    // links and runs on a Groovy 5 runtime, with behaviour consistent with Groovy 6.)
+    public static boolean isIn(final Object switchValue, final Object caseExpression) throws Throwable {
+        if (caseExpression == null) {
+            return switchValue == null;
+        }
+        // map membership is key-based; char-sequence membership is substring-based;
+        // every other receiver keeps its existing (isCase) semantics, incl. user-defined isCase
+        if (caseExpression instanceof Map) {
+            return ((Map) caseExpression).containsKey(switchValue);
+        }
+        if (caseExpression instanceof CharSequence && switchValue instanceof CharSequence) {
+            return caseExpression.toString().contains(switchValue.toString());
+        }
+        return isCase(switchValue, caseExpression);
+    }
+
+    public static boolean isNotIn(final Object switchValue, final Object caseExpression) throws Throwable {
+        return !isIn(switchValue, caseExpression);
+    }
+
     //compare
     public static boolean compareIdentical(final Object left, final Object right) {
         return left == right;

--- a/src/main/java/org/codehaus/groovy/transform/OperatorRenameASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/OperatorRenameASTTransformation.java
@@ -48,9 +48,11 @@ import static org.codehaus.groovy.syntax.Types.BITWISE_OR;
 import static org.codehaus.groovy.syntax.Types.BITWISE_OR_EQUAL;
 import static org.codehaus.groovy.syntax.Types.BITWISE_XOR;
 import static org.codehaus.groovy.syntax.Types.BITWISE_XOR_EQUAL;
+import static org.codehaus.groovy.syntax.Types.COMPARE_NOT_IN;
 import static org.codehaus.groovy.syntax.Types.COMPARE_TO;
 import static org.codehaus.groovy.syntax.Types.DIVIDE;
 import static org.codehaus.groovy.syntax.Types.DIVIDE_EQUAL;
+import static org.codehaus.groovy.syntax.Types.KEYWORD_IN;
 import static org.codehaus.groovy.syntax.Types.LEFT_SHIFT;
 import static org.codehaus.groovy.syntax.Types.LEFT_SHIFT_EQUAL;
 import static org.codehaus.groovy.syntax.Types.MINUS;
@@ -105,6 +107,9 @@ public class OperatorRenameASTTransformation extends ClassCodeExpressionTransfor
         addIfFound(anno, nameTable, "or");
         addIfFound(anno, nameTable, "xor");
         addIfFound(anno, nameTable, "compareTo");
+        // GROOVY-9848: membership operators (in / !in)
+        addIfFound(anno, nameTable, "isIn");
+        addIfFound(anno, nameTable, "isNotIn");
         if (parent instanceof ClassNode) {
             super.visitClass((ClassNode) parent);
         } else if (parent instanceof ConstructorNode) {
@@ -125,6 +130,19 @@ public class OperatorRenameASTTransformation extends ClassCodeExpressionTransfor
         if (expr instanceof BinaryExpression) {
             final BinaryExpression be = (BinaryExpression) expr;
             int type = be.getOperation().getType();
+            // GROOVY-9848: the membership operators are handled explicitly -- their public member
+            // names (isIn/isNotIn) are fixed here rather than derived from getOperationName, and the
+            // operands are reversed (`a in b` dispatches on the right operand, i.e. b.name(a)).
+            if (type == KEYWORD_IN || type == COMPARE_NOT_IN) {
+                String memberName = (type == KEYWORD_IN) ? "isIn" : "isNotIn";
+                if (nameTable.containsKey(memberName)) {
+                    Expression left = transform(be.getLeftExpression());
+                    Expression right = transform(be.getRightExpression());
+                    Expression result = callX(right, nameTable.get(memberName), left);
+                    result.setSourcePosition(be);
+                    return result;
+                }
+            }
             String oldName = getOperationName(type);
             if (nameTable.containsKey(oldName)) {
                 boolean isEqualOperator = removeAssignment(type) != type;

--- a/src/test/groovy/org/codehaus/groovy/transform/OperatorRenameTransformTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/transform/OperatorRenameTransformTest.groovy
@@ -39,6 +39,79 @@ class OperatorRenameTransformTest extends GroovyShellTestCase {
         '''
     }
 
+    // GROOVY-9848: @OperatorRename can opt a scope into key-based map membership (the Groovy 6
+    // default). Groovy 5's own default `in` stays value-based (isCase).
+    void testMembershipRenameOptsIntoKeyMembership() {
+        assertScript '''
+            assert !('b' in [a:1, b:0])              // Groovy 5 default: value-based (0 is falsy)
+
+            @groovy.transform.OperatorRename(isIn='containsKey')
+            def keyBased() {
+                assert 'b' in [a:1, b:0]             // opted in: containsKey
+                assert !('z' in [a:1, b:0])
+            }
+            keyBased()
+        '''
+    }
+
+    // GROOVY-9848 / GROOVY-2456: `isIn='contains'` opts a scope into substring string membership
+    // (the Groovy 6 default for char sequences). It also leaves collections/ranges unchanged
+    // (their `contains` already matches the default `in`); only maps are unsupported (no `contains`).
+    void testMembershipRenameOptsIntoSubstringMembership() {
+        assertScript '''
+            assert !('ell' in 'hello')               // Groovy 5 default: equality (no substring)
+
+            @groovy.transform.OperatorRename(isIn='contains')
+            def substring() {
+                assert 'ell' in 'hello'              // opted in: String.contains
+                assert !('xyz' in 'hello')
+                assert 'llo' in "he${'llo'}"         // GString
+                assert 2 in [1, 2, 3]                // collections unchanged (Collection.contains)
+                assert 3 in (1..5)                   // ranges unchanged
+            }
+            substring()
+        '''
+    }
+
+    void testMembershipRenameToIsCaseIsHarmlessOnGroovy5() {
+        assertScript '''
+            @groovy.transform.OperatorRename(isIn='isCase', isNotIn='isNotCase')
+            def f() {
+                assert !('b' in [a:1, b:0])          // no-op vs Groovy 5 default (still value-based)
+                assert 'a' in [a:1, b:0]
+                assert 'b' !in [a:1, b:0]
+            }
+            f()
+        '''
+    }
+
+    void testMembershipRenameUnderCompileStatic() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            @groovy.transform.OperatorRename(isIn='containsKey')
+            boolean has(Map<String,Integer> m, String k) { k in m }
+            assert has([a:1, b:0], 'b')              // containsKey -> true even for value 0
+            assert !has([a:1], 'z')
+        '''
+    }
+
+    // The ScriptBytecodeAdapter.isIn helper backported for forward binary compatibility with
+    // Groovy 6 in-operator codegen (Map -> containsKey, CharSequence -> contains, else -> isCase).
+    void testScriptBytecodeAdapterIsInHelper() {
+        assertScript '''
+            import org.codehaus.groovy.runtime.ScriptBytecodeAdapter as SBA
+            assert  SBA.isIn('b', [a:1, b:0])        // map -> containsKey (value 0 irrelevant)
+            assert !SBA.isIn('z', [a:1, b:0])
+            assert  SBA.isIn('ell', 'hello')         // char sequence -> contains
+            assert  SBA.isIn(2, [1, 2, 3])           // collection -> contains (via isCase)
+            assert  SBA.isNotIn('z', [a:1])
+            // does not mutate a withDefault map
+            def dm = [:].withDefault{ 1 }
+            assert !SBA.isIn('x', dm)
+            assert !dm.containsKey('x')
+        '''
+    }
+
     void testOperatorRenameSimulateMatrixNamesFromCommonLibs() {
         assertScript '''
             @groovy.transform.TupleConstructor


### PR DESCRIPTION
Partial backport of: Change map membership (in) from value-truthy to key-based