### PR TITLE
GROOVY-12263: Invoke cached Closure doCall targets via MethodHandle

### DIFF
--- a/src/main/java/groovy/lang/Closure.java
+++ b/src/main/java/groovy/lang/Closure.java
@@ -48,10 +48,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -560,6 +563,13 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
                 if (m != null && CallOverride.guardsPass(override.guards[arity], arguments)) {
                     target = m;
                 }
+            } else {
+                // High-arity doCall: cached asSpreader of type (Object, Object[])Object.
+                // The 0..ARITY_LIMIT-1 invokeExact switch is unchanged.
+                CallOverride.SpreadSlot slot = override.spreadFor(arity);
+                if (slot != null && CallOverride.guardsPass(slot.guards, arguments)) {
+                    return invokeCached(slot.handle, slot.method, this, arguments);
+                }
             }
             if (target != null) {
                 MethodHandle handle = override.handles[arity];
@@ -616,11 +626,12 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
     }
 
     /**
-     * {@code invokeExact} against a handle adapted to
-     * {@link MethodType#genericMethodType(int) genericMethodType(arity+1)}
-     * (fixed-arity {@code Object} receiver and arguments, {@code Object} return).
-     * Cases {@code 0..ARITY_LIMIT-1} match that type exactly; the spreader
-     * is the type-correct fallback if the limit grows without a matching case.
+     * {@code invokeExact} against a cached handle. Cases {@code 0..ARITY_LIMIT-1}
+     * match {@link MethodType#genericMethodType(int) genericMethodType(arity+1)}.
+     * The default is a handle already adapted to
+     * {@link MethodType#genericMethodType(int, boolean) genericMethodType(1, true)}
+     * ({@code (Object, Object[])Object}) at lookup — {@code asSpreader} is not
+     * applied per call.
      */
     private static Object invokeHandle(final MethodHandle handle, final Closure<?> self, final Object[] arguments) throws Throwable {
         switch (arguments.length) {
@@ -635,7 +646,7 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
             case 4:
                 return handle.invokeExact((Object) self, arguments[0], arguments[1], arguments[2], arguments[3]);
             default:
-                return handle.asSpreader(Object[].class, arguments.length).invokeExact((Object) self, arguments);
+                return handle.invokeExact((Object) self, arguments);
         }
     }
 
