### PR TITLE
GROOVY-12151: hoist eligible closure bodies to a shared adapter @Pack…

### DIFF
--- a/build-logic/src/main/groovy/org.apache.groovy-tested.gradle
+++ b/build-logic/src/main/groovy/org.apache.groovy-tested.gradle
@@ -87,6 +87,11 @@ tasks.withType(Test).configureEach {
     if (lambdaHoist != null) {
         systemProperty 'groovy.target.lambda.hoist', lambdaHoist
     }
+    // Forward the automatic @CompileStatic closure-packing flag (GEP-27) to the test JVM. Set only when present.
+    def closurePack = findProperty('groovy.target.closure.pack') ?: System.getProperty('groovy.target.closure.pack')
+    if (closurePack != null) {
+        systemProperty 'groovy.target.closure.pack', closurePack
+    }
     def testdb = System.properties['groovy.testdb.props']
     if (testdb) {
         systemProperty 'groovy.testdb.props', testdb
@@ -250,6 +255,13 @@ tasks.withType(GroovyCompile).configureEach {
                 languageVersion = JavaLanguageVersion.of(feature)
             }
         }
+    }
+    // Forward the opt-in closure-packing flag (GEP-27) to the forked Groovy compiler: packing happens
+    // at compile time, so test sources are only packed when the compiler JVM sees the property (the
+    // Test-task systemProperty above covers runtime assertScript compilation). Set only when present.
+    def closurePack = findProperty('groovy.target.closure.pack') ?: System.getProperty('groovy.target.closure.pack')
+    if (closurePack != null) {
+        groovyOptions.forkOptions.jvmArgs += ["-Dgroovy.target.closure.pack=${closurePack}" as String]
     }
 }
 

