### PR TITLE
avoid decoding the request URI in HttpBuilder.appendQuery

### DIFF
--- a/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpBuilder.groovy
+++ b/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpBuilder.groovy
@@ -624,8 +624,8 @@ final class HttpBuilder {
         }
 
         List<String> pairs = new ArrayList<>()
-        if (uri.query != null && !uri.query.isEmpty()) {
-            pairs.add(uri.query)
+        if (uri.rawQuery != null && !uri.rawQuery.isEmpty()) {
+            pairs.add(uri.rawQuery)
         }
 
         queryValues.each { String key, Object value ->
@@ -635,7 +635,24 @@ final class HttpBuilder {
         }
 
         String query = pairs.join('&')
-        return new URI(uri.scheme, uri.authority, uri.path, query, uri.fragment)
+        // reassemble from the encoded components: the multi-argument URI constructor
+        // takes decoded ones, which would turn a %2F or %2E in the original path back
+        // into a separator or a dot segment
+        StringBuilder rebuilt = new StringBuilder()
+        if (uri.scheme != null) {
+            rebuilt.append(uri.scheme).append(':')
+        }
+        if (uri.rawAuthority != null) {
+            rebuilt.append('//').append(uri.rawAuthority)
+        }
+        if (uri.rawPath != null) {
+            rebuilt.append(uri.rawPath)
+        }
+        rebuilt.append('?').append(query)
+        if (uri.rawFragment != null) {
+            rebuilt.append('#').append(uri.rawFragment)
+        }
+        return URI.create(rebuilt.toString())
     }
 
     private static String encodeQueryComponent(final String value) {

--- a/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderTest.groovy
+++ b/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderTest.groovy
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows
 
 import java.nio.charset.StandardCharsets
 import java.time.Duration
+import java.util.concurrent.atomic.AtomicReference
 
 class HttpBuilderTest {
 
@@ -37,7 +38,7 @@ class HttpBuilderTest {
     void setup() {
         server = HttpServer.create(new InetSocketAddress('127.0.0.1', 0), 0)
         server.createContext('/hello') { exchange ->
-            String body = "method=${exchange.requestMethod};query=${exchange.requestURI.query};ua=${exchange.requestHeaders.getFirst('User-Agent')}"
+            String body = "method=${exchange.requestMethod};query=${exchange.requestURI.rawQuery};ua=${exchange.requestHeaders.getFirst('User-Agent')}"
             byte[] bytes = body.getBytes(StandardCharsets.UTF_8)
             exchange.sendResponseHeaders(200, bytes.length)
             exchange.responseBody.withCloseable { it.write(bytes) }
@@ -523,6 +524,50 @@ class HttpBuilderTest {
 
         assert result.status == 200
         assert result.body == 'method=GET'
+    }
+
+    @Test
+    void appendedQueryKeepsPercentEncodedPathSegments() {
+        AtomicReference<URI> seen = capture('/encoded')
+        HttpBuilder http = HttpBuilder.http { baseUri rootUri }
+
+        http.get('/encoded/a%2Fb') { query page: 1 }
+
+        assert seen.get().rawPath == '/encoded/a%2Fb'
+    }
+
+    @Test
+    void appendedQueryKeepsExistingEncodedQueryValues() {
+        AtomicReference<URI> seen = capture('/existing')
+        HttpBuilder http = HttpBuilder.http { baseUri rootUri }
+
+        http.get('/existing?filter=a%26admin%3D1') { query page: 1 }
+
+        assert seen.get().rawQuery == 'filter=a%26admin%3D1&page=1'
+    }
+
+    @Test
+    void confinedRequestWithQueryStaysInsideTheBasePath() {
+        AtomicReference<URI> seen = capture('/api')
+        HttpBuilder http = HttpBuilder.http {
+            baseUri "${rootUri}api/v2/"
+            confineToBaseUri true
+        }
+
+        http.get('..%2Fadmin') { query page: 1 }
+
+        assert seen.get().rawPath == '/api/v2/..%2Fadmin'
+    }
+
+    private AtomicReference<URI> capture(String path) {
+        AtomicReference<URI> seen = new AtomicReference<>()
+        server.createContext(path) { exchange ->
+            seen.set(exchange.requestURI)
+            byte[] bytes = 'ok'.getBytes(StandardCharsets.UTF_8)
+            exchange.sendResponseHeaders(200, bytes.length)
+            exchange.responseBody.withCloseable { it.write(bytes) }
+        }
+        seen
     }
 
     private void redirect(String path, int status, String location) {


### PR DESCRIPTION
appendQuery rebuilds the request URI with the multi-argument URI constructor, which takes decoded components, so passing uri.path and uri.query decodes every percent escape and re-emits it literally: a path segment of a%2Fb turns into two segments, %2e%2e turns into a real dot segment, and an existing query value of a%26admin%3D1 splits off a second parameter. That also weakens confineToBaseUri, since resolveUri runs enforceConfinement before appendQuery and that check deliberately compares raw path segments, so get('..%2Fadmin') { query page: 1 } passes confinement and is then sent as /api/v2/../admin. Reassembling from the raw components leaves everything except the query untouched; the three new tests fail on the current code, and the existing queryDslUsesRfc3986StyleEncoding was asserting against requestURI.query, which decoded once and masked the DSL escapes being encoded twice, so its fixture now reads rawQuery.