### PR TITLE
GROOVY-12154: box primitive lambda param when the target SAM param is…

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/AbstractFunctionalInterfaceWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/AbstractFunctionalInterfaceWriter.java
@@ -153,12 +153,18 @@ public interface AbstractFunctionalInterfaceWriter {
 
         ClassNode type;
         if (isPrimitiveType(parameterType)) {
-            if (!isPrimitiveType(inferredType)) {
-                // The non-primitive type and primitive type are not allowed to mix since Java 9+
-                // java.lang.invoke.LambdaConversionException: Type mismatch for instantiated parameter 0: class java.lang.Integer is not a subtype of int
-                type = getUnwrapper(inferredType).getPlainNodeReference(false);
+            // The lambda parameter is declared with a primitive type; reduce the inferred type to it.
+            ClassNode primitive = isPrimitiveType(inferredType) ? inferredType : getUnwrapper(inferredType);
+            if (isPrimitiveType(targetType)) {
+                // The functional-interface parameter is itself primitive, so the implementation method
+                // stays primitive (GROOVY-9790: otherwise "Integer is not a subtype of int").
+                type = primitive.getPlainNodeReference(false);
             } else {
-                type = inferredType.getPlainNodeReference(false);
+                // GROOVY-12154: the functional-interface parameter is a reference type, so the
+                // implementation method must accept the BOXED type -- LambdaMetafactory links against
+                // the erased SAM signature (Object) and will not unbox to a primitive
+                // (java.lang.invoke.LambdaConversionException: int is not a subtype of class java.lang.Object).
+                type = getWrapper(primitive).getPlainNodeReference();
             }
         } else if (isPrimitiveType(inferredType)) {
             // GROOVY-9790: bootstrap method initialization exception raised when lambda parameter type is wrong

--- a/src/test/groovy/bugs/Groovy12154.groovy
+++ b/src/test/groovy/bugs/Groovy12154.groovy
@@ -1,0 +1,112 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bugs
+
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+final class Groovy12154 {
+
+    // A lambda with a primitive-typed parameter targeting a generic functional interface used to
+    // compile cleanly but throw at runtime (LambdaConversionException: int is not a subtype of
+    // class java.lang.Object), because the implementation method kept the primitive parameter type
+    // while LambdaMetafactory links against the erased (reference) SAM signature.
+
+    @Test
+    void testPrimitiveParamTargetingGenericSam() {
+        assertScript '''
+            import java.util.function.Function
+            @groovy.transform.CompileStatic
+            class T {
+                Function<Integer, Integer> f = (int a) -> a * 2
+                Integer m() { f.apply(5) }
+            }
+            assert new T().m() == 10
+        '''
+    }
+
+    @Test
+    void testMultiplePrimitiveParamsTargetingGenericSam() {
+        assertScript '''
+            import java.util.function.BiFunction
+            @groovy.transform.CompileStatic
+            class T {
+                BiFunction<Integer, Integer, Integer> f = (int a, int b) -> a + b
+                List m() { [f.apply(1, 2), f.apply(5, 5)] }
+            }
+            assert new T().m() == [3, 10]
+        '''
+    }
+
+    @Test
+    void testPrimitiveParamWithDefaultTargetingGenericSam() {
+        assertScript '''
+            import java.util.function.BiFunction
+            @groovy.transform.CompileStatic
+            class T {
+                BiFunction<Integer, Integer, Integer> f = (int a, int b = 10) -> a + b
+                List m() { [f.apply(1, 2), f.apply(5, 5)] }
+            }
+            assert new T().m() == [3, 10]
+        '''
+    }
+
+    @Test
+    void testLongPrimitiveParamTargetingGenericSam() {
+        assertScript '''
+            import java.util.function.Function
+            @groovy.transform.CompileStatic
+            class T {
+                Function<Long, Long> f = (long a) -> a * 2L
+                Long m() { f.apply(5L) }
+            }
+            assert new T().m() == 10L
+        '''
+    }
+
+    // Regressions: a primitive-parameter functional interface must still use a primitive impl param.
+
+    @Test
+    void testPrimitiveParamTargetingPrimitiveSam() {
+        assertScript '''
+            import java.util.function.IntUnaryOperator
+            @groovy.transform.CompileStatic
+            class T {
+                IntUnaryOperator f = (int a) -> a * 2
+                int m() { f.applyAsInt(5) }
+            }
+            assert new T().m() == 10
+        '''
+    }
+
+    @Test
+    void testUntypedAndBoxedParamsUnaffected() {
+        assertScript '''
+            import java.util.function.Function
+            @groovy.transform.CompileStatic
+            class T {
+                Function<Integer, Integer> u = (a) -> a * 2
+                Function<Integer, Integer> b = (Integer a) -> a * 2
+                List m() { [u.apply(5), b.apply(5)] }
+            }
+            assert new T().m() == [10, 10]
+        '''
+    }
+}


### PR DESCRIPTION
… a reference type

A @CompileStatic lambda declaring a primitive parameter (e.g. (int a) -> ...) against a generic functional interface (e.g. Function<Integer,Integer>) compiled cleanly but threw at runtime:

  java.lang.invoke.LambdaConversionException:
    int is not a subtype of class java.lang.Object

AbstractFunctionalInterfaceWriter.convertParameterType always emitted a primitive implementation-method parameter when the lambda declared a primitive, ignoring the target (functional-interface) parameter type. But LambdaMetafactory links against the erased SAM signature (Object) and will not unbox to a primitive, so the implementation method must accept the boxed type when the SAM parameter is a reference type. It stays primitive only when the SAM parameter is itself primitive (e.g. IntUnaryOperator), preserving GROOVY-9790.