### PR TITLE
GROOVY-12166 backport: STC: scope statement-level instanceof narrowing to the …

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -2163,6 +2163,7 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
     @Override
     public void visitProperty(final PropertyNode node) {
         boolean osc = typeCheckingContext.isInStaticContext;
+        typeCheckingContext.pushTemporaryTypeInfo(); // GROOVY-12166: member scope
         try {
             typeCheckingContext.isInStaticContext = node.isInStaticContext();
             currentProperty = node;
@@ -2171,6 +2172,7 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
             visitClassCodeContainer(node.getSetterBlock());
         } finally {
             currentProperty = null;
+            typeCheckingContext.popTemporaryTypeInfo();
             typeCheckingContext.isInStaticContext = osc;
         }
     }
@@ -2178,6 +2180,7 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
     @Override
     public void visitField(final FieldNode node) {
         boolean osc = typeCheckingContext.isInStaticContext;
+        typeCheckingContext.pushTemporaryTypeInfo(); // GROOVY-12166: member scope
         try {
             typeCheckingContext.isInStaticContext = node.isInStaticContext();
             currentField = node;
@@ -2185,6 +2188,7 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
             visitInitialExpression(node.getInitialExpression(), new FieldExpression(node), node);
         } finally {
             currentField = null;
+            typeCheckingContext.popTemporaryTypeInfo();
             typeCheckingContext.isInStaticContext = osc;
         }
     }
@@ -2971,6 +2975,11 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
     @Override
     protected void visitConstructorOrMethod(final MethodNode node, final boolean isConstructor) {
         typeCheckingContext.pushEnclosingMethod(node);
+        // GROOVY-12166: statement-level instanceof narrowing (return, assert)
+        // records into the enclosing temporary-type-info frame; scope it to
+        // this member so narrowing keyed by a shared node (e.g. a FieldNode)
+        // cannot leak into members visited later
+        typeCheckingContext.pushTemporaryTypeInfo();
         final ClassNode returnType = node.getReturnType(); // GROOVY-10660: implicit return case
         if (!isConstructor && (isClosureWithType(returnType) || isFunctionalInterface(returnType))) {
             new ReturnAdder(returnStmt -> applyTargetType(returnType, returnStmt.getExpression())).visitMethod(node);
@@ -2989,6 +2998,7 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
             if (node.getCode() != null) superCall.setSourcePosition(node.getCode());
             superCall.visit(this);
         }
+        typeCheckingContext.popTemporaryTypeInfo();
         typeCheckingContext.popEnclosingMethod();
     }
 
