### PR TITLE
GROOVY-12203: False positive "name clash" for a valid override when a…

### DIFF
--- a/src/main/java/org/codehaus/groovy/ast/GenericsType.java
+++ b/src/main/java/org/codehaus/groovy/ast/GenericsType.java
@@ -475,7 +475,9 @@ public class GenericsType extends ASTNode {
                                     GenericsType gt = new GenericsType(redirectBoundType.getLowerBound());
                                     if (gt.isPlaceholder()) {
                                         // check for recursive generic typedef, like in <T extends Comparable<? super T>>
-                                        gt = classNodePlaceholders.getOrDefault(new GenericsTypeName(gt.getName()), gt);
+                                        GenericsType argument = classNodePlaceholders.get(new GenericsTypeName(gt.getName()));
+                                        // GROOVY-12203: a wildcard argument does not instantiate the type variable
+                                        if (argument != null && !argument.isWildcard()) gt = argument;
                                     }
                                     // GROOVY-6095, GROOVY-9338
                                     if (classNodeType.isWildcard()) {
@@ -494,7 +496,9 @@ public class GenericsType extends ASTNode {
                                         GenericsType gt = new GenericsType(upperBound);
                                         if (gt.isPlaceholder()) {
                                             // check for recursive generic typedef, like in <T extends Comparable<? super T>>
-                                            gt = classNodePlaceholders.getOrDefault(new GenericsTypeName(gt.getName()), gt);
+                                            GenericsType argument = classNodePlaceholders.get(new GenericsTypeName(gt.getName()));
+                                            // GROOVY-12203: a wildcard argument does not instantiate the type variable
+                                            if (argument != null && !argument.isWildcard()) gt = argument;
                                         }
                                         // GROOVY-6095, GROOVY-9338
                                         if (classNodeType.isWildcard()) {

--- a/src/test/groovy/groovy/OverrideTest.groovy
+++ b/src/test/groovy/groovy/OverrideTest.groovy
@@ -229,6 +229,28 @@ final class OverrideTest {
         assert err.message.contains("name clash: m(I<java.lang.String>) in class 'C' and m(I<java.lang.Object>) in interface 'I' have the same erasure, yet neither overrides the other")
     }
 
+    // GROOVY-12203
+    @Test
+    void testCovariantParameterType7() {
+        assertScript '''
+            interface Box<T> { }
+
+            interface Spec {
+                def <T extends Number> void m(Box<? super T> b)
+                def <T extends Number> void n(Box<? extends T> b)
+            }
+
+            class Impl implements Spec {
+                @Override
+                <T extends Number> void m(Box<? super T> b) { }
+                @Override
+                <T extends Number> void n(Box<? extends T> b) { }
+            }
+
+            new Impl()
+        '''
+    }
+
     @Test
     void testOverrideOnMethodWithDefaultParameters() {
         assertScript '''


### PR DESCRIPTION
… `? super` wildcard uses a type that declares the same type variable name