### PR TITLE
GEP-27: compact non-capturing lambda compilation (opt-in)

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesLambdaWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesLambdaWriter.java
@@ -18,9 +18,11 @@
  */
 package org.codehaus.groovy.classgen.asm.sc;
 
+import org.apache.groovy.util.SystemUtil;
 import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.CodeVisitorSupport;
 import org.codehaus.groovy.ast.ConstructorNode;
 import org.codehaus.groovy.ast.InnerClassNode;
 import org.codehaus.groovy.ast.MethodNode;
@@ -43,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.groovy.ast.tools.ClassNodeUtils.addGeneratedMethod;
 import static org.codehaus.groovy.ast.ClassHelper.CLOSURE_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.GENERATED_LAMBDA_TYPE;
 import static org.codehaus.groovy.ast.ClassHelper.OBJECT_TYPE;
@@ -62,6 +65,7 @@ import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.CHECKCAST;
 import static org.objectweb.asm.Opcodes.DUP;
@@ -253,12 +257,25 @@ public class StaticTypesLambdaWriter extends LambdaWriter implements AbstractFun
 
     private GeneratedLambda getOrAddGeneratedLambda(final LambdaExpression expression, final MethodNode abstractMethod) {
         return generatedLambdas.computeIfAbsent(expression, expr -> {
+            // Build the lambda class first: this resolves capture/instance-member analysis correctly (a
+            // doCall on the lambda class sees the enclosing class as an outer), and makes doCall static iff
+            // the lambda is non-capturing.
             ClassNode lambdaClass = createLambdaClass(expr, ACC_FINAL | ACC_PUBLIC | ACC_STATIC, abstractMethod);
+            MethodNode lambdaMethod = getLambdaMethod(lambdaClass);
+
+            // Like Java, a non-capturing (static doCall), non-serializable lambda needs no generated class:
+            // hoist its static impl onto the enclosing class and bootstrap the metafactory directly against it.
+            // Opt-in (default off) while IDE/tooling compatibility is verified; set -Dgroovy.target.lambda.hoist=true.
+            if (isLambdaHoistEnabled() && !requiresLambdaInstance(lambdaMethod)
+                    && !expr.isSerializable() && !containsNestedFunction(expr.getCode())) {
+                MethodNode implMethod = hoistLambdaMethodToEnclosingClass(lambdaMethod);
+                return new GeneratedLambda(controller.getClassNode(), implMethod, null, Parameter.EMPTY_ARRAY, true, false);
+            }
+
             controller.getAcg().addInnerClass(lambdaClass);
             lambdaClass.addInterface(GENERATED_LAMBDA_TYPE);
             lambdaClass.putNodeMetaData(StaticCompilationMetadataKeys.STATIC_COMPILE_NODE, Boolean.TRUE);
             lambdaClass.putNodeMetaData(WriterControllerFactory.class, (WriterControllerFactory) x -> controller);
-            MethodNode lambdaMethod = getLambdaMethod(lambdaClass);
             return new GeneratedLambda(
                 lambdaClass,
                 lambdaMethod,
@@ -270,10 +287,62 @@ public class StaticTypesLambdaWriter extends LambdaWriter implements AbstractFun
         });
     }
 
+    /**
+     * Re-homes a non-capturing lambda's already-prepared {@code static doCall} (types resolved, outer static
+     * references qualified) as a {@code private static} synthetic method on the enclosing class, so no per-lambda
+     * inner class is generated and the metafactory bootstraps directly against the enclosing class.
+     */
+    private MethodNode hoistLambdaMethodToEnclosingClass(final MethodNode lambdaMethod) {
+        MethodNode implMethod = new MethodNode(nextLambdaImplMethodName(),
+                ACC_PRIVATE | ACC_STATIC | ACC_SYNTHETIC, lambdaMethod.getReturnType(),
+                lambdaMethod.getParameters(), lambdaMethod.getExceptions(), lambdaMethod.getCode());
+        implMethod.setSourcePosition(lambdaMethod);
+        implMethod.putNodeMetaData(StaticCompilationMetadataKeys.STATIC_COMPILE_NODE, Boolean.TRUE);
+        addGeneratedMethod(controller.getClassNode(), implMethod);
+        // Added after the ReturnAdder phase (an inner class would get it via full compilation), so wire the
+        // implicit return for an expression-bodied lambda here (idempotent when returns already present).
+        new org.codehaus.groovy.classgen.ReturnAdder().visitMethod(implMethod);
+        return implMethod;
+    }
+
     /** {@inheritDoc} */
     @Override
     protected ClassNode createClosureClass(final ClosureExpression expression, final int modifiers) {
         return staticTypesClosureWriter.createClosureClass(expression, modifiers);
+    }
+
+    private static boolean containsNestedFunction(final Statement code) {
+        if (code == null) return false;
+        boolean[] found = {false};
+        code.visit(new CodeVisitorSupport() {
+            @Override public void visitClosureExpression(final ClosureExpression e) { found[0] = true; }
+            @Override public void visitLambdaExpression(final LambdaExpression e) { found[0] = true; }
+        });
+        return found[0];
+    }
+
+    /**
+     * Whether non-capturing SAM lambdas are hoisted onto the enclosing class (no generated lambda class).
+     * Opt-in via {@code -Dgroovy.target.lambda.hoist=true} while IDE/tooling compatibility is verified;
+     * the property is read per lambda so it can be toggled without a JVM restart.
+     */
+    private static boolean isLambdaHoistEnabled() {
+        return SystemUtil.getBooleanSafe("groovy.target.lambda.hoist");
+    }
+
+    private int lambdaImplCounter;
+
+    private String nextLambdaImplMethodName() {
+        ClassNode enclosing = controller.getClassNode();
+        MethodNode enclosingMethod = controller.getMethodNode();
+        String owner = (enclosingMethod != null) ? enclosingMethod.getName().replace('<', '_').replace('>', '_') : "init";
+        String base = "$lambda$" + owner + "$" + (lambdaImplCounter++);
+        String name = base;
+        int extra = 0;
+        while (!enclosing.getMethods(name).isEmpty()) {
+            name = base + "$" + (extra++);
+        }
+        return name;
     }
 
     /**

--- a/src/test/groovy/groovy/transform/stc/LambdaHoistTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/LambdaHoistTest.groovy
@@ -1,0 +1,157 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform.stc
+
+import org.codehaus.groovy.control.CompilationUnit
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.Phases
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * Tests for the opt-in {@code groovy.target.lambda.hoist} optimization: a non-capturing, non-serializable
+ * lambda targeting a functional interface has its body compiled as a {@code private static} method on the
+ * enclosing class (with LambdaMetafactory bootstrapped directly against it), so no per-lambda class is
+ * generated. Capturing, instance-accessing, serializable and nested cases fall back to a generated lambda
+ * class. The property is read per lambda, so it can be toggled per compilation here.
+ */
+final class LambdaHoistTest {
+
+    private static final String PROP = 'groovy.target.lambda.hoist'
+
+    /** Compiles the source with hoisting on/off and returns the sorted generated class names. */
+    private static List<String> classNames(String src, boolean hoist) {
+        withHoist(hoist) {
+            def cu = new CompilationUnit(new CompilerConfiguration())
+            cu.addSource('L.groovy', src)
+            cu.compile(Phases.CLASS_GENERATION)
+            cu.classes.collect { it.name }.sort()
+        }
+    }
+
+    /** Evaluates the source (with a trailing expression) with hoisting on/off. */
+    private static Object eval(String src, String tail, boolean hoist) {
+        withHoist(hoist) { new GroovyShell().evaluate(src + '\n' + tail) }
+    }
+
+    private static <T> T withHoist(boolean hoist, Closure<T> work) {
+        String previous = System.getProperty(PROP)
+        if (hoist) System.setProperty(PROP, 'true') else System.clearProperty(PROP)
+        try {
+            work.call()
+        } finally {
+            if (previous != null) System.setProperty(PROP, previous) else System.clearProperty(PROP)
+        }
+    }
+
+    private static int lambdaClassCount(List<String> names) {
+        names.count { it.contains('_lambda') }
+    }
+
+    private static final String SRC = '''import groovy.transform.CompileStatic
+        import java.util.function.*
+        @CompileStatic
+        class L {
+            Function<Integer,Integer> nonCap()      { (Integer x) -> x * 2 }
+            Function<Integer,Integer> cap(int base) { (Integer x) -> x + base }
+            static Function<Integer,Integer> inStatic() { (Integer x) -> x * 3 }
+            Function<Integer,Integer> callsStatic() { (Integer x) -> helper(x) }
+            static int helper(int n) { n + 1000 }
+        }'''
+
+    @Test
+    void nonCapturingLambdaIsHoistedWhenEnabled() {
+        def names = classNames(SRC, true)
+        // Only the capturing lambda keeps its class; nonCap/inStatic/callsStatic are hoisted onto L.
+        assertEquals(1, lambdaClassCount(names), "expected only the capturing lambda class, got: $names")
+        // The hoisted impls are private static $lambda$ methods on L.
+        def hoisted = eval(SRC, 'new L()', true).getClass().declaredMethods.findAll { it.name.startsWith('$lambda$') }
+        assertTrue(hoisted.size() >= 3, "expected hoisted \$lambda\$ methods on L, got: ${hoisted*.name}")
+    }
+
+    @Test
+    void hoistedLambdasBehaveIdenticallyAndStaySingletons() {
+        def l = eval(SRC, 'new L()', true)
+        assertEquals(42, l.nonCap().apply(21))
+        assertEquals(105, l.cap(100).apply(5))           // capturing path preserved
+        assertEquals(12, l.class.inStatic().apply(4))    // lambda in a static method
+        assertEquals(1005, l.callsStatic().apply(5))     // qualified outer static call
+        // non-capturing metafactory instance is a zero-alloc singleton
+        assertTrue(l.nonCap().is(l.nonCap()))
+    }
+
+    @Test
+    void disabledByDefaultKeepsTheLambdaClass() {
+        def names = classNames(SRC, false)
+        // With hoisting off, every lambda (incl. the non-capturing ones) generates a class, as today.
+        assertTrue(lambdaClassCount(names) >= 4, "expected lambda classes when disabled, got: $names")
+        // ...and still behaves correctly.
+        assertEquals(42, eval(SRC, 'new L().nonCap().apply(21)', false))
+    }
+
+    @Test
+    void instanceAccessingLambdaIsNotHoisted() {
+        String src = '''import groovy.transform.CompileStatic
+            import java.util.function.IntSupplier
+            @CompileStatic
+            class Counter { int count = 7; IntSupplier supplier() { () -> count } }'''
+        def names = classNames(src, true)
+        assertEquals(1, lambdaClassCount(names), "instance-accessing lambda must keep its class: $names")
+        assertEquals(7, eval(src, 'new Counter().supplier().getAsInt()', true))
+    }
+
+    @Test
+    void serializableNonCapturingLambdaFallsBackAndRoundTrips() {
+        String src = '''import groovy.transform.CompileStatic
+            import java.util.function.Function
+            @CompileStatic
+            class S {
+                static Function<Integer,Integer> make() {
+                    (Function<Integer,Integer> & Serializable) (Integer x) -> x * 2
+                }
+            }'''
+        def names = classNames(src, true)
+        assertEquals(1, lambdaClassCount(names), "serializable lambda must keep its class: $names")
+        def roundTripped = eval(src, '''
+            def f = S.make()
+            def out = new ByteArrayOutputStream()
+            new ObjectOutputStream(out).writeObject(f)
+            def f2 = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray())).readObject()
+            ((java.util.function.Function) f2).apply(10)
+        ''', true)
+        assertEquals(20, roundTripped)
+    }
+
+    @Test
+    void lambdaContainingNestedFunctionIsNotHoisted() {
+        String src = '''import groovy.transform.CompileStatic
+            import java.util.function.Supplier
+            @CompileStatic
+            class N {
+                Supplier<List<Integer>> outer() { () -> [1, 2, 3].collect { it * 2 } }
+            }'''
+        def names = classNames(src, true)
+        // The outer lambda nests a closure, so it is not hoisted (kept flat for the first step).
+        assertFalse(lambdaClassCount(names) == 0, "nested-function case should keep a lambda class: $names")
+        assertEquals([2, 4, 6], eval(src, 'new N().outer().get()', true))
+    }
+}


### PR DESCRIPTION
A statically compiled lambda targeting a functional interface currently generates a per-lambda class extending groovy.lang.Closure, even though its runtime value is a LambdaMetafactory-produced functional-interface instance and (when non-capturing) a zero-allocation singleton. The generated class only holds a static doCall.

Like the JVM does for Java lambdas, hoist the body of a non-capturing, non-serializable SAM lambda into a private static method on the enclosing class and bootstrap LambdaMetafactory directly against it, so no per-lambda class is generated. Capturing, instance-accessing, serializable and nested cases are unchanged (they keep the generated lambda class).

Behaviour is preserved (verified: Predicate/BiFunction, lambdas in static methods, qualified outer static calls, serializable round-trips, singleton identity); stack traces now name a $lambda$ method on the enclosing class (Java-like).

Gated by an opt-in system property, groovy.target.lambda.hoist (default off), read per lambda so it can be toggled without a JVM restart, while IDE/tooling compatibility with the changed generated-class shape is verified. Default off keeps existing behaviour and tests unchanged.

See GEP-27 (Compact Closure and Lambda Compilation) for the broader design.