### PR TITLE
GROOVY-12124: Modernize the TimeCategory date/time DSL: add a java.ti…

### DIFF
--- a/src/main/java/groovy/time/BaseDuration.java
+++ b/src/main/java/groovy/time/BaseDuration.java
@@ -30,7 +30,11 @@ import java.util.List;
  * Base class for date and time durations.
  *
  * @see Duration
+ * @deprecated Superseded by the quirk-free DSLs: {@code org.apache.groovy.dateutil.TimeCategory}
+ * (and its {@code java.util.Date}-based duration classes) or {@code org.apache.groovy.datetime.TimeCategory}
+ * (producing {@code java.time} types). This legacy class is retained, unchanged, for backward compatibility.
  */
+@Deprecated
 public abstract class BaseDuration implements Comparable<BaseDuration> {
     /**
      * Year component.

--- a/src/main/java/groovy/time/DatumDependentDuration.java
+++ b/src/main/java/groovy/time/DatumDependentDuration.java
@@ -29,7 +29,12 @@ import java.util.Date;
  * <p>
  * I don't know how many days in a month unless I know the name of the month 
  * (and if it's a leap year if the month is February)
+ *
+ * @deprecated Superseded by {@code org.apache.groovy.dateutil.DatumDependentDuration} (the
+ * dequirked {@code java.util.Date} flavor) or {@code java.time.Period}. This legacy class is
+ * retained, unchanged, for backward compatibility.
  */
+@Deprecated
 public class DatumDependentDuration extends BaseDuration {
     /**
      * Creates a datum-dependent duration.

--- a/src/main/java/groovy/time/Duration.java
+++ b/src/main/java/groovy/time/Duration.java
@@ -31,7 +31,12 @@ import java.util.Date;
  * <p>
  * If you ask Duration to convert itself to milliseconds then it will work on the basis of 24 hours
  * in a day. If you add or subtract it from a date it will take daylight saving into account.
+ *
+ * @deprecated Superseded by {@code org.apache.groovy.dateutil.Duration} (the dequirked
+ * {@code java.util.Date} flavor) or {@code java.time.Duration}/{@code java.time.Period}.
+ * This legacy class is retained, unchanged, for backward compatibility.
  */
+@Deprecated
 public class Duration extends BaseDuration {
     /**
      * Creates a fixed duration.

--- a/src/main/java/groovy/time/TimeCategory.java
+++ b/src/main/java/groovy/time/TimeCategory.java
@@ -37,7 +37,12 @@ import java.util.TimeZone;
  * </pre>
  *
  * @see BaseDuration
+ * @deprecated Use one of the quirk-free replacements instead:
+ * {@code org.apache.groovy.datetime.TimeCategory} (produces {@code java.time} types) or
+ * {@code org.apache.groovy.dateutil.TimeCategory} (produces {@code java.util.Date}). This
+ * legacy category is retained, unchanged, for backward compatibility.
  */
+@Deprecated
 public class TimeCategory {
     /*
      * Methods to allow Date Duration arithmetic

--- a/src/main/java/groovy/time/TimeDatumDependentDuration.java
+++ b/src/main/java/groovy/time/TimeDatumDependentDuration.java
@@ -24,7 +24,13 @@ import java.util.Date;
 /**
  * TimeDatumDuration represents a time period which results from an
  * arithmetic operation between a TimeDuration object and a DatumDuration object
+ *
+ * @deprecated Superseded by {@code org.apache.groovy.dateutil.TimeDatumDependentDuration} (the
+ * dequirked {@code java.util.Date} flavor) or the {@code java.time} DSL in
+ * {@code org.apache.groovy.datetime.TimeCategory}. This legacy class is retained, unchanged,
+ * for backward compatibility.
  */
+@Deprecated
 public class TimeDatumDependentDuration extends DatumDependentDuration {
     /**
      * Creates a mixed time and datum-dependent duration.

--- a/src/main/java/groovy/time/TimeDuration.java
+++ b/src/main/java/groovy/time/TimeDuration.java
@@ -33,8 +33,12 @@ import java.util.Date;
  * <p>
  * If you ask Duration to convert itself to milliseconds then it will work on the basis of 60 seconds in a minute.
  * If you add or subtract it from a date it will take leap seconds into account.
+ *
+ * @deprecated Superseded by {@code org.apache.groovy.dateutil.TimeDuration} (the dequirked
+ * {@code java.util.Date} flavor) or {@code java.time.Duration}. This legacy class is retained,
+ * unchanged, for backward compatibility.
  */
-
+@Deprecated
 public class TimeDuration extends Duration {
     /**
      * Creates a time duration without a day component.

--- a/src/test/groovy/groovy/time/DatumDependentDurationTest.groovy
+++ b/src/test/groovy/groovy/time/DatumDependentDurationTest.groovy
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.*
  * DatumDependentDuration represents durations whose length in milliseconds
  * cannot be determined without knowing the datum point (e.g., months, years).
  */
+@Deprecated
 class DatumDependentDurationTest {
 
     // ===== Constructor and Getter Tests =====

--- a/src/test/groovy/groovy/time/DurationTest.groovy
+++ b/src/test/groovy/groovy/time/DurationTest.groovy
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 
+@Deprecated
 class DurationTest {
     @Test
     void testFixedDurationArithmetic() {
@@ -138,7 +139,7 @@ class DurationTest {
     }
 
     @Test
-    void testDatumDependantArithmetic() {
+    void testDatumDependentArithmetic() {
         use(TimeCategory) {
             def start = new Date(961552080000)
             def then = (start + 1.month) + 1.week

--- a/src/test/groovy/groovy/time/TimeDatumDependentDurationTest.groovy
+++ b/src/test/groovy/groovy/time/TimeDatumDependentDurationTest.groovy
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*
 /**
  * Unit tests for {@link TimeDatumDependentDuration} class.
  */
+@Deprecated
 class TimeDatumDependentDurationTest {
 
     @Test

--- a/src/test/groovy/groovy/time/TimeDurationTest.groovy
+++ b/src/test/groovy/groovy/time/TimeDurationTest.groovy
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*
 /**
  * Unit tests for {@link TimeDuration} class.
  */
+@Deprecated
 class TimeDurationTest {
 
     @Test

--- a/subprojects/groovy-datetime/src/main/java/org/apache/groovy/datetime/TimeCategory.java
+++ b/subprojects/groovy-datetime/src/main/java/org/apache/groovy/datetime/TimeCategory.java
@@ -1,0 +1,178 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.datetime;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.temporal.Temporal;
+
+/**
+ * A {@code java.time}-based DSL for convenient date/time manipulation, the modern
+ * counterpart to the legacy {@code groovy.time.TimeCategory}. Numbers gain properties
+ * that produce {@link Duration} (time-based amounts) or {@link Period} (date-based
+ * amounts), which compose with the {@code java.time} types via their native arithmetic:
+ * <pre class="groovyTestCase">
+ * import java.time.LocalDate
+ * import java.time.LocalDateTime
+ * use (org.apache.groovy.datetime.TimeCategory) {
+ *     assert LocalDate.of(2000, 1, 1) + 2.months == LocalDate.of(2000, 3, 1)
+ *     assert 2.days.ago instanceof LocalDate
+ *     assert 1.hour.from.now instanceof LocalDateTime
+ * }
+ * </pre>
+ * <p>
+ * Time-based units ({@code nanoseconds}, {@code milliseconds}, {@code seconds},
+ * {@code minutes}, {@code hours}) yield a {@link Duration}; date-based units
+ * ({@code days}, {@code weeks}, {@code months}, {@code years}) yield a {@link Period}.
+ * The two are not combined into a single amount (as {@code java.time} intends); instead
+ * they compose by chaining, e.g. {@code someDateTime + 2.months + 3.hours}.
+ * <p>
+ * Unlike the legacy DSL, {@code .ago}/{@code .from.now} never floor the time-of-day:
+ * a {@link Duration} resolves against {@link LocalDateTime#now()} (time preserved) and a
+ * {@link Period} against {@link LocalDate#now()} (date only, so no time component exists).
+ */
+public class TimeCategory {
+
+    /* ******** time-based amounts -> java.time.Duration ******** */
+
+    public static Duration getNanoseconds(final Integer self) {
+        return Duration.ofNanos(self);
+    }
+
+    public static Duration getNanosecond(final Integer self) {
+        return getNanoseconds(self);
+    }
+
+    public static Duration getMilliseconds(final Integer self) {
+        return Duration.ofMillis(self);
+    }
+
+    public static Duration getMillisecond(final Integer self) {
+        return getMilliseconds(self);
+    }
+
+    public static Duration getSeconds(final Integer self) {
+        return Duration.ofSeconds(self);
+    }
+
+    public static Duration getSecond(final Integer self) {
+        return getSeconds(self);
+    }
+
+    public static Duration getMinutes(final Integer self) {
+        return Duration.ofMinutes(self);
+    }
+
+    public static Duration getMinute(final Integer self) {
+        return getMinutes(self);
+    }
+
+    public static Duration getHours(final Integer self) {
+        return Duration.ofHours(self);
+    }
+
+    public static Duration getHour(final Integer self) {
+        return getHours(self);
+    }
+
+    /* ******** date-based amounts -> java.time.Period ******** */
+
+    public static Period getDays(final Integer self) {
+        return Period.ofDays(self);
+    }
+
+    public static Period getDay(final Integer self) {
+        return getDays(self);
+    }
+
+    public static Period getWeeks(final Integer self) {
+        return Period.ofWeeks(self);
+    }
+
+    public static Period getWeek(final Integer self) {
+        return getWeeks(self);
+    }
+
+    public static Period getMonths(final Integer self) {
+        return Period.ofMonths(self);
+    }
+
+    public static Period getMonth(final Integer self) {
+        return getMonths(self);
+    }
+
+    public static Period getYears(final Integer self) {
+        return Period.ofYears(self);
+    }
+
+    public static Period getYear(final Integer self) {
+        return getYears(self);
+    }
+
+    /* ******** relative-time terminals ******** */
+
+    /**
+     * The {@link LocalDateTime} this time-based duration before now (time-of-day preserved).
+     */
+    public static LocalDateTime getAgo(final Duration self) {
+        return LocalDateTime.now().minus(self);
+    }
+
+    /**
+     * The {@link LocalDate} this date-based period before today.
+     */
+    public static LocalDate getAgo(final Period self) {
+        return LocalDate.now().minus(self);
+    }
+
+    /**
+     * Helper for {@code duration.from.now}; the resulting temporal is a {@link LocalDateTime}.
+     */
+    public static From getFrom(final Duration self) {
+        return new From(LocalDateTime.now().plus(self));
+    }
+
+    /**
+     * Helper for {@code period.from.now}; the resulting temporal is a {@link LocalDate}.
+     */
+    public static From getFrom(final Period self) {
+        return new From(LocalDate.now().plus(self));
+    }
+
+    /**
+     * Helper returned by {@link #getFrom}, supporting the {@code .now} / {@code .today} suffix.
+     */
+    public static final class From {
+        private final Temporal point;
+
+        private From(final Temporal point) {
+            this.point = point;
+        }
+
+        public Temporal getNow() {
+            return point;
+        }
+
+        public Temporal getToday() {
+            return point;
+        }
+    }
+}

--- a/subprojects/groovy-datetime/src/spec/doc/_working-with-datetime-types.adoc
+++ b/subprojects/groovy-datetime/src/spec/doc/_working-with-datetime-types.adoc
@@ -302,6 +302,39 @@ result is negative:
 include::../test/gdk/WorkingWithDateTimeTypesTest.groovy[tags=rightshift_operator_negative,indent=0]
 -------------------------------------
 
+=== A number-based DSL for periods and durations
+
+The `org.apache.groovy.datetime.TimeCategory` category adds properties to numbers for
+producing `Duration` (time-based) and `Period` (date-based) values, giving a concise DSL
+for date/time manipulation:
+
+[source,groovy]
+-------------------------------------
+import java.time.LocalDate
+import java.time.LocalDateTime
+use (org.apache.groovy.datetime.TimeCategory) {
+    assert 1.hour == java.time.Duration.ofHours(1)
+    assert 2.months == java.time.Period.ofMonths(2)
+
+    // apply amounts to temporals via their native arithmetic
+    assert LocalDate.of(2000, 1, 1) + 2.months == LocalDate.of(2000, 3, 1)
+
+    // date-based and time-based amounts compose by chaining
+    def base = LocalDateTime.of(2000, 1, 1, 0, 0, 0)
+    assert base + 1.month + 3.hours == LocalDateTime.of(2000, 2, 1, 3, 0, 0)
+
+    // relative-time terminals: a Period yields a LocalDate, a Duration a LocalDateTime
+    assert 2.days.ago instanceof LocalDate
+    assert 1.hour.from.now instanceof LocalDateTime
+}
+-------------------------------------
+
+Time-based units (`nanoseconds`, `milliseconds`, `seconds`, `minutes`, `hours`) produce a
+`Duration`; date-based units (`days`, `weeks`, `months`, `years`) produce a `Period`. This is
+the modern counterpart to the (now deprecated) `groovy.time.TimeCategory`. A `java.util.Date`
+flavored equivalent, `org.apache.groovy.dateutil.TimeCategory`, is available in the
+`groovy-dateutil` module.
+
 == Converting between legacy and JSR 310 types
 
 Despite the shortcomings of `Date`, `Calendar`, and `TimeZone` types in the `java.util` package

--- a/subprojects/groovy-datetime/src/test/groovy/org/apache/groovy/datetime/TimeCategoryTest.groovy
+++ b/subprojects/groovy-datetime/src/test/groovy/org/apache/groovy/datetime/TimeCategoryTest.groovy
@@ -1,0 +1,100 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.datetime
+
+import org.junit.jupiter.api.Test
+
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.Period
+
+/**
+ * Tests the {@code java.time}-based {@link org.apache.groovy.datetime.TimeCategory} DSL.
+ */
+class TimeCategoryTest {
+
+    @Test
+    void testTimeBasedProducersYieldDuration() {
+        use(TimeCategory) {
+            assert 5.nanoseconds == Duration.ofNanos(5)
+            assert 5.milliseconds == Duration.ofMillis(5)
+            assert 1.second == Duration.ofSeconds(1)
+            assert 2.seconds == Duration.ofSeconds(2)
+            assert 3.minutes == Duration.ofMinutes(3)
+            assert 4.hours == Duration.ofHours(4)
+        }
+    }
+
+    @Test
+    void testDateBasedProducersYieldPeriod() {
+        use(TimeCategory) {
+            assert 1.day == Period.ofDays(1)
+            assert 2.days == Period.ofDays(2)
+            assert 1.week == Period.ofWeeks(1)
+            assert 3.months == Period.ofMonths(3)
+            assert 2.years == Period.ofYears(2)
+        }
+    }
+
+    @Test
+    void testDateArithmeticViaNativePlus() {
+        use(TimeCategory) {
+            assert LocalDate.of(2000, 1, 1) + 2.months == LocalDate.of(2000, 3, 1)
+            assert LocalDate.of(2000, 1, 1) + 1.week == LocalDate.of(2000, 1, 8)
+            assert LocalDate.of(2000, 1, 1) - 1.year == LocalDate.of(1999, 1, 1)
+
+            def base = LocalDateTime.of(2000, 1, 1, 0, 0, 0)
+            assert base + 2.hours == LocalDateTime.of(2000, 1, 1, 2, 0, 0)
+            // date-based and time-based amounts compose by chaining
+            assert base + 1.month + 3.hours == LocalDateTime.of(2000, 2, 1, 3, 0, 0)
+        }
+    }
+
+    @Test
+    void testAgoReturnTypes() {
+        use(TimeCategory) {
+            assert 2.days.ago instanceof LocalDate
+            assert 3.months.ago instanceof LocalDate
+            assert 1.hour.ago instanceof LocalDateTime
+            assert 30.minutes.ago instanceof LocalDateTime
+        }
+    }
+
+    @Test
+    void testFromNowReturnTypes() {
+        use(TimeCategory) {
+            assert 2.days.from.now instanceof LocalDate
+            assert 1.hour.from.now instanceof LocalDateTime
+            assert 1.hour.from.today instanceof LocalDateTime
+        }
+    }
+
+    @Test
+    void testAgoAndFromNowValues() {
+        use(TimeCategory) {
+            assert 1.day.ago == LocalDate.now().minusDays(1)
+            assert 2.weeks.from.now == LocalDate.now().plusWeeks(2)
+            // time-based resolves against LocalDateTime (time-of-day preserved, never floored)
+            def approx = LocalDateTime.now().plusHours(1)
+            def actual = 1.hour.from.now
+            assert Duration.between(actual, approx).abs() < Duration.ofSeconds(2)
+        }
+    }
+}

--- a/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/BaseDuration.java
+++ b/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/BaseDuration.java
@@ -1,0 +1,187 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.dateutil;
+
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Base class for date and time durations (dequirked, {@code java.util.Date}-flavored).
+ * <p>
+ * This is the B1 prototype: the same value-class model as the legacy
+ * {@code groovy.time.BaseDuration}, but with the historical quirks removed:
+ * <ul>
+ *   <li><b>ago / from.now no longer zero the time-of-day</b> for date-based durations —
+ *       the behavior is now uniform across all durations (time is preserved), so a single
+ *       implementation lives here rather than divergent overrides per subclass.</li>
+ *   <li><b>{@link #toMilliseconds()} is deterministic</b> — datum-dependent amounts (years,
+ *       months) use {@link ChronoUnit}'s estimated durations rather than resolving against
+ *       {@code new Date()} ("now"), so the result no longer depends on when it is called.</li>
+ * </ul>
+ *
+ * @see Duration
+ */
+public abstract class BaseDuration implements Comparable<BaseDuration> {
+    /** Estimated milliseconds in a year (ChronoUnit.YEARS = 365.2425 days). */
+    static final long MILLIS_PER_YEAR = ChronoUnit.YEARS.getDuration().toMillis();
+    /** Estimated milliseconds in a month (ChronoUnit.MONTHS = 30.436875 days). */
+    static final long MILLIS_PER_MONTH = ChronoUnit.MONTHS.getDuration().toMillis();
+
+    protected final int years;
+    protected final int months;
+    protected final int days;
+    protected final int hours;
+    protected final int minutes;
+    protected final int seconds;
+    protected final int millis;
+
+    protected BaseDuration(final int years, final int months, final int days, final int hours, final int minutes, final int seconds, final int millis) {
+        this.years = years;
+        this.months = months;
+        this.days = days;
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+        this.millis = millis;
+    }
+
+    protected BaseDuration(final int days, final int hours, final int minutes, final int seconds, final int millis) {
+        this(0, 0, days, hours, minutes, seconds, millis);
+    }
+
+    public int getYears()   { return this.years; }
+    public int getMonths()  { return this.months; }
+    public int getDays()    { return this.days; }
+    public int getHours()   { return this.hours; }
+    public int getMinutes() { return this.minutes; }
+    public int getSeconds() { return this.seconds; }
+    public int getMillis()  { return this.millis; }
+
+    /**
+     * Adds this duration to the supplied date.
+     */
+    public Date plus(final Date date) {
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.add(Calendar.YEAR, this.years);
+        cal.add(Calendar.MONTH, this.months);
+        cal.add(Calendar.DAY_OF_YEAR, this.days);
+        cal.add(Calendar.HOUR_OF_DAY, this.hours);
+        cal.add(Calendar.MINUTE, this.minutes);
+        cal.add(Calendar.SECOND, this.seconds);
+        cal.add(Calendar.MILLISECOND, this.millis);
+        return cal.getTime();
+    }
+
+    /**
+     * Converts this duration to milliseconds.
+     * <p>
+     * DEQUIRKED (B): deterministic. Years and months use {@link ChronoUnit} estimates
+     * (a year is exactly 12 estimated months, so {@code 1.year == 12.months}); days and
+     * below are exact assuming 24-hour days. The result never depends on the current date.
+     */
+    public long toMilliseconds() {
+        return years * MILLIS_PER_YEAR
+                + months * MILLIS_PER_MONTH
+                + days * 86_400_000L
+                + hours * 3_600_000L
+                + minutes * 60_000L
+                + seconds * 1_000L
+                + millis;
+    }
+
+    /**
+     * The date this duration ago.
+     * <p>
+     * DEQUIRKED (A): the time-of-day is preserved (no flooring to midnight),
+     * uniformly for all duration kinds.
+     */
+    public Date getAgo() {
+        final Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.YEAR, -this.years);
+        cal.add(Calendar.MONTH, -this.months);
+        cal.add(Calendar.DAY_OF_YEAR, -this.days);
+        cal.add(Calendar.HOUR_OF_DAY, -this.hours);
+        cal.add(Calendar.MINUTE, -this.minutes);
+        cal.add(Calendar.SECOND, -this.seconds);
+        cal.add(Calendar.MILLISECOND, -this.millis);
+        return cal.getTime();
+    }
+
+    /**
+     * Helper for computing dates relative to the current time.
+     * DEQUIRKED (A): time-of-day preserved.
+     */
+    public From getFrom() {
+        return new From() {
+            @Override
+            public Date getNow() {
+                final Calendar cal = Calendar.getInstance();
+                cal.add(Calendar.YEAR, BaseDuration.this.years);
+                cal.add(Calendar.MONTH, BaseDuration.this.months);
+                cal.add(Calendar.DAY_OF_YEAR, BaseDuration.this.days);
+                cal.add(Calendar.HOUR_OF_DAY, BaseDuration.this.hours);
+                cal.add(Calendar.MINUTE, BaseDuration.this.minutes);
+                cal.add(Calendar.SECOND, BaseDuration.this.seconds);
+                cal.add(Calendar.MILLISECOND, BaseDuration.this.millis);
+                return cal.getTime();
+            }
+        };
+    }
+
+    @Override
+    public int compareTo(BaseDuration other) {
+        return Long.compare(toMilliseconds(), other.toMilliseconds());
+    }
+
+    @Override
+    public String toString() {
+        List<String> buffer = new ArrayList<>();
+        if (years != 0)   buffer.add(years + " years");
+        if (months != 0)  buffer.add(months + " months");
+        if (days != 0)    buffer.add(days + " days");
+        if (hours != 0)   buffer.add(hours + " hours");
+        if (minutes != 0) buffer.add(minutes + " minutes");
+        if (seconds != 0 || millis != 0) {
+            int normMillis = millis % 1000;
+            int normSeconds = seconds + (millis - normMillis) / 1000;
+            String secPart = (normSeconds == 0) ? (normMillis < 0 ? "-0" : "0") : String.valueOf(normSeconds);
+            buffer.add(secPart + "." + padLeft(String.valueOf(Math.abs(normMillis))) + " seconds");
+        }
+        return buffer.isEmpty() ? "0" : String.join(", ", buffer);
+    }
+
+    private static String padLeft(String s) {
+        StringBuilder sb = new StringBuilder(s);
+        while (sb.length() < 3) sb.insert(0, '0');
+        return sb.toString();
+    }
+
+    /** Helper for computing dates relative to the current time. */
+    public abstract static class From {
+        public abstract Date getNow();
+
+        public Date getToday() {
+            return getNow();
+        }
+    }
+}

--- a/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/DatumDependentDuration.java
+++ b/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/DatumDependentDuration.java
@@ -1,0 +1,68 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.dateutil;
+
+/**
+ * A duration that includes years and/or months, whose exact length depends on the datum.
+ * <p>
+ * DEQUIRKED: {@code toMilliseconds()} is now deterministic (see {@link BaseDuration}); it
+ * no longer resolves against "now". {@code getAgo()}/{@code getFrom()} are inherited and no
+ * longer zero the time-of-day.
+ */
+public class DatumDependentDuration extends BaseDuration {
+    public DatumDependentDuration(final int years, final int months, final int days, final int hours, final int minutes, final int seconds, final int millis) {
+        super(years, months, days, hours, minutes, seconds, millis);
+    }
+
+    public DatumDependentDuration plus(final DatumDependentDuration rhs) {
+        return new DatumDependentDuration(getYears() + rhs.getYears(), getMonths() + rhs.getMonths(),
+                getDays() + rhs.getDays(), getHours() + rhs.getHours(),
+                getMinutes() + rhs.getMinutes(), getSeconds() + rhs.getSeconds(),
+                getMillis() + rhs.getMillis());
+    }
+
+    public DatumDependentDuration plus(final TimeDatumDependentDuration rhs) {
+        return rhs.plus(this);
+    }
+
+    public DatumDependentDuration plus(final Duration rhs) {
+        return new DatumDependentDuration(getYears(), getMonths(),
+                getDays() + rhs.getDays(), getHours() + rhs.getHours(),
+                getMinutes() + rhs.getMinutes(), getSeconds() + rhs.getSeconds(),
+                getMillis() + rhs.getMillis());
+    }
+
+    public DatumDependentDuration plus(final TimeDuration rhs) {
+        return rhs.plus(this);
+    }
+
+    public DatumDependentDuration minus(final DatumDependentDuration rhs) {
+        return new DatumDependentDuration(getYears() - rhs.getYears(), getMonths() - rhs.getMonths(),
+                getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+
+    public DatumDependentDuration minus(final Duration rhs) {
+        return new DatumDependentDuration(getYears(), getMonths(),
+                getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+}

--- a/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/Duration.java
+++ b/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/Duration.java
@@ -1,0 +1,72 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.dateutil;
+
+/**
+ * A context-independent duration: days and below, whose length is known without a datum.
+ * <p>
+ * DEQUIRKED: {@code toMilliseconds()}, {@code getAgo()} and {@code getFrom()} are now
+ * inherited from {@link BaseDuration} (uniform, deterministic, time-preserving); only the
+ * type-preserving arithmetic remains here.
+ */
+public class Duration extends BaseDuration {
+    public Duration(final int days, final int hours, final int minutes, final int seconds, final int millis) {
+        super(days, hours, minutes, seconds, millis);
+    }
+
+    public Duration plus(final Duration rhs) {
+        return new Duration(getDays() + rhs.getDays(), getHours() + rhs.getHours(),
+                getMinutes() + rhs.getMinutes(), getSeconds() + rhs.getSeconds(),
+                getMillis() + rhs.getMillis());
+    }
+
+    public Duration plus(final TimeDuration rhs) {
+        return rhs.plus(this);
+    }
+
+    public DatumDependentDuration plus(final DatumDependentDuration rhs) {
+        return rhs.plus(this);
+    }
+
+    public Duration minus(final Duration rhs) {
+        return new Duration(getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+
+    public TimeDuration minus(final TimeDuration rhs) {
+        return new TimeDuration(getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+
+    public DatumDependentDuration minus(final DatumDependentDuration rhs) {
+        return new DatumDependentDuration(-rhs.getYears(), -rhs.getMonths(),
+                getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+
+    public TimeDatumDependentDuration minus(final TimeDatumDependentDuration rhs) {
+        return new TimeDatumDependentDuration(-rhs.getYears(), -rhs.getMonths(),
+                getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+}

--- a/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/TimeCategory.java
+++ b/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/TimeCategory.java
@@ -1,0 +1,138 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.dateutil;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * A dequirked, {@code java.util.Date}-flavored parallel to the legacy
+ * {@code groovy.time.TimeCategory}. Use as:
+ * <pre class="groovyTestCase">
+ * use (org.apache.groovy.dateutil.TimeCategory) {
+ *     println 1.minute.from.now
+ *     println 10.hours.ago
+ *     def someDate = new Date()
+ *     println someDate - 3.months
+ * }
+ * </pre>
+ * Differences from the legacy class: the deprecated {@code getTimeZone} and the
+ * {@code getDaylightSavingsOffset} helpers are dropped, and {@code .ago}/{@code .from.now}
+ * preserve the time-of-day (see {@link BaseDuration}).
+ *
+ * @see BaseDuration
+ */
+public class TimeCategory {
+
+    public static Date plus(final Date date, final BaseDuration duration) {
+        return duration.plus(date);
+    }
+
+    public static Date minus(final Date date, final BaseDuration duration) {
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.add(Calendar.YEAR, -duration.getYears());
+        cal.add(Calendar.MONTH, -duration.getMonths());
+        cal.add(Calendar.DAY_OF_YEAR, -duration.getDays());
+        cal.add(Calendar.HOUR_OF_DAY, -duration.getHours());
+        cal.add(Calendar.MINUTE, -duration.getMinutes());
+        cal.add(Calendar.SECOND, -duration.getSeconds());
+        cal.add(Calendar.MILLISECOND, -duration.getMillis());
+        return cal.getTime();
+    }
+
+    public static TimeDuration minus(final Date lhs, final Date rhs) {
+        long milliseconds = lhs.getTime() - rhs.getTime();
+        long days = milliseconds / (24 * 60 * 60 * 1000);
+        milliseconds -= days * 24 * 60 * 60 * 1000;
+        int hours = (int) (milliseconds / (60 * 60 * 1000));
+        milliseconds -= hours * 60 * 60 * 1000;
+        int minutes = (int) (milliseconds / (60 * 1000));
+        milliseconds -= minutes * 60 * 1000;
+        int seconds = (int) (milliseconds / 1000);
+        milliseconds -= seconds * 1000;
+        return new TimeDuration((int) days, hours, minutes, seconds, (int) milliseconds);
+    }
+
+    /* Integer producers: 1.month, 4.years etc. */
+
+    public static DatumDependentDuration getMonths(final Integer self) {
+        return new DatumDependentDuration(0, self, 0, 0, 0, 0, 0);
+    }
+
+    public static DatumDependentDuration getMonth(final Integer self) {
+        return getMonths(self);
+    }
+
+    public static DatumDependentDuration getYears(final Integer self) {
+        return new DatumDependentDuration(self, 0, 0, 0, 0, 0, 0);
+    }
+
+    public static DatumDependentDuration getYear(final Integer self) {
+        return getYears(self);
+    }
+
+    public static Duration getWeeks(final Integer self) {
+        return new Duration(self * 7, 0, 0, 0, 0);
+    }
+
+    public static Duration getWeek(final Integer self) {
+        return getWeeks(self);
+    }
+
+    public static Duration getDays(final Integer self) {
+        return new Duration(self, 0, 0, 0, 0);
+    }
+
+    public static Duration getDay(final Integer self) {
+        return getDays(self);
+    }
+
+    public static TimeDuration getHours(final Integer self) {
+        return new TimeDuration(0, self, 0, 0, 0);
+    }
+
+    public static TimeDuration getHour(final Integer self) {
+        return getHours(self);
+    }
+
+    public static TimeDuration getMinutes(final Integer self) {
+        return new TimeDuration(0, 0, self, 0, 0);
+    }
+
+    public static TimeDuration getMinute(final Integer self) {
+        return getMinutes(self);
+    }
+
+    public static TimeDuration getSeconds(final Integer self) {
+        return new TimeDuration(0, 0, 0, self, 0);
+    }
+
+    public static TimeDuration getSecond(final Integer self) {
+        return getSeconds(self);
+    }
+
+    public static TimeDuration getMilliseconds(final Integer self) {
+        return new TimeDuration(0, 0, 0, 0, self);
+    }
+
+    public static TimeDuration getMillisecond(final Integer self) {
+        return getMilliseconds(self);
+    }
+}

--- a/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/TimeDatumDependentDuration.java
+++ b/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/TimeDatumDependentDuration.java
@@ -1,0 +1,60 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.dateutil;
+
+/**
+ * The result of mixing a {@link TimeDuration} with a {@link DatumDependentDuration}.
+ */
+public class TimeDatumDependentDuration extends DatumDependentDuration {
+    public TimeDatumDependentDuration(int years, int months, int days, int hours, int minutes, int seconds, int millis) {
+        super(years, months, days, hours, minutes, seconds, millis);
+    }
+
+    @Override
+    public DatumDependentDuration plus(final Duration rhs) {
+        return new TimeDatumDependentDuration(getYears(), getMonths(),
+                getDays() + rhs.getDays(), getHours() + rhs.getHours(),
+                getMinutes() + rhs.getMinutes(), getSeconds() + rhs.getSeconds(),
+                getMillis() + rhs.getMillis());
+    }
+
+    @Override
+    public DatumDependentDuration plus(final DatumDependentDuration rhs) {
+        return new TimeDatumDependentDuration(getYears() + rhs.getYears(), getMonths() + rhs.getMonths(),
+                getDays() + rhs.getDays(), getHours() + rhs.getHours(),
+                getMinutes() + rhs.getMinutes(), getSeconds() + rhs.getSeconds(),
+                getMillis() + rhs.getMillis());
+    }
+
+    @Override
+    public DatumDependentDuration minus(final Duration rhs) {
+        return new TimeDatumDependentDuration(getYears(), getMonths(),
+                getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+
+    @Override
+    public DatumDependentDuration minus(final DatumDependentDuration rhs) {
+        return new TimeDatumDependentDuration(getYears() - rhs.getYears(), getMonths() - rhs.getMonths(),
+                getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+}

--- a/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/TimeDuration.java
+++ b/subprojects/groovy-dateutil/src/main/java/org/apache/groovy/dateutil/TimeDuration.java
@@ -1,0 +1,63 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.dateutil;
+
+/**
+ * A time period in hours, minutes, seconds and milliseconds (optionally with days).
+ * DEQUIRKED: {@code getAgo()}/{@code getFrom()} inherited from {@link BaseDuration}.
+ */
+public class TimeDuration extends Duration {
+    public TimeDuration(final int hours, final int minutes, final int seconds, final int millis) {
+        super(0, hours, minutes, seconds, millis);
+    }
+
+    public TimeDuration(final int days, final int hours, final int minutes, final int seconds, final int millis) {
+        super(days, hours, minutes, seconds, millis);
+    }
+
+    @Override
+    public Duration plus(final Duration rhs) {
+        return new TimeDuration(getDays() + rhs.getDays(), getHours() + rhs.getHours(),
+                getMinutes() + rhs.getMinutes(), getSeconds() + rhs.getSeconds(),
+                getMillis() + rhs.getMillis());
+    }
+
+    @Override
+    public DatumDependentDuration plus(final DatumDependentDuration rhs) {
+        return new TimeDatumDependentDuration(rhs.getYears(), rhs.getMonths(),
+                getDays() + rhs.getDays(), getHours() + rhs.getHours(),
+                getMinutes() + rhs.getMinutes(), getSeconds() + rhs.getSeconds(),
+                getMillis() + rhs.getMillis());
+    }
+
+    @Override
+    public Duration minus(final Duration rhs) {
+        return new TimeDuration(getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+
+    @Override
+    public DatumDependentDuration minus(final DatumDependentDuration rhs) {
+        return new TimeDatumDependentDuration(-rhs.getYears(), -rhs.getMonths(),
+                getDays() - rhs.getDays(), getHours() - rhs.getHours(),
+                getMinutes() - rhs.getMinutes(), getSeconds() - rhs.getSeconds(),
+                getMillis() - rhs.getMillis());
+    }
+}

--- a/subprojects/groovy-dateutil/src/spec/doc/_working-with-dateutil-types.adoc
+++ b/subprojects/groovy-dateutil/src/spec/doc/_working-with-dateutil-types.adoc
@@ -52,3 +52,27 @@ You can also create a new Date or Calendar based on an existing one:
 -------------------------------------
 include::../test/gdk/WorkingWithDateUtilTypesTest.groovy[tags=date_copyWith,indent=0]
 -------------------------------------
+
+=== A number-based DSL for durations
+
+The `org.apache.groovy.dateutil.TimeCategory` category adds properties to numbers for
+producing durations that can be added to or subtracted from `Date` instances:
+
+[source,groovy]
+-------------------------------------
+use (org.apache.groovy.dateutil.TimeCategory) {
+    def christmas = new Date(124, 11, 25)     // 25 Dec 2024
+    assert (christmas + 1.week - 3.days).date == 29
+    assert (christmas - christmas).toMilliseconds() == 0
+
+    def party = 2.hours + 30.minutes
+    assert party.toMilliseconds() == (150 * 60 * 1000)
+}
+-------------------------------------
+
+This is a dequirked, `java.util.Date`-flavored parallel to the (now deprecated)
+`groovy.time.TimeCategory`. Relative to the legacy class, `.ago`/`.from.now` preserve the
+time-of-day uniformly (they no longer floor day/month/year amounts to midnight), and
+`toMilliseconds()` is deterministic (years and months use fixed `java.time.temporal.ChronoUnit`
+estimates rather than resolving against the current date). A `java.time` flavored equivalent,
+`org.apache.groovy.datetime.TimeCategory`, is available in the `groovy-datetime` module.

--- a/subprojects/groovy-dateutil/src/test/groovy/org/apache/groovy/dateutil/DurationTest.groovy
+++ b/subprojects/groovy-dateutil/src/test/groovy/org/apache/groovy/dateutil/DurationTest.groovy
@@ -1,0 +1,171 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.dateutil
+
+import org.junit.jupiter.api.Test
+
+import java.time.temporal.ChronoUnit
+
+import static java.util.Calendar.DAY_OF_YEAR
+import static java.util.Calendar.MONTH
+import static java.util.Calendar.WEEK_OF_YEAR
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * Tests for the dequirked {@code org.apache.groovy.dateutil} Duration hierarchy.
+ */
+class DurationTest {
+
+    @Test
+    void testFixedDurationArithmetic() {
+        use(TimeCategory) {
+            def oneDay = 2.days - 1.day
+            assert oneDay.toMilliseconds() == (24 * 60 * 60 * 1000)
+
+            oneDay = 2.days - 1.day + 24.hours - 1440.minutes
+            assert oneDay.toMilliseconds() == (24 * 60 * 60 * 1000)
+        }
+    }
+
+    @Test
+    void testDurationToString() {
+        use(TimeCategory) {
+            assert (0.years).toString() == "0"
+            assert (3.years + 8.months + 4.days + 2.hours + 5.minutes + 12.milliseconds).toString() ==
+                    "3 years, 8 months, 4 days, 2 hours, 5 minutes, 0.012 seconds"
+            assert (4.days + 2.hours + 5.minutes + 12.milliseconds).toString() == "4 days, 2 hours, 5 minutes, 0.012 seconds"
+            assert (4.days + 2.hours + 5.minutes).toString() == "4 days, 2 hours, 5 minutes"
+            assert (5.seconds).toString() == "5.000 seconds"
+            assert ((-12).milliseconds).toString() == "-0.012 seconds"
+            assert (5.seconds + 12.milliseconds).toString() == "5.012 seconds"
+            assert (5.seconds + 1012.milliseconds).toString() == "6.012 seconds"
+        }
+    }
+
+    @Test
+    void testDurationComparison() {
+        use(TimeCategory) {
+            assert 1.week < 2.weeks
+            assert 3.weeks <= 4.weeks
+            assert 10.seconds == 10.seconds
+            assert 4.months >= 1.month
+            assert 10.days > 2.days
+            assert 3.months > 2.months
+            assert 1.second < 1.year
+            assert 1.day > 1000.seconds
+            assert 10.weeks < 10.years
+        }
+    }
+
+    @Test
+    void testConstructor() {
+        def duration = new Duration(1, 2, 3, 4, 5)
+        assertEquals(1, duration.days)
+        assertEquals(2, duration.hours)
+        assertEquals(3, duration.minutes)
+        assertEquals(4, duration.seconds)
+        assertEquals(5, duration.millis)
+    }
+
+    @Test
+    void testToMilliseconds() {
+        assertEquals(24 * 60 * 60 * 1000L, new Duration(1, 0, 0, 0, 0).toMilliseconds())
+        def d = new Duration(1, 2, 3, 4, 5)
+        assertEquals(((((1L * 24 + 2) * 60 + 3) * 60 + 4) * 1000) + 5, d.toMilliseconds())
+    }
+
+    @Test
+    void testDatumDependentToMillisecondsIsDeterministic() { // DEQUIRK B
+        // years/months use fixed ChronoUnit estimates; no dependence on the current date
+        assertEquals(ChronoUnit.YEARS.duration.toMillis(), new DatumDependentDuration(1, 0, 0, 0, 0, 0, 0).toMilliseconds())
+        assertEquals(ChronoUnit.MONTHS.duration.toMillis(), new DatumDependentDuration(0, 1, 0, 0, 0, 0, 0).toMilliseconds())
+        // a year is exactly twelve estimated months
+        assertEquals(new DatumDependentDuration(1, 0, 0, 0, 0, 0, 0).toMilliseconds(),
+                new DatumDependentDuration(0, 12, 0, 0, 0, 0, 0).toMilliseconds())
+    }
+
+    @Test
+    void testPlusDuration() {
+        def result = new Duration(1, 2, 3, 4, 5).plus(new Duration(1, 1, 1, 1, 1))
+        assertEquals(2, result.days); assertEquals(3, result.hours); assertEquals(4, result.minutes)
+        assertEquals(5, result.seconds); assertEquals(6, result.millis)
+    }
+
+    @Test
+    void testPlusDatumDependentDuration() {
+        def result = new Duration(1, 0, 0, 0, 0).plus(new DatumDependentDuration(1, 2, 3, 4, 5, 6, 7))
+        assertNotNull(result)
+        assertEquals(1, result.years); assertEquals(2, result.months)
+    }
+
+    @Test
+    void testMinusDatumDependentDuration() {
+        def result = new Duration(10, 5, 30, 20, 100).minus(new DatumDependentDuration(1, 2, 3, 1, 10, 5, 50))
+        assertEquals(-1, result.years); assertEquals(-2, result.months); assertEquals(7, result.days)
+    }
+
+    @Test
+    void testGetAgoPreservesTimeOfDay() { // DEQUIRK A
+        def ago = new Duration(1, 0, 0, 0, 0).getAgo()
+        def expected = Calendar.instance
+        expected.add(DAY_OF_YEAR, -1)
+        assertTrue Math.abs(expected.timeInMillis - ago.time) < 2000
+    }
+
+    @Test
+    void testGetFromPreservesTimeOfDay() { // DEQUIRK A
+        def now = new Duration(3, 0, 0, 0, 0).from.now
+        def expected = Calendar.instance
+        expected.add(DAY_OF_YEAR, 3)
+        assertTrue Math.abs(expected.timeInMillis - now.time) < 2000
+    }
+
+    @Test
+    void testMinutesAgo() { // See GROOVY-3687 - was already un-quirky for time durations
+        use(TimeCategory) {
+            def now = Calendar.instance
+            def before = 10.minutes.ago
+            now.add(Calendar.MINUTE, -11)
+            assertTrue now.timeInMillis < before.time
+        }
+    }
+
+    @Test
+    void testDatumDependentArithmetic() {
+        use(TimeCategory) {
+            def start = Calendar.instance
+            def date = new Date(start.time.time)
+
+            date += 2.months
+            start.add MONTH, 2
+            assertEquals start.time, date
+
+            date += 5.weeks
+            start.add WEEK_OF_YEAR, 5
+            assertEquals start.time, date
+
+            date -= (52.days + 123.minutes)
+            start.add DAY_OF_YEAR, -52
+            start.add Calendar.MINUTE, -123
+            assertEquals start.time, date
+        }
+    }
+}

--- a/subprojects/groovy-dateutil/src/test/groovy/org/apache/groovy/dateutil/TimeCategoryTest.groovy
+++ b/subprojects/groovy-dateutil/src/test/groovy/org/apache/groovy/dateutil/TimeCategoryTest.groovy
@@ -16,17 +16,20 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package groovy.time
+package org.apache.groovy.dateutil
 
 import org.junit.jupiter.api.Test
 
+import static java.util.Calendar.DAY_OF_YEAR
+import static java.util.Calendar.MONTH
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
- * Tests the groovy.time.TimeCategory class. 
- * Most of these tests use January 1 as a start time to avoid 
- * leap years and daylight savings time issues. 
+ * Tests the {@link org.apache.groovy.dateutil.TimeCategory} class, the dequirked
+ * {@code java.util.Date}-flavored parallel to the legacy {@code groovy.time.TimeCategory}.
+ * The arithmetic assertions are ported verbatim from the legacy suite; the final section
+ * exercises the two behaviors that were intentionally changed ("dequirked").
  */
-@Deprecated
 class TimeCategoryTest {
 
     @Test
@@ -145,7 +148,6 @@ class TimeCategoryTest {
         }
     }
 
-
     @Test
     void testDateSubtractionOnSeconds() {
         use(TimeCategory) {
@@ -153,10 +155,8 @@ class TimeCategoryTest {
             def oneSecondLater = new Date(100, 0, 1, 0, 0, 1)
             def twoSecondsLater = new Date(100, 0, 1, 0, 0, 2)
 
-            def result = oneSecondLater - current
-            assert result.seconds == 1
-            result = twoSecondsLater - current
-            assert result.seconds == 2
+            assert (oneSecondLater - current).seconds == 1
+            assert (twoSecondsLater - current).seconds == 2
         }
     }
 
@@ -164,13 +164,8 @@ class TimeCategoryTest {
     void testDateSubtractionOnMinutes() {
         use(TimeCategory) {
             def current = new Date(100, 0, 1, 0, 0, 0)
-            def oneMinuteLater = new Date(100, 0, 1, 0, 1, 0)
-            def twoMinutesLater = new Date(100, 0, 1, 0, 2, 0)
-
-            def result = oneMinuteLater - current
-            assert result.minutes == 1
-            result = twoMinutesLater - current
-            assert result.minutes == 2
+            assert (new Date(100, 0, 1, 0, 1, 0) - current).minutes == 1
+            assert (new Date(100, 0, 1, 0, 2, 0) - current).minutes == 2
         }
     }
 
@@ -178,13 +173,8 @@ class TimeCategoryTest {
     void testDateSubtractionOnHours() {
         use(TimeCategory) {
             def current = new Date(100, 0, 1, 0, 0, 0)
-            def oneHourLater = new Date(100, 0, 1, 1, 0, 0)
-            def twoHoursLater = new Date(100, 0, 1, 2, 0, 0)
-
-            def result = oneHourLater - current
-            assert result.hours == 1
-            result = twoHoursLater - current
-            assert result.hours == 2
+            assert (new Date(100, 0, 1, 1, 0, 0) - current).hours == 1
+            assert (new Date(100, 0, 1, 2, 0, 0) - current).hours == 2
         }
     }
 
@@ -192,29 +182,18 @@ class TimeCategoryTest {
     void testDateSubtractionOnDays() {
         use(TimeCategory) {
             def current = new Date(100, 0, 1, 0, 0, 0)
-            def oneDayLater = new Date(100, 0, 2, 0, 0, 0)
-            def twoDaysLater = new Date(100, 0, 3, 0, 0, 0)
-
-            def result = oneDayLater - current
-            assert result.days == 1
-            result = twoDaysLater - current
-            assert result.days == 2
+            assert (new Date(100, 0, 2, 0, 0, 0) - current).days == 1
+            assert (new Date(100, 0, 3, 0, 0, 0) - current).days == 2
         }
     }
 
     @Test
     void testDateSubtraction_NoYearsOrMonths() {
         use(TimeCategory) {
-            def yearOne = new Date(100, 0, 1, 0, 0, 0)
-            def yearThree = new Date(102, 0, 1, 0, 0, 0)
-
-            def result = yearThree - yearOne
-
-            //do NOT expect months and years to be
-            //set on the result of date subtraction
+            def result = new Date(102, 0, 1, 0, 0, 0) - new Date(100, 0, 1, 0, 0, 0)
+            // date subtraction does not populate months and years
             assert result.years == 0
             assert result.months == 0
-
         }
     }
 
@@ -246,13 +225,59 @@ class TimeCategoryTest {
     }
 
     @Test
-    void testDateEquality() {
+    void testZeroDurationFromNowIsNow() {
         use(TimeCategory) {
-            Date dt1 = 0.days.from.now
-            Date dt2 = new Date(0.days.from.now.time)
+            // Replaces the legacy testDateEquality, whose reproducibility relied on from.now
+            // flooring to midnight. Dequirked, a zero-length duration from now is now, with the
+            // time-of-day preserved; bracket the call so it is robust under scheduling delays.
+            long before = System.currentTimeMillis()
+            Date result = 0.days.from.now
+            long after = System.currentTimeMillis()
+            assert result.time >= before && result.time <= after
+        }
+    }
 
-            assert dt1 == dt2
-            assert dt1.toString() == dt2.toString()
+    // ===== Dequirked behavior (would fail against the legacy groovy.time.TimeCategory) =====
+
+    @Test
+    void testAgoPreservesTimeOfDay() { // DEQUIRK A
+        use(TimeCategory) {
+            def now = Calendar.instance
+            def before = 3.days.ago
+            now.add(DAY_OF_YEAR, -3)
+            // same wall-clock instant; legacy would have floored to midnight
+            assertTrue Math.abs(now.timeInMillis - before.time) < 2000
+        }
+    }
+
+    @Test
+    void testMonthAgoPreservesTimeOfDay() { // DEQUIRK A
+        use(TimeCategory) {
+            def now = Calendar.instance
+            def before = 1.month.ago
+            now.add(MONTH, -1)
+            assertTrue Math.abs(now.timeInMillis - before.time) < 2000
+        }
+    }
+
+    @Test
+    void testWeeksFromNowPreservesTimeOfDay() { // DEQUIRK A
+        use(TimeCategory) {
+            def now = Calendar.instance
+            now.add(DAY_OF_YEAR, 21)
+            def later = 3.weeks.from.now
+            assertTrue Math.abs(now.timeInMillis - later.time) < 2000
+        }
+    }
+
+    @Test
+    void testToMillisecondsIsDeterministic() { // DEQUIRK B
+        use(TimeCategory) {
+            // no dependence on "now": years and months use fixed ChronoUnit estimates
+            assert 1.year.toMilliseconds() == 12.months.toMilliseconds()
+            assert 2.weeks.toMilliseconds() == 14.days.toMilliseconds()
+            assert 5.months.toMilliseconds() ==
+                    5 * java.time.temporal.ChronoUnit.MONTHS.duration.toMillis()
         }
     }
 }


### PR DESCRIPTION
…me flavor and a dequirked java.util.Date flavor

See: https://issues.apache.org/jira/browse/GROOVY-12124