--- a/src/main/java/groovy/transform/PackedClosures.java
+++ b/src/main/java/groovy/transform/PackedClosures.java
@@ -1,0 +1,93 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform;
+
+import org.apache.groovy.lang.annotation.Incubating;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Opt-in for compact closure compilation: within the annotated class or method, an eligible closure
+ * literal's body is hoisted into a synthetic method on the enclosing class and the literal is replaced
+ * by a shared {@link org.codehaus.groovy.runtime.PackedClosure} adapter, instead of generating one
+ * inner class per closure. The value stays a real {@code groovy.lang.Closure}, so {@code curry},
+ * {@code memoize}, {@code trampoline} and iteration keep working; captured values are threaded by
+ * value (read-only) or via a shared {@code groovy.lang.Reference} (when written), so a packed closure
+ * behaves identically to the class-based form.
+ * <p>
+ * Packing is best-effort: a closure that cannot be packed is compiled exactly as today (a generated
+ * closure class), so the annotation is always safe to add. A closure is kept as a class when it:
+ * <ul>
+ *   <li>references {@code owner}, {@code delegate}, {@code thisObject}, {@code resolveStrategy},
+ *       {@code directive}, {@code metaClass} or {@code super} — it needs a real {@code Closure};</li>
+ *   <li>has default parameter values, or contains an anonymous inner class;</li>
+ *   <li>is nested inside another closure, or visibly escapes its method (returned, stored to a
+ *       field/property/index, appended, or placed in a collection literal);</li>
+ *   <li>under {@code @CompileStatic}, resolves a name against a delegate (e.g. via {@code @DelegatesTo}
+ *       or {@code with}) — packing is otherwise proven sound from the type checker's resolution.</li>
+ * </ul>
+ * Under dynamic compilation the annotation is a trust assertion the compiler cannot verify; the
+ * {@code PackedClosure} adapter then fails fast if a delegate is later set on a packed closure.
+ * Automatic packing of provably-safe {@code @CompileStatic} closures — without this annotation — is
+ * available behind the {@code groovy.target.closure.pack} flag. Use {@link #mode()} to have declines
+ * reported (or to opt a scope out).
+ *
+ * @see PackMode
+ */
+@Incubating
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface PackedClosures {
+    /**
+     * The packing behaviour of this scope: {@link PackMode#LENIENT} (pack, silent on declines, the
+     * default), {@link PackMode#WARN} (pack, a compiler warning per decline with the reason),
+     * {@link PackMode#STRICT} (pack, a compiler error on any decline), or {@link PackMode#DISABLED}
+     * (do not pack). The most-specific declaration wins, so a {@code DISABLED} method opts out of a
+     * packed class (and {@code DISABLED} also overrides the automatic {@code groovy.target.closure.pack}
+     * flag); the WARN/STRICT diagnostics apply only to the annotated scope, never to the flag.
+     */
+    PackMode mode() default PackMode.LENIENT;
+
+    /**
+     * The packing behaviour of a {@link PackedClosures} scope. {@link #LENIENT}, {@link #WARN} and
+     * {@link #STRICT} all pack, differing only in how they report a closure that could <em>not</em> be
+     * packed (declines are otherwise silent). {@link #DISABLED} is the opposite: it opts the scope out
+     * of packing entirely, so the most-specific declaration wins — a {@code DISABLED} method inside a
+     * packed class, or vice versa, and it overrides the automatic {@code groovy.target.closure.pack}
+     * flag as well.
+     */
+    @Incubating
+    enum PackMode {
+
+        /** Do not pack any closure in this scope; overrides an enclosing opt-in and the automatic flag. */
+        DISABLED,
+
+        /** Silently fall back to a generated closure class for any closure that cannot be packed (default). */
+        LENIENT,
+
+        /** Emit a compiler warning, naming the closure and why it declined, for each that cannot be packed. */
+        WARN,
+
+        /** Emit a compiler error for any closure in the scope that cannot be packed. */
+        STRICT
+    }
+}

--- a/src/main/java/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/java/org/codehaus/groovy/ast/ClassNode.java
@@ -1820,21 +1820,23 @@ faces:  if (method == null && asBoolean(getInterfaces())) { // GROOVY-11323
     }
 
     private void visitMethods(GroovyClassVisitor visitor) {
-        // create snapshot of the method list to avoid ConcurrentModificationException
-        List<MethodNode> methodList = new ArrayList<>(getMethods());
-        for (MethodNode mn : methodList) {
-            visitor.visitMethod(mn);
-        }
-
-        // visit the method nodes added while iterating,
-        // e.g. synthetic method for constructor reference
-        final List<MethodNode> newMethodList = getMethods();
-        if (newMethodList.size() > methodList.size()) { // if the newly added method nodes found, visit them
-            List<MethodNode> changedMethodList = new ArrayList<>(newMethodList);
-            boolean changed = changedMethodList.removeAll(methodList);
-            if (changed) {
-                for (MethodNode mn : changedMethodList) {
+        // Visit each method exactly once, including methods added WHILE visiting -- a synthetic method
+        // for a constructor reference, a lambda deserialization hook, or a hoisted closure body that in
+        // turn hoists a nested one. Track already-visited methods by identity (MethodNode uses the
+        // default equals) in a hash set for O(1) membership, and re-scan getMethods() after each round
+        // for the newly added ones, until none remain.
+        Set<MethodNode> visited = Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+        List<MethodNode> pending = new ArrayList<>(getMethods()); // snapshot avoids ConcurrentModificationException
+        while (!pending.isEmpty()) {
+            for (MethodNode mn : pending) {
+                if (visited.add(mn)) {
                     visitor.visitMethod(mn);
+                }
+            }
+            pending = new ArrayList<>();
+            for (MethodNode mn : getMethods()) {
+                if (!visited.contains(mn)) {
+                    pending.add(mn);
                 }
             }
         }

--- a/src/main/java/org/codehaus/groovy/classgen/asm/ClosureWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/ClosureWriter.java
@@ -18,12 +18,15 @@
  */
 package org.codehaus.groovy.classgen.asm;
 
+import groovy.transform.PackedClosures.PackMode;
 import org.codehaus.groovy.GroovyBugError;
+import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.CodeVisitorSupport;
 import org.codehaus.groovy.ast.ConstructorNode;
 import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.InnerClassNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
@@ -32,39 +35,62 @@ import org.codehaus.groovy.ast.VariableScope;
 import org.codehaus.groovy.ast.expr.ClassExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.ConstructorCallExpression;
+import org.codehaus.groovy.ast.expr.ArrayExpression;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.FieldExpression;
+import org.codehaus.groovy.ast.expr.ListExpression;
+import org.codehaus.groovy.ast.expr.MapEntryExpression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.PostfixExpression;
+import org.codehaus.groovy.ast.expr.PrefixExpression;
 import org.codehaus.groovy.ast.expr.TupleExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.ReturnStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.ast.tools.GenericsUtils;
 import org.codehaus.groovy.classgen.AsmClassGenerator;
+import org.codehaus.groovy.control.messages.WarningMessage;
+import org.codehaus.groovy.syntax.Types;
 import org.objectweb.asm.MethodVisitor;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.groovy.ast.tools.ClassNodeUtils.addGeneratedMethod;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.callThisX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.callX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorSuperX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.nullX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.returnS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.stmt;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
+import static org.codehaus.groovy.transform.sc.StaticCompilationMetadataKeys.STATIC_COMPILE_NODE;
 import static org.codehaus.groovy.transform.stc.StaticTypesMarker.INFERRED_RETURN_TYPE;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.AASTORE;
 import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
 import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ANEWARRAY;
 import static org.objectweb.asm.Opcodes.DUP;
 import static org.objectweb.asm.Opcodes.GETFIELD;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
@@ -94,6 +120,17 @@ public class ClosureWriter {
     /** The controller coordinating all bytecode writers for the current class. */
     protected final WriterController controller;
     private final Map<Expression, ClassNode> closureClasses = new HashMap<>();
+    private int packedCounter;
+    // Closures found in a syntactic position that lets them outlive the method are cached per method.
+    private final Map<MethodNode, Set<ClosureExpression>> escapingClosuresByMethod = new HashMap<>();
+    // Names assigned anywhere in a method (excluding declarations), cached per method: a capture must
+    // be Reference-threaded if it is written ANYWHERE in the enclosing method, not just inside the
+    // closure -- e.g. `def fib; fib = { n -> ... fib(n-1) ... }` writes fib after the closure is
+    // constructed, so a by-value capture would see the stale (null) value.
+    private final Map<MethodNode, Set<String>> writtenNamesByMethod = new HashMap<>();
+
+    /** Name prefix of the synthetic methods holding hoisted closure bodies. */
+    private static final String PACKED_METHOD_PREFIX = "$packed$closure$";
 
     /**
      * Creates a closure writer with the given controller.
@@ -110,6 +147,17 @@ public class ClosureWriter {
      * @param expression the closure expression
      */
     public void writeClosure(final ClosureExpression expression) {
+        // @PackedClosures spike: for an eligible top-level closure in a @PackedClosures scope, hoist the
+        // body to a method on the enclosing class and emit a shared PackedClosure adapter, instead of
+        // generating a per-closure inner class. Captured variables are threaded by value. Closures nested
+        // inside another closure are left alone (their enclosing context is a generated function, not the
+        // owner class), as are closures needing real Closure semantics.
+        if (chooseStrategy(expression) == PackStrategy.PACKED_ADAPTER) {
+            writePackedClosure(expression);
+            return;
+        }
+        reportUnpacked(expression); // @PackedClosures(mode = WARN | STRICT) diagnostics for declines
+
         CompileStack compileStack = controller.getCompileStack();
         MethodVisitor mv = controller.getMethodVisitor();
         ClassNode classNode = controller.getClassNode();
@@ -156,6 +204,510 @@ public class ClosureWriter {
         //cv.visitMethodInsn(INVOKESPECIAL, innerClassinternalName, "<init>", prototype + ")V");
         mv.visitMethodInsn(INVOKESPECIAL, closureClassinternalName, "<init>", BytecodeHelper.getMethodDescriptor(ClassHelper.VOID_TYPE, localVariableParams), false);
         controller.getOperandStack().replace(ClassHelper.CLOSURE_TYPE, localVariableParams.length);
+    }
+
+    /**
+     * GEP-27 capability analysis: choose the compilation strategy for a closure literal.
+     * <p>
+     * A closure is packed (S1, {@link PackStrategy#PACKED_ADAPTER}) when it is <em>triggered</em> —
+     * either the enclosing scope opts in via {@code @PackedClosures} (the dynamic trust path), or the
+     * capability analysis <em>proves</em> it delegate-independent under {@code @CompileStatic} (the
+     * automatic path, see {@link #isDelegateIndependent}) — and it is in a packable position:
+     * it needs no real {@code Closure} semantics we cannot reproduce ({@link #isPackable}), it is
+     * written directly in a method rather than nested in another closure (owner-retargeting for
+     * nested closures is later work), and it does not visibly escape its method. Otherwise it stays a
+     * full generated class (S0, {@link PackStrategy#FULL_CLASS}) exactly as today.
+     */
+    private PackStrategy chooseStrategy(final ClosureExpression expression) {
+        if (!isPackable(expression)) return PackStrategy.FULL_CLASS;
+        // The most-specific @PackedClosures mode in scope (method wins over class), or null if not
+        // annotated. DISABLED is a fine-grained opt-out that beats an enclosing opt-in AND the flag.
+        PackMode mode = annotatedMode();
+        if (mode == PackMode.DISABLED) return PackStrategy.FULL_CLASS;
+        boolean annotated = (mode != null); // LENIENT/WARN/STRICT all opt in (DISABLED handled above)
+        if (!isPackTriggered(expression, annotated)) return PackStrategy.FULL_CLASS;
+        if (controller.isInGeneratedFunction()) return PackStrategy.FULL_CLASS;
+        if (escapesEnclosingMethod(expression)) return PackStrategy.FULL_CLASS;
+        return PackStrategy.PACKED_ADAPTER;
+    }
+
+    /**
+     * Whether a packable, non-escaping closure literal should actually be packed. Dynamic compilation
+     * has no proof of delegate-independence, so the only trigger is the {@code @PackedClosures} trust
+     * assertion; {@code StaticTypesClosureWriter} overrides this to add the
+     * {@code groovy.target.closure.pack} flag and the delegate-independence proof.
+     *
+     * @param annotated whether a non-DISABLED {@code @PackedClosures} is in scope
+     */
+    protected boolean isPackTriggered(final ClosureExpression expression, final boolean annotated) {
+        return annotated;
+    }
+
+    /**
+     * A trigger-specific decline reason for {@link #declineReason}, or {@code null} if the trigger did
+     * not decline this closure. Only the static writer has one (a delegate-resolved body); the dynamic
+     * path trusts the annotation and never declines on trigger grounds.
+     */
+    protected String triggerDeclineReason(final ClosureExpression expression) {
+        return null;
+    }
+
+    /** Whether the hoisted body is compiled statically (true only for {@code @CompileStatic}). */
+    protected boolean compilesHoistedBodyStatically() {
+        return false;
+    }
+
+    /**
+     * Whether the packed adapter installs the runtime delegate guard. The dynamic trust path needs it
+     * (an unverifiable assertion must fail fast on misuse); the static writer proved independence, so
+     * it overrides this to {@code false} and a caller-set delegate is then stored and ignored.
+     */
+    protected boolean packedClosureUsesDelegateGuard() {
+        return true;
+    }
+
+    /** The closure's inferred return type, normalised the same way {@code createClosureClass} does for doCall. */
+    private static ClassNode inferredClosureReturnType(final ClosureExpression expression) {
+        ClassNode returnType = expression.getNodeMetaData(INFERRED_RETURN_TYPE);
+        if (returnType == null) returnType = ClassHelper.OBJECT_TYPE;
+        else if (returnType.isPrimaryClassNode()) returnType = returnType.getPlainNodeReference();
+        else if (ClassHelper.isPrimitiveType(returnType)) returnType = ClassHelper.getWrapper(returnType);
+        else if (GenericsUtils.hasUnresolvedGenerics(returnType)) returnType = GenericsUtils.nonGeneric(returnType);
+        return returnType;
+    }
+
+    /**
+     * The erasure of a captured variable's type, safe to declare on the hoisted method: generic
+     * placeholders are replaced by their bound (the hoisted method does not declare the enclosing
+     * method's type variables) and type arguments are dropped ({@code List<T>} → {@code List}).
+     */
+    private static ClassNode erasedType(final ClassNode type) {
+        ClassNode t = type;
+        if (t == null) return ClassHelper.OBJECT_TYPE;
+        if (t.isGenericsPlaceHolder()) t = t.redirect();
+        return t.getPlainNodeReference();
+    }
+
+    /**
+     * Reports a top-level closure that was NOT packed, per the {@code mode} of the enclosing
+     * {@code @PackedClosures} annotation (WARN => compiler warning, STRICT => compiler error). Only the
+     * annotation opts in; the automatic {@code groovy.target.closure.pack} path is always lenient. A
+     * nested closure is a structural decline (its enclosing context is a generated function, not the
+     * owner class), so it is not reported.
+     */
+    private void reportUnpacked(final ClosureExpression expression) {
+        if (controller.isInGeneratedFunction()) return;
+        PackMode mode = annotatedMode();
+        // LENIENT/DISABLED are both silent -- DISABLED asked NOT to pack, so a decline is expected
+        if (mode == null || mode == PackMode.LENIENT || mode == PackMode.DISABLED) return;
+        String msg = "@PackedClosures: closure was not packed -- " + declineReason(expression);
+        if (mode == PackMode.STRICT) {
+            controller.getSourceUnit().getErrorCollector()
+                    .addErrorAndContinue(msg, expression, controller.getSourceUnit());
+        } else {
+            // WARN is opt-in, so emit at LIKELY_ERRORS to show at the default warning level (the plain
+            // addWarning(text, node) uses POSSIBLE_ERRORS, which the default level suppresses). groovyc
+            // surfaces collected warnings on success since GROOVY-12132; Gradle/IDEs already do.
+            controller.getSourceUnit().addWarning(WarningMessage.LIKELY_ERRORS, msg, expression);
+        }
+    }
+
+    /** The most specific {@code @PackedClosures} mode in scope (method wins over class), or null if not annotated. */
+    private PackMode annotatedMode() {
+        MethodNode m = controller.getMethodNode();
+        PackMode mode = (m != null) ? packModeOf(m.getAnnotations()) : null;
+        if (mode != null) return mode;
+        for (ClassNode c = controller.getClassNode(); c != null; c = c.getOuterClass()) {
+            mode = packModeOf(c.getAnnotations());
+            if (mode != null) return mode;
+        }
+        return null;
+    }
+
+    /** The mode of a {@code @PackedClosures} in the given set (LENIENT if present without an explicit mode), or null. */
+    private static PackMode packModeOf(final List<AnnotationNode> annotations) {
+        for (AnnotationNode a : annotations) {
+            if (a.getClassNode() != null && "groovy.transform.PackedClosures".equals(a.getClassNode().getName())) {
+                Expression member = a.getMember("mode");
+                if (member instanceof PropertyExpression) {
+                    try {
+                        return PackMode.valueOf(((PropertyExpression) member).getPropertyAsString());
+                    } catch (IllegalArgumentException ignore) {
+                        // malformed member; treat as the default
+                    }
+                }
+                return PackMode.LENIENT;
+            }
+        }
+        return null;
+    }
+
+    /** Why {@link #chooseStrategy} declined this (packable, top-level) closure -- the message WARN/STRICT report. */
+    private String declineReason(final ClosureExpression expression) {
+        if (!isPackable(expression)) {
+            return "it needs a real Closure (uses owner/delegate/thisObject/resolveStrategy/super or metaClass, "
+                    + "has default parameter values, or contains an anonymous inner class)";
+        }
+        String triggerReason = triggerDeclineReason(expression);
+        if (triggerReason != null) return triggerReason;
+        if (escapesEnclosingMethod(expression)) {
+            return "it escapes its method (returned, stored to a field/property/index, appended, or in a collection literal)";
+        }
+        return "it is not eligible for packing in this scope";
+    }
+
+    /**
+     * Conservative compile-time escape gate. A packed closure is bound to the owner and backed by a
+     * shared adapter that fails fast if a delegate is later set on it. To avoid that surprise for the
+     * clearest cases, decline (keep a real closure class for) a closure literal that visibly escapes
+     * the method it is written in: stored into a field/property/index (e.g. {@code attrs.optionValue =
+     * { ... }}), returned, appended with {@code <<}, or placed in a list/map literal. Transitive escapes
+     * (via a local that is later returned) are intentionally not chased here; the runtime guard remains
+     * the backstop for those.
+     */
+    private boolean escapesEnclosingMethod(final ClosureExpression expression) {
+        MethodNode m = controller.getMethodNode();
+        if (m == null || m.getCode() == null) return false;
+        return escapingClosuresByMethod
+                .computeIfAbsent(m, k -> collectEscapingClosures(k.getCode()))
+                .contains(expression);
+    }
+
+    private static Set<ClosureExpression> collectEscapingClosures(final Statement code) {
+        Set<ClosureExpression> escaping = Collections.newSetFromMap(new IdentityHashMap<>());
+        code.visit(new CodeVisitorSupport() {
+            private void mark(final Expression e) {
+                if (e instanceof ClosureExpression) escaping.add((ClosureExpression) e);
+            }
+            @Override public void visitReturnStatement(final ReturnStatement statement) {
+                mark(statement.getExpression());
+                super.visitReturnStatement(statement);
+            }
+            @Override public void visitBinaryExpression(final BinaryExpression be) {
+                int op = be.getOperation().getType();
+                if (op == Types.EQUAL && !isLocalTarget(be.getLeftExpression())) {
+                    mark(be.getRightExpression());          // assigned to a field/property/index
+                } else if (op == Types.LEFT_SHIFT) {
+                    mark(be.getRightExpression());          // appended, e.g. list << { ... }
+                }
+                super.visitBinaryExpression(be);
+            }
+            @Override public void visitListExpression(final ListExpression le) {
+                le.getExpressions().forEach(this::mark);
+                super.visitListExpression(le);
+            }
+            @Override public void visitMapEntryExpression(final MapEntryExpression me) {
+                mark(me.getValueExpression());
+                super.visitMapEntryExpression(me);
+            }
+        });
+        return escaping;
+    }
+
+    /** True when an assignment target is a plain local variable (not a field/property that escapes). */
+    private static boolean isLocalTarget(final Expression lhs) {
+        if (!(lhs instanceof VariableExpression)) return false;   // property/field/index target
+        Variable v = ((VariableExpression) lhs).getAccessedVariable();
+        return !(v instanceof FieldNode) && !(v instanceof PropertyNode);
+    }
+
+    /**
+     * Spike packability gate: pack read-only closures (including nested and captures). Captured-variable
+     * writes are supported via Reference threading for a flat closure only (declined if the body also
+     * contains a nested closure, or uses an unsupported compound-assignment operator). Anything needing a
+     * real Closure — delegate/owner/thisObject/resolveStrategy or {@code super} — is declined.
+     */
+    private static boolean isPackable(final ClosureExpression expression) {
+        Statement code = expression.getCode();
+        if (code == null) return false;
+        // Default parameter values generate arity-overloaded doCall methods on a closure class;
+        // the single hoisted method cannot reproduce that dispatch, so decline.
+        if (expression.isParameterSpecified()) {
+            for (Parameter p : expression.getParameters()) {
+                if (p.hasInitialExpression()) return false;
+            }
+        }
+        boolean[] ok = {true};
+        code.visit(new CodeVisitorSupport() {
+            @Override public void visitClosureExpression(final ClosureExpression e) {
+                // A nested closure constructed inside the hoisted method gets the enclosing INSTANCE
+                // as its owner instead of the (packed) outer closure object. That is observationally
+                // equivalent for owner-chain resolution, but not for a nested body that names
+                // owner/delegate/thisObject explicitly -- so the outer packs only if every nested
+                // closure is itself packable.
+                if (!isPackable(e)) ok[0] = false;
+            }
+            @Override public void visitVariableExpression(final VariableExpression ve) {
+                if (ve.isSuperExpression() || FORBIDDEN_CLOSURE_NAMES.contains(ve.getName())) ok[0] = false;
+            }
+            @Override public void visitMethodCallExpression(final MethodCallExpression call) {
+                // implicit-this accessor/mutator forms of the same pseudo-properties, e.g. getDelegate()
+                if (call.isImplicitThis() && FORBIDDEN_CLOSURE_CALLS.contains(call.getMethodAsString())) ok[0] = false;
+                super.visitMethodCallExpression(call);
+            }
+            @Override public void visitConstructorCallExpression(final ConstructorCallExpression cce) {
+                // an anonymous inner class in the body is generated against the enclosing closure
+                // class (its outer instance); hoisting would hand it the wrong enclosing instance
+                if (cce.isUsingAnonymousInnerClass()) ok[0] = false;
+                super.visitConstructorCallExpression(cce);
+            }
+        });
+        // All write forms to captured variables are supported: the shared Reference is passed as a
+        // holder parameter, so the ASM generator emits the implicit get()/set() exactly as it does
+        // for a closure class -- no operator restrictions.
+        return ok[0];
+    }
+
+    private static Set<String> capturedNames(final ClosureExpression expression) {
+        Set<String> captured = new HashSet<>();
+        VariableScope vs = expression.getVariableScope();
+        if (vs != null) {
+            for (Iterator<Variable> it = vs.getReferencedLocalVariablesIterator(); it.hasNext(); ) {
+                captured.add(it.next().getName());
+            }
+        }
+        return captured;
+    }
+
+    /** Captured variables that are written (reassigned) in the body — these need Reference threading. */
+    private Set<String> writtenCaptureNames(final ClosureExpression expression) {
+        Set<String> captured = capturedNames(expression);
+        Set<String> written = new HashSet<>(collectWrittenNames(expression.getCode()));
+        MethodNode m = controller.getMethodNode();
+        if (m != null && m.getCode() != null) {
+            written.addAll(writtenNamesByMethod.computeIfAbsent(m, k -> collectWrittenNames(k.getCode())));
+        }
+        written.retainAll(captured);
+        return written;
+    }
+
+    /** Names assigned or incremented in the given code (declarations with initializers excluded). */
+    private static Set<String> collectWrittenNames(final Statement code) {
+        Set<String> written = new HashSet<>();
+        if (code == null) return written;
+        code.visit(new CodeVisitorSupport() { // descends into nested closures
+            @Override public void visitBinaryExpression(final BinaryExpression be) {
+                if (Types.isAssignment(be.getOperation().getType())
+                        && !(be instanceof org.codehaus.groovy.ast.expr.DeclarationExpression)
+                        && be.getLeftExpression() instanceof VariableExpression) {
+                    written.add(((VariableExpression) be.getLeftExpression()).getName());
+                }
+                super.visitBinaryExpression(be);
+            }
+            @Override public void visitPostfixExpression(final PostfixExpression pe) {
+                recordIncrement(pe.getExpression());
+                super.visitPostfixExpression(pe);
+            }
+            @Override public void visitPrefixExpression(final PrefixExpression pe) {
+                recordIncrement(pe.getExpression());
+                super.visitPrefixExpression(pe);
+            }
+            private void recordIncrement(final Expression operand) {
+                if (operand instanceof VariableExpression) {
+                    written.add(((VariableExpression) operand).getName());
+                }
+            }
+        });
+        return written;
+    }
+
+    // NB: metaClass resolves against the closure object ITSELF (per-closure-class identity), which
+    // the shared adapter cannot reproduce, so it declines like the other closure pseudo-properties.
+    private static final Set<String> FORBIDDEN_CLOSURE_NAMES =
+            new HashSet<>(java.util.Arrays.asList("owner", "delegate", "thisObject", "directive",
+                    "resolveStrategy", "metaClass"));
+
+    /** Accessor/mutator forms of the same pseudo-properties, called with implicit this. */
+    private static final Set<String> FORBIDDEN_CLOSURE_CALLS =
+            new HashSet<>(java.util.Arrays.asList("getOwner", "getDelegate", "getThisObject", "getDirective",
+                    "getResolveStrategy", "setDelegate", "setDirective", "setResolveStrategy",
+                    "getMaximumNumberOfParameters", "getParameterTypes", "getMetaClass", "setMetaClass",
+                    "invokeMethod", "getProperty", "setProperty"));
+
+    /**
+     * Rebinds captured-variable references in the moved body to the hoisted method's parameters,
+     * matched by the accessed {@link Variable}'s <em>identity</em> rather than by name. Groovy forbids
+     * shadowing an in-scope local/parameter, so a name match would be correct today; keying on identity
+     * keeps it correct even if that scoping rule ever relaxed, and never rewrites an unrelated binding
+     * that happens to share a captured name.
+     */
+    private static void rebindCaptured(final Statement body, final Map<Variable, Parameter> capturedParams) {
+        body.visit(new CodeVisitorSupport() {
+            @Override public void visitVariableExpression(final VariableExpression ve) {
+                Parameter p = capturedParams.get(ve.getAccessedVariable());
+                if (p != null) {
+                    ve.setAccessedVariable(p);
+                    // read-only captures become plain by-value params; written captures stay
+                    // closure-shared so the ASM generator routes them through the holder
+                    ve.setClosureSharedVariable(p.isClosureSharedVariable());
+                }
+            }
+        });
+    }
+
+    /**
+     * Emits a packed closure: hoists the body to a synthetic method on the enclosing class (captured
+     * variables become leading, by-value parameters) and constructs a shared {@code PackedClosure}
+     * adapter that dispatches to it — no inner class.
+     */
+    private void writePackedClosure(final ClosureExpression expression) {
+        ClassNode enclosing = controller.getClassNode();
+        MethodVisitor mv = controller.getMethodVisitor();
+        AsmClassGenerator acg = controller.getAcg();
+        OperandStack os = controller.getOperandStack();
+
+        List<String> captured = new ArrayList<>();
+        Map<String, ClassNode> capturedTypes = new HashMap<>();
+        Map<String, Variable> capturedVars = new HashMap<>(); // name -> the original captured variable
+        VariableScope vs = expression.getVariableScope();
+        if (vs != null) {
+            for (Iterator<Variable> it = vs.getReferencedLocalVariablesIterator(); it.hasNext(); ) {
+                Variable v = it.next();
+                captured.add(v.getName());
+                capturedTypes.put(v.getName(), erasedType(v.getOriginType()));
+                capturedVars.put(v.getName(), v);
+            }
+        }
+
+        Parameter[] closureParams = expression.isParameterSpecified()
+                ? expression.getParameters()
+                : new Parameter[]{new Parameter(ClassHelper.OBJECT_TYPE, "it")};
+        int arity = closureParams.length;
+
+        Set<String> written = writtenCaptureNames(expression);
+        Parameter[] methodParams = new Parameter[captured.size() + closureParams.length];
+        Map<Variable, Parameter> capturedByVar = new IdentityHashMap<>(); // original variable -> hoisted param
+        boolean typedBody = compilesHoistedBodyStatically();
+        for (int i = 0; i < captured.size(); i++) {
+            String cn = captured.get(i);
+            boolean isWritten = written.contains(cn);
+            Parameter p;
+            if (isWritten) {
+                // A written capture arrives as the SHARED groovy.lang.Reference itself: declare the
+                // parameter exactly like a closure-class constructor does (originType = value type,
+                // descriptor type = Reference, closure-shared + use-existing-reference), so
+                // CompileStack.init registers it as a holder and the ASM generator emits the implicit
+                // get()/set() on every read/write -- no AST rewriting, and the untouched body keeps
+                // the STC metadata that lets it compile statically.
+                ClassNode vt = capturedTypes.get(cn);
+                if (ClassHelper.isPrimitiveType(vt)) vt = ClassHelper.getWrapper(vt);
+                p = new Parameter(vt, cn);
+                p.setType(ClassHelper.makeReference());
+                p.setClosureSharedVariable(true);
+                p.putNodeMetaData(UseExistingReference.class, Boolean.TRUE);
+                // the static writer's type chooser must see the VALUE type: the holder load already
+                // dereferences, so resolving this variable as Reference would add a bogus checkcast
+                p.putNodeMetaData(org.codehaus.groovy.transform.stc.StaticTypesMarker.INFERRED_TYPE, vt);
+            } else {
+                // For a statically-compiled body, type the read-only capture from its declared type so
+                // the loads match the STC metadata already on the body expressions (otherwise the
+                // static writer falls back to dynamic dispatch on the type mismatch).
+                p = new Parameter(typedBody ? capturedTypes.get(cn) : ClassHelper.OBJECT_TYPE, cn);
+            }
+            methodParams[i] = p;
+            capturedByVar.put(capturedVars.get(cn), p);
+        }
+        System.arraycopy(closureParams, 0, methodParams, captured.size(), closureParams.length);
+
+        Statement body = expression.getCode();
+        rebindCaptured(body, capturedByVar);  // read-only -> plain param; written -> holder param
+
+        // In a static method there is no `this`: the owner is the enclosing class and the hoisted
+        // method must be static (loaded/dispatched against the class, not local slot 0).
+        boolean staticContext = controller.isStaticMethod();
+        String name = PACKED_METHOD_PREFIX + (packedCounter++);
+        // PRIVATE, not public: the body is reached only reflectively via PackedClosure.invokeHoisted, and
+        // a private method is invoked exactly (no virtual dispatch), so an inherited packed closure never
+        // dispatches to a same-named hoisted method a subclass happens to declare (GROOVY-12151 review).
+        int mods = ACC_PRIVATE | ACC_SYNTHETIC | (staticContext ? ACC_STATIC : 0);
+        // Same return type a generated closure class would give doCall, so implicit return-value
+        // coercion (e.g. GString -> String for a Closure<String>) happens identically.
+        ClassNode hoistedReturnType = typedBody ? inferredClosureReturnType(expression) : ClassHelper.OBJECT_TYPE;
+        MethodNode hoisted = new MethodNode(name, mods, hoistedReturnType,
+                methodParams, ClassNode.EMPTY_ARRAY, body);
+        // Added after the ReturnAdder phase, so run it ourselves: it wires implicit returns through
+        // every statement shape (trailing expressions, if/else branches, try/catch, ...).
+        new org.codehaus.groovy.classgen.ReturnAdder().visitMethod(hoisted);
+        // Typed static dispatch (GEP-27 phase 4): the original body expressions were already visited
+        // by StaticCompilationVisitor as part of the enclosing method, so they carry the metadata the
+        // static writer needs (DIRECT_METHOD_CALL_TARGET, inferred types) -- including types that were
+        // only inferred (@ClosureParams, implicit it), which arrive for free via checkcasts. Written
+        // captures ride the holder machinery, so their bodies compile statically too.
+        hoisted.putNodeMetaData(STATIC_COMPILE_NODE, typedBody ? Boolean.TRUE : Boolean.FALSE);
+        addGeneratedMethod(enclosing, hoisted);
+        // GROOVY-12150 visibility: a packed closure has no generated class, so mark it with the hoisted
+        // method it became. The AST browser then renders it via the same path it uses for the generated
+        // closure class of an unpacked closure; the trailing () distinguishes a method from a class.
+        expression.putNodeMetaData(GENERATED_CLOSURE_CLASS, enclosing.getName() + "." + name + "()");
+
+        String pc = "org/codehaus/groovy/runtime/PackedClosure";
+        mv.visitTypeInsn(NEW, pc);
+        mv.visitInsn(DUP);
+        if (staticContext) {
+            new ClassExpression(enclosing).visit(acg);   // owner = the enclosing class (static dispatch)
+        } else {
+            mv.visitVarInsn(ALOAD, 0);
+            os.push(ClassHelper.OBJECT_TYPE);            // owner = this
+        }
+        // A MethodHandle constant to the private hoisted method (resolved in this hosting class): no
+        // reflection, no name/arity lookup, and it binds the exact method so an inherited packed closure
+        // cannot misdispatch to a subclass's same-named method.
+        String hoistedDesc = BytecodeHelper.getMethodDescriptor(hoisted.getReturnType(), hoisted.getParameters());
+        mv.visitLdcInsn(new org.objectweb.asm.Handle(
+                staticContext ? org.objectweb.asm.Opcodes.H_INVOKESTATIC : org.objectweb.asm.Opcodes.H_INVOKESPECIAL,
+                BytecodeHelper.getClassInternalName(enclosing), name, hoistedDesc, false));
+        os.push(ClassHelper.make(java.lang.invoke.MethodHandle.class));
+        mv.visitLdcInsn(name);
+        os.push(ClassHelper.STRING_TYPE);   // method name (diagnostics only)
+        if (captured.isEmpty()) {
+            mv.visitInsn(ACONST_NULL);
+            os.push(ClassHelper.OBJECT_TYPE.makeArray());
+        } else {
+            // Build Object[] of captured values: written vars pass their shared Reference (so writes
+            // propagate), read-only vars pass their value.
+            BytecodeHelper.pushConstant(mv, captured.size());
+            os.push(ClassHelper.int_TYPE);
+            mv.visitTypeInsn(ANEWARRAY, "java/lang/Object");
+            os.replace(ClassHelper.OBJECT_TYPE.makeArray());
+            for (int i = 0; i < captured.size(); i++) {
+                String cn = captured.get(i);
+                mv.visitInsn(DUP);
+                os.push(ClassHelper.OBJECT_TYPE.makeArray());
+                BytecodeHelper.pushConstant(mv, i);
+                os.push(ClassHelper.int_TYPE);
+                if (written.contains(cn)) {
+                    loadReference(cn, controller);       // shared Reference holder
+                } else {
+                    new VariableExpression(cn).visit(acg); // value
+                    os.box();
+                }
+                mv.visitInsn(AASTORE);
+                os.remove(3);
+            }
+        }
+        // The closure's declared parameter types, so getParameterTypes()-keyed caller behaviour
+        // (DGM arity decisions, vararg collection) matches a generated closure class exactly.
+        BytecodeHelper.pushConstant(mv, arity);
+        os.push(ClassHelper.int_TYPE);
+        mv.visitTypeInsn(ANEWARRAY, "java/lang/Class");
+        os.replace(ClassHelper.CLASS_Type.makeArray());
+        for (int i = 0; i < arity; i++) {
+            mv.visitInsn(DUP);
+            os.push(ClassHelper.CLASS_Type.makeArray());
+            BytecodeHelper.pushConstant(mv, i);
+            os.push(ClassHelper.int_TYPE);
+            BytecodeHelper.visitClassLiteral(mv, erasedType(closureParams[i].getType()));
+            os.push(ClassHelper.CLASS_Type);
+            mv.visitInsn(AASTORE);
+            os.remove(3);
+        }
+        // strict guard only for the dynamic trust path; a statically PROVEN delegate-independent
+        // closure stores-and-ignores a caller-set delegate, like a @CompileStatic closure class.
+        mv.visitInsn(packedClosureUsesDelegateGuard() ? org.objectweb.asm.Opcodes.ICONST_1 : org.objectweb.asm.Opcodes.ICONST_0);
+        os.push(ClassHelper.boolean_TYPE);
+        mv.visitMethodInsn(INVOKESPECIAL, pc, "<init>",
+                "(Ljava/lang/Object;Ljava/lang/invoke/MethodHandle;Ljava/lang/String;[Ljava/lang/Object;[Ljava/lang/Class;Z)V", false);
+        os.replace(ClassHelper.CLOSURE_TYPE, 6); // owner, handle, name, captured[], paramTypes[], strict -> Closure
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/classgen/asm/PackStrategy.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/PackStrategy.java
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.classgen.asm;
+
+/**
+ * The compilation strategy the GEP-27 capability analysis selects for a closure literal: keep today's
+ * per-closure class, or pack the closure by hoisting its body to a method on the enclosing class behind
+ * a shared {@code PackedClosure} adapter. The GEP-27 lattice also foresees a metafactory strategy
+ * (functional-interface targets) and object elision, but those are separate, later work and are not
+ * represented here yet.
+ */
+public enum PackStrategy {
+
+    /** S0 — generate the per-closure class (today's behaviour); preserves all {@code Closure} capabilities. */
+    FULL_CLASS,
+
+    /** S1 — hoist the body to a method on the enclosing class behind a shared {@code PackedClosure} adapter. */
+    PACKED_ADAPTER
+}

--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesClosureWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesClosureWriter.java
@@ -18,16 +18,21 @@
  */
 package org.codehaus.groovy.classgen.asm.sc;
 
+import org.apache.groovy.util.SystemUtil;
 import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.ast.ClassCodeVisitorSupport;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.CodeVisitorSupport;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.expr.ArrayExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.classgen.asm.ClosureWriter;
 import org.codehaus.groovy.classgen.asm.WriterController;
 import org.codehaus.groovy.control.SourceUnit;
@@ -44,6 +49,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.nullX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.returnS;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.varX;
+import static org.codehaus.groovy.transform.stc.StaticTypesMarker.IMPLICIT_RECEIVER;
 import static org.codehaus.groovy.transform.stc.StaticTypesMarker.LAMBDA_MARKERS;
 
 /**
@@ -55,6 +61,75 @@ public class StaticTypesClosureWriter extends ClosureWriter {
      */
     public StaticTypesClosureWriter(WriterController wc) {
         super(wc);
+    }
+
+    // Under @CompileStatic the type checker's owner-vs-delegate resolution is authoritative, so the
+    // capability analysis can prove a closure delegate-independent and pack it automatically.
+    @Override
+    protected boolean isPackTriggered(final ClosureExpression expression, final boolean annotated) {
+        // Even the @PackedClosures opt-in needs the proof here: a delegate-resolved body compiles its
+        // IMPLICIT_RECEIVER expressions against Closure.getDelegate(), which a hoisted method cannot honour.
+        return (annotated || SystemUtil.getBooleanSafe("groovy.target.closure.pack"))
+                && isDelegateIndependent(expression);
+    }
+
+    @Override
+    protected String triggerDeclineReason(final ClosureExpression expression) {
+        return isDelegateIndependent(expression) ? null
+                : "it resolves a name against a delegate (e.g. via @DelegatesTo or with{})";
+    }
+
+    @Override
+    protected boolean compilesHoistedBodyStatically() {
+        return true;
+    }
+
+    @Override
+    protected boolean packedClosureUsesDelegateGuard() {
+        return false; // the type checker proved delegate-independence, so no runtime guard is needed
+    }
+
+    /**
+     * True when the type checker resolved every implicitly-received name in the closure (and its
+     * nested closures) against the owner/parameters rather than a delegate — the delegate-independence
+     * proof of the capability analysis. Under {@code @CompileStatic} STC records each name's resolution
+     * path as {@code IMPLICIT_RECEIVER}: a path ending in {@code "owner"} was resolved against the
+     * owner (safe), anything else (e.g. {@code "delegate"}, from {@code @DelegatesTo} or {@code with})
+     * went through a delegate — the same distinction STC itself makes. The marker can sit on a method
+     * call, a property expression, or a bare variable (e.g. {@code length} inside {@code with}), so
+     * all three are checked. If nothing resolved through a delegate, packing preserves resolution.
+     */
+    private boolean isDelegateIndependent(final ClosureExpression expression) {
+        Statement code = expression.getCode();
+        if (code == null) return false;
+        boolean[] delegateResolved = {false};
+        // Walk the whole closure tree, including nested closures: a delegate resolution anywhere in
+        // the body (e.g. an owner-passed closure whose inner closure resolves a name against the
+        // delegate) means the top closure carries a delegate chain that packing would break.
+        code.visit(new CodeVisitorSupport() {
+            @Override public void visitMethodCallExpression(final MethodCallExpression call) {
+                flag(call.getNodeMetaData(IMPLICIT_RECEIVER));
+                super.visitMethodCallExpression(call);
+            }
+            @Override public void visitPropertyExpression(final PropertyExpression pexp) {
+                flag(pexp.getNodeMetaData(IMPLICIT_RECEIVER));
+                super.visitPropertyExpression(pexp);
+            }
+            @Override public void visitVariableExpression(final VariableExpression ve) {
+                flag(ve.getNodeMetaData(IMPLICIT_RECEIVER));
+                // a name STC left dynamic (no local/param binding, no recorded receiver path) will be
+                // resolved at runtime through the closure's owner/delegate chain -- not provably owner
+                if (ve.getAccessedVariable() instanceof org.codehaus.groovy.ast.DynamicVariable
+                        && ve.getNodeMetaData(IMPLICIT_RECEIVER) == null) {
+                    delegateResolved[0] = true;
+                }
+                super.visitVariableExpression(ve);
+            }
+            private void flag(final Object receiver) {
+                if (receiver instanceof String && !((String) receiver).endsWith("owner")) delegateResolved[0] = true;
+            }
+        });
+        return !delegateResolved[0];
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/codehaus/groovy/runtime/PackedClosure.java
+++ b/src/main/java/org/codehaus/groovy/runtime/PackedClosure.java
@@ -1,0 +1,225 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.runtime;
+
+import groovy.lang.Closure;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+/**
+ * A single, shared {@link Closure} adapter for {@code @PackedClosures} compact closure compilation.
+ * <p>
+ * Normally the Groovy compiler generates one inner class per closure literal
+ * (e.g. {@code Owner$_method_closure1}). Under {@code @PackedClosures} an <em>eligible</em>
+ * closure body is instead hoisted into a synthetic method on the enclosing ("owner")
+ * class, and the closure literal is replaced by an instance of this one adapter class,
+ * which dispatches back to that method. This removes the per-closure generated class
+ * (and the deeply-nested {@code $_closure1$_closure2$_closure3} name explosion) while
+ * still yielding a real {@code groovy.lang.Closure} instance, so features that operate
+ * through {@code call()} (iteration, {@code curry}, {@code memoize}, {@code trampoline})
+ * continue to work.
+ * <p>
+ * Captured values are bound into the {@link java.lang.invoke.MethodHandle} at construction (the
+ * hoisted method has the shape {@code method(captured..., closureParams...)}), so a call dispatches
+ * the caller's arguments directly, without prepending the captures each time.
+ * Dispatch goes through a {@link java.lang.invoke.MethodHandle} constant to the private hoisted
+ * method (bound to the receiver for an instance method), so there is no reflection.
+ */
+public final class PackedClosure extends Closure<Object> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Object[] EMPTY = new Object[0];
+
+    private final MethodHandle handle;
+    private final String method;
+    private final boolean strict;
+    private final org.codehaus.groovy.reflection.ParameterTypes paramInfo;
+
+    /**
+     * @param owner        the enclosing instance the hoisted method lives on (also used as thisObject)
+     * @param handle       an invoke handle to the private hoisted method (a constant in the hosting
+     *                     class): dispatch needs no reflection and binds the exact method, so an
+     *                     inherited packed closure can never misdispatch to a subclass's method
+     * @param method       the name of the hoisted synthetic method (kept for diagnostics only)
+     * @param captured     values captured from the enclosing scope, bound into the handle at construction
+     * @param visibleTypes the closure's declared parameter types, so callers that key behaviour on
+     *                     {@code getParameterTypes()} (DGM arity/type decisions) and argument
+     *                     adaptation (vararg collection into a trailing array parameter) behave
+     *                     exactly as with a generated closure class
+     * @param strict       whether the delegate guard throws. {@code true} for the dynamic trust path
+     *                     (an unverifiable {@code @PackedClosures} assertion must fail fast on misuse);
+     *                     {@code false} when the type checker PROVED every free name owner-resolved.
+     */
+    public PackedClosure(final Object owner, final MethodHandle handle, final String method, final Object[] captured, final Class[] visibleTypes, final boolean strict) {
+        super(owner, owner);
+        // Bind the receiver for an instance method so the handle takes (captured..., args...); a static
+        // hoisted method passes the class as owner and its handle already takes no receiver. Then bind
+        // the captured values in ONCE and adapt to a canonical (Object[])->Object shape over the
+        // closure's own arguments, so each call is a single invokeExact over the caller's argument
+        // array -- no per-call array prepending the captures, no arg-boxing invokeWithArguments.
+        MethodHandle mh = (owner instanceof Class) ? handle : handle.bindTo(owner);
+        mh = mh.asType(mh.type().generic());
+        if (captured != null && captured.length > 0) {
+            mh = MethodHandles.insertArguments(mh, 0, captured);
+        }
+        this.handle = mh.asSpreader(Object[].class, visibleTypes.length);
+        this.method = method;
+        this.strict = strict;
+        this.maximumNumberOfParameters = visibleTypes.length;
+        this.parameterTypes = visibleTypes;
+        this.paramInfo = new org.codehaus.groovy.reflection.ParameterTypes(visibleTypes);
+    }
+
+    // GEP-27 runtime guard: a hoisted body binds free names to the owner at compile time, so it
+    // cannot honour a caller-set delegate. Rather than silently mis-resolve (returning the owner's
+    // member where a normal closure would reach the delegate), fail fast at the point of misuse.
+    // Setting the delegate to the owner is the harmless default and stays a no-op.
+    @Override
+    public void setDelegate(final Object delegate) {
+        if (strict && delegate != null && delegate != getOwner()) {
+            throw new UnsupportedOperationException(
+                    "Cannot set a delegate on a @PackedClosures closure (hoisted method '" + method
+                    + "'): its free names were bound to the owner at compile time, so an external "
+                    + "delegate cannot be honoured. Remove @PackedClosures from this scope, or "
+                    + "exclude this closure, if it relies on delegate-based resolution.");
+        }
+        super.setDelegate(delegate);
+    }
+
+    @Override
+    public void setResolveStrategy(final int resolveStrategy) {
+        // DELEGATE_FIRST/DELEGATE_ONLY need a delegate the hoisted body cannot consult; TO_SELF
+        // would resolve names against this shared adapter, which has no user-defined members.
+        // Only owner-based resolution (OWNER_FIRST/OWNER_ONLY) is reproducible by a hoisted body.
+        if (strict && resolveStrategy != OWNER_FIRST && resolveStrategy != OWNER_ONLY) {
+            throw new UnsupportedOperationException(
+                    "Cannot set resolveStrategy=" + strategyName(resolveStrategy)
+                    + " on a @PackedClosures closure (hoisted method '" + method + "'): a hoisted "
+                    + "body resolves free names against the owner at compile time, so only "
+                    + "OWNER_FIRST/OWNER_ONLY are supported. Remove @PackedClosures from this "
+                    + "scope, or exclude this closure.");
+        }
+        super.setResolveStrategy(resolveStrategy);
+    }
+
+    private static String strategyName(final int s) {
+        switch (s) {
+            case DELEGATE_FIRST: return "DELEGATE_FIRST";
+            case DELEGATE_ONLY:  return "DELEGATE_ONLY";
+            case TO_SELF:        return "TO_SELF";
+            default:             return String.valueOf(s);
+        }
+    }
+
+    // Dispatch call() straight to doCall: the generic varargs doCall is otherwise vararg-ambiguous
+    // through the metaclass when a single argument is itself an Object[] (the metaclass would treat
+    // the element as the whole argument list and spread it). Unwrap invoker exceptions exactly as
+    // Closure.call does, so user exceptions surface unwrapped.
+    @Override
+    public Object call(final Object... args) {
+        try {
+            return doCall(args);
+        } catch (InvokerInvocationException e) {
+            org.apache.groovy.internal.util.UncheckedThrow.rethrow(e.getCause());
+            return null; // unreachable
+        }
+    }
+
+    public Object doCall(final Object... args) {
+        Object[] provided = (args != null) ? args : EMPTY;
+        int arity = getMaximumNumberOfParameters();
+        // Fast path: the caller supplied exactly the declared number of arguments (the common
+        // each()/collect() call). Skip the List-destructuring, correctArguments and per-arg coercion
+        // adaptation -- the canonical handle's asType does any primitive (un)boxing -- and dispatch.
+        if (provided.length == arity) {
+            Class<?>[] types = getParameterTypes();
+            Object[] a = provided;
+            for (int i = 0; i < arity; i++) {
+                Object arg = a[i];
+                Class<?> t = types[i];
+                // The canonical handle's asType unboxes/widens primitives and passes exact reference
+                // matches; only a reference type the argument is NOT already an instance of needs Groovy
+                // coercion here (e.g. GString -> String), matching a generated closure class.
+                if (arg != null && !t.isPrimitive() && t != Object.class && !t.isInstance(arg)) {
+                    if (a == provided) a = provided.clone(); // don't mutate the caller's array
+                    try {
+                        a[i] = org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(arg, t);
+                    } catch (RuntimeException ignore) {
+                        // leave the argument as-is; the invoke below reports the mismatch
+                    }
+                }
+            }
+            return invokeHoisted(a); // captures are bound into the handle; dispatch just the arguments
+        }
+        // A real closure destructures a single List/Tuple argument across a multi-parameter
+        // signature ({ a, b -> } called with one Tuple2); mirror that before arity normalisation.
+        if (provided.length == 1 && arity > 1 && provided[0] instanceof java.util.List) {
+            provided = ((java.util.List<?>) provided[0]).toArray();
+        }
+        // With the real parameter types available, adapt arguments exactly as metaclass dispatch on
+        // a generated closure class would -- collecting excess args into a trailing array parameter
+        // ({ Object[] args -> } called with several values), and coercing each argument to its
+        // declared parameter type (Closure -> SAM interface, GString -> String, number conversions)
+        // as metaclass dispatch does.
+        if (paramInfo != null) {
+            try {
+                provided = paramInfo.correctArguments(provided);
+            } catch (RuntimeException ignore) {
+                // fall through to the arity normalisation below
+            }
+            Class<?>[] types = getParameterTypes();
+            for (int i = 0; i < provided.length && i < types.length; i++) {
+                Object arg = provided[i];
+                Class<?> type = types[i];
+                if (arg != null && type != Object.class && !type.isInstance(arg)) {
+                    try {
+                        provided[i] = org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(arg, type);
+                    } catch (RuntimeException ignore) {
+                        // leave the argument as-is; the invoke below reports the mismatch
+                    }
+                }
+            }
+        }
+        // Normalise the visible arguments to the closure's declared arity: pad missing with
+        // null (implicit-it / under-application) and drop extras (over-application), matching
+        // how a normal Groovy closure tolerates arity mismatches from callers such as each().
+        Object[] a = new Object[arity];
+        for (int i = 0; i < arity; i++) {
+            a[i] = (i < provided.length) ? provided[i] : null;
+        }
+        return invokeHoisted(a);
+    }
+
+    /**
+     * Invokes the hoisted method through its {@link MethodHandle} with the caller's arguments (the
+     * captured values are already bound into the handle). The handle is a compile-time constant, so
+     * there is no reflection, no access override, and no name/arity resolution; a written capture's
+     * shared {@code groovy.lang.Reference} is bound unchanged (the handle does not dereference it,
+     * unlike metaclass argument coercion would), so writes still propagate.
+     */
+    private Object invokeHoisted(final Object[] args) {
+        try {
+            return (Object) handle.invokeExact(args);
+        } catch (Throwable t) { // propagate the hoisted body's own throwable unchanged
+            org.apache.groovy.internal.util.UncheckedThrow.rethrow(t);
+            return null; // unreachable
+        }
+    }
+}

--- a/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/FieldsAndPropertiesStaticCompileTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/FieldsAndPropertiesStaticCompileTest.groovy
@@ -20,6 +20,7 @@ package org.codehaus.groovy.classgen.asm.sc
 
 import groovy.transform.stc.FieldsAndPropertiesSTCTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 
 /**
  * Unit tests for static compilation : fields and properties.
@@ -653,6 +654,8 @@ final class FieldsAndPropertiesStaticCompileTest extends FieldsAndPropertiesSTCT
 
     // GROOVY-7705, GROOVY-10687
     @Test
+    @DisabledIfSystemProperty(named = 'groovy.target.closure.pack', matches = 'true',
+        disabledReason = 'asserts the pre-pack generated closure-class bytecode shape; superseded when GEP-27 closure packing is enabled')
     void testPrivateFieldMutationInClosureUsesDirectAccess() {
         for (prefix in ['','this.','thisObject.','getThisObject().']) {
             assertScript """
@@ -675,6 +678,8 @@ final class FieldsAndPropertiesStaticCompileTest extends FieldsAndPropertiesSTCT
 
     // GROOVY-7705, GROOVY-10687
     @Test
+    @DisabledIfSystemProperty(named = 'groovy.target.closure.pack', matches = 'true',
+        disabledReason = 'asserts the pre-pack generated closure-class bytecode shape; superseded when GEP-27 closure packing is enabled')
     void testPrivateStaticFieldMutationInClosureUsesDirectAccess() {
         assertScript '''
             class Foo {

--- a/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/StaticCompileClosureGeneratedAnnotationTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/StaticCompileClosureGeneratedAnnotationTest.groovy
@@ -22,12 +22,15 @@ import groovy.transform.Generated
 import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.Phases
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 
 import java.lang.reflect.Method
 
 /**
  * Verifies if {@link Generated} annotations are added on {@code call} methods of generated closure classes when static compilation is used.
  */
+@DisabledIfSystemProperty(named = 'groovy.target.closure.pack', matches = 'true',
+    disabledReason = 'reflects on generated closure classes, which do not exist when GEP-27 closure packing is enabled')
 final class StaticCompileClosureGeneratedAnnotationTest {
 
     private CompilationUnit compileScript(String script) {

--- a/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/bugs/ReproducibleBytecodeBugs.groovy
+++ b/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/bugs/ReproducibleBytecodeBugs.groovy
@@ -21,6 +21,7 @@ package org.codehaus.groovy.classgen.asm.sc.bugs
 import groovy.transform.stc.StaticTypeCheckingTestCase
 import org.codehaus.groovy.classgen.asm.sc.StaticCompilationTestSupport
 import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 
 import static org.junit.jupiter.api.Assertions.fail
 
@@ -51,6 +52,8 @@ final class ReproducibleBytecodeBugs extends StaticTypeCheckingTestCase implemen
     }
 
     // GROOVY-8148
+    @DisabledIfSystemProperty(named = 'groovy.target.closure.pack', matches = 'true',
+        disabledReason = 'asserts the pre-pack generated closure-class bytecode shape; superseded when GEP-27 closure packing is enabled')
     @RepeatedTest(100)
     void testShouldAlwaysAddClosureSharedVariablesInSameOrder() {
         assertScript '''

--- a/src/test/groovy/org/codehaus/groovy/transform/ClosurePackCapabilityTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/transform/ClosurePackCapabilityTest.groovy
@@ -1,0 +1,214 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.transform
+
+import org.codehaus.groovy.control.CompilationUnit
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.Phases
+import org.junit.jupiter.api.Test
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Handle
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * The GEP-27 capability analysis: under {@code @CompileStatic} a closure the type checker resolved
+ * against the owner (no {@code DELEGATION_METADATA}) is provably delegate-independent, so it is
+ * packed <em>automatically</em> — no {@code @PackedClosures} annotation — when the {@code
+ * groovy.target.closure.pack} flag is set. Closures resolved against a delegate ({@code @DelegatesTo})
+ * are proven delegate-dependent and kept as classes; dynamic closures (no static resolution) are
+ * never auto-packed. The flag is read per compilation, so it is toggled per test.
+ */
+final class ClosurePackCapabilityTest {
+
+    private static final String PROP = 'groovy.target.closure.pack'
+
+    private static <T> T withFlag(boolean on, Closure<T> work) {
+        String previous = System.getProperty(PROP)
+        if (on) System.setProperty(PROP, 'true') else System.clearProperty(PROP)
+        try {
+            work.call()
+        } finally {
+            if (previous != null) System.setProperty(PROP, previous) else System.clearProperty(PROP)
+        }
+    }
+
+    private static List<String> classNames(String src, boolean flag) {
+        withFlag(flag) {
+            def cu = new CompilationUnit(new CompilerConfiguration())
+            cu.addSource('Src.groovy', src)
+            cu.compile(Phases.CLASS_GENERATION)
+            cu.classes.collect { it.name }.sort()
+        }
+    }
+
+    private static int closureClassCount(List<String> names) {
+        names.count { it.contains('_closure') }
+    }
+
+    private static Object eval(String src, String tail, boolean flag) {
+        withFlag(flag) { new GroovyShell().evaluate(src + '\n' + tail) }
+    }
+
+    private static final String STATIC_PLAIN = '''import groovy.transform.CompileStatic
+        @CompileStatic
+        class Plain {
+            List<Integer> doubled(List<Integer> xs) { xs.collect { Integer it -> it * 2 } }
+            int total(List<Integer> xs)            { int t = 0; xs.each { Integer it -> t += it }; t }
+        }'''
+
+    @Test
+    void staticDelegateIndependentClosuresAutoPackWhenFlagOn() {
+        // No @PackedClosures anywhere: the flag alone drives packing of the proven-safe closures.
+        assertEquals(0, closureClassCount(classNames(STATIC_PLAIN, true)),
+                'delegate-independent @CompileStatic closures should auto-pack')
+        def p = eval(STATIC_PLAIN, 'new Plain()', true)
+        assertEquals([2, 4, 6], p.doubled([1, 2, 3]))     // behaviour unchanged
+        assertEquals(6, p.total([1, 2, 3]))               // captured write, Reference-threaded
+    }
+
+    @Test
+    void nothingAutoPacksWhenFlagOff() {
+        // Default: no automatic packing, so @CompileStatic code is byte-for-byte as today.
+        assertTrue(closureClassCount(classNames(STATIC_PLAIN, false)) >= 2,
+                'with the flag off no closure should be auto-packed')
+        assertEquals([2, 4, 6], eval(STATIC_PLAIN, 'new Plain().doubled([1, 2, 3])', false))
+    }
+
+    @Test
+    void delegateResolvedClosuresAreProvenDependentAndKeptAsClasses() {
+        // The builder's closure resolves tag()/nest against the @DelegatesTo delegate, so STC marks it
+        // with DELEGATION_METADATA. The capability analysis must NOT auto-pack it (that would rebind
+        // the calls to the owner and break the DSL), and delegate resolution must still work.
+        String src = '''import groovy.transform.CompileStatic
+            class Builder {
+                List<String> tags = []
+                void tag(String t) { tags << t }
+                List<String> run(@DelegatesTo(Builder) Closure c) {
+                    c.delegate = this; c.resolveStrategy = Closure.DELEGATE_FIRST; c.call(); tags
+                }
+            }
+            @CompileStatic
+            class UsesDsl {
+                List<String> make() { new Builder().run { tag('a'); tag('b') } }
+            }'''
+        def names = classNames(src, true)
+        assertTrue(closureClassCount(names) >= 1, "delegate DSL closure must stay a class: $names")
+        assertEquals(['a', 'b'], eval(src, 'new UsesDsl().make()', true))
+    }
+
+    @Test
+    void autoPackedBodyIsStaticallyCompiled() {
+        // The hoisted body reuses the expressions StaticCompilationVisitor already annotated, and the
+        // read-only capture is passed as a typed leading parameter -- so the body compiles with static
+        // dispatch (zero invokedynamic), unlike the Reference-boxed closure-class form.
+        String src = '''import groovy.transform.CompileStatic
+            @CompileStatic
+            class T {
+                List<String> tag(List<String> xs, String p) { xs.collect { String s -> p + s } }
+            }'''
+        byte[] bytes = withFlag(true) {
+            def cu = new CompilationUnit(new CompilerConfiguration())
+            cu.addSource('T.groovy', src)
+            cu.compile(Phases.CLASS_GENERATION)
+            cu.classes.find { it.name == 'T' }.bytes
+        }
+        def hoisted = [:]
+        new ClassReader(bytes).accept(new ClassVisitor(Opcodes.ASM9) {
+            @Override
+            MethodVisitor visitMethod(int access, String name, String desc, String sig, String[] exc) {
+                if (!name.startsWith('$packed$')) return null
+                hoisted[name] = [desc: desc, indy: 0]
+                return new MethodVisitor(Opcodes.ASM9) {
+                    @Override
+                    void visitInvokeDynamicInsn(String n, String d, Handle bsm, Object... args) {
+                        hoisted[name].indy++
+                    }
+                }
+            }
+        }, 0)
+        assertEquals(1, hoisted.size(), "expected one hoisted method, got: ${hoisted.keySet()}")
+        def name = hoisted.keySet().iterator().next()
+        def info = hoisted[name]
+        assertTrue(info.desc.startsWith('(Ljava/lang/String;Ljava/lang/String;'),
+                "captured value should be a typed String parameter: ${info.desc}")
+        assertEquals(0, info.indy, "hoisted body should be statically dispatched, got ${info.indy} indy in $name")
+        assertEquals(['p-x'], eval(src, 'new T().tag(["x"], "p-")', true))
+    }
+
+    @Test
+    void writtenCapturesPackViaSharedReferenceHolder() {
+        // The shared Reference is passed straight into the hoisted method as a holder parameter, so
+        // the untouched body compiles with the implicit get()/set() the ASM generator already emits
+        // for closure classes. That supports every write form -- compound ops beyond +/-, and postfix
+        // increments with correct value-in-expression semantics.
+        String src = '''import groovy.transform.CompileStatic
+            @CompileStatic
+            class W {
+                int total(List<Integer> xs)  { int t = 0; xs.each { t += it }; t }
+                long lshift(List<Integer> xs){ long m = 1; xs.each { m <<= it }; m }     // beyond +/- compound
+                List<Integer> olds(List<Integer> xs) {
+                    int c = 10
+                    List<Integer> seen = []
+                    xs.each { seen << c++ }                                              // postfix VALUE used
+                    seen << c
+                    seen
+                }
+            }'''
+        assertEquals(0, closureClassCount(classNames(src, true)), 'all write forms should pack')
+        def w = eval(src, 'new W()', true)
+        assertEquals(6, w.total([1, 2, 3]))
+        assertEquals(32L, w.lshift([2, 3]))
+        assertEquals([10, 11, 12], w.olds([0, 0]))   // c++ yields the OLD value each time, then final c
+    }
+
+    @Test
+    void packedClosureDestructuresSingleListArgument() {
+        // Real closures destructure a single List/Tuple argument across a multi-param signature;
+        // the shared adapter must preserve that.
+        String src = '''import groovy.transform.CompileStatic
+            @CompileStatic
+            class D {
+                List<String> pairs(List<Tuple2<String, Integer>> ts) {
+                    List<String> out = []
+                    ts.each { String s, Integer n -> out << "$s=$n".toString() }
+                    out
+                }
+            }'''
+        assertEquals(0, closureClassCount(classNames(src, true)))
+        assertEquals(['a=1', 'b=2'],
+                eval(src, 'new D().pairs([Tuple.tuple("a", 1), Tuple.tuple("b", 2)])', true))
+    }
+
+    @Test
+    void dynamicClosuresAreNeverAutoPacked() {
+        // No @CompileStatic: the type checker never ran, so delegate-independence is unproven and the
+        // automatic path must not fire even with the flag on (only @PackedClosures could pack these).
+        String src = '''class Dyn {
+                List<Integer> doubled(List<Integer> xs) { xs.collect { it * 2 } }
+            }'''
+        assertTrue(closureClassCount(classNames(src, true)) >= 1,
+                'dynamic closures must not be auto-packed')
+        assertEquals([2, 4, 6], eval(src, 'new Dyn().doubled([1, 2, 3])', true))
+    }
+}

--- a/src/test/groovy/org/codehaus/groovy/transform/PackedClosuresTransformTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/transform/PackedClosuresTransformTest.groovy
@@ -1,0 +1,359 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.transform
+
+import org.codehaus.groovy.control.CompilationUnit
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import org.codehaus.groovy.control.Phases
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * Tests for {@link groovy.transform.PackedClosures}: eligible closure literals are
+ * hoisted into synthetic methods on the enclosing class and replaced by a single shared
+ * {@code PackedClosure} adapter, so no per-closure inner class is generated. Ineligible
+ * closures are left exactly as they are today.
+ */
+final class PackedClosuresTransformTest {
+
+    /** Compiles the source and returns the sorted names of every generated class. */
+    private static List<String> generatedClassNames(String src) {
+        def cu = new CompilationUnit(new CompilerConfiguration())
+        cu.addSource('Sample.groovy', src)
+        cu.compile(Phases.CLASS_GENERATION)
+        cu.classes.collect { it.name }.sort()
+    }
+
+    private static int closureClassCount(List<String> names) {
+        names.count { it.contains('_closure') }
+    }
+
+    /** Evaluates the source (which must end by yielding an instance) and returns it. */
+    private static Object instance(String src) {
+        new GroovyShell().evaluate(src)
+    }
+
+    private static final String SAMPLE = '''
+        @groovy.transform.PackedClosures
+        class Sample {
+            String simple()          { [1, 2, 3].collect { it * 2 }.join(',') }
+            String nested(Map m) {
+                def out = []
+                m.each { k, v -> [1, 2].each { i -> out << "${k}${v}${i}".toString() } }
+                out.join(',')
+            }
+            int readCapture(List<Integer> xs, int base) { (xs.collect { it + base }.sum()) as int }
+        }
+    '''
+
+    @Test
+    void eligibleClosuresGenerateNoClosureClasses() {
+        def names = generatedClassNames(SAMPLE)
+        // Without @PackedClosures this same source produces 4 closure classes, including the
+        // deeply-nested Sample$_nested_closure2$_closure4.
+        assertEquals(['Sample'], names, "only the owner class should be generated, got: $names")
+        assertEquals(0, closureClassCount(names))
+    }
+
+    @Test
+    void packedClosuresBehaveIdenticallyToPlainOnes() {
+        def plain = instance(SAMPLE.replace('@groovy.transform.PackedClosures', '') + '\n new Sample()')
+        def packed = instance(SAMPLE + '\n new Sample()')
+
+        assertEquals(plain.simple(), packed.simple())
+        assertEquals('2,4,6', packed.simple())
+
+        assertEquals(plain.nested([a: 1, b: 2]), packed.nested([a: 1, b: 2]))
+        assertEquals('a11,a12,b21,b22', packed.nested([a: 1, b: 2])) // nested closures + captured k, v
+
+        assertEquals(plain.readCapture([10, 20, 30], 5), packed.readCapture([10, 20, 30], 5))
+        assertEquals(75, packed.readCapture([10, 20, 30], 5)) // captured 'base' read by value
+    }
+
+    @Test
+    void writerModePacksMemoizeAndCapturedWriteButDeclinesDelegate() {
+        // Each class mixes an always-eligible closure with a second one. In the writer path a
+        // captured write is packed by threading a Reference, and memoize/curry operate on the shared
+        // adapter (a real Closure), so those pack too - only a closure that needs a real delegate is
+        // declined and kept as a class. Behavior is unchanged in every case.
+        def cases = [
+            [name: 'delegate (declines: needs a real delegate)',
+             keptClasses: 1,
+             src : '''@groovy.transform.PackedClosures
+                      class X {
+                        def eligible()   { [1, 2].collect { it + 1 } }
+                        def ineligible() { def sb = new StringBuilder(); def c = { delegate.append('hi') }
+                                           c.delegate = sb; c(); sb.toString() }
+                      }''',
+             expect: 'hi'],
+            [name: 'memoize (packs: adapter is a real Closure)',
+             keptClasses: 0,
+             src : '''@groovy.transform.PackedClosures
+                      class X {
+                        def eligible()   { [1, 2].collect { it + 1 } }
+                        def ineligible() { def c = { int n -> n * n }.memoize(); c(3) + c(3) }
+                      }''',
+             expect: 18],
+            [name: 'capturedWrite (packs: Reference-threaded)',
+             keptClasses: 0,
+             src : '''@groovy.transform.PackedClosures
+                      class X {
+                        def eligible()   { [1, 2].collect { it + 1 } }
+                        def ineligible() { int total = 0; [1, 2, 3].each { total += it }; total }
+                      }''',
+             expect: 6],
+        ]
+        cases.each { c ->
+            def names = generatedClassNames(c.src)
+            assertEquals(c.keptClasses, closureClassCount(names), "[${c.name}] closure classes kept: $names")
+            def obj = instance(c.src + '\n new X()')
+            assertEquals([2, 3], obj.eligible(), "[${c.name}] eligible closure result")
+            assertEquals(c.expect, obj.ineligible(), "[${c.name}] second closure result")
+        }
+    }
+
+    @Test
+    void escapingClosuresAreDeclinedAtCompileTime() {
+        // A packed closure is bound to the owner; a shared adapter fails fast if a delegate is later
+        // set on it. To avoid that surprise for the clearest cases, a closure that visibly escapes the
+        // method - stored into a field/property/index, returned, appended, or placed in a collection
+        // literal - is declined at compile time and kept as a normal closure class. Owner-local,
+        // non-escaping closures still pack. Behavior is unchanged either way.
+        String src = '''@groovy.transform.PackedClosures
+            class E {
+                Closure field
+                void toProperty(Map attrs) { attrs.optionValue = { it * 2 } }   // property/index store
+                void toField()             { field = { it + 1 } }               // field store
+                Closure returned()         { return { it - 1 } }                // returned
+                void appended(List sink)   { sink << { it } }                   // appended
+                int usesEach(List xs)      { int t = 0; xs.each { t += it }; t } // owner-local -> packs
+                List maps(List xs)         { xs.collect { it * 3 } }            // owner-local -> packs
+            }'''
+        def names = generatedClassNames(src)
+        // the four escaping closures are kept as classes; the two owner-local ones are packed away
+        assertEquals(4, closureClassCount(names), "escaping closures should be declined: $names")
+
+        def e = instance(src + '\n new E()')
+        def attrs = [:]; e.toProperty(attrs)
+        assertEquals(42, attrs.optionValue(21))      // declined closure still works
+        assertEquals(9, e.returned()(10))
+        assertEquals(6, e.usesEach([1, 2, 3]))       // packed closure still works
+        assertEquals([3, 6, 9], e.maps([1, 2, 3]))
+    }
+
+    /**
+     * Under {@code @CompileStatic} the transform applies a cast-to-context heuristic: the hoisted
+     * method is marked {@code @CompileStatic(SKIP)} (so its Object-typed body is checked dynamically),
+     * and where a packed result flows into a syntactically-declared target — a typed method return or
+     * a typed local declaration — the result is cast to that type so static type checking still infers
+     * correctly (e.g. {@code collect(...)} → {@code List<Integer>}). This covers a large fraction of
+     * real usage; the boundary is exercised by {@link #compileStaticBoundaryHasNoDeclaredTarget}.
+     */
+    @Test
+    void compileStaticPacksResultsWithDeclaredTargets() {
+        String src = '''import groovy.transform.CompileStatic
+            @CompileStatic
+            @groovy.transform.PackedClosures
+            class S {
+                List<Integer> doubled(List<Integer> xs)     { xs.collect { Integer it -> it * 2 } }          // implicit-return target
+                List<String>  tag(List<Integer> xs, String p){ xs.collect { Integer n -> p + n } }
+                String        join(List<Integer> xs)        { List<String> ss = xs.collect { Integer it -> "v$it".toString() }; ss.join(',') } // typed-local target
+                int           total(List<Integer> xs, int base){ int t = 0; xs.each { t += it + base }; t }   // captured write, packed via Reference
+            }'''
+        // every closure packs, including the captured-write one (Reference-threaded): no class remains
+        assertEquals(['S'], generatedClassNames(src))
+
+        def s = instance(src + '\n new S()')
+        assertEquals([2, 4, 6], s.doubled([1, 2, 3]))
+        assertEquals(['x1', 'x2'], s.tag([1, 2], 'x'))
+        assertEquals('v1,v2,v3', s.join([1, 2, 3]))
+        assertEquals(36, s.total([1, 2, 3], 10))
+    }
+
+    /**
+     * A packed result passed straight into a typed argument (no syntactic target declaration). The
+     * writer path infers through the {@code collect(...)} call, so this shape packs and behaves
+     * correctly. It is kept as a regression guard: the general {@code @CompileStatic} soundness story
+     * (reading already-computed inferred types rather than a cast-to-context heuristic) is still the
+     * Groovy 7 work per GEP-27, but this common no-declared-target shape must not regress into a
+     * compile error.
+     */
+    @Test
+    void compileStaticPacksResultPassedAsArgument() {
+        String passedAsArg = '''import groovy.transform.CompileStatic
+            @CompileStatic
+            @groovy.transform.PackedClosures
+            class Z {
+                int need(List<Integer> ys) { ys.sum() as int }
+                int m(List<Integer> xs)    { need(xs.collect { Integer it -> it * 2 }) }
+            }'''
+        assertEquals(['Z'], generatedClassNames(passedAsArg))   // closure packs, no class remains
+        assertEquals(12, instance(passedAsArg + '\n new Z()').m([1, 2, 3]))
+    }
+
+    /**
+     * The non-{@code @CompileStatic} counterpart to the two {@code compileStatic*} tests above (the
+     * {@code SAMPLE}-based tests already cover dynamic compilation generally). The same owner-local
+     * closure shapes — a returned result, a result passed straight as an argument, and a captured
+     * write — also pack under dynamic compilation via the {@code @PackedClosures} trust path, leaving
+     * no closure class and behaving identically.
+     */
+    @Test
+    void dynamicCompilationPacksTheSameClosureShapes() {
+        String src = '''@groovy.transform.PackedClosures
+            class D {
+                def doubled(List xs)         { xs.collect { it * 2 } }                    // result returned
+                int need(List ys)            { ys.sum() }
+                int passedAsArg(List xs)     { need(xs.collect { it * 2 }) }              // result passed as arg
+                int total(List xs, int base) { int t = 0; xs.each { t += it + base }; t } // captured write
+            }'''
+        assertEquals(['D'], generatedClassNames(src), 'every closure should pack: no class remains')
+        def d = instance(src + '\n new D()')
+        assertEquals([2, 4, 6], d.doubled([1, 2, 3]))
+        assertEquals(12, d.passedAsArg([1, 2, 3]))
+        assertEquals(36, d.total([1, 2, 3], 10))
+    }
+
+    @Test
+    void inheritedPackedClosureResolvesToItsOwnDeclaringClass() {
+        // A superclass's packed closure must not dispatch to a same-named hoisted method that a
+        // subclass happens to declare (GROOVY-12151 review): the adapter's MethodHandle is an
+        // invokespecial constant bound to the exact private method, so it is invoked exactly, not
+        // virtually. Both classes' first packed closure is $packed$closure$0, so a naive by-name
+        // resolution on the runtime class would run B's body for A's closure.
+        String src = '''@groovy.transform.PackedClosures
+            class A { def foo() { [1].collect { it + 1 } } }
+            @groovy.transform.PackedClosures
+            class B extends A { def bar() { [1].collect { it + 100 } } }'''
+        def b = instance(src + '\n new B()')
+        assertEquals([2], b.foo())    // A's closure body (it + 1), not B's (it + 100)
+        assertEquals([101], b.bar())
+    }
+
+    @Test
+    void capturedLocalShadowingAFieldIsReboundToTheLocalNotTheField() {
+        // The captured 'base' is a local that shadows the field of the same name (the one form of
+        // shadowing Groovy allows). Rebinding matches the captured variable by identity, so the
+        // hoisted method reads the captured local, not the field.
+        String src = '''@groovy.transform.PackedClosures
+            class C {
+                int base = 999
+                List m() { int base = 100; [1, 2].collect { it + base } }
+            }'''
+        assertEquals(['C'], generatedClassNames(src))          // the closure packs (no closure class)
+        assertEquals([101, 102], instance(src + '\n new C()').m())  // captured local 100, not field 999
+    }
+
+    /** Source with one closure that packs and one that declines (a with{} delegate DSL), at the given mode. */
+    private static String modeSrc(String mode) {
+        """import groovy.transform.CompileStatic
+           import groovy.transform.PackedClosures
+           import groovy.transform.PackedClosures.PackMode
+           @CompileStatic @PackedClosures(mode = PackMode.$mode)
+           class M {
+               List<String> ok(List<String> xs) { xs.collect { String s -> s.toUpperCase() } }
+               String dsl() { new StringBuilder().with { append('x'); toString() } }
+           }"""
+    }
+
+    /** Compiles the source and returns its collected warnings, or throws on a compile error. */
+    private static List warnings(String src) {
+        def cu = new CompilationUnit(new CompilerConfiguration())
+        cu.addSource('M.groovy', src)
+        cu.compile(Phases.CLASS_GENERATION)
+        cu.errorCollector.warnings ?: []
+    }
+
+    @Test
+    void modeLenientIsSilent() {
+        assertEquals(0, warnings(modeSrc('LENIENT')).size(), 'LENIENT must not warn on a decline')
+    }
+
+    @Test
+    void modeWarnReportsEachDeclineWithReason() {
+        def ws = warnings(modeSrc('WARN'))
+        assertEquals(1, ws.size(), "expected one warning for the declined with{} closure, got: ${ws*.message}")
+        assertTrue(ws[0].message.contains('not packed') && ws[0].message.contains('delegate'),
+                "warning should name the reason: ${ws[0].message}")
+    }
+
+    @Test
+    void modeStrictFailsCompilationOnADecline() {
+        def e = assertThrows(MultipleCompilationErrorsException) { warnings(modeSrc('STRICT')) }
+        assertTrue(e.message.contains('not packed'), "error should explain the decline: $e.message")
+    }
+
+    @Test
+    void modeAppliesOnlyToTheAnnotation_flagPathStaysLenient() {
+        // same declining closure, but driven by the flag with no annotation -> no diagnostics
+        String src = '''import groovy.transform.CompileStatic
+            @CompileStatic
+            class F { String dsl() { new StringBuilder().with { append('x'); toString() } } }'''
+        String prev = System.getProperty('groovy.target.closure.pack')
+        System.setProperty('groovy.target.closure.pack', 'true')
+        try {
+            assertEquals(0, warnings(src).size(), 'the automatic flag path must stay lenient (no warnings)')
+        } finally {
+            if (prev != null) System.setProperty('groovy.target.closure.pack', prev)
+            else System.clearProperty('groovy.target.closure.pack')
+        }
+    }
+
+    @Test
+    void modeDisabledMethodOptsOutOfAPackedClass() {
+        // the class opts in, but the DISABLED method is excluded -- most-specific wins
+        String src = '''import groovy.transform.CompileStatic
+            import groovy.transform.PackedClosures
+            import groovy.transform.PackedClosures.PackMode
+            @CompileStatic @PackedClosures
+            class C {
+                List<String> a(List<String> xs) { xs.collect { String s -> s.toUpperCase() } }
+                @PackedClosures(mode = PackMode.DISABLED)
+                List<String> b(List<String> xs) { xs.collect { String s -> s.toLowerCase() } }
+            }'''
+        // a() packs (no class); only b()'s closure remains
+        assertEquals(1, closureClassCount(generatedClassNames(src)),
+                'only the DISABLED method should keep its closure class')
+        def c = instance(src + '\n new C()')
+        assertEquals(['X'], c.a(['x']))
+        assertEquals(['x'], c.b(['X']))
+    }
+
+    @Test
+    void modeDisabledOverridesTheAutomaticFlag() {
+        String src = '''import groovy.transform.CompileStatic
+            import groovy.transform.PackedClosures
+            import groovy.transform.PackedClosures.PackMode
+            @CompileStatic @PackedClosures(mode = PackMode.DISABLED)
+            class C { List<String> a(List<String> xs) { xs.collect { String s -> s.toUpperCase() } } }'''
+        String prev = System.getProperty('groovy.target.closure.pack')
+        System.setProperty('groovy.target.closure.pack', 'true')
+        try {
+            assertEquals(1, closureClassCount(generatedClassNames(src)),
+                    'DISABLED must override the flag: the closure stays a class')
+        } finally {
+            if (prev != null) System.setProperty('groovy.target.closure.pack', prev)
+            else System.clearProperty('groovy.target.closure.pack')
+        }
+    }
+}

--- a/subprojects/groovy-console/src/test/groovy/groovy/console/ui/AstNodeToScriptAdapterTest.groovy
+++ b/subprojects/groovy-console/src/test/groovy/groovy/console/ui/AstNodeToScriptAdapterTest.groovy
@@ -1367,4 +1367,22 @@ b $$v"""/$,
         // the closure class does not exist yet, so nothing is rendered
         assert !compileToScript(script, CompilePhase.SEMANTIC_ANALYSIS).contains('/* => ')
     }
+
+    @Test
+    void testPackedClosureShowsHoistedMethodInsteadOfClass() {
+        String script = '''
+            @groovy.transform.PackedClosures
+            class Demo {
+                def packs() { [1, 2].each { it * 2 } }
+                def declines() { [1, 2].each { delegate.hashCode() } }
+            }
+        '''
+        String result = compileToScript(script, CompilePhase.CLASS_GENERATION)
+
+        // a packed closure has no generated class, so it is marked with the hoisted method it became
+        // (trailing () distinguishes it from a class); a closure that declines packing (here, because
+        // it uses delegate) keeps its generated closure class and is marked with that name
+        assert result.contains('/* => Demo.$packed$closure$0() */')
+        assert result.contains('/* => Demo$_declines_closure1 */')
+    }
 }


### PR DESCRIPTION
…edClosures/flag off by default (GEP-27 S1)

Add closure packing on top of the SAM-lambda hoisting: an eligible closure literal's body is hoisted into a synthetic method on the enclosing class and the literal is replaced by a shared PackedClosure adapter, removing the per-closure generated class (and the nested $_closure1$_closure2 name explosion) while the value stays a real groovy.lang.Closure.

Capability analysis (PackStrategy, ClosureWriter.chooseStrategy):
- a single decision point selects FULL_CLASS (S0) vs PACKED_ADAPTER (S1);
- triggered by the @PackedClosures annotation (trust path, dynamic or static), or automatically under @CompileStatic when the type checker PROVES the closure delegate-independent -- every implicitly-received name resolved against the owner, read from STC's IMPLICIT_RECEIVER paths (a path ending in "owner" is safe; "delegate", from @DelegatesTo/with, is not). Behind groovy.target.closure.pack.

Typed static dispatch (phase 4): the hoisted body reuses the expressions StaticCompilationVisitor already annotated, so under @CompileStatic it compiles statically -- read-only captures pass as typed leading parameters, inferred types (@ClosureParams, implicit it) arrive via metadata, and the method takes the closure's inferred return type. Packed bodies are statically dispatched with zero invokedynamic, often fewer indy sites than a closure class (which Reference-boxes captures as Object).

Written captures ride the compiler's holder machinery: the shared Reference is passed as a parameter (originType/closure-shared/UseExistingReference), so the body is not rewritten, compiles statically, and supports every write form (compound ops beyond +=, postfix value semantics).

Soundness for the dynamic trust path:
- PackedClosure runtime guard fails fast if a delegate / delegate-consulting resolveStrategy is set on a trust-packed closure; a statically proven closure tolerates it as a no-op (as a @CompileStatic closure class does today);
- compile-time escape decline keeps closures that visibly escape (stored to a field/property, returned, appended, in a collection literal) as classes.

Mechanism fidelity so a packed closure behaves like a generated closure class: correct owner/static dispatch in static methods; getParameterTypes() carries the real declared types; arguments are adapted as reflective dispatch would (vararg collection, single List/Tuple destructuring, per-arg coercion Closure->SAM and GString->String); call() dispatches straight to doCall with invoker-exception unwrapping; dispatch via a cached reflective Method (metaclass coercion would auto-dereference Reference holder arguments).

ClassNode.visitMethods: dedup newly-added methods by identity via an IdentityHashMap set (O(1)) instead of ArrayList.removeAll (O(n^2)). Visiting a method during code generation can add more (constructor-ref synthetic, lambda $deserializeLambda$, a hoisted body that hoists a nested one); the O(1) fixpoint visits them all and fixes a compile-time freeze the O(n^2) scan caused against method-generating visitors (e.g. groovy-contracts).

Tests: ClosurePackCapabilityTest and PackedClosuresTransformTest (proof, declines, auto-pack, zero-indy typed bodies, write forms, destructuring). Flag-on stress net 0 failures across LambdaTest + all *Closure*/*DelegatesTo* static-compile suites + ReproducibleBytecodeBugs; flag-off byte-identical (778 green); groovy-contracts compiles and tests clean.