### PR TITLE
GROOVY-12146: order reflection calls to ensure Annotation members are ordered

### DIFF
--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/Java8.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/Java8.java
@@ -70,6 +70,7 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.security.Permission;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -294,6 +295,9 @@ public class Java8 implements VMPlugin {
             Method[] declaredMethods;
             try {
                 declaredMethods = type.getDeclaredMethods();
+                // getDeclaredMethods does not guarantee an order, and HotSpot's varies between JVM
+                // runs; sort so the annotation is emitted deterministically for reproducible builds
+                Arrays.sort(declaredMethods, Comparator.comparing(Method::getName));
             } catch (SecurityException se) {
                 declaredMethods = EMPTY_METHOD_ARRAY;
             }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/GROOVY-12146 by canonicalizing at the source of the nondeterminism instead of at emission (the reverted 4.x approach also reordered source-compiled annotations, which stay in deterministic source order and don't need touching):

// Java8#configureAnnotation
declaredMethods = type.getDeclaredMethods();
Arrays.sort(declaredMethods, Comparator.comparing(Method::getName));

Annotation member methods cannot overload, so name gives a total order. Verified locally against GROOVY_5_0_X: the woven class emits a stable sorted order independent of the JVM, source-compiled annotations are unchanged, and TypeAnnotationsTest plus the trait transform suites pass.