### PR TITLE
GROOVY-10687: complete NestMembers after class generation instead of …

### DIFF
--- a/src/main/java/groovy/lang/GroovyClassLoader.java
+++ b/src/main/java/groovy/lang/GroovyClassLoader.java
@@ -39,6 +39,7 @@ import org.codehaus.groovy.runtime.memoize.ConcurrentCommonCache;
 import org.codehaus.groovy.runtime.memoize.EvictableCache;
 import org.codehaus.groovy.runtime.memoize.FlexibleCache;
 import org.codehaus.groovy.runtime.memoize.UnlimitedConcurrentCache;
+import org.codehaus.groovy.tools.GroovyClass;
 import org.codehaus.groovy.util.URLStreams;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -269,8 +270,19 @@ public class GroovyClassLoader extends URLClassLoader {
             return n;
         }));
 
+        // GROOVY-10687: prefer bytes from the unit, where the NestMembers
+        // attribute of each nest host was completed after class generation
+        var unitClasses = new LinkedHashMap<String, GroovyClass>();
+        for (GroovyClass gc : collector.unit.getClasses()) {
+            unitClasses.put(gc.getName(), gc);
+        }
         for (ClassNode cn : classes) {
-            collector.call(generatedClasses.get(cn), cn);
+            GroovyClass gc = unitClasses.get(cn.getName());
+            if (gc != null) {
+                collector.createClass(gc.getBytes(), cn);
+            } else {
+                collector.call(generatedClasses.get(cn), cn);
+            }
         }
     }
 

--- a/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
+++ b/src/main/java/org/codehaus/groovy/classgen/AsmClassGenerator.java
@@ -26,7 +26,6 @@ import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
-import org.codehaus.groovy.ast.CodeVisitorSupport;
 import org.codehaus.groovy.ast.ConstructorNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.GenericsType;
@@ -133,7 +132,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 
 import static org.apache.groovy.ast.tools.ClassNodeUtils.getField;
@@ -141,7 +139,6 @@ import static org.apache.groovy.ast.tools.ClassNodeUtils.getNestHost;
 import static org.apache.groovy.ast.tools.ExpressionUtils.isNullConstant;
 import static org.apache.groovy.ast.tools.ExpressionUtils.isSuperExpression;
 import static org.codehaus.groovy.ast.ClassHelper.isClassType;
-import static org.codehaus.groovy.ast.ClassHelper.isFunctionalInterface;
 import static org.codehaus.groovy.ast.ClassHelper.isObjectType;
 import static org.codehaus.groovy.ast.ClassHelper.isPrimitiveBoolean;
 import static org.codehaus.groovy.ast.ClassHelper.isPrimitiveByte;
@@ -437,11 +434,9 @@ public class AsmClassGenerator extends ClassGenerator {
                     createSyntheticStaticFields();
                 }
             }
