### PR TITLE
wrap malformed json number decode in JsonException

### DIFF
--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharScanner.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/CharScanner.java
@@ -499,16 +499,20 @@ public class CharScanner {
 
         final int length = index - from;
 
-        if (!foundDot && simple) {
-            if (isInteger(buffer, from, length)) {
-                value = parseIntFromTo(buffer, from, index);
-            } else if (isLong(buffer, from, length)) {
-                value = parseLongFromTo(buffer, from, index);
+        try {
+            if (!foundDot && simple) {
+                if (isInteger(buffer, from, length)) {
+                    value = parseIntFromTo(buffer, from, index);
+                } else if (isLong(buffer, from, length)) {
+                    value = parseLongFromTo(buffer, from, index);
+                } else {
+                    value = new BigInteger(new String(buffer, from, length));
+                }
             } else {
-                value = new BigInteger(new String(buffer, from, length));
+                value = new BigDecimal(buffer, from, length);
             }
-        } else {
-            value = new BigDecimal(buffer, from, length);
+        } catch (NumberFormatException e) {
+            return handle(Number.class, "unable to parse number: " + new String(buffer, from, length), e);
         }
 
         if (size != null) {

--- a/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserUsingCharacterSource.java
+++ b/subprojects/groovy-json/src/main/java/org/apache/groovy/json/internal/JsonParserUsingCharacterSource.java
@@ -149,14 +149,18 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
         char[] chars = characterSource.readNumber();
         Object value;
 
-        if (CharScanner.hasDecimalChar(chars, negative)) {
-            value = CharScanner.parseBigDecimal(chars);
-        } else if (CharScanner.isInteger(chars)) {
-            value = CharScanner.parseInt(chars);
-        } else if (CharScanner.isLong(chars)) {
-            value = CharScanner.parseLong(chars);
-        } else {
-            value = new BigInteger(new String(chars));
+        try {
+            if (CharScanner.hasDecimalChar(chars, negative)) {
+                value = CharScanner.parseBigDecimal(chars);
+            } else if (CharScanner.isInteger(chars)) {
+                value = CharScanner.parseInt(chars);
+            } else if (CharScanner.isLong(chars)) {
+                value = CharScanner.parseLong(chars);
+            } else {
+                value = new BigInteger(new String(chars));
+            }
+        } catch (NumberFormatException e) {
+            throw new JsonException("unable to parse number: " + new String(chars), e);
         }
 
         return value;

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperMalformedNumberTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperMalformedNumberTest.groovy
@@ -1,0 +1,78 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.json
+
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.shouldFail
+
+/**
+ * A leading digit or minus makes the parser enter number decoding, but a malformed exponent or a
+ * lone sign/point is only rejected when the token is finally handed to {@code new BigDecimal(...)}.
+ * The overlay parsers already wrap that {@link NumberFormatException} in a {@link JsonException}
+ * (see {@code NumberValue.bigDecimalValue}), but the default CHAR_BUFFER path
+ * ({@code CharScanner.parseJsonNumber}) and the CHARACTER_SOURCE path
+ * ({@code JsonParserUsingCharacterSource.decodeNumber}) let it escape raw, so a caller guarding
+ * untrusted input with {@code catch (JsonException)} would not catch it.
+ */
+class JsonSlurperMalformedNumberTest {
+
+    // Each starts with a digit or '-' so number decoding begins, but the token is not a valid number.
+    private static final List<String> MALFORMED = ['1e', '1E', '1e+', '1e-', '-.', '[1e]', '{"a":1e}']
+
+    @Test
+    void testDefaultParserRejectsMalformedNumber() {
+        // The default (CHAR_BUFFER) parser decodes numbers eagerly, so this used to throw
+        // NumberFormatException; it must now fail as a JsonException.
+        MALFORMED.each { doc ->
+            shouldFail(JsonException) {
+                new JsonSlurper().parseText(doc)
+            }
+        }
+    }
+
+    @Test
+    void testNoParserTypeLeaksNumberFormatError() {
+        // The security-relevant invariant: no parser type may surface a raw number-format error for
+        // this malformed input; it must be a JsonException or a value, never a NumberFormatException.
+        JsonParserType.values().each { type ->
+            MALFORMED.each { doc ->
+                def thrown = null
+                try {
+                    // toJson forces the lazy overlay parsers to materialize (decode) their values.
+                    JsonOutput.toJson(new JsonSlurper().setType(type).parseText(doc))
+                } catch (Throwable t) {
+                    thrown = t
+                }
+                assert !(thrown instanceof NumberFormatException),
+                        "$type leaked ${thrown.getClass().name} for '$doc'"
+            }
+        }
+    }
+
+    @Test
+    void testValidNumbersStillDecodeForAllParserTypes() {
+        JsonParserType.values().each { type ->
+            def slurper = new JsonSlurper().setType(type)
+            assert slurper.parseText('{"k":12}').k == 12, "integer for $type"
+            assert slurper.parseText('{"k":1.5}').k == 1.5, "decimal for $type"
+            assert slurper.parseText('{"k":1.5e3}').k == 1500, "exponent for $type"
+        }
+    }
+}


### PR DESCRIPTION
1. A value that starts with a digit or minus enters number decoding, but a malformed exponent or a lone sign/point such as `1e`, `1e+`, `1E`, or `-.` is only rejected when the collected token reaches `new BigDecimal(...)`.
2. The INDEX_OVERLAY and LAX overlay parsers already wrap that `NumberFormatException` in a `JsonException` (`NumberValue.bigDecimalValue`), but the default CHAR_BUFFER parser (`CharScanner.parseJsonNumber`) and the CHARACTER_SOURCE parser (`JsonParserUsingCharacterSource.decodeNumber`) let it propagate unwrapped, so an application guarding untrusted JSON with `catch (JsonException)` sees a raw `NumberFormatException` instead.
3. Wrapped the numeric construction at both sites so malformed numbers surface as `JsonException`, matching the overlay parsers. Added a regression test that checks all four parser types.
