### PR TITLE
GROOVY-12265: Fail Grape resolution on a checksum mismatch

### DIFF
--- a/subprojects/groovy-grape-maven/src/main/groovy/groovy/grape/maven/GrapeChecksumPolicyProvider.groovy
+++ b/subprojects/groovy-grape-maven/src/main/groovy/groovy/grape/maven/GrapeChecksumPolicyProvider.groovy
@@ -1,0 +1,168 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.grape.maven
+
+import groovy.transform.AutoFinal
+import groovy.transform.CompileStatic
+import org.eclipse.aether.RepositorySystemSession
+import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.repository.RepositoryPolicy
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider
+import org.eclipse.aether.transfer.ChecksumFailureException
+import org.eclipse.aether.transfer.TransferResource
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Supplies the checksum policy Grape uses for remote artifact downloads.
+ *
+ * <p>Maven Resolver's stock {@code CHECKSUM_POLICY_FAIL} rejects a download both when a
+ * published checksum does not match and when no checksum is published at all. Grape wants
+ * only the first of those: a mismatch means the bytes are not what the repository said they
+ * would be and must never reach the classpath, whereas a repository that simply publishes no
+ * {@code .sha1}/{@code .md5} is a common and legitimate situation, particularly for internal
+ * and older repositories.
+ *
+ * <p>This provider therefore delegates to the stock {@link ChecksumPolicyProvider} for every
+ * policy and wraps only the {@code fail} policy, relaxing its
+ * {@link ChecksumPolicy#onNoMoreChecksums()} response. The result matches the semantics the
+ * Ivy-backed engine has always had, so both Grape engines behave alike.
+ *
+ * @since 6.0.0
+ */
+@AutoFinal
+@CompileStatic
+class GrapeChecksumPolicyProvider implements ChecksumPolicyProvider {
+
+    private final ChecksumPolicyProvider delegate
+
+    /**
+     * Wraps the stock checksum policy provider.
+     *
+     * @param delegate the stock provider whose policies are wrapped
+     */
+    GrapeChecksumPolicyProvider(ChecksumPolicyProvider delegate) {
+        this.delegate = delegate
+    }
+
+    /**
+     * Returns the policy for the given resource, relaxing {@code fail} to tolerate artifacts
+     * that publish no checksum.
+     *
+     * @param session the session during which the request is made
+     * @param repository the repository hosting the resource
+     * @param resource the resource the policy will be applied to
+     * @param policy the identifier of the policy to apply
+     * @return the policy to apply, or {@code null} if checksums should be ignored
+     */
+    @Override
+    ChecksumPolicy newChecksumPolicy(RepositorySystemSession session, RemoteRepository repository, TransferResource resource, String policy) {
+        ChecksumPolicy checksumPolicy = delegate.newChecksumPolicy(session, repository, resource, policy)
+        if (checksumPolicy != null && RepositoryPolicy.CHECKSUM_POLICY_FAIL == policy) {
+            return new AbsenceTolerantChecksumPolicy(checksumPolicy, resource)
+        }
+        checksumPolicy
+    }
+
+    /**
+     * Returns the least strict of the two supplied policies.
+     *
+     * @param session the session during which the request is made
+     * @param policy1 a policy to compare
+     * @param policy2 a policy to compare
+     * @return the least strict policy of the two
+     */
+    @Override
+    String getEffectiveChecksumPolicy(RepositorySystemSession session, String policy1, String policy2) {
+        delegate.getEffectiveChecksumPolicy(session, policy1, policy2)
+    }
+
+    /**
+     * Wraps a checksum policy so that the absence of any published checksum is tolerated while
+     * every other outcome, in particular a mismatch, is left to the wrapped policy.
+     */
+    @AutoFinal
+    @CompileStatic
+    private static class AbsenceTolerantChecksumPolicy implements ChecksumPolicy {
+
+        private static final Logger LOG = LoggerFactory.getLogger(AbsenceTolerantChecksumPolicy)
+
+        private final ChecksumPolicy delegate
+        private final TransferResource resource
+
+        // Set when a checksum was published but could not be validated (a fetch, IO or
+        // calculation error, as opposed to a checksum simply not being published). A genuine
+        // absence never reaches onChecksumError; Maven Resolver's ChecksumValidator only calls
+        // it on an error, and skips a missing checksum silently. Reset per transfer attempt.
+        private boolean checksumErrorSeen
+
+        AbsenceTolerantChecksumPolicy(ChecksumPolicy delegate, TransferResource resource) {
+            this.delegate = delegate
+            this.resource = resource
+        }
+
+        @Override
+        boolean onChecksumMatch(String algorithm, ChecksumKind kind) {
+            delegate.onChecksumMatch(algorithm, kind)
+        }
+
+        @Override
+        void onChecksumMismatch(String algorithm, ChecksumKind kind, ChecksumFailureException exception) throws ChecksumFailureException {
+            delegate.onChecksumMismatch(algorithm, kind, exception)
+        }
+
+        @Override
+        void onChecksumError(String algorithm, ChecksumKind kind, ChecksumFailureException exception) throws ChecksumFailureException {
+            checksumErrorSeen = true
+            delegate.onChecksumError(algorithm, kind, exception)
+        }
+
+        /**
+         * Accepts the download only when no checksum was published at all; a checksum that was
+         * published but could not be validated is left to the wrapped {@code fail} policy, which
+         * rejects it.
+         *
+         * <p>This is the single point where the policy departs from the wrapped {@code fail}
+         * policy, and only for a genuine absence: tolerating a repository that publishes no
+         * checksum is the intent, whereas a checksum present but unreadable is closer to a
+         * mismatch than to an absence and must not be accepted unverified.
+         */
+        @Override
+        void onNoMoreChecksums() throws ChecksumFailureException {
+            if (checksumErrorSeen) {
+                delegate.onNoMoreChecksums() // fail policy: rejects the unverifiable artifact
+            }
+            LOG.debug('No checksum published for {}{}; accepting the artifact unverified',
+                resource.repositoryUrl, resource.resourceName)
+        }
+
+        @Override
+        void onTransferRetry() {
+            checksumErrorSeen = false // each attempt re-validates from scratch
+            delegate.onTransferRetry()
+        }
+
+        @Override
+        boolean onTransferChecksumFailure(ChecksumFailureException exception) {
+            delegate.onTransferChecksumFailure(exception)
+        }
+    }
+}

--- a/subprojects/groovy-grape-maven/src/main/groovy/groovy/grape/maven/GrapeMaven.groovy
+++ b/subprojects/groovy-grape-maven/src/main/groovy/groovy/grape/maven/GrapeMaven.groovy
@@ -45,6 +45,7 @@ import org.eclipse.aether.resolution.ArtifactRequest
 import org.eclipse.aether.resolution.ArtifactResult
 import org.eclipse.aether.resolution.DependencyRequest
 import org.eclipse.aether.resolution.DependencyResolutionException
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider
 import org.eclipse.aether.supplier.RepositorySystemSupplier
 import org.eclipse.aether.transfer.AbstractTransferListener
 import org.eclipse.aether.transfer.TransferEvent
@@ -415,11 +416,11 @@ class GrapeMaven implements GrapeEngine {
      * @return the resolved artifact URIs
      */
     URI[] getDependencies(Map args, List depsInfo, MavenGrabRecord... grabRecords) {
-        try (RepositorySystem system = new RepositorySystemSupplier().get()) {
+        try (RepositorySystem system = new GrapeRepositorySystemSupplier().get()) {
             def localRepo = new LocalRepository(grapeCacheDir.toPath())
             String checksumPolicy = args.disableChecksums ?
                 RepositoryPolicy.CHECKSUM_POLICY_IGNORE :
-                RepositoryPolicy.CHECKSUM_POLICY_WARN
+                RepositoryPolicy.CHECKSUM_POLICY_FAIL
 
             // Extract exclusions from args if provided by @GrabExclude
             List<Map<String, String>> exclusions = (List<Map<String, String>>) args.get('excludes') ?: []
@@ -877,6 +878,18 @@ class GrapeMaven implements GrapeEngine {
         if (e instanceof RuntimeException) return (RuntimeException) e
         String msg = e.message ?: e.class.name
         return new RuntimeException("Error grabbing Grapes -- ${msg}", e)
+    }
+
+    /**
+     * Repository system supplier which installs Grape's own checksum policy provider in place
+     * of the stock one, so that {@code CHECKSUM_POLICY_FAIL} rejects mismatched artifacts
+     * without also rejecting artifacts that publish no checksum.
+     */
+    private static class GrapeRepositorySystemSupplier extends RepositorySystemSupplier {
+        @Override
+        protected ChecksumPolicyProvider createChecksumPolicyProvider() {
+            new GrapeChecksumPolicyProvider(super.createChecksumPolicyProvider())
+        }
     }
 
 }

--- a/subprojects/groovy-grape-maven/src/test/groovy/groovy/grape/maven/GrapeChecksumPolicyProviderTest.groovy
+++ b/subprojects/groovy-grape-maven/src/test/groovy/groovy/grape/maven/GrapeChecksumPolicyProviderTest.groovy
@@ -1,0 +1,134 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.grape.maven
+
+import org.eclipse.aether.DefaultRepositorySystemSession
+import org.eclipse.aether.RepositorySystemSession
+import org.eclipse.aether.internal.impl.DefaultChecksumPolicyProvider
+import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.repository.RepositoryPolicy
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind
+import org.eclipse.aether.transfer.ChecksumFailureException
+import org.eclipse.aether.transfer.TransferResource
+import org.junit.jupiter.api.Test
+
+import java.util.function.Function
+
+import static groovy.test.GroovyAssert.shouldFail
+
+/**
+ * Tests that Grape's checksum policy rejects mismatched artifacts while tolerating artifacts
+ * for which no checksum is published.
+ */
+final class GrapeChecksumPolicyProviderTest {
+
+    private static final GrapeChecksumPolicyProvider PROVIDER =
+        new GrapeChecksumPolicyProvider(new DefaultChecksumPolicyProvider())
+
+    private static final RepositorySystemSession SESSION =
+        new DefaultRepositorySystemSession({ Runnable r -> Boolean.FALSE } as Function)
+
+    private static final RemoteRepository REPOSITORY =
+        new RemoteRepository.Builder('test', 'default', 'https://repo.example.invalid/maven2').build()
+
+    private static final TransferResource RESOURCE = new TransferResource(
+        'test', 'https://repo.example.invalid/maven2', 'org/example/demo/1.0/demo-1.0.jar', null, null, null)
+
+    private static ChecksumPolicy policyFor(String policy) {
+        PROVIDER.newChecksumPolicy(SESSION, REPOSITORY, RESOURCE, policy)
+    }
+
+    private static ChecksumFailureException mismatch() {
+        ChecksumFailureException.mismatch('expected', ChecksumKind.REMOTE_EXTERNAL.name(), 'actual')
+    }
+
+    @Test
+    void testAbsentChecksumIsToleratedUnderFail() {
+        ChecksumPolicy policy = policyFor(RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+        // Grape accepts the artifact, matching the Ivy-backed engine.
+        policy.onNoMoreChecksums()
+
+        // Guard the premise: the stock policy this one wraps rejects the same situation, so
+        // the test above is meaningful and will start failing if Maven Resolver ever relaxes
+        // CHECKSUM_POLICY_FAIL itself.
+        ChecksumPolicy stock = new DefaultChecksumPolicyProvider()
+            .newChecksumPolicy(SESSION, REPOSITORY, RESOURCE, RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+        shouldFail(ChecksumFailureException) {
+            stock.onNoMoreChecksums()
+        }
+    }
+
+    @Test
+    void testMismatchedChecksumStillFailsUnderFail() {
+        ChecksumPolicy policy = policyFor(RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+
+        // A mismatch is rejected: the wrapped fail policy throws, carrying the mismatch detail.
+        ChecksumFailureException thrown = shouldFail(ChecksumFailureException) {
+            policy.onChecksumMismatch('SHA-1', ChecksumKind.REMOTE_EXTERNAL, mismatch())
+        } as ChecksumFailureException
+        assert thrown.expected == 'expected'
+        assert thrown.actual == 'actual'
+
+        // A mismatch must not be accepted even after the retry opportunity.
+        assert !policy.onTransferChecksumFailure(mismatch())
+    }
+
+    @Test
+    void testUnreadableChecksumIsRejectedUnderFail() {
+        // A published checksum that could not be validated (an error, not an absence) must not be
+        // tolerated: only a genuine absence is. Maven Resolver signals the error via
+        // onChecksumError before reaching onNoMoreChecksums.
+        ChecksumPolicy policy = policyFor(RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+        policy.onChecksumError('SHA-1', ChecksumKind.REMOTE_EXTERNAL,
+            ChecksumFailureException.processingFailure('unreadable', new IOException('boom')))
+        shouldFail(ChecksumFailureException) {
+            policy.onNoMoreChecksums()
+        }
+    }
+
+    @Test
+    void testMatchingChecksumIsAcceptedUnderFail() {
+        ChecksumPolicy policy = policyFor(RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+        assert policy.onChecksumMatch('SHA-1', ChecksumKind.REMOTE_EXTERNAL)
+    }
+
+    @Test
+    void testWarnPolicyIsLeftUnwrapped() {
+        ChecksumPolicy policy = policyFor(RepositoryPolicy.CHECKSUM_POLICY_WARN)
+        // Stock warn semantics: a failure is logged and the artifact accepted anyway.
+        assert policy.onTransferChecksumFailure(mismatch())
+        policy.onNoMoreChecksums()
+    }
+
+    @Test
+    void testIgnorePolicyRemainsNull() {
+        assert policyFor(RepositoryPolicy.CHECKSUM_POLICY_IGNORE) == null
+    }
+
+    @Test
+    void testEffectiveChecksumPolicyIsDelegated() {
+        assert PROVIDER.getEffectiveChecksumPolicy(SESSION,
+            RepositoryPolicy.CHECKSUM_POLICY_FAIL,
+            RepositoryPolicy.CHECKSUM_POLICY_WARN) == RepositoryPolicy.CHECKSUM_POLICY_WARN
+        assert PROVIDER.getEffectiveChecksumPolicy(SESSION,
+            RepositoryPolicy.CHECKSUM_POLICY_WARN,
+            RepositoryPolicy.CHECKSUM_POLICY_IGNORE) == RepositoryPolicy.CHECKSUM_POLICY_IGNORE
+    }
+}

--- a/subprojects/groovy-grape-maven/src/test/groovy/groovy/grape/maven/GrapeMavenTest.groovy
+++ b/subprojects/groovy-grape-maven/src/test/groovy/groovy/grape/maven/GrapeMavenTest.groovy
@@ -19,6 +19,7 @@
 package groovy.grape.maven
 
 import groovy.grape.Grape
+import org.eclipse.aether.transfer.ChecksumFailureException
 import org.junit.jupiter.api.Test
 
 import java.nio.file.Files
@@ -148,6 +149,55 @@ ${depsXml}
         assert uris.any { it.toString().contains('root-artifact-1.0.0.jar') }
         assert uris.any { it.toString().contains('dep-required-1.0.0.jar') }
         assert !uris.any { it.toString().contains('dep-optional-1.0.0.jar') }
+    }
+
+    @Test
+    void testArtifactWithoutChecksumsResolves() {
+        File repoDir = new File(Files.createTempDirectory('grape-maven-nochecksum-test').toFile(), 'repo')
+
+        String g = 'dev.grape.nochecksum'
+        deleteCachedGroup(g)
+        publishArtifact(repoDir, g, 'plain', '1.0.0')
+
+        Grape.addResolver(name: 'local-nochecksum-test', root: repoDir.toURI().toString(), m2Compatible: true)
+        URI[] uris = Grape.resolve([autoDownload: true, classLoader: new GroovyClassLoader()],
+            [groupId: g, artifactId: 'plain', version: '1.0.0'])
+
+        // A repository that publishes no .sha1/.md5 must still resolve, matching the Ivy engine.
+        assert uris.any { it.toString().contains('plain-1.0.0.jar') }
+    }
+
+    @Test
+    void testArtifactWithMismatchedChecksumIsRejected() {
+        File repoDir = new File(Files.createTempDirectory('grape-maven-badchecksum-test').toFile(), 'repo')
+
+        String g = 'dev.grape.badchecksum'
+        deleteCachedGroup(g)
+        publishArtifact(repoDir, g, 'tampered', '1.0.0')
+
+        // Publish a checksum that does not describe the jar, as a tampered mirror would.
+        File artifactDir = new File(repoDir, g.replace('.', '/') + '/tampered/1.0.0')
+        new File(artifactDir, 'tampered-1.0.0.jar.sha1').text = '0' * 40
+
+        Grape.addResolver(name: 'local-badchecksum-test', root: repoDir.toURI().toString(), m2Compatible: true)
+        def ex = shouldFail {
+            Grape.resolve([autoDownload: true, classLoader: new GroovyClassLoader()],
+                [groupId: g, artifactId: 'tampered', version: '1.0.0'])
+        }
+
+        // Ensure it failed for the checksum, not for some unrelated resolution problem.
+        assert hasCauseOfType(ex, ChecksumFailureException)
+    }
+
+    private static boolean hasCauseOfType(Throwable t, Class<? extends Throwable> type) {
+        for (Throwable c = t; c != null; c = c.cause) {
+            if (type.isInstance(c)) return true
+            for (Throwable s : c.suppressed) {
+                if (hasCauseOfType(s, type)) return true
+            }
+            if (c.cause.is(c)) break
+        }
+        return false
     }
 
     @Test


### PR DESCRIPTION
The Maven-backed Grape engine resolved with CHECKSUM_POLICY_WARN, so an artifact whose published checksum did not match was logged and then added to the class loader and had its META-INF services processed. The Ivy-backed engine fails resolution in that situation, so the Maven engine silently dropped an integrity check that Grape already had.

Resolve with CHECKSUM_POLICY_FAIL instead. Maven Resolver's stock fail policy also rejects artifacts that publish no checksum at all, which the Ivy engine accepts and which is common for internal and older repositories, so install a checksum policy provider that wraps the fail policy and relaxes only its onNoMoreChecksums() response. Both engines then behave alike and no artifact resolvable today stops resolving.

The disableChecksums opt-out is unchanged: @GrabConfig(disableChecksums=true), -Dgroovy.grape.disableChecksums and Grape.setDisableChecksums(boolean) all still map to CHECKSUM_POLICY_IGNORE.