@@ -1490,14 +1501,22 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
     private static final class CallOverride {
         private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
         /**
-         * Cached arities: {@code 0..ARITY_LIMIT-1}. Sized to cover every callback shape the GDK
-         * drives (iteration and inject/withIndex variants peak at three parameters, plus slack).
+         * Specialised {@code invokeExact} cutoff: cases {@code 0..ARITY_LIMIT-1} use a
+         * fixed-arity handle. Sized to cover every callback shape the GDK drives
+         * (iteration and inject/withIndex variants peak at three parameters, plus slack).
+         * Higher arities are cached separately as {@link #SPREADER_TYPE} handles.
          */
         static final int ARITY_LIMIT = 5;
         /**
+         * Cached high-arity shape: {@code (Object, Object[])Object}. Built once at
+         * lookup with {@code asSpreader}; {@code invokeHandle} then {@code invokeExact}s it.
+         */
+        static final MethodType SPREADER_TYPE = MethodType.genericMethodType(1, true);
+        static final SpreadSlot[] NO_SPREAD = new SpreadSlot[0];
+        /**
          * Marker instance indicating that no dispatch targets exist.
          */
-        static final CallOverride NONE = new CallOverride(new Method[ARITY_LIMIT], new Class[ARITY_LIMIT][], new boolean[ARITY_LIMIT], new MethodHandle[ARITY_LIMIT]);
+        static final CallOverride NONE = new CallOverride(new Method[ARITY_LIMIT], new Class[ARITY_LIMIT][], new boolean[ARITY_LIMIT], new MethodHandle[ARITY_LIMIT], NO_SPREAD);
         /**
          * Cached {@code doCall} targets indexed by parameter count, or null where absent,
          * ambiguous, or inaccessible — {@code call} selects a {@code doCall}, so the cache is
@@ -1530,14 +1549,49 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
          * for {@code invokeExact}, or null when the method cannot be adapted.
          * The call path prefers the handle so {@code Method.invoke} is not on
          * the GDK {@code each}/{@code collect} hot path.
+         * Slots {@code 0..ARITY_LIMIT-1} are {@code genericMethodType(arity+1)};
+         * higher arities live in {@link #spread}.
          */
         final MethodHandle[] handles;
+        /**
+         * Exact-arity {@code doCall} targets with {@code arity >= ARITY_LIMIT},
+         * each adapted to {@link #SPREADER_TYPE}. Empty when the class has none.
+         */
+        final SpreadSlot[] spread;
 
-        private CallOverride(Method[] byArity, Class<?>[][] guards, boolean[] callForm, MethodHandle[] handles) {
+        private CallOverride(Method[] byArity, Class<?>[][] guards, boolean[] callForm, MethodHandle[] handles, SpreadSlot[] spread) {
             this.byArity = byArity;
             this.guards = guards;
             this.callForm = callForm;
             this.handles = handles;
+            this.spread = spread;
+        }
+
+        /**
+         * One high-arity {@code doCall}: exact parameter count, optional 12164
+         * guards, and a lookup-time spreader handle.
+         */
+        static final class SpreadSlot {
+            final int arity;
+            final Method method;
+            final Class<?>[] guards;
+            final MethodHandle handle;
+
+            SpreadSlot(final int arity, final Method method, final Class<?>[] guards, final MethodHandle handle) {
+                this.arity = arity;
+                this.method = method;
+                this.guards = guards;
+                this.handle = handle;
+            }
+        }
+
+        SpreadSlot spreadFor(final int arity) {
+            for (SpreadSlot slot : spread) {
+                if (slot.arity == arity) {
+                    return slot;
+                }
+            }
+            return null;
         }
 
         static boolean guardsPass(Class<?>[] guards, Object[] args) {
@@ -1551,8 +1605,10 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
 
         /**
          * Finds the subclass's {@code doCall} declarations, one target per arity — {@code call}
-         * selects a {@code doCall}, so the cache is keyed on the doCall declarations themselves
-         * and any visibility the MOP would dispatch is accepted (the hierarchy is walked with
+         * selects a {@code doCall}, so the cache is keyed on the doCall declarations themselves.
+         * Arities {@code 0..ARITY_LIMIT-1} use specialised {@code invokeExact}; higher arities
+         * are stored as {@link #SPREADER_TYPE} handles. Any visibility the MOP would dispatch
+         * is accepted (the hierarchy is walked with
          * {@code getDeclaredMethods}; an overridden signature keeps its most-derived form).
          * Bridge methods are skipped (their erased twin is the real declaration), as are static
          * declarations and methods with array-typed parameters (that shape belongs to vararg
@@ -1583,6 +1639,9 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
             Method[] exact = new Method[ARITY_LIMIT];
             Method[] typed = new Method[ARITY_LIMIT];
             boolean[] typedAmbiguous = new boolean[ARITY_LIMIT];
+            Map<Integer, Method> highExact = null;
+            Map<Integer, Method> highTyped = null;
+            Set<Integer> highAmbiguous = null;
             Set<String> seen = new HashSet<>();
             for (Class<?> c = type; c != null && c != Closure.class; c = c.getSuperclass()) {
                 for (Method m : c.getDeclaredMethods()) {
@@ -1592,13 +1651,29 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
                     Class<?>[] params = m.getParameterTypes();
                     if (!seen.add(java.util.Arrays.toString(params))) continue; // overridden below: most-derived wins
                     int arity = m.getParameterCount();
-                    if (arity >= ARITY_LIMIT) continue;
                     boolean allObject = true, hasArray = false;
                     for (Class<?> p : params) {
                         if (p != Object.class) allObject = false;
                         if (p.isArray()) hasArray = true;
                     }
                     if (hasArray) continue;
+                    if (arity >= ARITY_LIMIT) {
+                        if (highExact == null) {
+                            highExact = new HashMap<>();
+                            highTyped = new HashMap<>();
+                            highAmbiguous = new HashSet<>();
+                        }
+                        if (allObject) {
+                            highExact.putIfAbsent(arity, m);
+                        } else if (highExact.containsKey(arity)) {
+                            // all-Object at this arity already won, as for 0..ARITY_LIMIT-1
+                        } else if (highTyped.containsKey(arity)) {
+                            highAmbiguous.add(arity);
+                        } else {
+                            highTyped.put(arity, m);
+                        }
+                        continue;
+                    }
                     if (allObject) {
                         if (exact[arity] == null) exact[arity] = m;
                     } else if (typed[arity] != null) {
@@ -1650,22 +1725,66 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
                 }
                 any = true;
             }
-            if (!any) {
-                return NONE;
-            }
             MethodHandle[] handles = new MethodHandle[ARITY_LIMIT];
             for (int arity = 0; arity < ARITY_LIMIT; arity += 1) {
                 if (byArity[arity] != null) {
                     handles[arity] = unreflect(byArity[arity]);
                 }
             }
-            return new CallOverride(byArity, guards, callForm, handles);
+            SpreadSlot[] spread = buildSpread(highExact, highTyped, highAmbiguous);
+            if (spread.length > 0) {
+                any = true;
+            }
+            if (!any) {
+                return NONE;
+            }
+            return new CallOverride(byArity, guards, callForm, handles, spread);
+        }
+
+        private static SpreadSlot[] buildSpread(final Map<Integer, Method> highExact, final Map<Integer, Method> highTyped, final Set<Integer> highAmbiguous) {
+            if (highExact == null) {
+                return NO_SPREAD;
+            }
+            Set<Integer> arities = new HashSet<>(highExact.keySet());
+            arities.addAll(highTyped.keySet());
+            List<SpreadSlot> built = new ArrayList<>(arities.size());
+            for (Integer boxed : arities) {
+                int arity = boxed;
+                Method exact = highExact.get(boxed);
+                Method m = (exact != null) ? exact
+                        : (highAmbiguous.contains(boxed) ? null : highTyped.get(boxed));
+                if (m == null) {
+                    continue;
+                }
+                try {
+                    m.setAccessible(true);
+                } catch (RuntimeException ignored) {
+                    continue;
+                }
+                Class<?>[] g = null;
+                if (m != exact) {
+                    Class<?>[] params = m.getParameterTypes();
+                    g = new Class[arity];
+                    for (int i = 0; i < arity; i += 1) {
+                        g[i] = (params[i] == Object.class) ? null : wrapperOf(params[i]);
+                    }
+                }
+                built.add(new SpreadSlot(arity, m, g, unreflect(m)));
+            }
+            return built.isEmpty() ? NO_SPREAD : built.toArray(NO_SPREAD);
         }
 
         private static MethodHandle unreflect(final Method method) {
             try {
-                return LOOKUP.unreflect(method)
-                        .asType(MethodType.genericMethodType(method.getParameterCount() + 1));
+                int arity = method.getParameterCount();
+                MethodHandle handle = LOOKUP.unreflect(method)
+                        .asType(MethodType.genericMethodType(arity + 1));
+                if (arity >= ARITY_LIMIT) {
+                    // box first, then spread: asSpreader on a still-primitive handle
+                    // would demand a primitive array
+                    handle = handle.asSpreader(Object[].class, arity).asType(SPREADER_TYPE);
+                }
+                return handle;
             } catch (Exception ignored) {
                 // inaccessible or not adaptable: call() falls back to Method.invoke
                 return null;

--- a/src/main/java/groovy/lang/Closure.java
+++ b/src/main/java/groovy/lang/Closure.java
@@ -41,6 +41,9 @@ import java.io.InvalidObjectException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.io.Writer;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -543,13 +546,13 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
             CallOverride override = CALL_OVERRIDES.get(myClass);
             // call selects a doCall: the cache is keyed on the subclass's doCall declarations,
             // arity-indexed (GROOVY-12165) so the shapes the GDK drives hard (Map#each,
-            // eachWithIndex, inject) dispatch directly. An argument that is already an instance
-            // of each declared parameter type dispatches directly; anything that needs Groovy
-            // coercion (GString -> String, number conversions, null) falls through to the
-            // metaclass below, which coerces exactly as before (GROOVY-12164). A subclass with
-            // no doCall keeps the GROOVY-11911 call()/call(Object) compatibility carve-out,
-            // whose targets alone need the re-entry latch (a custom call override may delegate
-            // back to call(...), which must not re-dispatch to the same target).
+            // eachWithIndex, inject) dispatch directly via a cached MethodHandle. An argument
+            // that is already an instance of each declared parameter type dispatches directly;
+            // anything that needs Groovy coercion (GString -> String, number conversions, null)
+            // falls through to the metaclass below, which coerces exactly as before (GROOVY-12164).
+            // A subclass with no doCall keeps the GROOVY-11911 call()/call(Object) compatibility
+            // carve-out, whose targets alone need the re-entry latch (a custom call override may
+            // delegate back to call(...), which must not re-dispatch to the same target).
             Method target = null;
             int arity = arguments.length;
             if (arity < CallOverride.ARITY_LIMIT) {
@@ -559,25 +562,14 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
                 }
             }
             if (target != null) {
+                MethodHandle handle = override.handles[arity];
                 if (!override.callForm[arity]) {
                     // a doCall body: re-entry is ordinary recursion, no latch required
-                    try {
-                        return (V) target.invoke(this, arguments);
-                    } catch (InvocationTargetException ite) {
-                        UncheckedThrow.rethrow(ite.getCause());
-                        return null; // unreachable statement
-                    } catch (IllegalAccessException iae) {
-                        throw new GroovyRuntimeException(iae);
-                    }
+                    return invokeCached(handle, target, this, arguments);
                 } else if (!IN_CALL_FALLBACK.get()) {
                     IN_CALL_FALLBACK.set(Boolean.TRUE);
                     try {
-                        return (V) target.invoke(this, arguments);
-                    } catch (InvocationTargetException ite) {
-                        UncheckedThrow.rethrow(ite.getCause());
-                        return null; // unreachable statement
-                    } catch (IllegalAccessException iae) {
-                        throw new GroovyRuntimeException(iae);
+                        return invokeCached(handle, target, this, arguments);
                     } finally {
                         IN_CALL_FALLBACK.set(Boolean.FALSE);
                     }
@@ -591,6 +583,59 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
             return null; // unreachable statement
         } catch (Exception e) {
             return (V) throwRuntimeException(e);
+        }
+    }
+
+    /**
+     * Invokes a cached {@code doCall}/{@code call} target. Prefers the adapted
+     * {@link MethodHandle} so {@code Method.invoke} is not on the GDK
+     * {@code each}/{@code collect} hot path. Exceptions thrown by the body —
+     * including a body that itself throws {@link InvocationTargetException} or
+     * {@link IllegalAccessException} — are rethrown as-is on the handle path;
+     * the {@link Method#invoke} fallback unwraps only the wrapper
+     * {@link InvocationTargetException} that reflection introduces.
+     */
+    @SuppressWarnings("unchecked")
+    private static <V> V invokeCached(final MethodHandle handle, final Method target, final Closure<?> self, final Object[] arguments) {
+        if (handle != null) {
+            try {
+                return (V) invokeHandle(handle, self, arguments);
+            } catch (Throwable t) {
+                UncheckedThrow.rethrow(t);
+                return null;
+            }
+        }
+        try {
+            return (V) target.invoke(self, arguments);
+        } catch (InvocationTargetException ite) {
+            UncheckedThrow.rethrow(ite.getCause());
+            return null; // unreachable statement
+        } catch (IllegalAccessException iae) {
+            throw new GroovyRuntimeException(iae);
+        }
+    }
+
+    /**
+     * {@code invokeExact} against a handle adapted to
+     * {@link MethodType#genericMethodType(int) genericMethodType(arity+1)}
+     * (fixed-arity {@code Object} receiver and arguments, {@code Object} return).
+     * Cases {@code 0..ARITY_LIMIT-1} match that type exactly; the spreader
+     * is the type-correct fallback if the limit grows without a matching case.
+     */
+    private static Object invokeHandle(final MethodHandle handle, final Closure<?> self, final Object[] arguments) throws Throwable {
+        switch (arguments.length) {
+            case 0:
+                return handle.invokeExact((Object) self);
+            case 1:
+                return handle.invokeExact((Object) self, arguments[0]);
+            case 2:
+                return handle.invokeExact((Object) self, arguments[0], arguments[1]);
+            case 3:
+                return handle.invokeExact((Object) self, arguments[0], arguments[1], arguments[2]);
+            case 4:
+                return handle.invokeExact((Object) self, arguments[0], arguments[1], arguments[2], arguments[3]);
+            default:
+                return handle.asSpreader(Object[].class, arguments.length).invokeExact((Object) self, arguments);
         }
     }
 
@@ -1434,13 +1479,16 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
     }
 
     /**
-     * NOTE: this reflective cache is a bridge, not a destination. For compiler-generated closure
+     * NOTE: this cache is a bridge, not a destination. For compiler-generated closure
      * classes the long-term plan (GEP-27) is for the compiler to emit a {@code call(Object...)}
      * override that arity-dispatches directly to the right {@code doCall} — plain virtual
-     * dispatch, no reflection, module-system-clean — at which point this cache serves only
-     * legacy jars and hand-written subclasses. Extend it with that destination in mind.
+     * dispatch, no {@code MethodHandle} adaptation, module-system-clean — at which point this
+     * cache serves only legacy jars and hand-written subclasses. Until then cached targets
+     * are invoked via {@code MethodHandle} ({@code Method.invoke} only when the target cannot
+     * be adapted). Extend it with that destination in mind.
      */
     private static final class CallOverride {
+        private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
         /**
          * Cached arities: {@code 0..ARITY_LIMIT-1}. Sized to cover every callback shape the GDK
          * drives (iteration and inject/withIndex variants peak at three parameters, plus slack).
@@ -1449,7 +1497,7 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
         /**
          * Marker instance indicating that no dispatch targets exist.
          */
-        static final CallOverride NONE = new CallOverride(new Method[ARITY_LIMIT], new Class[ARITY_LIMIT][], new boolean[ARITY_LIMIT]);
+        static final CallOverride NONE = new CallOverride(new Method[ARITY_LIMIT], new Class[ARITY_LIMIT][], new boolean[ARITY_LIMIT], new MethodHandle[ARITY_LIMIT]);
         /**
          * Cached {@code doCall} targets indexed by parameter count, or null where absent,
          * ambiguous, or inaccessible — {@code call} selects a {@code doCall}, so the cache is
@@ -1476,11 +1524,20 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
          * dispatched body keep their own fast path).
          */
         final boolean[] callForm;
+        /**
+         * {@link MethodHandles#unreflect(Method)} of {@link #byArity}, adapted to
+         * {@link MethodType#genericMethodType(int) genericMethodType(arity+1)}
+         * for {@code invokeExact}, or null when the method cannot be adapted.
+         * The call path prefers the handle so {@code Method.invoke} is not on
+         * the GDK {@code each}/{@code collect} hot path.
+         */
+        final MethodHandle[] handles;
 
-        private CallOverride(Method[] byArity, Class<?>[][] guards, boolean[] callForm) {
+        private CallOverride(Method[] byArity, Class<?>[][] guards, boolean[] callForm, MethodHandle[] handles) {
             this.byArity = byArity;
             this.guards = guards;
             this.callForm = callForm;
+            this.handles = handles;
         }
 
         static boolean guardsPass(Class<?>[] guards, Object[] args) {
@@ -1593,7 +1650,26 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
                 }
                 any = true;
             }
-            return any ? new CallOverride(byArity, guards, callForm) : NONE;
+            if (!any) {
+                return NONE;
+            }
+            MethodHandle[] handles = new MethodHandle[ARITY_LIMIT];
+            for (int arity = 0; arity < ARITY_LIMIT; arity += 1) {
+                if (byArity[arity] != null) {
+                    handles[arity] = unreflect(byArity[arity]);
+                }
+            }
+            return new CallOverride(byArity, guards, callForm, handles);
+        }
+
+        private static MethodHandle unreflect(final Method method) {
+            try {
+                return LOOKUP.unreflect(method)
+                        .asType(MethodType.genericMethodType(method.getParameterCount() + 1));
+            } catch (Exception ignored) {
+                // inaccessible or not adaptable: call() falls back to Method.invoke
+                return null;
+            }
         }
 
         private static Method findOverride(Class<?> type, Class<?>... params) {

--- a/src/test/groovy/groovy/lang/ClosureCallHandleTest.groovy
+++ b/src/test/groovy/groovy/lang/ClosureCallHandleTest.groovy
@@ -18,6 +18,7 @@
  */
 package groovy.lang
 
+import org.codehaus.groovy.runtime.InvokerInvocationException
 import org.junit.jupiter.api.Test
 
 import java.lang.invoke.MethodHandle
@@ -52,9 +53,11 @@ final class ClosureCallHandleTest {
         def c = new Closure(this) {
             def doCall(String s) { s.toUpperCase() }
         }
-        assert c.call('ab') == 'AB'
+        // Java/GDK entry: Groovy c.call(...) is indy and binds to doCall, skipping guards
+        assert javaVarargsCall(c, 'ab') == 'AB'
         // GROOVY-12164: GString is not a String, so the MH/guard path must not fire
-        assert c.call("${'ab'}") == 'AB'
+        assert javaVarargsCall(c, "${'ab'}") == 'AB'
+        assert handleFor(c, 1) != null
     }
 
     @Test
@@ -137,7 +140,7 @@ final class ClosureCallHandleTest {
     @Test
     void 'arity at the cache limit is not cached'() {
         def five = { a, b, c, d, e -> a + b + c + d + e }
-        assert five.call(1, 2, 3, 4, 5) == 15
+        assert javaVarargsCall(five, 1, 2, 3, 4, 5) == 15
         assert cachedTarget(five, 5) == null
         assert handleFor(five, 5) == null
     }
@@ -148,14 +151,16 @@ final class ClosureCallHandleTest {
         def empty = new Closure(this) {
             void doCall() { side << 1 }
         }
-        assert empty.call() == null
+        assert javaVarargsCall(empty) == null
         assert side == [1]
+        assert handleFor(empty, 0) != null
 
         def boxed = new Closure(this) {
             int doCall(int x) { x + 1 }
         }
-        assert boxed.call(41) == 42
+        assert javaVarargsCall(boxed, 41) == 42
         assert [1, 2].collect(boxed) == [2, 3]
+        assert handleFor(boxed, 1) != null
     }
 
     @Test
@@ -191,8 +196,37 @@ final class ClosureCallHandleTest {
     @Test
     void 'curried and method-pointer closures stay on the metaclass path'() {
         def add = { a, b -> a + b }
-        assert add.curry(10).call(2) == 12
-        assert 'abc'.&substring.call(1) == 'bc'
+        def curried = add.curry(10)
+        assert javaVarargsCall(curried, 2) == 12
+        assert javaVarargsCall('abc'.&substring, 1) == 'bc'
+        assert handleFor(curried, 1) == null
+        assert handleFor('abc'.&substring, 1) == null
+    }
+
+    @Test
+    void 'invokeCached catch propagates throwers built as MethodHandles'() {
+        def c = { 1 }
+        Method method = findDoCall(c.getClass(), 0)
+        method.accessible = true
+        MethodHandle throwing = MethodHandles.dropArguments(
+                MethodHandles.throwException(Object, IllegalStateException)
+                        .bindTo(new IllegalStateException('mh-throw')),
+                0, Object)
+        def e = shouldFail(IllegalStateException) {
+            invokeCachedDirect(throwing, method, c, new Object[0])
+        }
+        assert e.message == 'mh-throw'
+    }
+
+    @Test
+    void 'invokeCached catch propagates NullPointerException from invokeHandle'() {
+        def c = { 1 }
+        Method method = findDoCall(c.getClass(), 0)
+        method.accessible = true
+        MethodHandle handle = handleFor(c, 0)
+        shouldFail(NullPointerException) {
+            invokeCachedDirect(handle, method, c, null)
+        }
     }
 
     @Test
@@ -246,6 +280,203 @@ final class ClosureCallHandleTest {
     }
 
     @Test
+    void 'java varargs call hits invokeHandle for arities zero through four'() {
+        // Groovy c.call(a,b,...) is indy and binds to doCall; the MH switch is on
+        // Closure.call(Object...), which Java/GDK uses.
+        def zero = { 42 }
+        assert javaVarargsCall(zero) == 42
+        def one = { x -> x }
+        assert javaVarargsCall(one, 'x') == 'x'
+        def two = { a, b -> a + b }
+        assert javaVarargsCall(two, 1, 2) == 3
+        def three = { a, b, c -> a + b + c }
+        assert javaVarargsCall(three, 1, 2, 3) == 6
+        def four = { a, b, c, d -> a + b + c + d }
+        assert javaVarargsCall(four, 1, 2, 3, 4) == 10
+    }
+
+    @Test
+    void 'java varargs call rethrows body throwables from the handle'() {
+        def boom = { throw new IllegalStateException('via-java-call') }
+        def e = shouldFail(IllegalStateException) {
+            javaVarargsCall(boom)
+        }
+        assert e.message == 'via-java-call'
+
+        def inner = new RuntimeException('inner')
+        def iteBody = { throw new InvocationTargetException(inner) }
+        def ite = shouldFail(InvocationTargetException) {
+            javaVarargsCall(iteBody)
+        }
+        assert ite.cause.is(inner)
+
+        def io = { throw new IOException('via-java-call-io') }
+        def ioe = shouldFail(IOException) {
+            javaVarargsCall(io)
+        }
+        assert ioe.message == 'via-java-call-io'
+
+        def err = { throw new Error('via-java-call-err') }
+        def error = shouldFail(Error) {
+            javaVarargsCall(err)
+        }
+        assert error.message == 'via-java-call-err'
+    }
+
+    @Test
+    void 'public call uses Method invoke when the cached handle is cleared'() {
+        def c = { x -> "r:$x" }
+        assert javaVarargsCall(c, 'a') == 'r:a'
+        assert handleFor(c, 1) != null
+        clearHandle(c, 1)
+        assert handleFor(c, 1) == null
+        assert javaVarargsCall(c, 'b') == 'r:b'
+    }
+
+    @Test
+    void 'public call unwraps InvocationTargetException when the handle is cleared'() {
+        def c = { throw new IllegalStateException('cleared-handle') }
+        try {
+            javaVarargsCall(c)
+        } catch (IllegalStateException ignored) {
+            // warms CallOverride so byArity[0] is populated
+        }
+        clearHandle(c, 0)
+        def e = shouldFail(IllegalStateException) {
+            javaVarargsCall(c)
+        }
+        assert e.message == 'cleared-handle'
+    }
+
+    @Test
+    void 'subclass with no doCall or call override resolves to CallOverride NONE'() {
+        def c = new Closure(this) {}
+        assert callOverrideOf(c).is(callOverrideNone())
+        shouldFail(MissingMethodException) {
+            javaVarargsCall(c)
+        }
+        Method lookup = Class.forName('groovy.lang.Closure$CallOverride')
+                .getDeclaredMethod('lookup', Class)
+        lookup.accessible = true
+        assert lookup.invoke(null, Closure).is(callOverrideNone())
+    }
+
+    @Test
+    void 'null arguments array skips the cached handle and uses the metaclass'() {
+        def c = { 7 }
+        assert javaVarargsCall(c) == 7
+        Method call = Closure.getMethod('call', Object[].class)
+        assert call.invoke(c, new Object[]{null}) == 7
+    }
+
+    @Test
+    void 'lookup skips static array and ambiguous doCall shapes'() {
+        def skipped = new Closure(this) {
+            static Object doCall(String ignored) { 'static' }
+            static Object call(Object ignored) { 'static-call' }
+            Object extra() { 'not-doCall' }
+            def doCall(Object[] args) { args }
+            def doCall() { 1 }
+        }
+        assert javaVarargsCall(skipped) == 1
+        assert handleFor(skipped, 0) != null
+        assert cachedTarget(skipped, 1) == null
+
+        def mixed = new Closure(this) {
+            def doCall(Object a, String b) { "$a:$b" }
+        }
+        assert javaVarargsCall(mixed, 1, 'x') == '1:x'
+        assert javaVarargsCall(mixed, 1, "${'x'}") == '1:x'
+        assert handleFor(mixed, 2) != null
+
+        def ambiguous = new Closure(this) {
+            def doCall(String s) { "s:$s" }
+            def doCall(Integer i) { "i:$i" }
+        }
+        assert javaVarargsCall(ambiguous, 'a') == 's:a'
+        assert javaVarargsCall(ambiguous, 2) == 'i:2'
+        assert cachedTarget(ambiguous, 1) == null
+        assert handleFor(ambiguous, 1) == null
+    }
+
+    @Test
+    void 'lookup keeps the most-derived doCall and boxes every primitive guard'() {
+        def child = new ChildDoCall()
+        assert javaVarargsCall(child, 'z') == 'child:z'
+        assert handleFor(child, 1) != null
+
+        def covariant = new StringDoCallClosure()
+        assert StringDoCallClosure.declaredMethods.any { it.name == 'doCall' && it.bridge }
+        assert javaVarargsCall(covariant, 7) == '7'
+        assert handleFor(covariant, 1) != null
+        assert !cachedTarget(covariant, 1).bridge
+
+        def primitives = new PrimitiveDoCalls()
+        assert javaVarargsCall(primitives, 1) == 2
+        assert javaVarargsCall(primitives, 1L, 2L) == 3L
+        assert javaVarargsCall(primitives, true, false, true) == true
+        assert javaVarargsCall(primitives, 1.0d, 2.0d, 3.0d, 4.0d) == 10.0d
+        assert handleFor(primitives, 1) != null
+        assert handleFor(primitives, 2) != null
+        assert handleFor(primitives, 3) != null
+        assert handleFor(primitives, 4) != null
+
+        def more = new MorePrimitiveDoCalls()
+        assert javaVarargsCall(more, (char) 'A') == (char) 'A'
+        assert javaVarargsCall(more, (byte) 1, (byte) 2) == (byte) 3
+        assert javaVarargsCall(more, (short) 1, (short) 2, (short) 3) == (short) 6
+        assert javaVarargsCall(more, 1.0f, 2.0f, 3.0f, 4.0f) == 10.0f
+        assert handleFor(more, 1) != null
+        assert handleFor(more, 2) != null
+        assert handleFor(more, 3) != null
+        assert handleFor(more, 4) != null
+    }
+
+    @Test
+    void 'InvokerInvocationException from the metaclass is unwrapped'() {
+        def c = { 1 }
+        c.metaClass = new DelegatingMetaClass(c.metaClass) {
+            @Override
+            Object invokeMethod(Object object, String methodName, Object[] arguments) {
+                throw new InvokerInvocationException(new IllegalStateException('via-mop'))
+            }
+        }
+        def e = shouldFail(IllegalStateException) {
+            javaVarargsCall(c)
+        }
+        assert e.message == 'via-mop'
+    }
+
+    @Test
+    void 'an active category or replaced metaclass skips the cached handle'() {
+        def c = { x -> "v:$x" }
+        assert javaVarargsCall(c, 'a') == 'v:a'
+        use(HandleTestCategory) {
+            assert javaVarargsCall(c, 'b') == 'v:b'
+        }
+        c.metaClass = c.metaClass
+        assert javaVarargsCall(c, 'c') == 'v:c'
+    }
+
+    @Test
+    void 'lookup helpers handle non-closure types and unboxable leftovers'() {
+        Class<?> callOverride = Class.forName('groovy.lang.Closure$CallOverride')
+        Method lookup = callOverride.getDeclaredMethod('lookup', Class)
+        lookup.accessible = true
+        assert lookup.invoke(null, String).is(callOverrideNone())
+
+        Method findOverride = callOverride.getDeclaredMethod('findOverride', Class, Class[])
+        findOverride.accessible = true
+        assert findOverride.invoke(null, Closure, [String] as Class[]) == null
+
+        Method wrapperOf = callOverride.getDeclaredMethod('wrapperOf', Class)
+        wrapperOf.accessible = true
+        assert wrapperOf.invoke(null, void) == void
+        assert wrapperOf.invoke(null, String) == String
+        assert wrapperOf.invoke(null, float) == Float
+    }
+
+    @Test
     void 'unreflect returns null when the method cannot be adapted'() {
         def hidden = new Object() {
             private void secret() {}
@@ -255,6 +486,42 @@ final class ClosureCallHandleTest {
         Method unreflect = callOverride.getDeclaredMethod('unreflect', Method)
         unreflect.accessible = true
         assert unreflect.invoke(null, method) == null
+    }
+
+    private static Object javaVarargsCall(Closure c, Object... args) {
+        Method m = Closure.getMethod('call', Object[].class)
+        try {
+            return m.invoke(c, new Object[]{args})
+        } catch (InvocationTargetException ite) {
+            throw ite.cause
+        }
+    }
+
+    private static Object callOverrideNone() {
+        def none = Class.forName('groovy.lang.Closure$CallOverride').getDeclaredField('NONE')
+        none.accessible = true
+        return none.get(null)
+    }
+
+    private static Object callOverrideOf(Closure closure) {
+        def table = Closure.getDeclaredField('CALL_OVERRIDES')
+        table.accessible = true
+        return table.get(null).get(closure.getClass())
+    }
+
+    private static void clearHandle(Closure closure, int arity) {
+        Object[] slots = handleSlots(closure)
+        slots[arity] = null
+    }
+
+    private static Object[] handleSlots(Closure closure) {
+        Class<?> callOverride = Class.forName('groovy.lang.Closure$CallOverride')
+        def table = Closure.getDeclaredField('CALL_OVERRIDES')
+        table.accessible = true
+        def override = table.get(null).get(closure.getClass())
+        def f = callOverride.getDeclaredField('handles')
+        f.accessible = true
+        return (Object[]) f.get(override)
     }
 
     private static Object callOverrideField(Closure closure, String field, int arity) {
@@ -303,4 +570,42 @@ final class ClosureCallHandleTest {
             throw ite.cause
         }
     }
+}
+
+class HandleTestCategory {
+    static Object identity(Object self) { self }
+}
+
+class ParentDoCall extends Closure {
+    ParentDoCall() { super(null) }
+
+    def doCall(Object o) { "parent:$o" }
+}
+
+class ChildDoCall extends ParentDoCall {
+    def doCall(Object o) { "child:$o" }
+}
+
+class PrimitiveDoCalls extends Closure {
+    PrimitiveDoCalls() { super(null) }
+
+    int doCall(int x) { x + 1 }
+
+    long doCall(long a, long b) { a + b }
+
+    boolean doCall(boolean a, boolean b, boolean c) { a || b || c }
+
+    double doCall(double a, double b, double c, double d) { a + b + c + d }
+}
+
+class MorePrimitiveDoCalls extends Closure {
+    MorePrimitiveDoCalls() { super(null) }
+
+    char doCall(char x) { x }
+
+    byte doCall(byte a, byte b) { (byte) (a + b) }
+
+    short doCall(short a, short b, short c) { (short) (a + b + c) }
+
+    float doCall(float a, float b, float c, float d) { a + b + c + d }
 }

--- a/src/test/groovy/groovy/lang/ClosureCallHandleTest.groovy
+++ b/src/test/groovy/groovy/lang/ClosureCallHandleTest.groovy
@@ -138,11 +138,59 @@ final class ClosureCallHandleTest {
     }
 
     @Test
-    void 'arity at the cache limit is not cached'() {
+    void 'arity at the specialised limit is cached as a spreader'() {
         def five = { a, b, c, d, e -> a + b + c + d + e }
         assert javaVarargsCall(five, 1, 2, 3, 4, 5) == 15
-        assert cachedTarget(five, 5) == null
-        assert handleFor(five, 5) == null
+        assert cachedTarget(five, 5) != null
+        MethodHandle handle = handleFor(five, 5)
+        assert handle != null
+        assert handle.type() == MethodType.genericMethodType(1, true)
+        shouldFail(MissingMethodException) {
+            javaVarargsCall(five, 1, 2, 3, 4)
+        }
+        shouldFail(MissingMethodException) {
+            javaVarargsCall(five, 1, 2, 3, 4, 5, 6)
+        }
+
+        def six = { a, b, c, d, e, f -> a + b + c + d + e + f }
+        assert javaVarargsCall(six, 1, 2, 3, 4, 5, 6) == 21
+        assert handleFor(six, 6).type() == MethodType.genericMethodType(1, true)
+        assert handleFor(six, 5) == null
+
+        def fiveInts = new Closure(this) {
+            int doCall(int a, int b, int c, int d, int e) { a + b + c + d + e }
+        }
+        assert javaVarargsCall(fiveInts, 1, 2, 3, 4, 5) == 15
+        assert handleFor(fiveInts, 5) != null
+
+        def boom = { a, b, c, d, e -> throw new IllegalStateException('five') }
+        def e = shouldFail(IllegalStateException) {
+            javaVarargsCall(boom, 1, 2, 3, 4, 5)
+        }
+        assert e.message == 'five'
+    }
+
+    @Test
+    void 'typed high-arity doCall still falls through when a guard fails'() {
+        def c = new Closure(this) {
+            def doCall(String a, String b, String c, String d, String e) {
+                a + b + c + d + e
+            }
+        }
+        assert javaVarargsCall(c, 'a', 'b', 'c', 'd', 'e') == 'abcde'
+        assert handleFor(c, 5) != null
+        assert javaVarargsCall(c, 'a', 'b', 'c', 'd', "${'e'}") == 'abcde'
+    }
+
+    @Test
+    void 'high-arity call override without doCall is not cached'() {
+        def c = new Closure(this) {
+            Object call(a, b, c, d, e) { 'wrapped' }
+        }
+        shouldFail(MissingMethodException) {
+            javaVarargsCall(c, 1, 2, 3, 4, 5)
+        }
+        assert handleFor(c, 5) == null
     }
 
     @Test
@@ -272,11 +320,11 @@ final class ClosureCallHandleTest {
         def c = new Closure(this) {
             def doCall(a, b, d, e, f) { [a, b, d, e, f] }
         }
-        Method method = findDoCall(c.getClass(), 5)
-        method.accessible = true
-        MethodHandle handle = MethodHandles.lookup().unreflect(method)
-                .asType(MethodType.genericMethodType(6))
+        MethodHandle handle = handleFor(c, 5)
+        assert handle != null
+        assert handle.type() == MethodType.genericMethodType(1, true)
         assert invokeHandleDirect(handle, c, [1, 2, 3, 4, 5] as Object[]) == [1, 2, 3, 4, 5]
+        assert javaVarargsCall(c, 1, 2, 3, 4, 5) == [1, 2, 3, 4, 5]
     }
 
     @Test
@@ -535,12 +583,43 @@ final class ClosureCallHandleTest {
         return (arity < slots.length) ? slots[arity] : null
     }
 
+    private static int arityLimit() {
+        def f = Class.forName('groovy.lang.Closure$CallOverride').getDeclaredField('ARITY_LIMIT')
+        f.accessible = true
+        return f.getInt(null)
+    }
+
     private static MethodHandle handleFor(Closure closure, int arity) {
-        return (MethodHandle) callOverrideField(closure, 'handles', arity)
+        if (arity < arityLimit()) {
+            return (MethodHandle) callOverrideField(closure, 'handles', arity)
+        }
+        return (MethodHandle) spreadSlotField(closure, arity, 'handle')
     }
 
     private static Method cachedTarget(Closure closure, int arity) {
-        return (Method) callOverrideField(closure, 'byArity', arity)
+        if (arity < arityLimit()) {
+            return (Method) callOverrideField(closure, 'byArity', arity)
+        }
+        return (Method) spreadSlotField(closure, arity, 'method')
+    }
+
+    private static Object spreadSlotField(Closure closure, int arity, String field) {
+        Class<?> callOverride = Class.forName('groovy.lang.Closure$CallOverride')
+        Object override = callOverrideOf(closure)
+        def spread = callOverride.getDeclaredField('spread')
+        spread.accessible = true
+        Object[] slots = (Object[]) spread.get(override)
+        Class<?> slotType = Class.forName('groovy.lang.Closure$CallOverride$SpreadSlot')
+        def arityField = slotType.getDeclaredField('arity')
+        arityField.accessible = true
+        def valueField = slotType.getDeclaredField(field)
+        valueField.accessible = true
+        for (Object slot : slots) {
+            if (arityField.getInt(slot) == arity) {
+                return valueField.get(slot)
+            }
+        }
+        return null
     }
 
     private static Method findDoCall(Class<?> type, int arity) {

--- a/src/test/groovy/groovy/lang/ClosureCallHandleTest.groovy
+++ b/src/test/groovy/groovy/lang/ClosureCallHandleTest.groovy
@@ -1,0 +1,306 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.lang
+
+import org.junit.jupiter.api.Test
+
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+
+import static groovy.test.GroovyAssert.shouldFail
+
+/**
+ * Generated and hand-written closures must keep the same call semantics after
+ * the MethodHandle fast path is used for {@code doCall} / {@code call} targets.
+ * Handle-thrown exceptions surface as the body threw them; {@code Method.invoke}
+ * is used only when a target cannot be adapted, and only then is its wrapper
+ * {@link InvocationTargetException} unwrapped.
+ */
+final class ClosureCallHandleTest {
+
+    @Test
+    void 'gdk each collect findAll and inject still dispatch'() {
+        assert [1, 2, 3].collect { it * 2 } == [2, 4, 6]
+        assert [1, 2, 3].findAll { it > 1 } == [2, 3]
+        def sum = 0
+        [1, 2, 3].each { sum += it }
+        assert sum == 6
+        assert [1, 2, 3].inject(0) { a, b -> a + b } == 6
+    }
+
+    @Test
+    void 'typed doCall falls through to the metaclass when a guard fails'() {
+        def c = new Closure(this) {
+            def doCall(String s) { s.toUpperCase() }
+        }
+        assert c.call('ab') == 'AB'
+        // GROOVY-12164: GString is not a String, so the MH/guard path must not fire
+        assert c.call("${'ab'}") == 'AB'
+    }
+
+    @Test
+    void 'exceptions from doCall are rethrown unwrapped'() {
+        def c = { throw new IllegalStateException('boom') }
+        def e = shouldFail(IllegalStateException) {
+            c.call()
+        }
+        assert e.message == 'boom'
+    }
+
+    @Test
+    void 'InvocationTargetException from the body is not treated as a reflection wrapper'() {
+        def inner = new RuntimeException('inner')
+        def c = { throw new InvocationTargetException(inner) }
+        def e = shouldFail(InvocationTargetException) {
+            c.call()
+        }
+        assert e.cause.is(inner)
+    }
+
+    @Test
+    void 'IllegalAccessException from the body is not wrapped as GroovyRuntimeException'() {
+        // Invoke the Java varargs entry reflectively: GroovyAssert.shouldFail and Groovy
+        // call sites unwrap GroovyRuntimeException, which would hide the wrap-as-GRE bug.
+        def c = { throw new IllegalAccessException('nope') }
+        try {
+            // Method.invoke is itself varargs: wrap the Object[] argument so we
+            // pass one parameter to call(Object...), not zero.
+            Closure.getMethod('call', Object[].class).invoke(c, new Object[]{new Object[0]})
+            assert false: 'expected InvocationTargetException'
+        } catch (InvocationTargetException ite) {
+            assert ite.cause instanceof IllegalAccessException
+            assert !(ite.cause instanceof GroovyRuntimeException)
+            assert ite.cause.message == 'nope'
+        }
+    }
+
+    @Test
+    void 'checked exceptions from doCall surface as thrown'() {
+        def c = { throw new IOException('io') }
+        def e = shouldFail(IOException) {
+            c.call()
+        }
+        assert e.message == 'io'
+    }
+
+    @Test
+    void 'errors from doCall surface as thrown'() {
+        def c = { throw new Error('err') }
+        def e = shouldFail(Error) {
+            c.call()
+        }
+        assert e.message == 'err'
+    }
+
+    @Test
+    void 'zero through four argument call forms keep their results'() {
+        def zero = { 42 }
+        assert zero.call() == 42
+        def one = { x -> x }
+        assert one.call('x') == 'x'
+        def two = { a, b -> a + b }
+        assert two.call(1, 2) == 3
+        def three = { a, b, c -> a + b + c }
+        assert three.call(1, 2, 3) == 6
+        def four = { a, b, c, d -> a + b + c + d }
+        assert four.call(1, 2, 3, 4) == 10
+        assert [a: 1, b: 2].inject(0) { acc, k, v -> acc + v } == 3
+        def seen = []
+        [x: 1].eachWithIndex { k, v, i -> seen << "$k:$v:$i".toString() }
+        assert seen == ['x:1:0']
+        assert handleFor(zero, 0) != null
+        assert handleFor(one, 1) != null
+        assert handleFor(two, 2) != null
+        assert handleFor(three, 3) != null
+        assert handleFor(four, 4) != null
+    }
+
+    @Test
+    void 'arity at the cache limit is not cached'() {
+        def five = { a, b, c, d, e -> a + b + c + d + e }
+        assert five.call(1, 2, 3, 4, 5) == 15
+        assert cachedTarget(five, 5) == null
+        assert handleFor(five, 5) == null
+    }
+
+    @Test
+    void 'void and primitive doCall adapt through the handle'() {
+        def side = []
+        def empty = new Closure(this) {
+            void doCall() { side << 1 }
+        }
+        assert empty.call() == null
+        assert side == [1]
+
+        def boxed = new Closure(this) {
+            int doCall(int x) { x + 1 }
+        }
+        assert boxed.call(41) == 42
+        assert [1, 2].collect(boxed) == [2, 3]
+    }
+
+    @Test
+    void 'null Object argument reaches an all-Object doCall'() {
+        def c = { it }
+        assert c.call((Object) null) == null
+    }
+
+    @Test
+    void 'call-form override is invoked via the handle and the re-entry latch still holds'() {
+        def wrapped = new Closure(this) {
+            @Override
+            Object call(Object arg) {
+                return 'wrapped:' + arg
+            }
+        }
+        // Java/GDK entry: call(Object...) must agree with virtual call(Object)
+        assert wrapped.call(new Object[]{'x'}) == 'wrapped:x'
+        assert ['a'].collect(wrapped) == ['wrapped:a']
+        assert handleFor(wrapped, 1) != null
+
+        def reenter = new Closure(this) {
+            @Override
+            Object call() {
+                return call(new Object[0])
+            }
+            Object doCall() { 99 }
+        }
+        assert reenter.call(new Object[0]) == 99
+        assert handleFor(reenter, 0) != null
+    }
+
+    @Test
+    void 'curried and method-pointer closures stay on the metaclass path'() {
+        def add = { a, b -> a + b }
+        assert add.curry(10).call(2) == 12
+        assert 'abc'.&substring.call(1) == 'bc'
+    }
+
+    @Test
+    void 'invokeCached falls back to Method invoke when the handle is null'() {
+        def c = { x -> "r:$x" }
+        Method method = findDoCall(c.getClass(), 1)
+        method.accessible = true
+        assert invokeCachedDirect(null, method, c, ['z'] as Object[]) == 'r:z'
+    }
+
+    @Test
+    void 'invokeCached unwraps InvocationTargetException from Method invoke'() {
+        def c = { throw new IllegalStateException('via-reflect') }
+        Method method = findDoCall(c.getClass(), 0)
+        method.accessible = true
+        def e = shouldFail(IllegalStateException) {
+            invokeCachedDirect(null, method, c, new Object[0])
+        }
+        assert e.message == 'via-reflect'
+    }
+
+    @Test
+    void 'invokeCached wraps IllegalAccessException from Method invoke'() {
+        def c = new Closure(this) {
+            private Object doCall() { 'secret' }
+        }
+        Method method = c.getClass().getDeclaredMethod('doCall')
+        method.accessible = false
+        Method invokeCached = Closure.getDeclaredMethod('invokeCached', MethodHandle, Method, Closure, Object[])
+        invokeCached.accessible = true
+        try {
+            invokeCached.invoke(null, null, method, c, new Object[0])
+            assert false: 'expected InvocationTargetException wrapping GroovyRuntimeException'
+        } catch (InvocationTargetException ite) {
+            // catch the reflective wrapper so GroovyAssert does not unwrap GRE
+            assert ite.cause instanceof GroovyRuntimeException
+            assert ite.cause.cause instanceof IllegalAccessException
+        }
+    }
+
+    @Test
+    void 'invokeHandle spreader covers arity beyond the specialised switch'() {
+        def c = new Closure(this) {
+            def doCall(a, b, d, e, f) { [a, b, d, e, f] }
+        }
+        Method method = findDoCall(c.getClass(), 5)
+        method.accessible = true
+        MethodHandle handle = MethodHandles.lookup().unreflect(method)
+                .asType(MethodType.genericMethodType(6))
+        assert invokeHandleDirect(handle, c, [1, 2, 3, 4, 5] as Object[]) == [1, 2, 3, 4, 5]
+    }
+
+    @Test
+    void 'unreflect returns null when the method cannot be adapted'() {
+        def hidden = new Object() {
+            private void secret() {}
+        }
+        Method method = hidden.getClass().getDeclaredMethod('secret')
+        Class<?> callOverride = Class.forName('groovy.lang.Closure$CallOverride')
+        Method unreflect = callOverride.getDeclaredMethod('unreflect', Method)
+        unreflect.accessible = true
+        assert unreflect.invoke(null, method) == null
+    }
+
+    private static Object callOverrideField(Closure closure, String field, int arity) {
+        Class<?> callOverride = Class.forName('groovy.lang.Closure$CallOverride')
+        def table = Closure.getDeclaredField('CALL_OVERRIDES')
+        table.accessible = true
+        def override = table.get(null).get(closure.getClass())
+        def f = callOverride.getDeclaredField(field)
+        f.accessible = true
+        Object[] slots = (Object[]) f.get(override)
+        return (arity < slots.length) ? slots[arity] : null
+    }
+
+    private static MethodHandle handleFor(Closure closure, int arity) {
+        return (MethodHandle) callOverrideField(closure, 'handles', arity)
+    }
+
+    private static Method cachedTarget(Closure closure, int arity) {
+        return (Method) callOverrideField(closure, 'byArity', arity)
+    }
+
+    private static Method findDoCall(Class<?> type, int arity) {
+        Method found = type.getDeclaredMethods().find { Method m ->
+            m.name == 'doCall' && m.parameterCount == arity && !m.bridge
+        }
+        assert found != null: "no doCall/${arity} on ${type.name}"
+        return found
+    }
+
+    private static Object invokeCachedDirect(MethodHandle handle, Method target, Closure self, Object[] args) {
+        Method m = Closure.getDeclaredMethod('invokeCached', MethodHandle, Method, Closure, Object[])
+        m.accessible = true
+        try {
+            return m.invoke(null, handle, target, self, args)
+        } catch (InvocationTargetException ite) {
+            throw ite.cause
+        }
+    }
+
+    private static Object invokeHandleDirect(MethodHandle handle, Closure self, Object[] args) {
+        Method m = Closure.getDeclaredMethod('invokeHandle', MethodHandle, Closure, Object[])
+        m.accessible = true
+        try {
+            return m.invoke(null, handle, self, args)
+        } catch (InvocationTargetException ite) {
+            throw ite.cause
+        }
+    }
+}

--- a/src/test/java/groovy/lang/StringDoCallClosure.java
+++ b/src/test/java/groovy/lang/StringDoCallClosure.java
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.lang;
+
+/**
+ * Covariant {@code doCall} so javac emits a bridge. {@code CallOverride} must
+ * skip that bridge and cache the most-derived declaration.
+ */
+class ObjectDoCallClosure extends Closure<Object> {
+
+    ObjectDoCallClosure() {
+        super(null);
+    }
+
+    public Object doCall(final Object value) {
+        return value;
+    }
+}
+
+public final class StringDoCallClosure extends ObjectDoCallClosure {
+
+    public StringDoCallClosure() {
+        super();
+    }
+
+    @Override
+    public String doCall(final Object value) {
+        return String.valueOf(value);
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-12263

# Performance Verification Report

**Subject.** `1c3820bff71419b5c40e73142bbf3e82210ea317` — *Invoke cached Closure doCall targets via MethodHandle*

**Baseline.** `9bb195dee52e82518bb5f4e5cda9ddbf08c16d39` — immediate parent of the subject. The only production delta is `src/main/java/groovy/lang/Closure.java`. The accompanying unit-test file is not on the JMH hot path.

**Verdict.** The change delivers a statistically significant, host-stable, and *path-specific* improvement on the Java/GDK `Closure.call` entry that the commit claims to accelerate.

On the four GDK iteration benches that actually execute `DefaultGroovyMethods` → `Closure.call(Object)` → `call(Object...)`, wall-clock time falls by **13–21%** (geometric mean **1.168×**, about **4–6 ns per callback**). Groovy `invokedynamic` call sites that already bind straight to `doCall` are unchanged (geomean **0.990×**). A `MethodClosure` negative control is unchanged (**0.994×**). Host-calibration rulers sit at **0.998×**, so the GDK movement is not a host-speed artifact.

---

## 1. What was compared

`git diff --stat 9bb195dee5 1c3820bff7`:

| File | Role |
|---|---|
| `src/main/java/groovy/lang/Closure.java` | Production: cached `doCall` / `call` targets are invoked via `MethodHandle.invokeExact` instead of `Method.invoke`. |
| `src/test/groovy/groovy/lang/ClosureCallHandleTest.groovy` | Tests only. Not loaded by the JMH measurement loops. |

No other module, Gradle flag, or benchmark source differs between the two worktrees.

**Isolated bytecode check** (same class extracted from each JMH fat JAR):

| Artifact | `Closure.class` SHA-256 | `invokeExact` count | `Method.invoke` count |
|---|---|---|---|
| Baseline JAR | `7426d0a0…5461d609` | **0** | **2** |
| Target JAR | `2475a3f1…3e76a198` | **6** | **1** |

The six `invokeExact` sites are the specialized 0–4-arity cases plus the defensive spreader. The remaining `Method.invoke` is the documented fallback when `unreflect` fails. The two JARs therefore implement the two dispatch strategies under test and nothing else.

---

## 2. Measurement protocol

The experiment is a *paired, same-host, same-JVM, sequential* comparison of two isolated builds. It is deliberately *not* a comparison against the 90-day gh-pages history: that history is dominated by runner-hardware noise (see `subprojects/performance/README.adoc`).

### 2.1 Isolation

- Separate git worktrees at the two SHAs (`/tmp/groovy-base-9bb195d`, `/tmp/groovy-mh-1c3820b`).
- Each worktree built with `./gradlew :performance:jmhJar --offline`.
- JMH executed against that worktree’s own fat JAR (`performance-6.0.0-SNAPSHOT-jmh.jar`).
- Runs were **serial**, not concurrent, so they did not contend for the six vCPUs.

### 2.2 JMH configuration

These flags override the `@Fork(2)` annotations on the benchmark classes.

| Parameter | Value | Rationale |
|---|---|---|
| Benchmarks | `org.apache.groovy.perf.ClosureBench` (19 methods) + `org.apache.groovy.perf.HostCalibrationBench` (3 rulers) | The project’s own closure suite plus the core-hz hardware rulers |
| Mode / unit | `AverageTime`, as declared by the benches (`ms/op` for `ClosureBench`, `us/op` for rulers) | Lower is better |
| Forks | **4** independent JVMs | Between-fork variance is visible; one noisy fork cannot dominate |
| Warmup | 4 × 2 s | Past the C1/C2 transition on these loops |
| Measurement | 5 × 2 s | 20 samples per bench (4 × 5) |
| Heap | `-Xms2g -Xmx2g -XX:+AlwaysPreTouch` | Removes heap-resize and first-touch noise |
| Confidence | JMH default **99.9%** CI | Primary significance criterion: non-overlapping CIs |
| Order | Baseline first (23:49–00:19), target second (00:19–00:48), same host | Calibration rulers quantify any thermal or neighbor drift |

### 2.3 Host

| Item | Value |
|---|---|
| Host | `hera` |
| CPU | AMD EPYC 7763, 6 vCPUs, 1 thread/core |
| Memory | 23 GiB |
| OS | Linux 6.15.5 x86_64 |
| JDK | Amazon Corretto **25.0.2+10-LTS** (`25.0.2-amzn`) |
| Frequency governor | not exposed (`cpufreq` n/a) |

### 2.4 How “faster” is defined

For `AverageTime`, **speedup = baseline / target**. Values greater than 1 mean the target is faster. A result is labeled **faster** or **slower** only when the two 99.9% CIs do not overlap; otherwise **inconclusive**.

A Welch two-sample *t* on the 20 raw iteration samples is reported as a secondary check (`t`, Welch–Satterthwaite `df`). Two-sided *p*-values are not tabulated: SciPy is not installed on this host, and every GDK *t* exceeds 11 on `df > 22`, which is `p ≪ 0.001` under any reasonable tail model.

---

## 3. Path analysis: which benches *must* move

The production change lives **only** in `Closure.call(Object...)`. A bench can improve only if its steady-state work actually enters that method.

Generated closures declare `doCall(...)` and do **not** override `call(Object)`. Two distinct caller shapes then arise:

1. **Java / GDK entry.** `DefaultGroovyMethods.each` / `collect` / `findAll` / `inject` compile as Java `closure.call(item)` (or `call(acc, val)`). That resolves to `Closure.call(Object)` / `call(Object, Object)`, which wrap into `call(Object...)`. This is the path named in the commit comment (the `each` / `collect` hot path). **Primary treatment.**

2. **Groovy `invokedynamic` entry.** `c(i)` and `c.call(i)` in `ClosureBench` compile to the same indy site, `invoke:(Lgroovy/lang/Closure;I)`. After warmup the site binds **directly to `doCall(Object)`** and never enters `Closure.call(Object...)`. **Must not move.** Confirmed by disassembly of `ClosureBench.closureCallMethod` and `closureReuse` in the target JAR, and by the generated class `ClosureBench$_closureCallMethod_closure14` exposing only `doCall` / `doCall()`.

3. **Adapters that re-enter a generated closure.** `CurriedClosure` and `MethodClosure` are explicitly `CallOverride.NONE`. `ComposedClosure.doCall(Object[])` is array-typed and likewise uncached. Their *outer* call stays on the metaclass. The *inner* generated bodies, however, are invoked via `call(...)` after uncurry or composition, so they **can** pick up the `MethodHandle` path. These are **secondary / indirect**, not clean negatives.

4. **True negative control.** `list.&size` is a `MethodClosure`: `CallOverride.lookup` returns `NONE`, and there is no generated `doCall` body to re-enter. **Must not move.**

5. **Hardware rulers.** `HostCalibrationBench.{cpuIntegerOps, memoryPointerChase, allocationChurn}` are pure Java and Groovy-independent. Their geometric mean is the **calibration factor**. A factor near 1 means the two 29-minute windows ran at equivalent host speed.

```
                    Groovy indy  ──►  doCall            (ClosureBench.closureReuse / .closureCallMethod)
                                         ▲
Java/GDK call(Object)                    │
    └─► Closure.call(Object...) ──► Method.invoke   [baseline]
                                └─► invokeExact     [target]   ◄── this commit
                                         │
Curried / Composed outer ──► metaclass ──┘ (re-enters inner call(...))
MethodClosure            ──► metaclass, no generated doCall
```

---

## 4. Results

### 4.1 Hardware calibration (must be ~1.0×)

| Ruler | Baseline | Target | Speedup | 99.9% CIs | Verdict |
|---|---:|---:|---:|---|---|
| `cpuIntegerOps` | 407.502 ± 1.914 µs/op | 405.945 ± 1.898 µs/op | 1.004× | overlap | inconclusive |
| `memoryPointerChase` | 1419.758 ± 52.048 µs/op | 1451.855 ± 19.503 µs/op | 0.978× | overlap | inconclusive |
| `allocationChurn` | 96.799 ± 4.399 µs/op | 95.504 ± 3.902 µs/op | 1.014× | overlap | inconclusive |
| **Geomean** |  |  | **0.998×** |  | **no host drift** |

The second window is 0.2% slower on the geometric mean of the rulers — well inside JMH noise, and in the *opposite* direction of the GDK result. A 17% GDK movement cannot be attributed to the machine speeding up.

### 4.2 Primary treatment — GDK Java callbacks (must improve if the claim is true)

Each of these methods performs **1 000 000** closure invocations per JMH op (`ITERATIONS/10` outer loops × a 10-element list, or 2-arg `inject` over the same list). Scores are therefore also **nanoseconds per callback**, including iterator and DGM overhead.

| Benchmark | Baseline (ms/op) | Target (ms/op) | Speedup | Δ per call | 99.9% CIs | Welch *t* (df) | Verdict |
|---|---:|---:|---:|---:|---|---:|---|
| `eachWithClosure` | 34.438 ± 0.666 | 29.404 ± 0.385 | **1.171×** | **−5.03 ns** | disjoint | 25.41 (30.4) | **faster** |
| `collectWithClosure` | 36.576 ± 1.598 | 31.454 ± 0.481 | **1.163×** | **−5.12 ns** | disjoint | 11.92 (22.4) | **faster** |
| `findAllWithClosure` | 34.202 ± 0.986 | 30.313 ± 0.906 | **1.128×** | **−3.89 ns** | disjoint | 11.28 (37.7) | **faster** |
| `injectWithClosure` | 34.052 ± 1.019 | 28.095 ± 0.677 | **1.212×** | **−5.96 ns** | disjoint | 18.90 (33.0) | **faster** |
| **Geomean** |  |  | **1.168×** | **≈ −5.0 ns** |  |  | **all four faster** |

Per-fork means (ms/op) — every fork of every GDK bench moves in the same direction; this is not a single lucky fork:

| Bench | Baseline forks | Target forks |
|---|---|---|
| `each` | 34.28, 34.05, 34.51, 34.92 | 29.12, 29.54, 29.54, 29.42 |
| `collect` | 36.04, 37.11, 35.90, 37.25 | 31.67, 31.37, 31.44, 31.34 |
| `findAll` | 34.46, 34.72, 33.66, 33.97 | 30.34, 30.65, 30.24, 30.02 |
| `inject` | 34.41, 34.46, 33.62, 33.73 | 27.47, 28.61, 28.18, 28.12 |

Relative CI half-width stays in the 1.3–4.4% band on both sides; the target is if anything tighter. `findAll` saves a little less (~3.9 ns) than `each` / `collect` / `inject` (~5–6 ns), which is consistent with `BooleanClosureWrapper` adding a fixed cost that the `MethodHandle` change does not touch.

**Reading the 5 ns.** A Groovy-indy `doCall` of `{ it * 2 }` is ~2.2 ns in the same process (`closureCallMethod`). The GDK benches spend ~34 ns per callback, of which iterator + DGM + `call(Object)` array wrap + `doCall` body account for the rest. Removing `Method.invoke`’s reflective wrapper from that mix and replacing it with `invokeExact` is expected to save a handful of nanoseconds, not tens. The measured −5 ns/call matches that model. It is **not** a 17% reduction inside `doCall` itself; it is a 17% reduction in the *GDK callback round-trip*, which is exactly the surface the commit optimizes.

### 4.3 Groovy indy sites (must *not* improve)

| Benchmark | Baseline | Target | Speedup | Verdict |
|---|---:|---:|---:|---|
| `closureCallMethod` | 2.202 ± 0.094 | 2.200 ± 0.073 | 1.001× | inconclusive |
| `closureReuse` | 2.220 ± 0.105 | 2.182 ± 0.059 | 1.017× | inconclusive |
| `closureWithCapture` | 2.601 ± 0.062 | 2.580 ± 0.067 | 1.008× | inconclusive |
| `closureModifyCapture` | 4.813 ± 0.168 | 4.862 ± 0.184 | 0.990× | inconclusive |
| `closureMultiParams` | 14.942 ± 0.316 | 14.855 ± 0.443 | 1.006× | inconclusive |
| `simpleClosureCreation` | 29.528 ± 0.691 | 29.288 ± 0.807 | 1.008× | inconclusive |
| `closureAsParameter` | 28.606 ± 2.925 | 29.563 ± 3.470 | 0.968× | inconclusive |
| `closureDelegation` | 50.361 ± 1.603 | 46.799 ± 2.949 | 1.076× | inconclusive |
| `nestedClosures` | 33.478 ± 5.876 | 39.171 ± 7.665 | 0.855× | inconclusive |
| **Geomean** |  |  | **0.990×** | **flat** |

`nestedClosures` and `closureDelegation` have wide CIs (inner allocation and property-dispatch work dominate) and still overlap. The near-2.2 ns `closureCallMethod` / `closureReuse` pair is identical to 0.1%. This group is the **specificity check**: if the whole JVM had simply gotten faster, these would have moved with the GDK benches. They did not.

### 4.4 Adapters and the true negative control

| Benchmark | Path | Baseline | Target | Speedup | Verdict |
|---|---|---:|---:|---:|---|
| `methodReference` | `MethodClosure` → `NONE` | 87.927 ± 3.022 | 88.473 ± 3.352 | **0.994×** | inconclusive |
| `curriedClosure` | outer `NONE`, inner re-enters `call` | 24.920 ± 0.757 | 20.975 ± 0.936 | 1.188× | faster |
| `rightCurriedClosure` | same | 25.006 ± 0.564 | 20.072 ± 0.690 | 1.246× | faster |
| `closureComposition` | `doCall(Object[])` uncached; inners via `call` | 39.456 ± 0.952 | 33.935 ± 1.119 | 1.163× | faster |

`methodReference` is the clean negative and does not move (*t* = −0.47). Curry, rcurry, and compose **do** move, in the same 16–25% band as the GDK group. That is expected once the inner generated closures are taken into account: `CurriedClosure` is excluded from the cache *so that* `MetaClassImpl` can uncurry and re-enter, and that re-entry is a `call(...)` on a generated closure. Treating them as proof of a general, unspecified speedup would be wrong; treating them as a contradiction would also be wrong. They are a **consistent secondary effect**.

### 4.5 Context benches (not a test of this commit)

| Benchmark | Baseline | Target | Speedup | Verdict |
|---|---:|---:|---:|---|
| `closureTrampoline` | 44.738 ± 2.324 | 44.550 ± 2.327 | 1.004× | inconclusive |
| `closureSpread` | 1786.532 ± 64.833 | 1832.367 ± 94.159 | 0.975× | inconclusive |

Trampoline is dominated by `TrampolineClosure` machinery. Spread (`sum3(*args)`) is dominated by argument packing. CIs overlap.

---

## 5. Why this is the MethodHandle change, not a confound

| Alternative explanation | Why it is rejected |
|---|---|
| Host sped up between the two 29-minute windows | Calibration geomean **0.998×**; integer-ruler CIs overlap; the 0.4% `cpuIntegerOps` tick is smaller than, and opposite in direction to, a 17% GDK claim. |
| Different sources, flags, or dependency versions | `git diff` is two files; both JARs built `--offline` from worktrees pinned at the two SHAs; `Closure.class` hashes and `invokeExact` counts match the intended implementations. |
| JIT / fork noise | 4 forks; every GDK fork moves the same way; 20 samples; 99.9% CIs disjoint; Welch *t* ∈ [11, 25]. |
| “Everything that uses a closure got faster” | Indy `doCall` sites and `MethodClosure` did **not** move. The improvement is confined to callers that enter `Closure.call(Object...)`. |
| The test-file change affected the benches | `ClosureCallHandleTest` is not referenced from `ClosureBench`. |
| Packed closures hiding the path | Packing is opt-in (`@PackedClosures` / `groovy.target.closure.pack`). `ClosureBench` is compiled without it; the generated classes extend `Closure` and implement `GeneratedClosure` with `doCall` only. |

---

## 6. What this report does *not* claim

- It does **not** claim that Groovy dynamic dispatch in general is 17% faster. Groovy-indy `c(i)` was already ~2.2 ns/call and stays there.
- It does **not** claim a 17% reduction inside `doCall`. The ~5 ns is the reflective-invoke overhead disappearing from the Java `call` wrapper around `doCall`.
- It does **not** compare against the gh-pages 90-day dashboard. That comparison is hardware-dominated; this one is a same-host A/B of two commits.
- It does **not** measure cold start, allocation (`-prof gc` was not attached, to keep the timing run clean), or packed-closure dispatch (`PackedClosure` overrides `call` and never uses this cache).
- Frequency-governor data is unavailable on this VM; calibration rulers are the substitute.

---

## 7. Conclusion

On a same-host, 4-fork, 99.9%-CI JMH comparison of the isolated parent and the MethodHandle commit:

1. **The advertised path is faster.** GDK `each` / `collect` / `findAll` / `inject` improve by **1.13–1.21×** (geomean **1.168×**, **−4 to −6 ns per callback**). All four 99.9% CIs are disjoint; all four fork sets move in the same direction.
2. **The improvement is specific.** Groovy-indy sites that bind to `doCall` (geomean **0.990×**) and `MethodClosure` (**0.994×**) do not move.
3. **The host did not move.** Calibration geomean **0.998×**.
4. **Secondary adapters behave as the architecture predicts.** Curry and compose improve because they re-enter generated `call(...)`; they are not counterexamples.

The performance claim of `1c3820b` is therefore **confirmed** for the Java/GDK `Closure.call` hot path, at a magnitude that matches the cost of `Method.invoke` being removed, and with no detectable regression on the paths the change is designed to leave alone.

---

## Appendix A — Reproducing this run

```bash
git worktree add /tmp/groovy-base-9bb195d 9bb195dee52e82518bb5f4e5cda9ddbf08c16d39
git worktree add /tmp/groovy-mh-1c3820b   1c3820bff71419b5c40e73142bbf3e82210ea317

(cd /tmp/groovy-base-9bb195d && ./gradlew :performance:jmhJar --offline)
(cd /tmp/groovy-mh-1c3820b   && ./gradlew :performance:jmhJar --offline)

java -jar /tmp/groovy-base-9bb195d/subprojects/performance/build/libs/performance-6.0.0-SNAPSHOT-jmh.jar \
  org.apache.groovy.perf.ClosureBench org.apache.groovy.perf.HostCalibrationBench \
  -f 4 -wi 4 -i 5 -w 2s -r 2s -rf json -foe true \
  -jvmArgsAppend '-Xms2g -Xmx2g -XX:+AlwaysPreTouch' \
  -rff jmh-base.json -o jmh-base.txt

java -jar /tmp/groovy-mh-1c3820b/subprojects/performance/build/libs/performance-6.0.0-SNAPSHOT-jmh.jar \
  org.apache.groovy.perf.ClosureBench org.apache.groovy.perf.HostCalibrationBench \
  -f 4 -wi 4 -i 5 -w 2s -r 2s -rf json -foe true \
  -jvmArgsAppend '-Xms2g -Xmx2g -XX:+AlwaysPreTouch' \
  -rff jmh-target.json -o jmh-target.txt
```

Raw JMH JSON from this run: `/tmp/grok-1000/jmh-base.json`, `/tmp/grok-1000/jmh-target.json`.

## Appendix B — Artifact hashes

| Item | Value |
|---|---|
| Baseline SHA | `9bb195dee52e82518bb5f4e5cda9ddbf08c16d39` |
| Target SHA | `1c3820bff71419b5c40e73142bbf3e82210ea317` |
| Baseline JMH JAR SHA-256 | `e321d268c7e099519e3f9e8b1b38d9bba5e11bf8151ee928f4a12156d4e40016` |
| Target JMH JAR SHA-256 | `4cd0b63d1ca9a7f9cb383bae2b594adfc3cb079790260d3415aa2308d5f02b17` |
| Baseline window | 2026-08-15 23:49:53 – 2026-08-16 00:19:05 +09 |
| Target window | 2026-08-16 00:19:15 – 2026-08-16 00:48:23 +09 |
