### PR TITLE
GROOVY-12233: StringEscapeUtils.unescapeJava mis-decodes and silently…

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/StringEscapeUtils.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StringEscapeUtils.java
@@ -271,6 +271,7 @@ public class StringEscapeUtils {
      * 
      * @param str  the <code>String</code> to unescape, may be null
      * @return a new unescaped <code>String</code>, <code>null</code> if null string input
+     * @throws JsonException if a <code>'\\u'</code> escape is not followed by four hexadecimal digits
      */
     public static String unescapeJava(String str) {
         if (str == null) {
@@ -300,6 +301,7 @@ public class StringEscapeUtils {
      * @param str  the <code>String</code> to unescape, may be null
      * @throws IllegalArgumentException if the Writer is <code>null</code>
      * @throws IOException if error occurs on underlying Writer
+     * @throws JsonException if a <code>'\\u'</code> escape is not followed by four hexadecimal digits
      */
     public static void unescapeJava(Writer out, String str) throws IOException {
         if (out == null) {
@@ -318,18 +320,18 @@ public class StringEscapeUtils {
                 // if in unicode, then we're reading unicode
                 // values in somehow
                 unicode.append(ch);
+                if (!isHexDigit(ch)) {
+                    // Integer.parseInt would accept a sign or a non-ASCII digit here, but an
+                    // escape carries exactly four hexadecimal digits and nothing else
+                    throw new JsonException("Unable to parse unicode value: \\u" + unicode);
+                }
                 if (unicode.length() == 4) {
                     // unicode now contains the four hex digits
                     // which represents our unicode character
-                    try {
-                        int value = Integer.parseInt(unicode.toString(), 16);
-                        out.write((char) value);
-                        unicode.setLength(0);
-                        inUnicode = false;
-                        hadSlash = false;
-                    } catch (NumberFormatException nfe) {
-                        throw new RuntimeException("Unable to parse unicode value: " + unicode, nfe);
-                    }
+                    out.write((char) Integer.parseInt(unicode.toString(), 16));
+                    unicode.setLength(0);
+                    inUnicode = false;
+                    hadSlash = false;
                 }
                 continue;
             }
@@ -378,11 +380,20 @@ public class StringEscapeUtils {
             }
             out.write(ch);
         }
+        if (inUnicode) {
+            // the string ended in the middle of an escape, so the digits read so far are not a
+            // value; dropping them silently would lose input the caller never asked us to discard
+            throw new JsonException("Unable to parse unicode value: \\u" + unicode);
+        }
         if (hadSlash) {
             // then we're in the weird case of a \ at the end of the
             // string, let's output it anyway.
             out.write('\\');
         }
+    }
+
+    private static boolean isHexDigit(char ch) {
+        return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f');
     }
 
     /**

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/StringEscapeUtilsTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/StringEscapeUtilsTest.groovy
@@ -393,9 +393,54 @@ class StringEscapeUtilsTest {
 
     @Test
     void testUnescapeJavaInvalidUnicode() {
-        assertThrows(RuntimeException, { ->
+        assertThrows(JsonException, { ->
             StringEscapeUtils.unescapeJava("\\uZZZZ")
         })
+    }
+
+    // GROOVY-12233: A \u escape carries exactly four hexadecimal digits. Integer.parseInt(s, 16) is a looser
+    // grammar than that: it also accepts a leading sign and any Unicode digit, so escapes that no
+    // Java or JavaScript source could contain were unescaping to a real character.
+    @Test
+    void testUnescapeJavaRejectsSignedUnicode() {
+        // '+041' parses as 0x41, so this used to yield 'A'
+        assertThrows(JsonException, { ->
+            StringEscapeUtils.unescapeJava("\\u+041")
+        })
+        // '-001' parses as -1, so this used to yield the char 0xFFFF
+        assertThrows(JsonException, { ->
+            StringEscapeUtils.unescapeJava("\\u-001")
+        })
+    }
+
+    @Test
+    void testUnescapeJavaRejectsNonAsciiUnicodeDigits() {
+        // the Arabic-Indic digits for 1234, which used to yield the char 0x1234
+        assertThrows(JsonException, { ->
+            StringEscapeUtils.unescapeJava("\\u\u0661\u0662\u0663\u0664")
+        })
+    }
+
+    // A \u escape cut short by the end of the input used to leave the loop mid-escape, silently
+    // discarding both the escape and the digits already read, rather than reporting the input as
+    // malformed the way a trailing backslash does.
+    @Test
+    void testUnescapeJavaRejectsTruncatedUnicode() {
+        ["\\u", "\\u1", "\\u12", "\\u123", "x\\u12"].each { input ->
+            assertThrows(JsonException, { ->
+                StringEscapeUtils.unescapeJava(input)
+            }, "must reject '$input'")
+        }
+    }
+
+    @Test
+    void testUnescapeJavaValidUnicodeBoundaries() {
+        assertEquals("\u0000", StringEscapeUtils.unescapeJava("\\u0000"))
+        assertEquals("\uffff", StringEscapeUtils.unescapeJava("\\uffff"))
+        assertEquals("\u00e9", StringEscapeUtils.unescapeJava("\\u00e9"), "lower-case digits")
+        assertEquals("\u00e9", StringEscapeUtils.unescapeJava("\\u00E9"), "upper-case digits")
+        // a surrogate pair is two escapes, and ordinary text may follow the fourth digit
+        assertEquals("\ud83d\ude00ef", StringEscapeUtils.unescapeJava("\\ud83d\\ude00ef"))
     }
 
     @Test


### PR DESCRIPTION
… drops malformed \u escapes