### PR TITLE
GROOVY-12236: Allow @ASTTest to be disabled via a groovy.asttest.enab…

### DIFF
--- a/src/main/groovy/org/codehaus/groovy/transform/ASTTestTransformation.groovy
+++ b/src/main/groovy/org/codehaus/groovy/transform/ASTTestTransformation.groovy
@@ -52,18 +52,29 @@ import static org.codehaus.groovy.control.CompilePhase.fromPhaseNumber as toComp
 class ASTTestTransformation implements ASTTransformation, CompilationUnitAware {
 
     /**
+     * System property which, when set to {@code false}, makes {@link groovy.transform.ASTTest} a no-op.
+     * Compiling source containing the annotation then no longer evaluates its closure. Mirrors the
+     * {@code groovy.grape.enable} switch for {@code @Grab}.
+     */
+    public static final String ENABLE_PROPERTY = 'groovy.asttest.enable'
+
+    /**
      * Compilation unit that owns the current transformation.
      */
     CompilationUnit compilationUnit
 
     /**
      * Validates the annotation and schedules execution of its AST assertions.
+     * <p>
+     * Does nothing when {@value #ENABLE_PROPERTY} is set to {@code false}.
      *
      * @param nodes the annotation node and annotated AST node
      * @param source the source unit containing the annotation
      */
     @Override
     void visit(final ASTNode[] nodes, final SourceUnit source) {
+        if (!Boolean.parseBoolean(System.getProperty(ENABLE_PROPERTY, 'true'))) return
+
         AnnotationNode annotationNode = nodes[0]
 
         def member = annotationNode.getMember('phase')

--- a/src/main/java/groovy/transform/ASTTest.java
+++ b/src/main/java/groovy/transform/ASTTest.java
@@ -53,6 +53,14 @@ import java.lang.annotation.Target;
  * <p>
  * The <code>node</code> variable refers to the AST node where the AST test annotation is put. In the previous example,
  * it means that <i>node</i> refers to the declaration "int x".
+ * <p>
+ * Because the closure is evaluated during compilation, merely <em>compiling</em> source which carries this
+ * annotation executes that code, whether or not the compiled result is subsequently run. Setting the
+ * {@code groovy.asttest.enable} system property to {@code false} makes the annotation a no-op, in the same
+ * way that {@code groovy.grape.enable} turns off {@code @Grab} dependency resolution. Consider doing so when
+ * compiling source you do not control; see the Apache Groovy
+ * <a href="https://github.com/apache/groovy/blob/master/THREAT_MODEL.md">threat model</a> for what compiling
+ * such source does and does not imply.
  *
  * @since 2.0.0
  */

--- a/src/test/groovy/groovy/transform/ASTTestEnableTest.groovy
+++ b/src/test/groovy/groovy/transform/ASTTestEnableTest.groovy
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform
+
+import groovy.junit6.plugin.ForkedJvm
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.assertScript
+import static groovy.test.GroovyAssert.shouldFail
+
+/**
+ * Tests the {@code groovy.asttest.enable} switch for the {@link ASTTest} AST transform.
+ */
+final class ASTTestEnableTest {
+
+    /** Compiling this fails only if the test closure is actually evaluated. */
+    private static final String SCRIPT_WITH_FAILING_AST_TEST = '''
+        @groovy.transform.ASTTest(value = {
+            assert false : 'test closure was evaluated'
+        })
+        class C {}
+        new C()
+    '''
+
+    @Test
+    void testEnabledByDefault() {
+        assert System.getProperty('groovy.asttest.enable') == null
+
+        def error = shouldFail(SCRIPT_WITH_FAILING_AST_TEST)
+        assert error.message.contains('test closure was evaluated')
+    }
+
+    @Test
+    @ForkedJvm(systemProperties = ['groovy.asttest.enable=false'])
+    void testDisabledBySystemProperty() {
+        assert System.getProperty('groovy.asttest.enable') == 'false'
+
+        // the annotation is a no-op, so the failing closure never runs
+        assertScript SCRIPT_WITH_FAILING_AST_TEST
+    }
+
+    @Test
+    @ForkedJvm(systemProperties = ['groovy.asttest.enable=true'])
+    void testExplicitlyEnabledBySystemProperty() {
+        def error = shouldFail(SCRIPT_WITH_FAILING_AST_TEST)
+        assert error.message.contains('test closure was evaluated')
+    }
+}


### PR DESCRIPTION
…le system property

The @ASTTest closure is evaluated during compilation, so merely compiling source which carries the annotation executes that code, whether or not the compiled result is subsequently run. Embedders which compile source they do not control have no way to turn this off.

Add a groovy.asttest.enable system property, defaulting to true, which makes the annotation a no-op when set to false. This mirrors groovy.grape.enable for @Grab. The check is in visit(), so the closure is never scheduled onto a compilation phase rather than being scheduled and skipped.

The property is read per-visit rather than into a static final field so that it can be exercised without relying on JVM startup state. Being a system property it is process-wide, exactly as groovy.grape.enable is: a JVM cannot enable @ASTTest for one compilation and disable it for another.