### PR TITLE
GROOVY-12139: vararg-of-arrays argument wrapping fails under classic …

### DIFF
--- a/src/main/java/org/codehaus/groovy/reflection/ParameterTypes.java
+++ b/src/main/java/org/codehaus/groovy/reflection/ParameterTypes.java
@@ -20,6 +20,7 @@ package org.codehaus.groovy.reflection;
 
 import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.classgen.asm.util.TypeUtil;
+import org.codehaus.groovy.runtime.ArrayTypeUtils;
 import org.codehaus.groovy.runtime.MetaClassHelper;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 import org.codehaus.groovy.runtime.wrappers.Wrapper;
@@ -271,18 +272,25 @@ public class ParameterTypes {
             args[aCount] = Array.newInstance(vaType, 0);
             return args;
         } else if (aCount == pCount) {
-            // the number of arguments is correct, but if the last argument
-            // is no array we have to wrap it in an array; if last argument
-            // is null, then we don't have to do anything
+            // the number of arguments is correct, but unless the last argument
+            // is null or usable as the varargs array itself — assignable, or
+            // an array of the same dimension whose elements the argument
+            // coercion below can convert (e.g. Integer[] for int...) — it is a
+            // single element and has to be wrapped in an array; being an array
+            // is not sufficient: a byte[] passed to a byte[]... parameter is
+            // an element, not the byte[][] varargs array (GROOVY-11182, GROOVY-12139)
             var lastArgument = getArgClass(arguments[aCount - 1]);
-            if (lastArgument != null && !lastArgument.isArray()) {
+            var varargsType = paramTypes[pCount - 1].getTheClass();
+            if (lastArgument == null || varargsType.isAssignableFrom(lastArgument)
+                    || (lastArgument.isArray()
+                        && ArrayTypeUtils.dimension(lastArgument) == ArrayTypeUtils.dimension(varargsType))) {
+                // we may have to box the argument!
+                return unwrappedArguments;
+            } else {
                 Object[] args = new Object[pCount];
                 System.arraycopy(unwrappedArguments, 0, args, 0, pCount - 1);
                 args[pCount-1] = makeCommonArray(unwrappedArguments, pCount - 1, vaType);
                 return args;
-            } else {
-                // we may have to box the argument!
-                return unwrappedArguments;
             }
         } else if (aCount > pCount) {
             // wrap tail arguments in an array

--- a/src/test/groovy/bugs/Groovy11182.groovy
+++ b/src/test/groovy/bugs/Groovy11182.groovy
@@ -18,21 +18,35 @@
  */
 package bugs
 
+import org.codehaus.groovy.control.CompilerConfiguration
 import org.junit.jupiter.api.Test
 
 import static groovy.test.GroovyAssert.assertScript
 
 final class Groovy11182 {
 
+    private static final String SCRIPT = '''
+        def foo(byte[]... byteArrays) {
+            assert byteArrays.length == 1
+            assert byteArrays[0].length == 4
+        }
+
+        foo("test".bytes)
+    '''
+
     @Test
     void testVariadicPrimitiveArray() {
-        assertScript '''
-            def foo(byte[]... byteArrays) {
-                assert byteArrays.length == 1
-                assert byteArrays[0].length == 4
-            }
+        assertScript SCRIPT
+    }
 
-            foo("test".bytes)
-        '''
+    // GROOVY-12139: the classic call-site path dispatches through
+    // MetaMethod#doMethodInvoke, whose varargs correction used to pass any
+    // trailing array through unwrapped instead of wrapping it when it is not
+    // assignable to the varargs parameter type (byte[] into byte[][])
+    @Test
+    void testVariadicPrimitiveArrayClassic() {
+        def config = new CompilerConfiguration()
+        config.optimizationOptions.indy = false
+        new GroovyShell(config).evaluate SCRIPT
     }
 }


### PR DESCRIPTION
…compilation

GROOVY-11182's reproducer (a single byte[] passed to a byte[]... parameter) still failed with IllegalArgumentException when dispatched through MetaMethod#doMethodInvoke — the classic call-site path, and any other route through the reflective MOP invocation. The original fix only added a test; the invokedynamic chain's own varargs adaptation happened to handle the case, masking the gap under the default compilation mode.

Root cause: ParameterTypes#fitToVargs treated any trailing array argument as the pre-packed varargs array. Being an array is not sufficient — a byte[] passed to byte[]... is a single element of the byte[][] varargs array. The argument now passes through only when it is assignable to the varargs parameter type or is an array of the same dimension (whose elements the downstream argument coercion converts, e.g. Integer[] for int...); otherwise it is wrapped as an element.

Adds a classic-compilation (indy=false) variant of the GROOVY-11182 test. Also reproducible on GROOVY_5_0_X, so a candidate for backport.