### PR TITLE
GROOVY-12254: Make defer fully contextual: parse as a keyword only inside async closures

### DIFF
--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -46,6 +46,7 @@ options {
 
 @members {
     private int inSwitchExpressionLevel = 0;
+    private int inAsyncClosureLevel = 0;
 
     public static class GroovyParserRuleContext extends ParserRuleContext implements NodeMetaDataHandler {
         private Map metaDataMap = null;
@@ -662,7 +663,8 @@ statement
     |   { inSwitchExpressionLevel > 0 }?
         yieldStatement                                                                                      #yieldStmtAlt
     |   YIELD RETURN nls expression                                                                         #yieldReturnStmtAlt
-    |   DEFER nls statementExpression                                                                       #deferStmtAlt
+    |   { inAsyncClosureLevel > 0 }?
+        DEFER nls statementExpression                                                                       #deferStmtAlt
     |   identifier COLON nls statement                                                                      #labeledStmtAlt
     |   assertStatement                                                                                     #assertStmtAlt
     |   localVariableDeclaration                                                                            #localVariableDeclarationStmtAlt
@@ -809,7 +811,7 @@ expression
     :   castParExpression castOperandExpression                                             #castExprAlt
 
     // async closure/lambda must come before postfixExpression to resolve ambiguity with method call, e.g. async { ... }
-    |   ASYNC nls closureOrLambdaExpression                                                 #asyncClosureExprAlt
+    |   ASYNC nls { inAsyncClosureLevel++; } closureOrLambdaExpression { inAsyncClosureLevel--; }   #asyncClosureExprAlt
 
     // await expression: single-arg or multi-arg (parenthesized or unparenthesized)
     |   AWAIT nls ( LPAREN expression (COMMA nls expression)* RPAREN

--- a/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AstBuilder.java
@@ -981,6 +981,13 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
 
     @Override
     public ExpressionStatement visitDeferStmtAlt(final DeferStmtAltContext ctx) {
+        if (!Boolean.TRUE.equals(asyncClosureStack.peek())) {
+            throw createParsingFailedException(
+                    asyncClosureStack.contains(Boolean.TRUE)
+                            ? "defer must be used directly in the body of an async closure, not in a nested closure"
+                            : "defer must be used inside an async closure",
+                    ctx);
+        }
         Expression action;
         ExpressionStatement stmtExprStmt = (ExpressionStatement) this.visit(ctx.statementExpression());
         Expression expr = stmtExprStmt.getExpression();
@@ -3108,6 +3115,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
 
     @Override
     public Expression visitAsyncClosureExprAlt(final AsyncClosureExprAltContext ctx) {
+        nextClosureIsAsync = true;
         ClosureExpression closure = this.visitClosureOrLambdaExpression(ctx.closureOrLambdaExpression());
         return configureAST(AsyncTransformHelper.transformAsyncClosure(closure), ctx);
     }
@@ -3938,10 +3946,13 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     @Override
     public LambdaExpression visitStandardLambdaExpression(final StandardLambdaExpressionContext ctx) {
         switchExpressionRuleContextStack.push(ctx);
+        asyncClosureStack.push(nextClosureIsAsync);
+        nextClosureIsAsync = false;
         try {
             return configureAST(this.createLambda(ctx.standardLambdaParameters(), ctx.lambdaBody()), ctx);
         } finally {
             switchExpressionRuleContextStack.pop();
+            asyncClosureStack.pop();
         }
     }
 
@@ -3975,6 +3986,8 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     @Override
     public ClosureExpression visitClosure(final ClosureContext ctx) {
         switchExpressionRuleContextStack.push(ctx);
+        asyncClosureStack.push(nextClosureIsAsync);
+        nextClosureIsAsync = false;
         visitingClosureCount += 1;
         try {
             Parameter[] parameters = asBoolean(ctx.formalParameterList())
@@ -3993,6 +4006,7 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
             return configureAST(new ClosureExpression(parameters, code), ctx);
         } finally {
             switchExpressionRuleContextStack.pop();
+            asyncClosureStack.pop();
             visitingClosureCount -= 1;
         }
     }
@@ -4976,6 +4990,10 @@ public class AstBuilder extends GroovyParserBaseVisitor<Object> {
     private final Deque<ClassNode> classNodeStack = new ArrayDeque<>();
     private final Deque<List<InnerClassNode>> anonymousInnerClassesDefinedInMethodStack = new ArrayDeque<>();
     private final Deque<GroovyParserRuleContext> switchExpressionRuleContextStack = new ArrayDeque<>();
+    /** one entry per enclosing closure/lambda: TRUE if it is the closure of an {@code async} expression */
+    private final Deque<Boolean> asyncClosureStack = new ArrayDeque<>();
+    /** set just before visiting the closure/lambda of an {@code async} expression; consumed by the closure/lambda visit */
+    private boolean nextClosureIsAsync;
 
     private Tuple2<GroovyParserRuleContext, Exception> numberFormatError;
 

--- a/src/test/groovy/groovy/AsyncAwaitTest.groovy
+++ b/src/test/groovy/groovy/AsyncAwaitTest.groovy
@@ -642,6 +642,87 @@ final class AsyncAwaitTest {
         '''
     }
 
+    @Test
+    void testDeferInAsyncLambda() {
+        assertScript '''
+            def log = []
+            def task = async () -> {
+                defer { log << 'cleanup' }
+                log << 'work'
+                42
+            }
+            assert await(task) == 42
+            assert log == ['work', 'cleanup']
+        '''
+    }
+
+    @Test
+    void testDeferOutsideAsyncIsPlainMethodCall() {
+        // outside an async closure, `defer` stays an ordinary identifier,
+        // so with no defer method in scope this fails at runtime, not compile time
+        def err = shouldFail(MissingMethodException, '''
+            defer { println 'cleanup' }
+        ''')
+        assert err.message.contains('defer')
+    }
+
+    @Test
+    void testDeferAsDslMethodOutsideAsync() {
+        assertScript '''
+            log = []
+            def defer(c) { log << (c instanceof Closure ? c() : c) }
+            defer { 'dsl closure' }
+            defer 'dsl command'
+            assert log == ['dsl closure', 'dsl command']
+        '''
+    }
+
+    @Test
+    void testDeferAsMethodInClassOutsideAsync() {
+        assertScript '''
+            class Registry {
+                def actions = []
+                def defer(action) {
+                    actions << action
+                }
+                def register() {
+                    defer 'cleanup'
+                }
+            }
+            def r = new Registry()
+            r.register()
+            assert r.actions == ['cleanup']
+        '''
+    }
+
+    @Test
+    void testDeferInNestedClosureInsideAsyncFails() {
+        def err = shouldFail '''
+            def task = async {
+                [1, 2, 3].each {
+                    defer { println 'cleanup' }
+                }
+            }
+        '''
+        assert err.message.contains('defer must be used directly in the body of an async closure')
+    }
+
+    @Test
+    void testDeferInNestedAsyncClosure() {
+        assertScript '''
+            def log = []
+            def outer = async {
+                def inner = async {
+                    defer { log << 'inner cleanup' }
+                    'inner'
+                }
+                await inner
+            }
+            assert await(outer) == 'inner'
+            assert log == ['inner cleanup']
+        '''
+    }
+
     // === executor configuration ===
 
     @Test


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/GROOVY-12254