### PR TITLE
GROOVY-12274: HttpBuilder: drop default headers on a redirect to anot…

### DIFF
--- a/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpBuilder.groovy
+++ b/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpBuilder.groovy
@@ -34,6 +34,9 @@ import java.util.concurrent.CompletableFuture
 
 /**
  * Tiny DSL over JDK {@link HttpClient}.
+ * <p>
+ * Redirect following is opt-in; see {@link Config#followRedirects(boolean)} for the
+ * policy applied to headers when a redirect leaves the origin of the first request.
  *
  * @since 6.0.0
  */
@@ -46,7 +49,7 @@ final class HttpBuilder {
     private final boolean confineToBaseUri
     private final boolean followRedirectsManually
 
-    /** Maximum number of redirects followed when confinement handles them itself. */
+    /** Maximum number of redirects followed by the manual redirect loop. */
     private static final int MAX_REDIRECTS = 5
 
     private HttpBuilder(final Config config) {
@@ -54,20 +57,21 @@ final class HttpBuilder {
         if (config.connectTimeout != null) {
             clientBuilder.connectTimeout(config.connectTimeout)
         }
-        // When confinement is active we must see every 3xx ourselves so the base-URI
-        // gate can be applied to each hop; the JDK client would otherwise follow
-        // redirects internally, escaping confinement. Only the unconfined case
-        // delegates redirect-following to the JDK.
-        followRedirectsManually = config.confineToBaseUri && config.followRedirects
-        if (config.followRedirects && !followRedirectsManually) {
-            clientBuilder.followRedirects(HttpClient.Redirect.NORMAL)
-        }
+        // Every 3xx is seen here rather than followed inside the JDK client, so that each hop
+        // can be gated: a confined hop against the base URI, and any hop against the origin the
+        // caller's headers were set for.
+        followRedirectsManually = config.followRedirects
         if (config.clientConfigurer != null) {
             Closure<?> code = (Closure<?>) config.clientConfigurer.clone()
             code.resolveStrategy = Closure.DELEGATE_FIRST
             code.delegate = clientBuilder
             code.call(clientBuilder)
         }
+        // Redirect policy is owned by the followRedirects flag above. A redirect policy set on
+        // the raw builder (via clientConfig) would make the JDK client follow hops internally,
+        // where no hop can be gated and the caller's headers travel to whatever origin a
+        // Location names — so any such setting is overridden, after the configurer has run.
+        clientBuilder.followRedirects(HttpClient.Redirect.NEVER)
         client = clientBuilder.build()
         baseUri = config.baseUri
         defaultHeaders = Collections.unmodifiableMap(new LinkedHashMap<>(config.headers))
@@ -217,7 +221,8 @@ final class HttpBuilder {
         if (followRedirectsManually) {
             future = future.thenCompose { HttpResponse<String> response ->
                 followRedirectsAsync(method, httpRequest.uri(), response, headers,
-                        requestSpec.body, requestSpec.timeout, requestSpec.bodyHandler, 0)
+                        requestSpec.body, requestSpec.timeout, requestSpec.bodyHandler, 0,
+                        httpRequest.uri(), false)
             }
         }
         return future.thenApply { HttpResponse<String> response -> new HttpResult(response) }
@@ -297,6 +302,10 @@ final class HttpBuilder {
      * <p>
      * Streaming always uses {@code HttpResponse.BodyHandlers.ofPublisher()};
      * any {@code bodyHandler} configured on the {@code RequestSpec} is ignored.
+     * <p>
+     * Streaming requests never follow redirects, whatever
+     * {@link Config#followRedirects} is set to: a 3xx response is returned
+     * as-is, and its {@code Location} header is left to the caller.
      *
      * @param method the HTTP method to use
      * @param uri the absolute or base-relative request URI
@@ -339,10 +348,10 @@ final class HttpBuilder {
     }
 
     private HttpRequest buildStreamRequest(final String method, final Object uri, final Closure<?> spec) {
-        // Note: streaming does not auto-follow redirects under confinement. Because
-        // the body is an unbuffered publisher, a 3xx is returned to the caller as-is
-        // rather than followed. This is safe (no bypass) but not transparent; callers
-        // who need confined streaming redirects should resolve the Location themselves.
+        // Note: streaming never auto-follows redirects. Because the response body is an
+        // unbuffered publisher, a 3xx is returned to the caller as-is rather than followed;
+        // callers who need streaming redirects should resolve the Location themselves. This
+        // also means no hop can escape the gates above, at the cost of transparency.
         RequestSpec requestSpec = evalSpec(spec)
         URI resolvedUri = resolveUri(uri, requestSpec.queryParameters)
         return buildHopRequest(method, resolvedUri, combinedHeaders(requestSpec), requestSpec.body, requestSpec.timeout)
@@ -393,14 +402,16 @@ final class HttpBuilder {
     }
 
     /**
-     * Synchronously follows redirects while confinement is active, applying
-     * {@link #enforceConfinement} to every hop. Because a confined hop must share
-     * the base URI's origin, a redirect to another host is rejected outright — so
-     * sensitive headers can never leak across origins here.
+     * Synchronously follows redirects, applying {@link #enforceConfinement} to every hop while
+     * confinement is active, and shedding the caller's headers on any hop that leaves the
+     * origin the request started from — keeping only {@code Content-Type} on a hop that
+     * forwards the body it describes.
      */
     private HttpResponse<String> followRedirects(String method, URI currentUri, HttpResponse<String> response,
                                                  Map<String, String> headers, Object body,
                                                  Duration timeout, HttpResponse.BodyHandler<String> bodyHandler) {
+        URI origin = currentUri
+        boolean leftOrigin = false
         int redirects = 0
         while (true) {
             URI target = redirectTarget(currentUri, response)
@@ -408,12 +419,16 @@ final class HttpBuilder {
                 return response
             }
             if (++redirects > MAX_REDIRECTS) {
-                throw new RuntimeException("Too many redirects (> " + MAX_REDIRECTS + ") for request confined to " + baseUri)
+                throw new RuntimeException("Too many redirects (> " + MAX_REDIRECTS + ") for request to " + origin)
             }
             String nextMethod = redirectMethod(method, response.statusCode())
             boolean sameMethod = nextMethod == method
             Object nextBody = sameMethod ? body : null
             Map<String, String> nextHeaders = sameMethod ? headers : withoutBodyHeaders(headers)
+            leftOrigin = leftOrigin || !sameOrigin(origin, target)
+            if (leftOrigin) {
+                nextHeaders = nextBody != null ? contentTypeOnly(nextHeaders) : [:]
+            }
             HttpRequest httpRequest = buildHopRequest(nextMethod, target, nextHeaders, nextBody, timeout)
             response = send(nextMethod, httpRequest, bodyHandler)
             currentUri = target
@@ -431,7 +446,7 @@ final class HttpBuilder {
     private CompletableFuture<HttpResponse<String>> followRedirectsAsync(
             String method, URI currentUri, HttpResponse<String> response,
             Map<String, String> headers, Object body, Duration timeout,
-            HttpResponse.BodyHandler<String> bodyHandler, int redirects) {
+            HttpResponse.BodyHandler<String> bodyHandler, int redirects, URI origin, boolean leftOrigin) {
         URI target = redirectTarget(currentUri, response)
         if (target == null) {
             return CompletableFuture.completedFuture(response)
@@ -439,24 +454,32 @@ final class HttpBuilder {
         if (redirects + 1 > MAX_REDIRECTS) {
             CompletableFuture<HttpResponse<String>> failed = new CompletableFuture<>()
             failed.completeExceptionally(
-                    new RuntimeException("Too many redirects (> " + MAX_REDIRECTS + ") for request confined to " + baseUri))
+                    new RuntimeException("Too many redirects (> " + MAX_REDIRECTS + ") for request to " + origin))
             return failed
         }
         String nextMethod = redirectMethod(method, response.statusCode())
         boolean sameMethod = nextMethod == method
         Object nextBody = sameMethod ? body : null
         Map<String, String> nextHeaders = sameMethod ? headers : withoutBodyHeaders(headers)
+        boolean nextLeftOrigin = leftOrigin || !sameOrigin(origin, target)
+        if (nextLeftOrigin) {
+            nextHeaders = nextBody != null ? contentTypeOnly(nextHeaders) : [:]
+        }
         HttpRequest httpRequest = buildHopRequest(nextMethod, target, nextHeaders, nextBody, timeout)
         return client.sendAsync(httpRequest, bodyHandler).thenCompose { HttpResponse<String> next ->
-            followRedirectsAsync(nextMethod, target, next, nextHeaders, nextBody, timeout, bodyHandler, redirects + 1)
+            followRedirectsAsync(nextMethod, target, next, nextHeaders, nextBody, timeout, bodyHandler,
+                    redirects + 1, origin, nextLeftOrigin)
         }
     }
 
     /**
      * Returns the confinement-checked redirect target for a response, or
-     * {@code null} if the response is not a followable redirect (non-3xx, or a
-     * 3xx with no {@code Location}). Throws {@link SecurityException} via
-     * {@link #enforceConfinement} if the target escapes the base URI.
+     * {@code null} if the response is not a followable redirect: non-3xx, a
+     * 3xx with no {@code Location}, or a hop from an https URL to a plain
+     * http one — which, matching {@link HttpClient.Redirect#NORMAL}, is
+     * returned to the caller rather than followed. Throws
+     * {@link SecurityException} via {@link #enforceConfinement} if the target
+     * escapes the base URI.
      */
     private URI redirectTarget(final URI currentUri, final HttpResponse<?> response) {
         int status = response.statusCode()
@@ -469,6 +492,9 @@ final class HttpBuilder {
         }
         URI target = currentUri.resolve(location).normalize()
         enforceConfinement(target)
+        if ('https'.equalsIgnoreCase(currentUri.scheme) && !'https'.equalsIgnoreCase(target.scheme)) {
+            return null
+        }
         return target
     }
 
@@ -489,6 +515,23 @@ final class HttpBuilder {
             default:
                 return method // 307/308 preserve method and body
         }
+    }
+
+    /**
+     * Keeps only the {@code Content-Type} header. Used on a cross-origin hop that forwards
+     * the request body (307/308): the header describes a payload that server receives
+     * anyway, while a body without it is rejected or misparsed by many servers — matching
+     * browsers, which strip credentials on a cross-origin redirect but send body-describing
+     * headers along with the body.
+     */
+    private static Map<String, String> contentTypeOnly(final Map<String, String> headers) {
+        Map<String, String> copy = new LinkedHashMap<>()
+        headers.each { String name, String value ->
+            if ('Content-Type'.equalsIgnoreCase(name)) {
+                copy.put(name, value)
+            }
+        }
+        return copy
     }
 
     private static Map<String, String> withoutBodyHeaders(final Map<String, String> headers) {
@@ -694,7 +737,10 @@ final class HttpBuilder {
          */
         Duration requestTimeout
         /**
-         * Whether redirects should be followed automatically.
+         * Whether redirects should be followed automatically. When enabled, a hop that
+         * leaves the origin of the first request sheds the caller's headers; see
+         * {@link #followRedirects(boolean)} for the full policy. Defaults to {@code false},
+         * returning any 3xx response to the caller as-is.
          */
         boolean followRedirects
         /**
@@ -742,7 +788,21 @@ final class HttpBuilder {
         }
 
         /**
-         * Enables or disables automatic redirect following.
+         * Enables or disables automatic redirect following. When enabled, at most five
+         * hops are followed, rewriting methods like {@link HttpClient.Redirect#NORMAL}:
+         * 301/302 downgrade {@code POST} to {@code GET} (dropping the body), 303
+         * downgrades everything except {@code HEAD} to {@code GET}, and 307/308 preserve
+         * the method and body.
+         * <p>
+         * Headers are treated as configured for one origin: the scheme, host, and
+         * effective port of the first request. A hop that stays on that origin keeps
+         * every header. A hop that leaves it sheds all caller-supplied headers — builder
+         * defaults and per-request headers alike — for the remainder of the chain,
+         * including any later hop back to the original origin. The one exception is
+         * {@code Content-Type}, which stays with a 307/308 hop that forwards the body it
+         * describes. A hop from an https URL to a plain http one is never followed; the
+         * 3xx is returned to the caller. Callers who need credentials sent to a redirect
+         * target on another origin should issue a request to that target directly.
          *
          * @param value {@code true} to follow redirects
          */
@@ -784,6 +844,10 @@ final class HttpBuilder {
         /**
          * Provides direct access to the underlying {@code HttpClient.Builder}
          * for advanced configuration (authenticator, SSL context, proxy, cookie handler, etc.).
+         * <p>
+         * Redirect policy is the exception: it is owned by {@link #followRedirects} so that
+         * every hop can be gated against confinement and against the origin the caller's
+         * headers were set for. A redirect policy set on the raw builder here is overridden.
          *
          * @param configurer a closure taking an {@code HttpClient.Builder}
          */

--- a/subprojects/groovy-http-builder/src/spec/doc/http-builder.adoc
+++ b/subprojects/groovy-http-builder/src/spec/doc/http-builder.adoc
@@ -199,7 +199,108 @@ def http = HttpBuilder.http {
 ----
 
 The `clientConfig` closure receives the `HttpClient.Builder` before `build()`
-is called, so any JDK-supported configuration is available.
+is called, so any JDK-supported configuration is available — with one
+exception: the redirect policy is owned by `followRedirects` (see
+<<redirects,Redirects>>), so a policy set on the raw builder is overridden.
+
+[[redirects]]
+== Redirects
+
+Redirects are not followed by default: a 3xx response is returned to the
+caller, which can inspect its `Location` header and decide what to do.
+Opt in with `followRedirects true`:
+
+[source,groovy]
+----
+def http = HttpBuilder.http {
+    baseUri 'https://api.example.com'
+    followRedirects true
+    header 'Authorization', "Bearer ${token}"
+}
+----
+
+At most 5 hops are followed. Methods are rewritten the same way as the JDK's
+`HttpClient.Redirect.NORMAL` policy: `301` and `302` downgrade `POST` to
+`GET` (dropping the body), `303` downgrades everything except `HEAD` to
+`GET`, and `307`/`308` preserve the method and body.
+
+=== Headers do not leave their origin
+
+Headers configured on the builder or on an individual request are treated as
+intended for one origin only: the scheme, host, and port of the first
+request. Which of them hold credentials is not something `HttpBuilder` can
+know — a token may sit in `Authorization`, `Cookie`, `X-Api-Key`, or any
+custom header — so the policy does not name header names:
+
+* A hop that stays on the origin keeps every header.
+* A hop that leaves the origin sheds _all_ caller-supplied headers, builder
+  defaults and per-request headers alike, for the remainder of the chain.
+  Returning to the original origin later does not restore them: once another
+  server directs the chain, no hop gets the credentials back.
+* The one exception is `Content-Type` on a `307`/`308` hop, which forwards
+  the request body: the header describing that body travels with it, as in
+  browsers.
+* A hop from an `https` URL to a plain `http` URL is never followed
+  (matching `HttpClient.Redirect.NORMAL`); the 3xx is returned to the
+  caller.
+
+Note that the scheme is part of the origin, so a redirect from
+`http://api.example.com` to `https://api.example.com` also sheds headers.
+
+Streaming requests (`streamAsync` and friends) never follow redirects; a
+3xx is always returned as-is.
+
+=== Which settings for which scenario
+
+[cols="1,1"]
+|===
+| Scenario | What to configure
+
+| Same-origin API that occasionally redirects (`/old` → `/new`)
+| `followRedirects true` — headers survive every same-origin hop
+
+| API that redirects downloads to a CDN or pre-signed URL (e.g. an API host
+  redirecting to cloud storage)
+| `followRedirects true` — credentials are shed on the cross-origin hop,
+  which such targets expect (pre-signed URLs typically reject requests that
+  also carry an `Authorization` header)
+
+| Service that redirects to a sibling host which must receive your
+  credentials (e.g. a regional endpoint on another hostname)
+| Send the request to the final host directly; or leave `followRedirects`
+  off, read `Location` from the 3xx, and re-issue the request yourself — an
+  explicit decision to send credentials to the second origin
+
+| Server upgrades `http` to `https` with a redirect
+| Configure the `https` URL as the `baseUri` so no upgrade hop is needed
+
+| Requests (and redirect hops) must never leave the API at all
+| `confineToBaseUri true` — see below
+
+| Streaming a response served behind a redirect
+| Resolve the `Location` of the 3xx yourself and stream from the target
+|===
+
+=== Confining requests to the base URI
+
+When request URIs are built from untrusted input, `confineToBaseUri true`
+rejects any request — and any redirect hop — that resolves outside the
+`baseUri` namespace, whether to another origin or above the base path
+(e.g. via `..` segments or an absolute path). Violations throw
+`SecurityException` instead of executing. It requires `baseUri` to be set:
+
+[source,groovy]
+----
+def http = HttpBuilder.http {
+    baseUri 'https://api.example.com/v2/'
+    confineToBaseUri true
+    followRedirects true
+}
+
+http.get('items/42')              // ok: https://api.example.com/v2/items/42
+http.get('../admin')              // SecurityException: escapes /v2/
+http.get('https://evil.example')  // SecurityException: different origin
+----
 
 == Async Requests
 
@@ -363,7 +464,8 @@ interface MyApi {
 - `connectTimeout` -- how long to wait for the TCP connection (client-level, in seconds)
 - `requestTimeout` -- default request timeout applied to all methods (in seconds)
 - `@Timeout(value)` -- per-method override of the request timeout (in seconds)
-- `followRedirects` -- whether to follow HTTP redirects
+- `followRedirects` -- whether to follow HTTP redirects, with the
+  origin-confined header semantics described in <<redirects,Redirects>>
 
 Default `0` means no timeout.
 

--- a/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderRedirectHeaderTest.groovy
+++ b/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderRedirectHeaderTest.groovy
@@ -1,0 +1,246 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.http
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpResponse
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.BiPredicate
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * GROOVY-12274: headers the caller configured for one origin must not be carried to another by
+ * following a redirect. The JDK client cannot be relied on for this. It protects only the header
+ * names it knows about, so a credential in any other header is forwarded regardless; and whether
+ * it protects even those depends on the update level of the JDK in use.
+ */
+class HttpBuilderRedirectHeaderTest {
+
+    static HttpServer origin
+    static HttpServer elsewhere
+    static int originPort
+    static int elsewherePort
+    /** Headers seen by whichever endpoint served the final hop; written on server threads. */
+    static final Map<String, String> received = new ConcurrentHashMap<>()
+    /** Counts final-hop arrivals, so a negative assertion cannot pass by the hop never happening. */
+    static final AtomicInteger arrivals = new AtomicInteger()
+    /** Body seen by whichever endpoint served the final hop; written on server threads. */
+    static volatile String receivedBody
+
+    @BeforeAll
+    static void setUpClass() {
+        origin = HttpServer.create(new InetSocketAddress('127.0.0.1', 0), 0)
+        originPort = origin.address.port
+        elsewhere = HttpServer.create(new InetSocketAddress('127.0.0.1', 0), 0)
+        elsewherePort = elsewhere.address.port
+
+        // The redirect target is passed as the query so one handler serves every case.
+        origin.createContext('/redirect') { HttpExchange exchange ->
+            exchange.responseHeaders.add('Location', exchange.requestURI.query)
+            exchange.sendResponseHeaders(302, -1)
+            exchange.close()
+        }
+        // 307 variant: the method and body are preserved across the hop.
+        origin.createContext('/redirect307') { HttpExchange exchange ->
+            exchange.responseHeaders.add('Location', exchange.requestURI.query)
+            exchange.sendResponseHeaders(307, -1)
+            exchange.close()
+        }
+        [origin, elsewhere].each { server ->
+            server.createContext('/target') { HttpExchange exchange ->
+                arrivals.incrementAndGet()
+                record(exchange)
+                receivedBody = exchange.requestBody.text
+                byte[] body = 'ok'.bytes
+                exchange.sendResponseHeaders(200, body.length)
+                exchange.responseBody.withStream { it.write(body) }
+            }
+        }
+        // Second hop for the return-to-origin case.
+        elsewhere.createContext('/bounce') { HttpExchange exchange ->
+            exchange.responseHeaders.add('Location', URLDecoder.decode(exchange.requestURI.query, 'UTF-8'))
+            exchange.sendResponseHeaders(302, -1)
+            exchange.close()
+        }
+        origin.start()
+        elsewhere.start()
+    }
+
+    @AfterAll
+    static void tearDownClass() {
+        origin?.stop(0)
+        elsewhere?.stop(0)
+    }
+
+    @BeforeEach
+    void setUp() {
+        received.clear()
+        arrivals.set(0)
+        receivedBody = null
+    }
+
+    private static void record(HttpExchange exchange) {
+        ['Authorization', 'Cookie', 'X-Api-Key', 'Accept', 'Content-Type'].each { name ->
+            def values = exchange.requestHeaders.get(name)
+            if (values) received.put(name, values.first())
+        }
+    }
+
+    private static HttpBuilder builderWithHeaders() {
+        HttpBuilder.http {
+            baseUri "http://127.0.0.1:${originPort}"
+            followRedirects true
+            headers([
+                    'Authorization': 'Bearer SECRET-TOKEN',
+                    'Cookie'       : 'session=SECRET-COOKIE',
+                    'X-Api-Key'    : 'SECRET-KEY',
+                    'Accept'       : 'text/plain',
+            ])
+        }
+    }
+
+    @Test
+    void testHeadersAreNotCarriedToAnotherOrigin() {
+        builderWithHeaders().get("/redirect?http://127.0.0.1:${elsewherePort}/target")
+
+        assert arrivals.get() == 1, 'the redirect was not followed, so the test proves nothing'
+        assert received.isEmpty(),
+                "a redirect to another origin received ${received.keySet()}"
+    }
+
+    @Test
+    void testCustomHeaderIsNotCarriedEither() {
+        // The header the JDK never protects, on any update level: the whole reason this is not
+        // left to the platform.
+        builderWithHeaders().get("/redirect?http://127.0.0.1:${elsewherePort}/target")
+
+        assert arrivals.get() == 1, 'the redirect was not followed, so the test proves nothing'
+        assert received['X-Api-Key'] == null
+    }
+
+    @Test
+    void testHeadersSurviveARedirectWithinTheSameOrigin() {
+        builderWithHeaders().get("/redirect?http://127.0.0.1:${originPort}/target")
+
+        assert received['Authorization'] == 'Bearer SECRET-TOKEN'
+        assert received['X-Api-Key'] == 'SECRET-KEY'
+        assert received['Accept'] == 'text/plain'
+    }
+
+    @Test
+    void testHeadersAreNotCarriedToAnotherOriginAsynchronously() {
+        builderWithHeaders()
+                .requestAsync('GET', "/redirect?http://127.0.0.1:${elsewherePort}/target")
+                .join()
+
+        assert arrivals.get() == 1, 'the redirect was not followed, so the test proves nothing'
+        assert received.isEmpty(),
+                "an asynchronous redirect to another origin received ${received.keySet()}"
+    }
+
+    @Test
+    void testClientConfigCannotHandRedirectsBackToTheJdkClient() {
+        // A redirect policy set on the raw builder would make the JDK client follow hops
+        // internally, bypassing the header shedding; it is overridden, so the manual loop
+        // still follows the redirect and the other origin still sees no caller headers.
+        def builder = HttpBuilder.http {
+            baseUri "http://127.0.0.1:${originPort}"
+            followRedirects true
+            // X-Api-Key is the discriminating probe: a JDK-followed hop forwards it on every
+            // JDK version, so this test fails without the override no matter the platform
+            headers(['Authorization': 'Bearer SECRET-TOKEN', 'X-Api-Key': 'SECRET-KEY'])
+            clientConfig { it.followRedirects(HttpClient.Redirect.NORMAL) }
+        }
+        builder.get("/redirect?http://127.0.0.1:${elsewherePort}/target")
+
+        assert arrivals.get() == 1, 'the redirect was not followed, so the test proves nothing'
+        assert received.isEmpty(),
+                "a redirect to another origin received ${received.keySet()}"
+    }
+
+    @Test
+    void testContentTypeTravelsWithABodyForwardedAcrossOrigins() {
+        // A 307 forwards the body, so the header describing it goes too — the one caller
+        // header that survives leaving the origin. Credentials are still shed.
+        builderWithHeaders().post("/redirect307?http://127.0.0.1:${elsewherePort}/target") {
+            json([user: 'alice'])
+        }
+
+        assert arrivals.get() == 1, 'the redirect was not followed, so the test proves nothing'
+        assert receivedBody == '{"user":"alice"}'
+        assert received['Content-Type'] == 'application/json'
+        assert received['Authorization'] == null
+        assert received['Cookie'] == null
+        assert received['X-Api-Key'] == null
+    }
+
+    @Test
+    void testContentTypeIsShedWhenTheBodyIsDropped() {
+        // A 302 downgrades POST to GET and drops the body, so Content-Type no longer
+        // describes anything and is shed along with every other caller header.
+        builderWithHeaders().post("/redirect?http://127.0.0.1:${elsewherePort}/target") {
+            json([user: 'alice'])
+        }
+
+        assert arrivals.get() == 1, 'the redirect was not followed, so the test proves nothing'
+        assert receivedBody == ''
+        assert received.isEmpty(),
+                "a body-dropping redirect to another origin received ${received.keySet()}"
+    }
+
+    @Test
+    void testHttpsToHttpDowngradeHopIsNotFollowed() {
+        // Matching HttpClient.Redirect.NORMAL, a hop from an https URL to a plain http one
+        // is never followed: the 3xx surfaces to the caller instead. Exercised at the
+        // decision level since the test rig has no TLS endpoint.
+        def builder = HttpBuilder.http {
+            baseUri 'https://secure.example.com'
+            followRedirects true
+        }
+        def start = URI.create('https://secure.example.com/start')
+
+        assert builder.redirectTarget(start, redirectResponse('http://127.0.0.1/target')) == null
+        assert builder.redirectTarget(start, redirectResponse('https://other.example.com/target')) ==
+                URI.create('https://other.example.com/target')
+    }
+
+    private static HttpResponse redirectResponse(String location) {
+        def headers = HttpHeaders.of(['Location': [location]], { a, b -> true } as BiPredicate)
+        [statusCode: { -> 302 }, headers: { -> headers }] as HttpResponse
+    }
+
+    @Test
+    void testHeadersAreNotRestoredByReturningToTheOrigin() {
+        // Once a chain has left the origin the caller's headers are gone for good; a hop back
+        // does not bring them out again.
+        String back = URLEncoder.encode("http://127.0.0.1:${originPort}/target", 'UTF-8')
+        builderWithHeaders().get("/redirect?http://127.0.0.1:${elsewherePort}/bounce?${back}")
+
+        assert arrivals.get() == 1, 'the chain did not reach the origin again, so the test proves nothing'
+        assert received['Authorization'] == null
+    }
+}


### PR DESCRIPTION
…her origin

With followRedirects and no confinement, redirect following was delegated to the JDK client, which re-issued the request to the Location target carrying the headers configured on the builder. Those headers are applied to every request, so a token or key among them was sent to whatever origin a redirect named.

The platform cannot be relied on for this. Measured against a cross-host redirect, on a chain that ends at a server which records what it received:

                        JDK 17.0.20    JDK 21.0.6    JDK 23.0.2
                        (2026-07)      (2025-01)     (2025-01)
  Authorization         stripped       forwarded     forwarded
  Cookie                stripped       forwarded     forwarded
  Proxy-Authorization   stripped       stripped      stripped
  X-Api-Key             forwarded      forwarded     forwarded

Two things follow. Whether the well known credential headers are protected depends on the update level of the JDK in use, which an application cannot choose. And a header the platform does not recognise is forwarded on every JDK, while the builder's headers may hold anything the caller put there, so a policy naming header names would repeat the same mistake at one remove.

Follow redirects here in every case rather than only under confinement, and drop the caller's headers for good once a hop leaves the origin the request started from. Same-origin redirects are unaffected, as is confinement, which already rejected a cross-origin hop outright. A chain which returns to the original origin does not get the headers back, since by then they have been seen by another server.

Note this drops all of the caller's headers rather than a chosen few: which of them carry credentials is not something this class can know.