### PR TITLE
use Files.createTempFile for owner-only groovysh/groovyc temp files

### DIFF
--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
@@ -54,6 +54,7 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1334,7 +1335,7 @@ public class Groovyc extends MatchingTask {
         // 32767 is the command line length limit on Windows
         if (fork && (count > 32767)) {
             try {
-                File tempFile = File.createTempFile("groovyc-files-", ".txt");
+                File tempFile = Files.createTempFile("groovyc-files-", ".txt").toFile();
                 temporaryFiles.add(tempFile);
                 PrintWriter pw = printWriter(tempFile);
                 for (File srcFile : compileList) {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/jline/GroovyBuiltins.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/jline/GroovyBuiltins.groovy
@@ -29,6 +29,7 @@ import org.jline.console.impl.Builtins
 import org.jline.reader.LineReader
 import org.jline.reader.Widget
 
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.function.Function
 import java.util.function.Supplier
@@ -78,7 +79,7 @@ class GroovyBuiltins extends Builtins {
             }
             boolean usingBuffer = opt.args().size() == 0
             if (usingBuffer) {
-                def temp = File.createTempFile('groovysh', '.groovy')
+                def temp = Files.createTempFile('groovysh', '.groovy').toFile()
                 temp.text = engine.buffer
                 input = new CommandInput(input.command(), [*input.args(), temp.absolutePath] as String[], input.terminal(), input.in(), input.out(), input.err())
             }
@@ -97,7 +98,7 @@ class GroovyBuiltins extends Builtins {
             boolean usingBuffer = opt.args().size() == 0
             def temp = null
             if (usingBuffer) {
-                temp = File.createTempFile('groovysh', '.groovy')
+                temp = Files.createTempFile('groovysh', '.groovy').toFile()
                 temp.text = engine.buffer
                 input = new CommandInput(input.command(), [*input.args(), temp.absolutePath] as String[], input.terminal(), input.in(), input.out(), input.err())
             }


### PR DESCRIPTION
1. groovysh `/less` and `/nano` write the interactive session buffer to a temp file created with `java.io.File.createTempFile`, which under a typical umask (022) is created world-readable (`rw-r--r--`). The buffer often holds connection strings, tokens, or credentials the user has typed.
2. `Groovyc.addSourceFiles` writes the forked compilers source-file list to a temp file the same way when the command line exceeds the Windows length limit.
3. On a shared host any other local user can then read these artifacts. This is the same CWE-377/378 class already addressed for temp *directories* by moving to NIO (the CVE-2020-17521 fix, listed as property P4 in `THREAT_MODEL.md`), but these temp *files* were still using the `java.io` API.

Switched the three sites to `java.nio.file.Files.createTempFile(...).toFile()`, which yields owner-only (`rw-------`) permissions on POSIX. Behavior for the owning user is unchanged; the forked compiler and the jline pager run as the same user, so the tighter mode does not affect them.

Verified locally that `java.io.File.createTempFile` produces `rw-r--r--` under umask 022 while `Files.createTempFile` produces `rw-------`; the two modules compile cleanly.