### PR TITLE
fix concurrent modification of ExpandoMetaClass mixinClasses

### DIFF
--- a/src/main/java/groovy/lang/ExpandoMetaClass.java
+++ b/src/main/java/groovy/lang/ExpandoMetaClass.java
@@ -49,11 +49,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -298,7 +298,7 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     private final Map<String, Object> expandoSubclassMethods = new ConcurrentHashMap<>(16, 0.75f, 1);
     private final Map<String, MetaProperty> expandoProperties = new ConcurrentHashMap<>(16, 0.75f, 1);
     private ClosureStaticMetaMethod invokeStaticMethodMethod;
-    private final Set<MixinInMetaClass> mixinClasses = new LinkedHashSet<>();
+    private final Set<MixinInMetaClass> mixinClasses = new CopyOnWriteArraySet<>();
 
     /**
      * Creates an expando meta class with explicit registry behaviour and additional methods.

--- a/src/test/groovy/groovy/lang/ExpandoMetaClassMixinConcurrencyTest.groovy
+++ b/src/test/groovy/groovy/lang/ExpandoMetaClassMixinConcurrencyTest.groovy
@@ -1,0 +1,90 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.lang
+
+import org.codehaus.groovy.reflection.MixinInMetaClass
+import org.junit.jupiter.api.Test
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.atomic.AtomicBoolean
+
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+final class ExpandoMetaClassMixinConcurrencyTest {
+
+    static class Target {}
+
+    // Adding a mixin (addMixinClass) mutates the backing mixin set while method
+    // dispatch iterates it (findMixinMethod). The set must tolerate that; a plain
+    // LinkedHashSet threw ConcurrentModificationException from the dispatching thread.
+    @Test
+    void mixinAddIsSafeAgainstConcurrentDispatch() {
+        def loader = new GroovyClassLoader()
+        // distinct category classes so every mixin is a fresh structural add
+        def categories = (0..<160).collect { i ->
+            loader.parseClass("class Cat_${i} { def catMethod_${i}() { 'x' } }", "Cat_${i}.groovy")
+        }
+
+        def emc = new ExpandoMetaClass(Target, false, true)
+        emc.initialize()
+
+        // pre-grow the set so each iteration spans a wide window
+        (0..<40).each { MixinInMetaClass.mixinClassesToMetaClass(emc, [categories[it]]) }
+
+        def errors = new CopyOnWriteArrayList<Throwable>()
+        def stop = new AtomicBoolean(false)
+        def emptyArgs = new Class[0]
+        def barrier = new CyclicBarrier(5)
+
+        def readers = (1..4).collect {
+            Thread.start {
+                try {
+                    barrier.await()
+                    while (!stop.get()) {
+                        emc.findMixinMethod('noSuchMixinMethod', emptyArgs)
+                    }
+                } catch (Throwable t) {
+                    errors << t
+                } finally {
+                    stop.set(true)
+                }
+            }
+        }
+        def writer = Thread.start {
+            try {
+                barrier.await()
+                for (int i = 40; i < categories.size() && !stop.get(); i++) {
+                    MixinInMetaClass.mixinClassesToMetaClass(emc, [categories[i]])
+                }
+            } catch (Throwable t) {
+                errors << t
+            } finally {
+                stop.set(true)
+            }
+        }
+
+        writer.join()
+        stop.set(true)
+        readers*.join()
+
+        assertTrue(errors.isEmpty(),
+                "concurrent mixin add during dispatch iteration threw: ${errors.isEmpty() ? '' : errors.first()}")
+    }
+}


### PR DESCRIPTION
Repro: on one thread call metaClass.mixin(someCategory) while another thread dispatches a method on the same class, so findMixinMethod iterates mixinClasses while addMixinClass adds to it.
Cause: mixinClasses is a plain LinkedHashSet with no locking, while every other backing collection in ExpandoMetaClass is a ConcurrentHashMap held alongside the read/write lock. A structural add during iteration throws ConcurrentModificationException in the dispatching thread.
Fix: keep the mixins in a CopyOnWriteArraySet, which is safe for concurrent read-while-modify and preserves insertion order plus the boolean add() dedup that GROOVY-11775 depends on.

Verified with a new test that throws ConcurrentModificationException on the old set and passes with the change; the existing mixin and ExpandoMetaClass suites stay green.