### PR TITLE
GROOVY-12269: Escape interpolation and line terminators in getOutputS…

### DIFF
--- a/subprojects/groovy-jsr223/src/main/java/org/codehaus/groovy/jsr223/GroovyScriptEngineFactory.java
+++ b/subprojects/groovy-jsr223/src/main/java/org/codehaus/groovy/jsr223/GroovyScriptEngineFactory.java
@@ -209,9 +209,16 @@ public class GroovyScriptEngineFactory implements ScriptEngineFactory {
 
     /**
      * Produces a Groovy statement that prints the supplied text.
+     * <p>
+     * The text is data, so it is rendered as a string literal with every character escaped
+     * that would otherwise change what the statement means: the quote and backslash that
+     * would end or re-escape the literal, the dollar that would make it an interpolating
+     * {@link groovy.lang.GString}, and the line terminators that would end the line. Other
+     * control characters are legal inside a Groovy string literal and are emitted as they
+     * are.
      *
      * @param toDisplay the text to render
-     * @return a {@code println} statement with embedded quotes and backslashes escaped
+     * @return a {@code println} statement which displays the text verbatim
      */
     @Override
     public String getOutputStatement(String toDisplay) {
@@ -226,6 +233,15 @@ public class GroovyScriptEngineFactory implements ScriptEngineFactory {
                     break;
                 case '\\':
                     buf.append("\\\\");
+                    break;
+                case '$':
+                    buf.append("\\$");
+                    break;
+                case '\n':
+                    buf.append("\\n");
+                    break;
+                case '\r':
+                    buf.append("\\r");
                     break;
                 default:
                     buf.append(ch);

--- a/subprojects/groovy-jsr223/src/test/groovy/org/codehaus/groovy/jsr223/GroovyScriptEngineFactoryTest.groovy
+++ b/subprojects/groovy-jsr223/src/test/groovy/org/codehaus/groovy/jsr223/GroovyScriptEngineFactoryTest.groovy
@@ -1,0 +1,94 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.jsr223
+
+import org.junit.jupiter.api.Test
+
+import javax.script.ScriptEngine
+import javax.script.ScriptEngineFactory
+
+/**
+ * Tests the code-generating methods of {@link GroovyScriptEngineFactory}.
+ */
+final class GroovyScriptEngineFactoryTest {
+
+    private final ScriptEngineFactory factory = new GroovyScriptEngineFactory()
+
+    /** Runs a generated statement and returns what it printed. */
+    private String outputOf(String statement) {
+        ScriptEngine engine = factory.scriptEngine
+        StringWriter captured = new StringWriter()
+        engine.context.writer = captured
+        engine.eval(statement)
+        captured.toString()
+    }
+
+    @Test
+    void testOutputStatementOfPlainText() {
+        assert factory.getOutputStatement('context') == 'println("context")'
+    }
+
+    @Test
+    void testOutputStatementEscapesCharactersThatWouldChangeItsMeaning() {
+        // A quote or backslash ends or re-escapes the literal, a dollar turns it into an
+        // interpolating GString, and a line terminator ends the line.
+        assert factory.getOutputStatement('"') == 'println("\\"")'
+        assert factory.getOutputStatement('\\') == 'println("\\\\")'
+        assert factory.getOutputStatement('$') == 'println("\\$")'
+        assert factory.getOutputStatement('\n') == 'println("\\n")'
+        assert factory.getOutputStatement('\r') == 'println("\\r")'
+    }
+
+    @Test
+    void testOutputStatementLeavesHarmlessControlCharactersAlone() {
+        // Legal inside a Groovy string literal, so escaping them would change the emitted
+        // text for input that already worked.
+        assert factory.getOutputStatement('a\tb') == 'println("a\tb")'
+    }
+
+    @Test
+    void testGeneratedStatementDisplaysTheTextVerbatim() {
+        // The contract is what the statement displays, not how it is spelled, so evaluate it.
+        ['context',
+         'plain text',
+         'quotes " and \\ backslashes',
+         'a $ dollar',
+         'interpolation ${1 + 1} stays literal',
+         'a $name that names no variable',
+         'two\nlines',
+         'carriage\rreturn',
+         'tabs\tand\tmore',
+         'everything: "\\ $ ${x} \n \r \t',
+         'nul\u0000bell\u0007esc\u001b',
+         'literal backslash-u: \\u0041',
+         'line sep\u2028para sep\u2029',
+         'unicode \u00e9 \u4e2d\u6587 \ud83d\ude00'].each { String text ->
+            assert outputOf(factory.getOutputStatement(text)) == text + System.lineSeparator()
+        }
+    }
+
+    @Test
+    void testProgramAndMethodCallSyntaxTakeCode() {
+        // Both take code by contract, so they concatenate rather than escape.
+        assert factory.getProgram('println("hello")', 'println("world")') ==
+                'println("hello")\nprintln("world")\n'
+        assert factory.getMethodCallSyntax('obj', 'foo', 'x') == 'obj.foo(x)'
+        assert factory.getMethodCallSyntax('obj', 'foo') == 'obj.foo()'
+    }
+}


### PR DESCRIPTION
…tatement

ScriptEngineFactory.getOutputStatement takes the text to display, which is data, and Groovy renders it as a double-quoted literal escaping only the quote and the backslash. Two characters were left to reach the generated code unaltered:

  - a dollar makes the literal an interpolating GString, so display text containing ${...} is evaluated rather than printed, and a bare $name leaks a binding;
  - a line terminator ends the line, so display text spanning lines emits a statement that does not compile at all.

Escape both, along with the carriage return. Other control characters such as tab are legal inside a Groovy string literal and are left alone, so output is unchanged for every input that already worked.

Nashorn is the precedent here: its factory had the same class of defect, reported on nashorn-dev in January 2017 as producing a syntax error for display text containing quotes, and was fixed by quoting the argument rather than by reinterpreting it as code. Groovy had already chosen the same reading by quoting and escaping at all; this completes it.

getProgram and getMethodCallSyntax take code by contract and are unchanged.

The factory's code-generating methods had no tests. The new ones assert the emitted spelling for each escaped character, and separately evaluate the generated statement and compare what it prints with the original text, since displaying the text verbatim is the actual contract. Without the fix the first fails on the dollar and the second fails to compile.