### PR TITLE
GROOVY-12277: Encode source-derived text emitted into generated HTML

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
@@ -658,7 +658,10 @@ public class SimpleGroovyClassDoc extends SimpleGroovyAbstractableElementDoc imp
         }
 
         if (type.startsWith("#"))
-            return "<a href='" + resolveMethodArgs(rootDoc, classDoc, type) + "'>" + (label == null ? type.substring(1) : label) + "</a>";
+            // The target and label both come from the doc comment, so they are encoded for the
+            // context each lands in: the href is an attribute value, the label is element text.
+            return "<a href='" + encodeAttribute(resolveMethodArgs(rootDoc, classDoc, type)) + "'>"
+                    + encodeAngleBrackets(label == null ? type.substring(1) : label) + "</a>";
 
         if (type.endsWith("[]")) {
             String componentType = type.substring(0, type.length() - 2);
@@ -738,7 +741,8 @@ public class SimpleGroovyClassDoc extends SimpleGroovyAbstractableElementDoc imp
                 ? target[0].replace('$', '.')
                 : target[0].replace('.', '/').replace('$', '.');
         String url = relativeRoot + targetPath + ".html" + (target.length > 1 ? "#" + target[1] : "");
-        return "<a href='" + url + "' title='" + shortClassName + "'>" + shortClassName + "</a>";
+        return "<a href='" + encodeAttribute(url) + "' title='" + encodeAttribute(shortClassName) + "'>"
+                + encodeAngleBrackets(shortClassName) + "</a>";
     }
 
     private GroovyClassDoc resolveClass(GroovyRootDoc rootDoc, String name) {

--- a/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
+++ b/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/gstringTemplates/classLevel/classDocName.html
@@ -72,7 +72,10 @@
         (t.isStatic()?"static&nbsp;":"")
     }
     def annotations = { t, sepChar ->
-        t.annotations() ? t.annotations().collect{ it.isTypeAvailable()?'@'+linkable(it.type().typeName())+it.description():'@'+it.name()+it.description()}.join(sepChar) + sepChar : ''
+        // An annotation's name and description are source text, not markup: description()
+        // re-embeds the annotation's arguments verbatim. Only linkable() produces HTML here.
+        def encode = { org.codehaus.groovy.tools.groovydoc.SimpleGroovyClassDoc.encodeAngleBrackets(it ?: '') }
+        t.annotations() ? t.annotations().collect{ it.isTypeAvailable()?'@'+linkable(it.type().typeName())+encode(it.description()):'@'+encode(it.name())+encode(it.description())}.join(sepChar) + sepChar : ''
     }
     def elementTypes = [
         "required":"true",

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -385,6 +385,81 @@ public class GroovyDocToolTest extends GroovyTestCase {
         return output.getText(MOCK_DIR + "/" + pkg + "/" + simpleName + ".html");
     }
 
+    // GROOVY-12277: a {@link} label and target are doc-comment text that groovydoc puts into
+    // the href and title of an anchor it builds itself, so they must be encoded for those
+    // contexts. This is groovydoc's own construction, not the documented raw-HTML passthrough
+    // of a comment body.
+    public void testLinkTagCannotBreakOutOfTheAnchorItBuilds() throws Exception {
+        String pkg = "org/codehaus/groovy/tools/groovydoc/testfiles/docfiles";
+        Path tmp = Files.createTempDirectory("linktag-");
+        Path pkgDir = tmp.resolve(pkg);
+        Files.createDirectories(pkgDir);
+        Files.writeString(pkgDir.resolve("Helper.groovy"),
+                "package " + pkg.replace('/', '.') + "\nclass Helper { void go() {} }\n");
+        // The label of the resolved-class link ('Helper ...') lands in the title attribute of the
+        // anchor buildUrl constructs; the target of the method link ('#go(...)') lands in its href.
+        // Each payload closes its ' delimiter, so if written unencoded the title/href ends early
+        // and the trailing text becomes a live attribute of the anchor.
+        Files.writeString(pkgDir.resolve("LinkTag.groovy"),
+                "package " + pkg.replace('/', '.') + "\n" +
+                "/**\n" +
+                " * See {@link Helper TITLEPWN' onbreak='x(1)}\n" +
+                " * and {@link #go(a' onmouseover='alert(2)) L}\n" +
+                " */\n" +
+                "class LinkTag {}\n");
+
+        // Both files must be rendered together so 'Helper' resolves and the class-link path
+        // (buildUrl) is actually exercised; rendering LinkTag alone drops the unresolved link.
+        String doc = renderTogether(tmp, pkg, List.of("Helper", "LinkTag"), "LinkTag");
+        assertNotNull(doc);
+        // A broken title reads title='TITLEPWN' onbreak=...; the encoded one keeps the quote as
+        // &#39; so the marker is never immediately followed by a closing quote. (The label also
+        // appears as harmless element text, so key on the title= context, not the bare marker.)
+        assertFalse("a resolved-class link label broke out of its title attribute in:\n" + doc,
+                doc.contains("title='TITLEPWN'"));
+        assertFalse("a method link target broke out of its href attribute in:\n" + doc,
+                doc.contains("onmouseover='alert"));
+    }
+
+    private String renderTogether(Path sourcePath, String pkg, List<String> simpleNames, String target) throws Exception {
+        GroovyDocTool tool = new GroovyDocTool(
+                new FileSystemResourceManager("src/main/resources"),
+                new String[]{sourcePath.toString()},
+                GroovyDocTemplateInfo.DEFAULT_DOC_TEMPLATES,
+                GroovyDocTemplateInfo.DEFAULT_PACKAGE_TEMPLATES,
+                GroovyDocTemplateInfo.DEFAULT_CLASS_TEMPLATES,
+                new ArrayList<>(), null, new Properties()
+        );
+        List<String> paths = new ArrayList<>();
+        for (String name : simpleNames) {
+            paths.add(pkg + "/" + name + ".groovy");
+        }
+        tool.add(paths);
+        MockOutputTool output = new MockOutputTool();
+        tool.renderToOutput(output, MOCK_DIR);
+        return output.getText(MOCK_DIR + "/" + pkg + "/" + target + ".html");
+    }
+
+    // GROOVY-12277: an annotation's name and description are source text re-embedded verbatim
+    // into the declaration block, so unlike a doc comment they carry no passthrough licence.
+    public void testAnnotationTextIsEncodedInDeclarations() throws Exception {
+        String pkg = "org/codehaus/groovy/tools/groovydoc/testfiles/docfiles";
+        Path tmp = Files.createTempDirectory("annotation-");
+        Path pkgDir = tmp.resolve(pkg);
+        Files.createDirectories(pkgDir);
+        Files.writeString(pkgDir.resolve("Meta.groovy"),
+                "package " + pkg.replace('/', '.') + "\n" +
+                "@interface Meta { String value() }\n");
+        Files.writeString(pkgDir.resolve("Annotated.groovy"),
+                "package " + pkg.replace('/', '.') + "\n" +
+                "@Meta('<img src=q onerror=alert(1)>')\n" +
+                "class Annotated {}\n");
+
+        String doc = renderSingle(tmp, pkg, "Annotated");
+        assertNotNull(doc);
+        assertFalse("annotation text was emitted as markup in:\n" + doc, doc.contains("<img src=q"));
+    }
+
     // Auto-strip opt-out: {@snippet file="X" keepHeader=true} preserves the
     // file content verbatim, and lang is inferred from the file's extension
     // when no explicit lang= is given.


### PR DESCRIPTION
Two places where groovydoc builds HTML around text taken from the source it is documenting, without encoding it for the context it lands in.

A {@link} or @see reference is split into a target and a label, both of which are then concatenated into an anchor the tool constructs: the target into href, the label into the element text, and for a resolved class the short name into title as well. None was encoded, so a reference could close the attribute and open a tag of its own. Encode each for its context, the attributes through encodeAttribute and the text through encodeAngleBrackets.

An annotation's name and description are emitted into the class declaration and every member heading. description() carries the annotation's arguments as they were written, so an annotation holding a string literal put that literal into the page verbatim. Encode both, leaving the linkable() call alone since that one does produce markup.

This is groovydoc's own construction rather than the raw HTML a doc comment body may contain by javadoc parity, so the passthrough that covers a comment body does not extend to it. For the annotation case the text is not from a comment at all: it is source code, and reaches the page without any doc comment being written.

Not changed: the @default tag GroovydocJavaVisitor appends for an annotation member's default value. It is added to the raw comment text and no template renders it as a declaration, and constantValueExpression() is only tested for nullity, so that value does not reach a declaration block.