### PR TITLE
GROOVY-12144: Fix AstNodeToScriptAdapter decompiler rendering fidelity (GROOVY_5_0_X backport)

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/console/ui/AstNodeToScriptAdapter.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/console/ui/AstNodeToScriptAdapter.groovy
@@ -392,6 +392,9 @@ class AstNodeToScriptVisitor implements CompilationUnit.IPrimaryClassNodeOperati
                 }
                 first = false
                 print it.name
+                if (!it.placeholder && !it.wildcard) {
+                    visitGenerics it.type?.genericsTypes
+                }
                 if (it.upperBounds) {
                     print ' extends '
                     boolean innerFirst = true
@@ -685,6 +688,7 @@ class AstNodeToScriptVisitor implements CompilationUnit.IPrimaryClassNodeOperati
             print '?'
         }
         print '.'
+        visitGenerics expression.genericsTypes
         Expression method = expression.method
         if (method instanceof ConstantExpression) {
             visitConstantExpression(method, true)
@@ -727,7 +731,7 @@ class AstNodeToScriptVisitor implements CompilationUnit.IPrimaryClassNodeOperati
         boolean isAssign = expression?.operation?.type == Types.ASSIGN
         boolean isAccess = expression?.operation?.type == Types.LEFT_SQUARE_BRACKET
         if (!isAssign || expression?.rightExpression !instanceof EmptyExpression) {
-            print isAccess ? '[' : " ${expression?.operation?.text} "
+            print isAccess ? (expression.safe ? '?[' : '[') : " ${expression?.operation?.text} "
             expression?.rightExpression?.visit this
             if (isAccess) {
                 print ']'
@@ -765,6 +769,8 @@ class AstNodeToScriptVisitor implements CompilationUnit.IPrimaryClassNodeOperati
         if (expression?.parameters) {
             visitParameters expression?.parameters
             print ' ->'
+        } else if (expression?.parameters == null) {
+            print ' ->'
         }
         printLineBreak()
         indented {
@@ -798,7 +804,9 @@ class AstNodeToScriptVisitor implements CompilationUnit.IPrimaryClassNodeOperati
     void visitRangeExpression(RangeExpression expression) {
         print '('
         expression?.from?.visit this
+        if (expression.exclusiveLeft) print '<'
         print '..'
+        if (expression.exclusiveRight) print '<'
         expression?.to?.visit this
         print ')'
     }
@@ -811,7 +819,7 @@ class AstNodeToScriptVisitor implements CompilationUnit.IPrimaryClassNodeOperati
         } else if (expression?.isSafe()) {
             print '?'
         }
-        print '.'
+        print expression instanceof AttributeExpression ? '.@' : '.'
         if (expression?.property instanceof ConstantExpression) {
             visitConstantExpression((ConstantExpression) expression?.property, true)
         } else {
@@ -837,6 +845,18 @@ class AstNodeToScriptVisitor implements CompilationUnit.IPrimaryClassNodeOperati
             print "'$escaped'"
         } else {
             print expression.value
+            // re-append the literal's type suffix so re-parsing yields the same type
+            // (Integer and BigDecimal are the literal defaults and need no suffix)
+            def value = expression.value
+            if (value instanceof Long) {
+                print 'L'
+            } else if (value instanceof Float) {
+                print 'F'
+            } else if (value instanceof Double) {
+                print 'D'
+            } else if (value instanceof BigInteger) {
+                print 'G'
+            }
         }
     }
 
@@ -1044,7 +1064,9 @@ class AstNodeToScriptVisitor implements CompilationUnit.IPrimaryClassNodeOperati
 
     @Override
     void visitShortTernaryExpression(ElvisOperatorExpression expression) {
-        visitTernaryExpression expression
+        expression?.booleanExpression?.visit this
+        print ' ?: '
+        expression?.falseExpression?.visit this
     }
 
     @Override

--- a/subprojects/groovy-console/src/test/groovy/groovy/console/ui/AstNodeToScriptAdapterTest.groovy
+++ b/subprojects/groovy-console/src/test/groovy/groovy/console/ui/AstNodeToScriptAdapterTest.groovy
@@ -172,8 +172,8 @@ final class AstNodeToScriptAdapterTest extends GroovyTestCase {
 
         assert result.contains('public class Tree<V> extends java.lang.Object implements groovy.lang.GroovyObject')
         assert result.contains('private java.lang.Object<V> value') // todo: is Object<V> correct? How do you know?
-        assert result.contains('private java.util.List<Tree> branches') // should the <? extends V> be dropped?
-        assert result.contains('branches = new java.util.ArrayList<Tree>()') // should the <? extends V> be dropped?
+        assert result.contains('private java.util.List<Tree<? extends java.lang.Object<V>>> branches')
+        assert result.contains('branches = new java.util.ArrayList<Tree<? extends java.lang.Object<V>>>()')
         assert result.contains('public Tree(java.lang.Object<V> value)') // again, is this correct?
         assert result.contains(' public java.lang.Object<V> getValue()') // is this correct?
         assert result.contains('public void setValue(java.lang.Object<V> value)')
@@ -387,7 +387,7 @@ final class AstNodeToScriptAdapterTest extends GroovyTestCase {
 
         assert result.contains('private static final transient java.util.logging.Logger log')
         assert result.contains("log = java.util.logging.Logger.getLogger('Event')")
-        assert result.contains('return log.isLoggable(java.util.logging.Level.FINE) ? log.fine(this.someMethod()) : null')
+        assert result.contains('return log.isLoggable(java.util.logging.Level.@FINE) ? log.fine(this.someMethod()) : null')
     }
 
     void testFieldDeclarationWithValue() {
@@ -792,7 +792,7 @@ final class AstNodeToScriptAdapterTest extends GroovyTestCase {
                             foo ?: 'y'"""
         String result = compileToScript(script)
         assert result.contains("true || false ? 'y' : 'n'")
-        assert result.contains("foo ? foo : 'y'")
+        assert result.contains("foo ?: 'y'")
     }
 
     void testWhileLoop() {
@@ -1095,5 +1095,76 @@ final class AstNodeToScriptAdapterTest extends GroovyTestCase {
         String result = compileToScript(script)
 
         assert result.contains('(a as java.lang.String)')
+    }
+
+    // GROOVY-12144
+    void testNestedGenerics() {
+        String result = compileToScript('Map<String, List<Integer>> nested() { null }')
+        assert result.contains('java.util.Map<String, List<Integer>> nested()')
+    }
+
+    // GROOVY-12144
+    void testRangeExpressionExclusiveBounds() {
+        String result = compileToScript('''def a = 1..5
+            def b = 1..<5
+            def c = 1<..5
+            def d = 1<..<5''')
+        assert result.contains('(1..5)')
+        assert result.contains('(1..<5)')
+        assert result.contains('(1<..5)')
+        assert result.contains('(1<..<5)')
+    }
+
+    // GROOVY-12144
+    void testElvisOperator() {
+        String result = compileToScript('def a = c ?: d')
+        assert result.contains('c ?: d')
+        assert !result.contains('c ? c : d')
+    }
+
+    // GROOVY-12144
+    void testAttributeExpression() {
+        String result = compileToScript('''def a = other.@order
+            def b = foos*.@order
+            def c = other?.@order''')
+        assert result.contains('other.@order')
+        assert result.contains('foos*.@order')
+        assert result.contains('other?.@order')
+    }
+
+    // GROOVY-12144
+    void testClosureParameterArrow() {
+        String result = compileToScript('''def implicitIt = { it * 2 }
+            def noArgs = { -> 'x' }''')
+        assert result.contains('{ ->')
+        assert result =~ /\{\s*it \* 2/
+    }
+
+    // GROOVY-12144
+    void testSafeIndexAccess() {
+        String result = compileToScript('''def a = list?[0]
+            def b = map?['key']
+            list?[1] = 42''')
+        assert result.contains('list?[0]')
+        assert result.contains("map?['key']")
+        assert result.contains('list?[1] = 42')
+    }
+
+    // GROOVY-12144
+    void testNumericLiteralSuffixes() {
+        String result = compileToScript('''def a = 42L
+            def b = 2.5f
+            def c = 3.5d
+            def d = 10G''')
+        assert result.contains('= 42L')
+        assert result.contains('= 2.5F')
+        assert result.contains('= 3.5D')
+        assert result.contains('= 10G')
+    }
+
+    // GROOVY-12144
+    void testExplicitMethodTypeArguments() {
+        String result = compileToScript('def a = Collections.<String>emptyList()')
+        assert result.contains('java.util.Collections.<String>emptyList()')
     }
 }


### PR DESCRIPTION
This backports the eight decompiler-fidelity fixes from master (#2682, commit `4b27025962`) to `GROOVY_5_0_X`. `AstNodeToScriptVisitor` rendered several constructs so they did not round-trip; each fix is localized to one visitor method:

1. Nested generic type arguments dropped (`Map<String, List<Integer>>` → `Map<String, List>`) — `visitGenerics` recurses into concrete args.
2. Range bound exclusions dropped — `visitRangeExpression`.
3. Elvis rendered as a duplicated ternary (`c ?: d` → `c ? c : d`, evaluating `c` twice) — `visitShortTernaryExpression` emits `?:`.
4. Attribute access lost the at-sign (`obj.@f` → `obj.f`) — `visitPropertyExpression` emits `.@` for an `AttributeExpression`.
5. Explicit zero-arg closures lost the arrow (`{ -> ... }` → `{ ... }`) — `visitClosureExpression` distinguishes a null parameter list from `Parameter.EMPTY_ARRAY`.
6. Safe index access lost safe navigation (`list?[0]` → `list[0]`) — `visitBinaryExpression`.
7. Numeric literal type suffixes dropped (`42L/2.5f/3.5d/10G`) — `visitConstantExpression` re-appends `L/F/D/G`.
8. Explicit method-call type arguments dropped (`Collections.<String>emptyList()`) — `visitMethodCallExpression`.

One regression test per defect (GroovyTestCase style, matching the existing test class). Existing tests reconciled to the corrected output: `testTernaryOperaters` (elvis), `testGenericsInMethods` (nested generics now preserved), `testLogAnnotation` (`@Log`'s `Level.FINE` is an `AttributeExpression`, now renders `Level.@FINE`).

**Fixes apply as-is** — all APIs present on 5.0.

**Tests:** `:groovy-console:test` green; `AstNodeToScriptAdapterTest` 71/71 (validated with a forced `--no-build-cache --rerun-tasks` recompile+run).

Master PR: https://github.com/apache/groovy/pull/2682

---
🤖 Prepared with Claude Code (Opus 4.8) on behalf of @leonard84.