-            // GROOVY-10687
-            if (classNode.getOuterClass() == null && classNode.getInnerClasses().hasNext()) {
-                makeNestmateEntries(classNode);
-                moreNestmateEntries(classNode);
-            }
+            // GROOVY-10687: NestMembers of a nest host is completed by CompilationUnit
+            // once all of the host's classes -- including closure and anonymous inner
+            // classes materialized during bytecode generation -- have been generated
             // GROOVY-4649, GROOVY-6750, GROOVY-6808
             for (Iterator<InnerClassNode> it = classNode.getInnerClasses(); it.hasNext(); ) {
                 makeInnerClassEntry(it.next());
@@ -505,64 +500,6 @@ public class AsmClassGenerator extends ClassGenerator {
 
         int modifiers = adjustedClassModifiersForInnerClassTable(innerClass);
         classVisitor.visitInnerClass(innerClassInternalName, outerClassInternalName, innerClassName, modifiers);
-    }
-
-    private void makeNestmateEntries(final ClassNode classNode) {
-        for (Iterator<InnerClassNode> it = classNode.getInnerClasses(); it.hasNext(); ) {
-            ClassNode innerClass = it.next();
-            classVisitor.visitNestMember(BytecodeHelper.getClassInternalName(innerClass));
-            makeNestmateEntries(innerClass);
-        }
-    }
-
-    private void moreNestmateEntries(final ClassNode classNode) {
-        // edge case: nest host closures-within-closures
-        int[] n = {this.context.getClosureClassIndex()};
-        for (ClassNode innerClass : getInnerClasses()) {
-            if (innerClass instanceof InterfaceHelperClassNode) continue;
-            var toVisit = new TreeMap<String, ClosureExpression>(); // GROOVY-11780
-            var visitor = new CodeVisitorSupport() {
-                private String name = BytecodeHelper.getClassInternalName(innerClass);
-                private void visitNested(final String kind, final ClosureExpression expr) {
-                    String nest = name + "$_" + kind + n[0]++;
-                    classVisitor.visitNestMember(nest);
-                    toVisit.put(nest, expr);
-                }
-
-                /**
-                 * Registers nested closures as additional nest members.
-                 */
-                @Override
-                public  void visitClosureExpression(final ClosureExpression expression) {
-                    visitNested("closure", expression);
-                }
-
-                /**
-                 * Registers statically compiled functional-interface lambdas as nest members.
-                 */
-                @Override
-                public  void visitLambdaExpression(final LambdaExpression expression) {
-                    if (Boolean.TRUE.equals(innerClass.getNodeMetaData(org.codehaus.groovy.transform.sc.StaticCompilationMetadataKeys.STATIC_COMPILE_NODE))
-                            && isFunctionalInterface(expression.getNodeMetaData(org.codehaus.groovy.transform.stc.StaticTypesMarker.PARAMETER_TYPE))) {
-                        visitNested("lambda", expression);
-                    } else {
-                        super.visitLambdaExpression(expression);
-                    }
-                }
-            };
-
-            MethodNode doCall = innerClass.getMethods().get(0);
-            doCall.getCode().visit(visitor);
-
-            while (!toVisit.isEmpty()) {
-                var iter = toVisit.entrySet().iterator(); // take first entry
-                var next = iter.next();
-                iter.remove();
-
-                visitor.name = next.getKey(); // traverse
-                next.getValue().getCode().visit(visitor);
-            }
-        }
     }
 
     /*

--- a/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
@@ -23,14 +23,12 @@ import groovy.lang.GroovyRuntimeException;
 import groovy.transform.CompilationUnitAware;
 import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.ast.AnnotationNode;
-import org.codehaus.groovy.ast.ClassCodeVisitorSupport;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.CompileUnit;
 import org.codehaus.groovy.ast.GroovyClassVisitor;
 import org.codehaus.groovy.ast.InnerClassNode;
 import org.codehaus.groovy.ast.ModuleNode;
-import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.classgen.AsmClassGenerator;
 import org.codehaus.groovy.classgen.ClassCompletionVerifier;
 import org.codehaus.groovy.classgen.EnumCompletionVisitor;
@@ -51,6 +49,7 @@ import org.codehaus.groovy.tools.GroovyClass;
 import org.codehaus.groovy.transform.ASTTransformationVisitor;
 import org.codehaus.groovy.transform.AnnotationCollectorTransform;
 import org.codehaus.groovy.transform.trait.TraitComposer;
+import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
@@ -58,7 +57,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serial;
 import java.net.URL;
 import java.security.CodeSource;
 import java.util.ArrayList;
@@ -67,6 +65,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -306,6 +305,17 @@ public class CompilationUnit extends ProcessingUnit {
         addPhaseOperation(verification, Phases.CLASS_GENERATION);
 
         addPhaseOperation(classgen, Phases.CLASS_GENERATION);
+
+        addPhaseOperation((final SourceUnit source) -> {
+            // GROOVY-10687: nest members include closure and anonymous inner classes
+            // materialized while bytecode is generated, so the NestMembers attribute
+            // of each nest host is completed once all of its classes are generated
+            for (ClassNode classNode : source.getAST().getClasses()) {
+                if (classNode.getOuterClass() == null && classNode.getInnerClasses().hasNext()) {
+                    addNestMembers(classNode);
+                }
+            }
+        }, Phases.CLASS_GENERATION);
 
         addPhaseOperation(groovyClass -> {
             String name = groovyClass.getName().replace('.', File.separatorChar) + ".class";
@@ -1139,6 +1149,46 @@ public class CompilationUnit extends ProcessingUnit {
         return count;
     }
 
+    private void addNestMembers(final ClassNode host) {
+        List<String> members = new ArrayList<>();
+        collectNestMembers(host, members);
+        for (int i = 0, n = generatedClasses.size(); i < n; i += 1) {
+            GroovyClass groovyClass = generatedClasses.get(i);
+            if (groovyClass.getName().equals(host.getName())) {
+                generatedClasses.set(i, new GroovyClass(groovyClass.getName(), addNestMembers(groovyClass.getBytes(), members)));
+                break;
+            }
+        }
+    }
+
+    private static void collectNestMembers(final ClassNode classNode, final List<String> names) {
+        for (Iterator<InnerClassNode> it = classNode.getInnerClasses(); it.hasNext(); ) {
+            ClassNode innerClass = it.next();
+            names.add(innerClass.getName().replace('.', '/'));
+            collectNestMembers(innerClass, names);
+        }
+    }
+
+    private static byte[] addNestMembers(final byte[] bytes, final List<String> members) {
+        ClassReader reader = new ClassReader(bytes);
+        ClassWriter writer = new ClassWriter(0);
+        reader.accept(new ClassVisitor(CompilerConfiguration.ASM_API_VERSION, writer) {
+            private final Set<String> seen = new LinkedHashSet<>();
+            @Override
+            public void visitNestMember(final String nestMember) {
+                if (seen.add(nestMember)) super.visitNestMember(nestMember);
+            }
+            @Override
+            public void visitEnd() {
+                for (String member : members) {
+                    if (seen.add(member)) super.visitNestMember(member);
+                }
+                super.visitEnd();
+            }
+        }, 0);
+        return writer.toByteArray();
+    }
+
     private List<ClassNode> getPrimaryClassNodes(final boolean sort) {
         List<ClassNode> classes = getAST().getClasses();
 
@@ -1150,48 +1200,11 @@ public class CompilationUnit extends ProcessingUnit {
                 } else {
                     count = getSuperClassCount(cn) + 1000;
                 }
-                if (cn.getOuterClass() == null && hasInnerClassWithClosure(cn)) {
-                    count += 2000; // GROOVY-10687: nest host must follow members (with closures)
-                }
                 return count;
             }));
         }
 
         return classes;
-    }
-
-    private static boolean hasInnerClassWithClosure(final ClassNode cn) {
-        for (var it = cn.getInnerClasses(); it.hasNext(); ) {
-            class ClosureFound extends RuntimeException {
-                @Serial
-                private static final long serialVersionUID = 1;
-                @Override public Throwable fillInStackTrace() {
-                    return this;
-                }
-            }
-
-            var visitor = new ClassCodeVisitorSupport() {
-                @Override
-                public SourceUnit getSourceUnit() {
-                    return cn.getModule().getContext();
-                }
-                @Override
-                public void visitClosureExpression(final ClosureExpression ce) {
-                    throw new ClosureFound();
-                }
-            };
-
-            ClassNode innerClass = it.next();
-            try {
-                visitor.visitClass(innerClass);
-            } catch (ClosureFound done) {
-                return true;
-            }
-            if (hasInnerClassWithClosure(innerClass)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void changeBugText(final GroovyBugError e, final SourceUnit context) {

--- a/src/test/groovy/bugs/Groovy12188.groovy
+++ b/src/test/groovy/bugs/Groovy12188.groovy
@@ -1,0 +1,102 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bugs
+
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.assertScript
+import static groovy.test.GroovyAssert.shouldFail
+
+/**
+ * A generic abstract method implemented with a covariant (narrowed) return type is
+ * only recognised as implemented by {@code ClassCompletionVerifier} once the class
+ * declaring the override has been through {@code Verifier}, which adds the bridge
+ * method whose erased descriptor matches the abstract method's. Since the
+ * GROOVY-10687 fix, a top-level class whose inner class contains a closure is
+ * generated after its nest members — which can place it after its own subclass, so
+ * the subclass is verified before the bridge exists and compilation fails with
+ * "Abstract method 'T someValue()' is not implemented but a method of the same name
+ * but different return type is defined" (GROOVY-12188). These tests pin that the
+ * check recognises a covariant override independent of class generation order.
+ */
+final class Groovy12188 {
+
+    // the reporter's example: the nest host with an inner-class closure sorts after its subclass
+    @Test
+    void testCovariantOverrideWithNestedClassClosure() {
+        assertScript '''
+            abstract class ProviderSpec<T> {
+                abstract T someValue()
+            }
+
+            abstract class CollectionPropertySpec<C extends Collection<String>> extends ProviderSpec<C> {
+                C someValue() { return null }
+
+                static class Nested<T> {
+                    void trigger(Optional<T> p) { p.map { it } }
+                }
+            }
+
+            class DefaultListPropertyTest extends CollectionPropertySpec<List<String>> {
+            }
+
+            assert new DefaultListPropertyTest().someValue() == null
+        '''
+    }
+
+    // no ordering can help here: the nest host must follow its member for the
+    // NestMembers attribute but precede it for the bridge-based abstract check
+    @Test
+    void testCovariantOverrideWithNestMemberSubclass() {
+        assertScript '''
+            abstract class ProviderSpec<T> {
+                abstract T someValue()
+            }
+
+            abstract class CollectionPropertySpec<C extends Collection<String>> extends ProviderSpec<C> {
+                C someValue() { return null }
+
+                static class Inner extends CollectionPropertySpec<List<String>> {
+                    def c = { it }
+                }
+            }
+
+            assert new CollectionPropertySpec.Inner().someValue() == null
+        '''
+    }
+
+    // a same-name method whose return type is not covariant must still be rejected
+    @Test
+    void testNonCovariantReturnTypeStillRejected() {
+        def err = shouldFail '''
+            abstract class A<T extends Number> {
+                abstract T someValue()
+            }
+
+            class B extends A<Integer> {
+                String someValue() { return null }
+
+                static class Nested {
+                    def c = { it }
+                }
+            }
+        '''
+        assert err.message.contains('someValue')
+    }
+}


### PR DESCRIPTION
…reordering classgen

Closure and anonymous inner classes materialize while bytecode is being generated, so a nest host emitted in normal order could not list them in its NestMembers attribute. The previous approach sorted nest hosts to the back of the classgen queue, which broke the supers-before-subclasses invariant relied on by ClassCompletionVerifier (GROOVY-11753, GROOVY-12188) and still could not see a host's own nested closures, requiring name prediction (GROOVY-11780). No ordering satisfies both constraints once a nest member extends its own host.

Instead, restore plain hierarchy-order sorting and complete each nest host's NestMembers in a post-generation pass: once all of a module's classes are generated, the host's inner class list is complete, so its bytes are rewritten with the exact member set. GroovyClassLoader defines classes from the post-processed bytes. This removes the reordering, the closure-detection walk, and the member-name prediction, and is unaffected by whether a closure ultimately produces a class (GEP-27 closure packing).