### PR TITLE
Restrict trigger push branch for GitHub Workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,12 @@
 
 name: "CodeQL"
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -17,6 +17,9 @@ name: "Validate Gradle Wrapper"
 
 on:
   push:
+    branches:
+      - master
+      - GROOVY_*
     paths:
       - 'gradlew'
       - 'gradlew.bat'

--- a/.github/workflows/groovy-build-artifacts.yml
+++ b/.github/workflows/groovy-build-artifacts.yml
@@ -15,7 +15,12 @@
 
 name: Generate SNAPSHOT artifacts
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/groovy-build-coverage.yml
+++ b/.github/workflows/groovy-build-coverage.yml
@@ -15,7 +15,12 @@
 
 name: Build and test for coverage
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/groovy-build-dist.yml
+++ b/.github/workflows/groovy-build-dist.yml
@@ -15,7 +15,12 @@
 
 name: Generate SNAPSHOT distributions
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/groovy-build-performance.yml
+++ b/.github/workflows/groovy-build-performance.yml
@@ -15,7 +15,12 @@
 
 name: Performance check
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/groovy-build-test.yml
+++ b/.github/workflows/groovy-build-test.yml
@@ -15,7 +15,12 @@
 
 name: Build and test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/groovy-jmh-classic.yml
+++ b/.github/workflows/groovy-jmh-classic.yml
@@ -15,7 +15,12 @@
 
 name: jmh-classic
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/groovy-jmh.yml
+++ b/.github/workflows/groovy-jmh.yml
@@ -15,7 +15,12 @@
 
 name: jmh
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/groovy-rat-check.yml
+++ b/.github/workflows/groovy-rat-check.yml
@@ -15,7 +15,12 @@
 
 name: Check licenses
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - GROOVY_*
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Feature branches rarely need their own CI runs: the code is already tested when a pull request is opened against a release branch. If the push trigger has no branch restriction and pull_request is also configured, every push to a branch with an open PR runs the workflow twice: once for the push and once for the PR synchronisation.

Always give the push trigger an explicit list of branches: this stops branches created from a release branch from inheriting its workflow runs.

see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=430408443#GitHubActionsRecommendedPractices-Restrictthepushtriggertospecificbranches