### PR TITLE
don't follow symlinks when recursively deleting a directory

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -1743,7 +1743,14 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
         // delete contained files
         boolean result = true;
         for (File file : files) {
-            if (file.isDirectory()) {
+            if (Files.isSymbolicLink(file.toPath())) {
+                // remove the link itself; do not recurse through it into the target
+                try {
+                    Files.delete(file.toPath());
+                } catch (IOException e) {
+                    result = false;
+                }
+            } else if (file.isDirectory()) {
                 if (!deleteDir(file))
                     result = false;
             } else {

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -40,6 +40,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -359,7 +360,8 @@ public class FileSystemCompiler {
         if (!file.exists()) {
             return;
         }
-        if (file.isFile()) {
+        if (Files.isSymbolicLink(file.toPath()) || file.isFile()) {
+            // for a symbolic link, remove the link itself rather than following it into the target
             file.delete();
         } else if (file.isDirectory()) {
             File[] files = file.listFiles();

--- a/src/test/groovy/org/codehaus/groovy/runtime/DirectoryDeleteTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/runtime/DirectoryDeleteTest.groovy
@@ -20,6 +20,11 @@ package org.codehaus.groovy.runtime
 
 import org.junit.jupiter.api.Test
 
+import java.nio.file.Files
+import java.nio.file.LinkOption
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue
+
 
 /**
  * Test File.deleteDir() method in Groovy
@@ -56,5 +61,36 @@ class DirectoryDeleteTest {
         subdir.mkdir()
         new File(subdir, "testsubdir.txt").write("Test")
         assert dir.deleteDir()
+    }
+
+    @Test
+    void testDeleteDirDoesNotFollowSymlink() {
+        def base = Files.createTempDirectory("deleteDirSymlink").toFile()
+
+        // a directory outside the tree being deleted, holding a file that must survive
+        def outside = new File(base, "outside")
+        outside.mkdir()
+        def survivor = new File(outside, "survivor.txt")
+        survivor.write("keep")
+
+        // the tree we delete, containing a symlink pointing at the outside directory
+        def tree = new File(base, "tree")
+        tree.mkdir()
+        def link = new File(tree, "link")
+        try {
+            Files.createSymbolicLink(link.toPath(), outside.toPath())
+        } catch (IOException | UnsupportedOperationException e) {
+            assumeTrue(false, "symbolic links not supported on this platform: $e")
+        }
+
+        assert tree.deleteDir()
+
+        // the link and its parent are gone, but the target's contents are untouched
+        assert !tree.exists()
+        assert survivor.exists()
+        assert survivor.text == "keep"
+
+        outside.deleteDir()
+        base.deleteDir()
     }
 }

--- a/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
+++ b/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
@@ -1403,7 +1403,8 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
         // delete contained files
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(self)) {
             for (Path path : stream) {
-                if (Files.isDirectory(path)) {
+                // do not follow a symbolic link into its target; delete the link itself
+                if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
                     if (!deleteDir(path)) {
                         return false;
                     }

--- a/subprojects/groovy-nio/src/test/groovy/org/apache/groovy/nio/extensions/NioExtensionsTest.groovy
+++ b/subprojects/groovy-nio/src/test/groovy/org/apache/groovy/nio/extensions/NioExtensionsTest.groovy
@@ -724,6 +724,30 @@ class NioExtensionsTest extends Specification {
         !Files.exists(folder)
     }
 
+    def testDeleteDirDoesNotFollowSymlink() {
+        setup:
+        def base = Files.createTempDirectory(tempDir.toPath(), 'symlink_')
+        def outside = Files.createDirectory(base.resolve('outside'))
+        def survivor = outside.resolve('survivor.txt')
+        Files.write(survivor, 'keep'.bytes)
+        def tree = Files.createDirectory(base.resolve('tree'))
+        def link = tree.resolve('link')
+        try {
+            Files.createSymbolicLink(link, outside)
+        } catch (IOException | UnsupportedOperationException ignored) {
+            return // platform without symbolic link support
+        }
+
+        when:
+        def result = tree.deleteDir()
+
+        then:
+        result
+        !Files.exists(tree)
+        Files.exists(survivor)
+        new String(Files.readAllBytes(survivor)) == 'keep'
+    }
+
     def testWithWriter() {
         setup:
         def path = tempFile.toPath()


### PR DESCRIPTION
Repro: inside a directory, place a symlink pointing at another directory that lives outside the tree, then call `deleteDir()` on the outer directory. The linked-to directory's files are deleted along with the tree.

Cause: recursion is gated on `File.isDirectory()` / `Files.isDirectory(path)`, both of which follow symbolic links, so a link to a directory is treated as a subdirectory and walked into. The delete then reaches files outside the tree being removed (CWE-59).

Fix: check for a symbolic link first (`Files.isSymbolicLink` for the `File` paths, `LinkOption.NOFOLLOW_LINKS` for the `Path` path) and remove the link itself instead of following it. Applied at the three recursive-delete sites that share this behavior:

1. `ResourceGroovyMethods.deleteDir(File)`
2. `NioExtensions.deleteDir(Path)`
3. `FileSystemCompiler.deleteRecursive(File)`

Files outside the deleted tree now survive; the tree and the link entry are still fully removed, and the return value is unchanged for the ordinary (no-symlink) case. Added regression tests for the `File` and `Path` variants that skip where the platform has no symlink support.