### PR TITLE
GROOVY-12204: Support check-only compilation (stop after a configurab…

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilationUnit.java
@@ -708,10 +708,12 @@ public class CompilationUnit extends ProcessingUnit {
     // ACTIONS
 
     /**
-     * Synonym for {@code compile(Phases.ALL)}.
+     * Compiles the compilation unit from sources through the configured target
+     * phase; a synonym for {@code compile(Phases.ALL)} unless an earlier phase
+     * is set via {@link CompilerConfiguration#setTargetPhase(int)} (GROOVY-12204).
      */
     public void compile() throws CompilationFailedException {
-        compile(Phases.ALL);
+        compile(configuration.getTargetPhase());
     }
 
     /**

--- a/src/main/java/org/codehaus/groovy/control/CompilePhase.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilePhase.java
@@ -50,7 +50,7 @@ public enum CompilePhase {
     CANONICALIZATION(Phases.CANONICALIZATION),
 
     /**
-    * instruction set is chosen, for example java5 or pre java5
+    * Prepare for class generation, for example static type checking is performed in this phase
     */
     INSTRUCTION_SELECTION(Phases.INSTRUCTION_SELECTION),
 

--- a/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -332,6 +332,16 @@ public class CompilerConfiguration {
         }
 
         @Override
+        public void setTargetPhase(final int targetPhase) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setTargetPhase(final CompilePhase targetPhase) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void setTargetDirectory(final String directory) {
             throw new UnsupportedOperationException();
         }
@@ -476,6 +486,16 @@ public class CompilerConfiguration {
      */
     private boolean forInPerIterationCapture = true;
 
+    /**
+     * The target compile phase: the last phase to be processed when
+     * {@link CompilationUnit#compile()} is called without an explicit phase
+     * (GROOVY-12204). Defaults to {@link Phases#ALL}. An earlier phase, such as
+     * {@link Phases#INSTRUCTION_SELECTION}, gives a check-only compilation
+     * which reports parse, resolution, and static type-checking errors without
+     * generating class files.
+     */
+    private int targetPhase = Phases.ALL;
+
     private final List<CompilationCustomizer> compilationCustomizers = new LinkedList<>();
 
     /**
@@ -584,6 +604,7 @@ public class CompilerConfiguration {
         setRecompileGroovySource(configuration.getRecompileGroovySource());
         setMinimumRecompilationInterval(configuration.getMinimumRecompilationInterval());
         setTargetBytecode(configuration.getTargetBytecode());
+        setTargetPhase(configuration.getTargetPhase());
         setPreviewFeatures(configuration.isPreviewFeatures());
         setLogClassgen(configuration.isLogClassgen());
         setLogClassgenStackTraceMaxDepth(configuration.getLogClassgenStackTraceMaxDepth());
@@ -1496,5 +1517,50 @@ public class CompilerConfiguration {
      */
     public void setForInPerIterationCaptureEnabled(final boolean forInPerIterationCapture) {
         this.forInPerIterationCapture = forInPerIterationCapture;
+    }
+
+    /**
+     * Gets the target compile phase: the last phase to be processed when
+     * {@link CompilationUnit#compile()} is called without an explicit phase
+     * (GROOVY-12204). Defaults to {@link Phases#ALL}.
+     *
+     * @return the target phase number, one of the {@link Phases} constants
+     * @see #setTargetPhase(int)
+     * @since 6.0.0
+     */
+    public int getTargetPhase() {
+        return targetPhase;
+    }
+
+    /**
+     * Sets the target compile phase: the last phase to be processed when
+     * {@link CompilationUnit#compile()} is called without an explicit phase
+     * (GROOVY-12204). Values outside
+     * the range of the {@link Phases} constants are clamped into range.
+     * Setting {@link Phases#INSTRUCTION_SELECTION} gives a check-only
+     * compilation, as used by the {@code groovyc --check} option: parse,
+     * resolution, and static type-checking errors are reported but no class
+     * files are generated. Callers that pass an explicit phase to
+     * {@link CompilationUnit#compile(int)}, such as the AST browser, are
+     * unaffected by this setting.
+     *
+     * @param targetPhase the target phase number, one of the {@link Phases} constants
+     * @see #getTargetPhase()
+     * @since 6.0.0
+     */
+    public void setTargetPhase(final int targetPhase) {
+        this.targetPhase = Math.max(Phases.INITIALIZATION, Math.min(targetPhase, Phases.ALL));
+    }
+
+    /**
+     * Convenience overload of {@link #setTargetPhase(int)} taking the
+     * {@link CompilePhase} enum, e.g. for configuration scripts:
+     * {@code configuration.targetPhase = CompilePhase.INSTRUCTION_SELECTION}.
+     *
+     * @param targetPhase the target phase
+     * @since 6.0.0
+     */
+    public void setTargetPhase(final CompilePhase targetPhase) {
+        setTargetPhase(targetPhase.getPhaseNumber());
     }
 }

--- a/src/main/java/org/codehaus/groovy/control/Phases.java
+++ b/src/main/java/org/codehaus/groovy/control/Phases.java
@@ -32,10 +32,10 @@ public class Phases {
     public static final int SEMANTIC_ANALYSIS = 4;
     /** AST completion */
     public static final int CANONICALIZATION = 5;
-    /** Class generation (pt.1) */
+    /** Prepare for class generation */
     public static final int INSTRUCTION_SELECTION = 6;
-    /** Class generation (pt.2) */
-    public static final int CLASS_GENERATION = 7;   //
+    /** Bytecode generation */
+    public static final int CLASS_GENERATION = 7;
     /** Output of class to disk */
     public static final int OUTPUT = 8;
     /** Cleanup */

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -24,6 +24,7 @@ import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.ConfigurationException;
 import org.codehaus.groovy.control.ErrorCollector;
 import org.codehaus.groovy.control.Janitor;
+import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.control.messages.WarningMessage;
 import org.codehaus.groovy.runtime.ArrayGroovyMethods;
 import org.codehaus.groovy.runtime.DefaultGroovyStaticMethods;
@@ -556,6 +557,9 @@ public class FileSystemCompiler {
         @Option(names = {"--type-checked"}, description = "Use TypeChecked")
         private boolean typeChecked;
 
+        @Option(names = {"--check"}, description = "Check sources for errors without generating class files (stops compilation after static analysis)")
+        private boolean checkOnly;
+
         /**
          * Builds a compiler configuration from the parsed command-line options.
          *
@@ -578,6 +582,9 @@ public class FileSystemCompiler {
             configuration.setPreviewFeatures(previewFeatures);
             configuration.setSourceEncoding(encoding);
             configuration.setScriptBaseClass(scriptBaseClass);
+            if (checkOnly) {
+                configuration.setTargetPhase(Phases.INSTRUCTION_SELECTION);
+            }
             if (tolerance > 0) {
                 configuration.setTolerance(tolerance);
             }

--- a/src/spec/doc/core-metaprogramming.adoc
+++ b/src/spec/doc/core-metaprogramming.adoc
@@ -2966,7 +2966,7 @@ the source code
 * _Semantic Analysis_: Performs consistency and validity checks that the
 grammar can’t check for, and resolves classes.
 * _Canonicalization_: Complete building the AST
-* _Instruction Selection_: instruction set is chosen, for example Java 6 or Java 7 bytecode level
+* _Instruction Selection_: Prepare for class generation, for example static type checking is performed in this phase
 * _Class Generation_: creates the bytecode of the class in memory
 * _Output_: write the binary output to the file system
 * _Finalization_: Perform any last cleanup

--- a/src/spec/doc/tools-groovyc.adoc
+++ b/src/spec/doc/tools-groovyc.adoc
@@ -46,6 +46,7 @@ a number of command line switches:
 | | --encoding | Encoding of the source files | groovyc --encoding utf-8 script.groovy
 | | --help | Displays help for the command line groovyc tool | groovyc --help
 | -d | | Specify where to place generated class files. | groovyc -d target Person.groovy
+| | --check | Check sources for errors without generating class files (stops compilation after static analysis) | groovyc --check Person.groovy
 | -v | --version | Displays the compiler version | groovyc -v
 | -e | --exception | Displays the stack trace in case of compilation error | groovyc -e script.groovy
 | -w | --warningLevel | Sets how many warnings are reported after a successful compile: `0` (none), `1` (likely errors, the default), `2` (possible errors) or `3` (all). See <<section-groovyc-warnings,Compiler warnings>>. | groovyc -w 2 MyClass.groovy

--- a/src/test/groovy/org/codehaus/groovy/control/CompilerConfigurationTest.java
+++ b/src/test/groovy/org/codehaus/groovy/control/CompilerConfigurationTest.java
@@ -376,4 +376,43 @@ public final class CompilerConfigurationTest {
                 CompilerConfiguration.DEFAULT.setForInPerIterationCaptureEnabled(false));
         assertTrue(CompilerConfiguration.DEFAULT.isForInPerIterationCaptureEnabled());
     }
+
+    @Test // GROOVY-12204
+    public void testTargetPhaseDefaultsToAll() {
+        CompilerConfiguration config = new CompilerConfiguration();
+        assertEquals(Phases.ALL, config.getTargetPhase());
+    }
+
+    @Test // GROOVY-12204
+    public void testTargetPhaseSetterAndClamping() {
+        CompilerConfiguration config = new CompilerConfiguration();
+        config.setTargetPhase(Phases.INSTRUCTION_SELECTION);
+        assertEquals(Phases.INSTRUCTION_SELECTION, config.getTargetPhase());
+        config.setTargetPhase(CompilePhase.CANONICALIZATION);
+        assertEquals(Phases.CANONICALIZATION, config.getTargetPhase());
+        config.setTargetPhase(0); // below INITIALIZATION: clamped
+        assertEquals(Phases.INITIALIZATION, config.getTargetPhase());
+        config.setTargetPhase(42); // above ALL: clamped
+        assertEquals(Phases.ALL, config.getTargetPhase());
+    }
+
+    @Test // GROOVY-12204
+    public void testTargetPhaseCopyConstructor() {
+        CompilerConfiguration src = new CompilerConfiguration();
+        src.setTargetPhase(Phases.INSTRUCTION_SELECTION);
+        CompilerConfiguration copy = new CompilerConfiguration(src);
+        assertEquals(Phases.INSTRUCTION_SELECTION, copy.getTargetPhase());
+        src.setTargetPhase(Phases.ALL);
+        // copy is independent
+        assertEquals(Phases.INSTRUCTION_SELECTION, copy.getTargetPhase());
+    }
+
+    @Test // GROOVY-12204
+    public void testDefaultConfigurationTargetPhaseIsImmutable() {
+        assertThrows(UnsupportedOperationException.class, () ->
+                CompilerConfiguration.DEFAULT.setTargetPhase(Phases.INSTRUCTION_SELECTION));
+        assertThrows(UnsupportedOperationException.class, () ->
+                CompilerConfiguration.DEFAULT.setTargetPhase(CompilePhase.INSTRUCTION_SELECTION));
+        assertEquals(Phases.ALL, CompilerConfiguration.DEFAULT.getTargetPhase());
+    }
 }

--- a/src/test/groovy/org/codehaus/groovy/tools/FileSystemCompilerTest.java
+++ b/src/test/groovy/org/codehaus/groovy/tools/FileSystemCompilerTest.java
@@ -22,6 +22,7 @@ import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.classgen.GeneratorContext;
 import org.codehaus.groovy.control.CompilePhase;
 import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.customizers.CompilationCustomizer;
 import org.codehaus.groovy.control.messages.WarningMessage;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -172,6 +174,42 @@ public class FileSystemCompilerTest {
         }
         configuration.setTargetDirectory(dir.toFile());
         FileSystemCompiler.doCompilation(configuration, null, new String[]{file.getPath()}, false, warningWriter);
+    }
+
+    // GROOVY-12204: a target phase before CLASS_GENERATION must suppress class file output
+    @Test
+    public void testCheckOnlyCompileProducesNoClassFiles(@TempDir Path dir) throws Exception {
+        CompilerConfiguration configuration = new CompilerConfiguration();
+        configuration.setTargetPhase(Phases.INSTRUCTION_SELECTION);
+        compile(dir, "CheckDemo", "class CheckDemo { }", configuration, null);
+        assertFalse(Files.exists(dir.resolve("CheckDemo.class")), "check-only compile must not write class files");
+
+        // control: the same shape of source with the default configuration does produce a class file
+        compile(dir, "FullDemo", "class FullDemo { }", null, null);
+        assertTrue(Files.exists(dir.resolve("FullDemo.class")), "sanity: full compile writes class files");
+    }
+
+    // GROOVY-12204: check-only compilation still surfaces static type-checking errors
+    @Test
+    public void testCheckOnlyCompileReportsTypeErrors(@TempDir Path dir) throws Exception {
+        CompilerConfiguration configuration = new CompilerConfiguration();
+        configuration.setTargetPhase(Phases.INSTRUCTION_SELECTION);
+        Exception e = assertThrows(Exception.class, () ->
+                compile(dir, "CheckError", "@groovy.transform.CompileStatic\nclass CheckError { int f() { int x = 'oops'; x } }", configuration, null));
+        assertTrue(e.getMessage().contains("Cannot assign value of type"), "expected a static type-checking error but got: " + e.getMessage());
+        assertFalse(Files.exists(dir.resolve("CheckError.class")));
+    }
+
+    // GROOVY-12204: --check command-line sugar for a check-only compile
+    @Test
+    public void testCheckCommandLineOption(@TempDir Path dir) throws Exception {
+        File file = dir.resolve("CliCheckDemo.groovy").toFile();
+        Files.write(file.toPath(), "class CliCheckDemo { }".getBytes(StandardCharsets.UTF_8));
+        FileSystemCompiler.commandLineCompile(new String[] {"--check", "-d", dir.toString(), file.getPath()});
+        assertFalse(Files.exists(dir.resolve("CliCheckDemo.class")), "--check must not write class files");
+
+        FileSystemCompiler.commandLineCompile(new String[] {"-d", dir.toString(), file.getPath()});
+        assertTrue(Files.exists(dir.resolve("CliCheckDemo.class")), "sanity: without --check the class file is written");
     }
 
     @Test


### PR DESCRIPTION
…le compile phase) https://issues.apache.org/jira/browse/GROOVY-12204

Add a targetPhase property to CompilerConfiguration (default Phases.ALL) which the no-arg CompilationUnit.compile() now honors; callers that name an explicit phase, such as the AST browser, are unaffected. The new groovyc --check option is sugar for setting the target phase to INSTRUCTION_SELECTION: parse, resolution, and static type-checking errors are still reported but no class files are generated, giving a faster feedback loop for editors, CI checks, and coding agents.