### PR TITLE
GROOVY-12128: groovy-contracts: loop contract checks fire at points t…

### DIFF
--- a/subprojects/groovy-contracts/src/main/java/groovy/contracts/Decreases.java
+++ b/subprojects/groovy-contracts/src/main/java/groovy/contracts/Decreases.java
@@ -36,8 +36,10 @@ import java.lang.annotation.Target;
  * {@code >= 0} for numeric types) — a well-founded measure.
  * <p>
  * <b>On a loop</b> ({@code for}/{@code while}/{@code do-while}) the expression is
- * evaluated at the start and end of each iteration and must decrease per
- * iteration; a {@link org.apache.groovy.contracts.LoopVariantViolation
+ * evaluated at the start of each iteration and must be non-negative there and
+ * strictly decrease between consecutive iterations (so progress made by a classic
+ * {@code for} loop's update expression is seen); a
+ * {@link org.apache.groovy.contracts.LoopVariantViolation
  * LoopVariantViolation} is thrown otherwise. The measure may also be a
  * {@link java.util.List} compared lexicographically.
  * <pre>

--- a/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/VariantSupport.java
+++ b/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/VariantSupport.java
@@ -90,6 +90,24 @@ public final class VariantSupport {
         }
     }
 
+    /**
+     * Loop-variant entry point for the first iteration of a loop, where no previous value
+     * exists to compare against: if enabled, verify a scalar {@link Number} measure is
+     * non-negative at loop entry (GROOVY-12128), throwing {@link LoopVariantViolation}
+     * otherwise. This mirrors the non-negative floor {@link #describeFailure} applies to
+     * every subsequent iteration-start value. {@link List} (lexicographic) measures have no
+     * single deciding component at entry, so they are not floor-checked here.
+     *
+     * @param curr      the variant at first loop entry
+     * @param className the enclosing class name (for {@code -ea}/{@code -da} gating)
+     */
+    public static void checkLoopVariantEntry(final Object curr, final String className) {
+        if (!enabled(className)) return;
+        if (curr instanceof Number && ((Number) curr).doubleValue() < 0) {
+            throw new LoopVariantViolation("<groovy.contracts.Decreases> loop variant is negative at loop entry: " + curr);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private static String describeScalar(final Object prev, final Object curr) {
         Comparable<Object> prevComp = (Comparable<Object>) prev;

--- a/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/ast/LoopContractSupport.java
+++ b/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/ast/LoopContractSupport.java
@@ -21,6 +21,7 @@ package org.apache.groovy.contracts.ast;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassCodeVisitorSupport;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.DoWhileStatement;
 import org.codehaus.groovy.ast.stmt.ForStatement;
 import org.codehaus.groovy.ast.stmt.WhileStatement;
@@ -132,6 +133,24 @@ final class LoopContractSupport {
     }
 
     /**
+     * Find the {@link BlockStatement} that directly contains a loop statement, so bookkeeping
+     * state that must survive across iterations (GROOVY-12128) can be declared just before the
+     * loop. Returns {@code null} when the loop is not a direct child of a block (e.g. the
+     * braceless branch of an {@code if}).
+     *
+     * @param source the current source unit
+     * @param target the loop statement to locate
+     * @return the directly enclosing block, or {@code null}
+     */
+    static BlockStatement enclosingBlock(final SourceUnit source, final ASTNode target) {
+        ClassNode enclosing = enclosingClassNode(source, target);
+        if (enclosing == null) return null;
+        BlockFinder finder = new BlockFinder(target);
+        finder.visitClass(enclosing);
+        return finder.found;
+    }
+
+    /**
      * Find the {@link ClassNode} enclosing a loop statement, or {@code null} if it cannot be
      * determined.
      *
@@ -147,6 +166,29 @@ final class LoopContractSupport {
             if (finder.found) return classNode;
         }
         return null;
+    }
+
+    private static final class BlockFinder extends ClassCodeVisitorSupport {
+        private final ASTNode target;
+        private BlockStatement found;
+
+        BlockFinder(final ASTNode target) {
+            this.target = target;
+        }
+
+        @Override
+        protected SourceUnit getSourceUnit() {
+            return null;
+        }
+
+        @Override
+        public void visitBlockStatement(final BlockStatement block) {
+            if (found == null && block.getStatements().contains(target)) {
+                found = block;
+                return;
+            }
+            super.visitBlockStatement(block);
+        }
     }
 
     private static final class EnclosingFinder extends ClassCodeVisitorSupport {

--- a/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/ast/LoopInvariantASTTransformation.java
+++ b/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/ast/LoopInvariantASTTransformation.java
@@ -31,6 +31,7 @@ import org.codehaus.groovy.ast.expr.BooleanExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.DoWhileStatement;
 import org.codehaus.groovy.ast.stmt.LoopingStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.control.CompilationUnit;
@@ -43,8 +44,14 @@ import java.util.List;
 
 /**
  * Handles {@link Invariant} annotations placed on loop statements ({@code for},
- * {@code while}, {@code do-while}). The invariant closure is evaluated as an
- * assertion at the start of each loop iteration.
+ * {@code while}, {@code do-while}). For {@code for} and {@code while} loops the
+ * invariant closure is evaluated as an assertion at the start of each loop
+ * iteration. For {@code do-while} loops it is evaluated after each body
+ * execution instead (GROOVY-12128): the body runs before the first condition
+ * check, so the invariant only needs to be established by that first execution —
+ * checking it at loop entry would reject valid loops. (A {@code continue} inside
+ * a {@code do-while} jumps straight to the condition and therefore skips the
+ * check for that pass.)
  * <p>
  * When {@code @Invariant} is placed on a class (its original usage), this
  * transform returns immediately, letting the existing global contract pipeline
@@ -106,7 +113,14 @@ public class LoopInvariantASTTransformation implements ASTTransformation, Compil
         );
         wrapped.setSourcePosition(annotation);
 
-        injectAtLoopBodyStart(loopStatement, wrapped);
+        // GROOVY-12128: a do-while establishes its invariant with the first body execution
+        // (the body runs before the first condition check), so check after each execution
+        // rather than at iteration start
+        if (loopStatement instanceof DoWhileStatement) {
+            injectAtLoopBodyEnd(loopStatement, wrapped);
+        } else {
+            injectAtLoopBodyStart(loopStatement, wrapped);
+        }
 
         // The invariant closure lived inside a statement annotation, so the compiler's resolution
         // passes never reached it; re-resolve types, static imports and variable scopes now that the
@@ -122,6 +136,19 @@ public class LoopInvariantASTTransformation implements ASTTransformation, Compil
             BlockStatement newBody = new BlockStatement();
             newBody.addStatements(((BlockStatement) check).getStatements());
             newBody.addStatement(loopBody);
+            newBody.setSourcePosition(loopBody);
+            loopStatement.setLoopBlock(newBody);
+        }
+    }
+
+    private static void injectAtLoopBodyEnd(LoopingStatement loopStatement, Statement check) {
+        Statement loopBody = loopStatement.getLoopBlock();
+        if (loopBody instanceof BlockStatement block) {
+            block.getStatements().addAll(((BlockStatement) check).getStatements());
+        } else {
+            BlockStatement newBody = new BlockStatement();
+            newBody.addStatement(loopBody);
+            newBody.addStatements(((BlockStatement) check).getStatements());
             newBody.setSourcePosition(loopBody);
             loopStatement.setLoopBlock(newBody);
         }

--- a/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/ast/LoopVariantASTTransformation.java
+++ b/subprojects/groovy-contracts/src/main/java/org/apache/groovy/contracts/ast/LoopVariantASTTransformation.java
@@ -50,24 +50,34 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.declS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.geX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.ifElseS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.localVarX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ltX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.nullX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.stmt;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.throwS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
 
 /**
  * Handles {@link Decreases} annotations placed on loop statements ({@code for},
- * {@code while}, {@code do-while}). The closure must return a value that
- * strictly decreases on every iteration and remains non-negative.
+ * {@code while}, {@code do-while}). The closure must return a value that is
+ * non-negative at the start of each iteration and strictly decreases between
+ * consecutive iterations.
  * <p>
  * The transformation injects code to:
  * <ol>
- *   <li>Save the expression value at the start of each iteration.</li>
- *   <li>Re-evaluate it at the end of the iteration.</li>
- *   <li>Assert the value has strictly decreased.</li>
- *   <li>Assert the value is non-negative.</li>
+ *   <li>Evaluate the expression at the start of each iteration.</li>
+ *   <li>On the first iteration, assert a scalar measure is non-negative at
+ *       loop entry (well-foundedness).</li>
+ *   <li>On subsequent iterations, assert it has strictly decreased since the
+ *       previous iteration start, and is non-negative (GROOVY-12128: comparing
+ *       iteration starts — rather than the start and end of one pass — sees
+ *       progress made by a classic {@code for} loop's update expression, which
+ *       runs after the body, and does not demand non-negativity after the
+ *       final body execution).</li>
  * </ol>
+ * The final iteration's decrease is intentionally unchecked: a loop that has
+ * exited needs no further termination evidence.
  * <p>
  * Example:
  * <pre>
@@ -116,31 +126,76 @@ public class LoopVariantASTTransformation implements ASTTransformation, Compilat
         String suffix = Long.toString(COUNTER.getAndIncrement());
         String prevVarName = "$_gc_decreases_prev_" + suffix;
         String currVarName = "$_gc_decreases_curr_" + suffix;
+        String seenVarName = "$_gc_decreases_seen_" + suffix;
 
-        // At start of iteration: def prevVar = <expression>
-        Statement savePrev = declS(localVarX(prevVarName, ClassHelper.dynamicType()), variantExpression);
-        savePrev.setSourcePosition(annotation);
-
-        // At end of iteration: def currVar = <expression copy>
-        // We need a fresh copy of the expression for re-evaluation
-        Expression variantCopy = copyExpression(closureExpression);
-        Statement saveCurr = declS(localVarX(currVarName, ClassHelper.dynamicType()), variantCopy);
-        saveCurr.setSourcePosition(annotation);
-
-        // Assert (if enabled): currVar < prevVar and non-negative — delegated to the
-        // shared VariantSupport, gated by the enclosing class's -ea/-da configuration.
         String className = LoopContractSupport.enclosingClassName(source, (ASTNode) loopStatement);
-        Statement decreaseCheck = stmt(
-                callX(
-                        ClassHelper.make(VariantSupport.class),
-                        "checkLoopVariant",
-                        args(varX(prevVarName), varX(currVarName), constX(className))
-                )
-        );
-        decreaseCheck.setSourcePosition(annotation);
+        BlockStatement enclosingBlock = LoopContractSupport.enclosingBlock(source, (ASTNode) loopStatement);
 
-        // Inject: save at start, check at end
-        injectAtLoopBodyStartAndEnd(loopStatement, savePrev, block(saveCurr, decreaseCheck));
+        if (enclosingBlock != null) {
+            // GROOVY-12128: measure the variant at the start of each iteration and compare
+            // consecutive iteration-start values. Measuring within a single pass (body start vs
+            // body end) misses progress made by a classic for loop's update expression, which
+            // runs after the body end, and wrongly demands non-negativity after the final body
+            // execution instead of at iteration entry.
+            Statement declPrev = declS(localVarX(prevVarName, ClassHelper.dynamicType()), nullX());
+            declPrev.setSourcePosition(annotation);
+            Statement declSeen = declS(localVarX(seenVarName, ClassHelper.boolean_TYPE), constX(false, true));
+            declSeen.setSourcePosition(annotation);
+            List<Statement> siblings = enclosingBlock.getStatements();
+            siblings.addAll(siblings.indexOf(loopStatement), List.of(declPrev, declSeen));
+
+            Statement saveCurr = declS(localVarX(currVarName, ClassHelper.dynamicType()), variantExpression);
+            saveCurr.setSourcePosition(annotation);
+            // on the first iteration there is no previous value to compare against, but a scalar
+            // measure must already be non-negative at loop entry (well-foundedness)
+            Statement decreaseCheck = ifElseS(
+                    boolX(varX(seenVarName)),
+                    stmt(callX(
+                            ClassHelper.make(VariantSupport.class),
+                            "checkLoopVariant",
+                            args(varX(prevVarName), varX(currVarName), constX(className))
+                    )),
+                    stmt(callX(
+                            ClassHelper.make(VariantSupport.class),
+                            "checkLoopVariantEntry",
+                            args(varX(currVarName), constX(className))
+                    ))
+            );
+            decreaseCheck.setSourcePosition(annotation);
+            Statement markSeen = assignS(varX(seenVarName), constX(true, true));
+            markSeen.setSourcePosition(annotation);
+            Statement savePrev = assignS(varX(prevVarName), varX(currVarName));
+            savePrev.setSourcePosition(annotation);
+
+            injectAtLoopBodyStart(loopStatement, block(saveCurr, decreaseCheck, markSeen, savePrev));
+        } else {
+            // The loop is not a direct child of a block (e.g. a braceless if branch), so there is
+            // nowhere to hoist cross-iteration state; fall back to the single-pass measurement.
+
+            // At start of iteration: def prevVar = <expression>
+            Statement savePrev = declS(localVarX(prevVarName, ClassHelper.dynamicType()), variantExpression);
+            savePrev.setSourcePosition(annotation);
+
+            // At end of iteration: def currVar = <expression copy>
+            // We need a fresh copy of the expression for re-evaluation
+            Expression variantCopy = copyExpression(closureExpression);
+            Statement saveCurr = declS(localVarX(currVarName, ClassHelper.dynamicType()), variantCopy);
+            saveCurr.setSourcePosition(annotation);
+
+            // Assert (if enabled): currVar < prevVar and non-negative — delegated to the
+            // shared VariantSupport, gated by the enclosing class's -ea/-da configuration.
+            Statement decreaseCheck = stmt(
+                    callX(
+                            ClassHelper.make(VariantSupport.class),
+                            "checkLoopVariant",
+                            args(varX(prevVarName), varX(currVarName), constX(className))
+                    )
+            );
+            decreaseCheck.setSourcePosition(annotation);
+
+            // Inject: save at start, check at end
+            injectAtLoopBodyStartAndEnd(loopStatement, savePrev, block(saveCurr, decreaseCheck));
+        }
 
         // The variant closure lived inside a statement annotation, so the compiler's resolution
         // passes never reached it; re-resolve types, static imports and variable scopes now that the
@@ -171,6 +226,19 @@ public class LoopVariantASTTransformation implements ASTTransformation, Compilat
             return exprStmt.getExpression().transformExpression(expr -> expr);
         }
         return null;
+    }
+
+    private static void injectAtLoopBodyStart(LoopingStatement loopStatement, Statement bookkeeping) {
+        Statement loopBody = loopStatement.getLoopBlock();
+        if (loopBody instanceof BlockStatement block) {
+            block.getStatements().addAll(0, ((BlockStatement) bookkeeping).getStatements());
+        } else {
+            BlockStatement newBody = new BlockStatement();
+            newBody.addStatements(((BlockStatement) bookkeeping).getStatements());
+            newBody.addStatement(loopBody);
+            newBody.setSourcePosition(loopBody);
+            loopStatement.setLoopBlock(newBody);
+        }
     }
 
     private static void injectAtLoopBodyStartAndEnd(LoopingStatement loopStatement,

--- a/subprojects/groovy-contracts/src/test/groovy/org/apache/groovy/contracts/tests/inv/LoopDecreasesTests.groovy
+++ b/subprojects/groovy-contracts/src/test/groovy/org/apache/groovy/contracts/tests/inv/LoopDecreasesTests.groovy
@@ -95,6 +95,86 @@ class LoopDecreasesTests extends BaseTestClass {
         '''
     }
 
+    // GROOVY-12128: a classic for loop runs its update expression after the body, so a variant
+    // whose progress lives in the update clause used to be re-evaluated before any progress had
+    // registered and could never decrease. The variant is now measured at the start of each
+    // iteration and consecutive iteration-start values are compared.
+    @Test
+    void decreasesOnClassicForLoopWithUpdateClauseProgress() {
+        assertScript '''
+            import groovy.contracts.Decreases
+
+            int n = 3
+            int i = 0
+            @Decreases({ n - i })
+            for (i = 0; i < n; i++) { }
+            assert i == 3
+        '''
+    }
+
+    // GROOVY-12128: compound update expressions (j += 2) progress in the update clause too
+    @Test
+    void decreasesOnClassicForLoopWithCompoundUpdate() {
+        assertScript '''
+            import groovy.contracts.Decreases
+
+            int last = -1
+            @Decreases({ 10 - j })
+            for (int j = 0; j < 10; j += 2) {
+                last = j
+            }
+            assert last == 8
+        '''
+    }
+
+    // GROOVY-12128: the well-foundedness obligation is non-negativity at iteration entry, not
+    // after the final body execution — a loop that overshoots below zero on its last pass still
+    // terminates and must not be flagged.
+    @Test
+    void decreasesMayOvershootOnFinalIteration() {
+        assertScript '''
+            import groovy.contracts.Decreases
+
+            int n = 5
+            @Decreases({ n })
+            while (n > 0) {
+                n -= 2
+            }
+            assert n == -1
+        '''
+    }
+
+    // GROOVY-12128: a for loop whose update clause makes no progress is still caught (at the
+    // second iteration entry, where the variant has not decreased)
+    @Test
+    void decreasesViolationWhenForUpdateMakesNoProgress() {
+        shouldFail AssertionError, '''
+            import groovy.contracts.Decreases
+
+            int guard = 0
+            @Decreases({ 5 - i })
+            for (int i = 0; i < 5; i = i) {
+                if (++guard > 10) break
+            }
+        '''
+    }
+
+    // GROOVY-12128: a scalar measure that is already negative at first loop entry is not
+    // well-founded, even when the loop happens to exit after a single iteration (the only
+    // shape the consecutive-iteration comparison alone would let through)
+    @Test
+    void decreasesViolationWhenNegativeAtFirstEntry() {
+        shouldFail AssertionError, '''
+            import groovy.contracts.Decreases
+
+            int n = 1
+            @Decreases({ n - 2 })
+            while (n > 0) {
+                n--
+            }
+        '''
+    }
+
     @Test
     void decreasesWithExpression() {
         assertScript '''

--- a/subprojects/groovy-contracts/src/test/groovy/org/apache/groovy/contracts/tests/inv/LoopInvariantTests.groovy
+++ b/subprojects/groovy-contracts/src/test/groovy/org/apache/groovy/contracts/tests/inv/LoopInvariantTests.groovy
@@ -85,6 +85,64 @@ class LoopInvariantTests extends BaseTestClass {
         '''
     }
 
+    // GROOVY-12128: a do-while runs its body before the first condition check, so the loop
+    // invariant only needs to be established by that first body execution; checking it at loop
+    // entry rejects valid loops.
+    @Test
+    void invariantOnDoWhileEstablishedByFirstBodyExecution() {
+        assertScript '''
+            import groovy.contracts.*
+
+            class C {
+                @Requires({ n >= 1 })
+                @Ensures({ result == n })
+                static int countUp(int n) {
+                    int i = 0
+                    @Invariant({ 1 <= i && i <= n })
+                    @Decreases({ n - i })
+                    do { i++ } while (i < n)
+                    return i
+                }
+            }
+
+            assert C.countUp(1) == 1
+            assert C.countUp(3) == 3
+        '''
+    }
+
+    // GROOVY-12128: the do-while invariant is checked after each body execution, so a body
+    // that breaks the invariant is caught even when the invariant held at loop entry.
+    @Test
+    void invariantOnDoWhileViolatedByBodyThrows() {
+        shouldFail AssertionError, '''
+            import groovy.contracts.Invariant
+
+            int i = 0
+            @Invariant({ i <= 2 })
+            do {
+                i += 5
+            } while (false)
+        '''
+    }
+
+    // GROOVY-12128: an invariant is not required to hold at a break exit (only on the paths
+    // that continue looping), so the do-while end-of-body check must be skipped by break —
+    // matching the while/for placement, where break likewise exits after the entry check.
+    @Test
+    void invariantOnDoWhileNotRequiredAtBreak() {
+        assertScript '''
+            import groovy.contracts.Invariant
+
+            int i = 0
+            @Invariant({ i <= 2 })
+            do {
+                i = 99
+                break
+            } while (true)
+            assert i == 99
+        '''
+    }
+
     @Test
     void multipleInvariantsOnLoop() {
         assertScript '''


### PR DESCRIPTION
…hat disagree with loop semantics

A do-while runs its body before the first condition check, so its loop @Invariant only needs to be established by that first body execution; checking it at loop entry rejected valid loops. The invariant is now checked after each body execution for do-while (start-of-iteration placement is unchanged for for/while), and is intentionally not checked at break exits, matching standard loop-invariant semantics.

A @Decreases variant was measured at the start and end of a single pass, which misses progress made by a classic for loop's update expression (it runs after the body end) and demanded non-negativity after the final body execution. The variant is now evaluated once at the start of each iteration: a scalar measure must be non-negative at entry (well-foundedness), and consecutive iteration-start values must strictly decrease. The cross-iteration state is hoisted into the block directly enclosing the loop; when the loop is not a direct child of a block (e.g. a braceless if branch), the previous single-pass measurement is kept as a fallback.