@@ -3029,7 +3039,9 @@ out:    if ((samParameterTypes.length == 1 && isOrImplements(samParameterTypes[0
         // GROOVY-5450: create fake constructor node so final field analysis can allow write within non-static initializer block(s)
         ConstructorNode init = new ConstructorNode(0, null, null, new BlockStatement(node.getObjectInitializerStatements(), null));
         typeCheckingContext.pushEnclosingMethod(init);
+        typeCheckingContext.pushTemporaryTypeInfo(); // GROOVY-12166: member scope
         super.visitObjectInitializerStatements(node);
+        typeCheckingContext.popTemporaryTypeInfo();
         typeCheckingContext.popEnclosingMethod();
     }
 

--- a/src/test/groovy/bugs/Groovy12166.groovy
+++ b/src/test/groovy/bugs/Groovy12166.groovy
@@ -1,0 +1,133 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bugs
+
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+/**
+ * GROOVY-12166: statement-level {@code instanceof} narrowing keyed by a shared
+ * field node must not leak out of the member being visited into other members
+ * of the class (spurious {@code checkcast} → {@code ClassCastException}).
+ */
+final class Groovy12166 {
+
+    private static final String TYPES = '''
+        abstract class Base {
+            String describe() { 'base' }
+            abstract void unrelated()
+        }
+        class Alpha extends Base { void unrelated() {} }
+        class Beta  extends Base { void unrelated() {} }
+    '''
+
+    @Test
+    void testExplicitReturnInstanceofDoesNotNarrowFieldClassWide() {
+        assertScript TYPES + '''
+            @groovy.transform.CompileStatic
+            class Holder {
+                private Base field
+                Holder(Base f) { this.field = f }
+                boolean isAlpha() { return field instanceof Alpha }
+                String use() { field.describe() }
+            }
+            def h = new Holder(new Beta())
+            assert !h.isAlpha()
+            assert h.use() == 'base'
+        '''
+    }
+
+    @Test
+    void testAssertInstanceofDoesNotNarrowFieldClassWide() {
+        assertScript TYPES + '''
+            @groovy.transform.CompileStatic
+            class Holder {
+                private Base field
+                Holder(Base f) { this.field = f }
+                void check() { assert field instanceof Alpha }
+                String use() { field.describe() }
+            }
+            // check() is never called; field holds a Beta
+            assert new Holder(new Beta()).use() == 'base'
+        '''
+    }
+
+    @Test
+    void testNarrowingIsIndependentOfMethodDeclarationOrder() {
+        assertScript TYPES + '''
+            @groovy.transform.CompileStatic
+            class Holder {
+                private Base field
+                Holder(Base f) { this.field = f }
+                String use() { field.describe() }
+                boolean isAlpha() { return field instanceof Alpha }
+                String useAfter() { field.describe() }
+            }
+            def h = new Holder(new Beta())
+            assert !h.isAlpha()
+            assert h.use() == 'base'
+            assert h.useAfter() == 'base'
+        '''
+    }
+
+    @Test
+    void testFieldInitializerInstanceofDoesNotNarrowClassWide() {
+        assertScript TYPES + '''
+            @groovy.transform.CompileStatic
+            class Holder {
+                private Base field
+                private boolean flag = (field instanceof Alpha)
+                Holder(Base f) { this.field = f }
+                String use() { field.describe() }
+            }
+            assert new Holder(new Beta()).use() == 'base'
+        '''
+    }
+
+    @Test
+    void testIntraMethodNarrowingStillWorks() {
+        // narrowing within a member must be unaffected: assert flow typing and
+        // if-branch narrowing still apply to subsequent statements
+        assertScript TYPES + '''
+            class Gamma extends Base {
+                void unrelated() {}
+                String extra() { 'gamma' }
+            }
+            @groovy.transform.CompileStatic
+            class Holder {
+                private Base field
+                Holder(Base f) { this.field = f }
+                String viaAssert() {
+                    assert field instanceof Gamma
+                    field.extra() // narrowing from assert applies here
+                }
+                String viaIf() {
+                    if (field instanceof Gamma) {
+                        return field.extra()
+                    }
+                    'other'
+                }
+            }
+            def h = new Holder(new Gamma())
+            assert h.viaAssert() == 'gamma'
+            assert h.viaIf() == 'gamma'
+        '''
+    }
+}


### PR DESCRIPTION
…member being visited

Temporary type information from instanceof is keyed by the target variable — for a field access, the shared FieldNode. if/loops/ternaries and expression statements bracket their own frames, but a narrowing recorded at statement level (an explicit `return field instanceof Sub`, or an `assert field instanceof Sub`, whose propagation to subsequent statements is intentional) lands in the enclosing frame, which was the frame pushed for the whole class visit. Keyed by the shared FieldNode, it then applied to every member visited afterwards: the checker stamped the narrowed type on unrelated field reads and the static compiler emitted a spurious checkcast, throwing ClassCastException at runtime whenever the field held a different subtype.

Members now push their own frame (methods and constructors, property and field initializers, object initializer blocks), so statement-level narrowing still flows within a member but can never survive into another; narrowing has no meaning past the member boundary. Intra-member flow typing (assert, if-branch) is unchanged.

The checker-side leak predates Groovy 5 but was masked by codegen: StaticTypesTypeChooser resolved types from the declared target first until GROOVY-11375 (5.0.0-alpha-9) gave the expression-stamped inferred type priority, exposing the stale narrowing as a checkcast. That change is correct; the fix belongs here.