### PR TITLE
GROOVY-12279: SecureASTCustomizer: apply import rules to a method poi…

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
+++ b/src/main/java/org/codehaus/groovy/control/customizers/SecureASTCustomizer.java
@@ -828,8 +828,9 @@ public class SecureASTCustomizer extends CompilationCustomizer {
      * Set this option to true to apply the import rules to types which appear in the source without an
      * import statement, most usefully to prevent a class being instantiated by fully qualified name.
      * <p>
-     * The rules are applied to the constructed type of a constructor call, and to the receiver type of a
-     * method call or a static method call. They are not applied to every class node: class literals,
+     * The rules are applied to the constructed type of a constructor call, to the receiver type of a
+     * method call or a static method call, and to the type a method pointer or method reference is
+     * taken on. They are not applied to every class node: class literals,
      * property and attribute access, cast and declaration types, and catch types are not examined. Note
      * also that the receiver type is the static type of that expression, which for a dynamically typed
      * receiver is {@code java.lang.Object} rather than the class the call reaches at runtime.
@@ -1513,9 +1514,14 @@ public class SecureASTCustomizer extends CompilationCustomizer {
                         assertImportIsAllowed(typename);
                         assertStaticImportIsAllowed(expr.getMethod(), typename);
                     } else if (expression instanceof MethodPointerExpression expr) {
-                        final String typename = expr.getType().getName();
+                        // A method pointer's own type is fixed to groovy.lang.Closure by its
+                        // constructor, so the class the import rules are about is the one the
+                        // pointer is taken on, and the member is the method it names.
+                        final String typename = getExpressionType(expr.getExpression().getType()).getName();
                         assertImportIsAllowed(typename);
-                        assertStaticImportIsAllowed(expr.getText(), typename);
+                        Expression methodName = expr.getMethodName();
+                        assertStaticImportIsAllowed(methodName instanceof ConstantExpression
+                                ? methodName.getText() : null, typename);
                     }
                 } catch (SecurityException e) {
                     throw new SecurityException("Indirect import checks prevents usage of expression", e);

--- a/src/test/groovy/org/codehaus/groovy/control/customizers/SecureASTCustomizerTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/control/customizers/SecureASTCustomizerTest.groovy
@@ -336,6 +336,45 @@ final class SecureASTCustomizerTest {
         }
     }
 
+    // GROOVY-12279: a method pointer's own type is fixed to groovy.lang.Closure, so the
+    // indirect import check was asking about Closure rather than about the class the pointer
+    // is taken on. In deny mode that let the pointer through; in allow mode it rejected every
+    // pointer, since Closure is never in an allow list.
+    @Test
+    void testIndirectImportCheckUsesMethodPointerTargetWhenDenied() {
+        customizer.disallowedImports = ['java.util.LinkedList']
+        customizer.indirectImportCheckEnabled = true
+        def shell = new GroovyShell(configuration)
+        assert hasSecurityException {
+            shell.evaluate('return java.util.LinkedList.&size')
+        }
+        assert hasSecurityException {
+            shell.evaluate('return java.util.LinkedList::size')
+        }
+        // The constructor form was already checked, and stays checked.
+        assert hasSecurityException {
+            shell.evaluate('return new java.util.LinkedList()')
+        }
+    }
+
+    @Test
+    void testIndirectImportCheckUsesMethodPointerTargetWhenAllowed() {
+        customizer.allowedImports = ['java.util.ArrayList']
+        customizer.indirectImportCheckEnabled = true
+        def shell = new GroovyShell(configuration)
+        // Permitted because the target is allowed. Previously refused, because the type being
+        // asked about was Closure, which no allow list names.
+        shell.evaluate('return java.util.ArrayList.&size')
+        shell.evaluate('return java.util.ArrayList::size')
+        // A target which is not allowed is still refused, in both pointer and reference form.
+        assert hasSecurityException {
+            shell.evaluate('return java.util.LinkedList.&size')
+        }
+        assert hasSecurityException {
+            shell.evaluate('return java.util.LinkedList::size')
+        }
+    }
+
     @Test
     void testAllowedIndirectImports() {
         customizer.allowedImports = ['java.util.ArrayList']


### PR DESCRIPTION
…nter's target type

The indirect import check asked about a method pointer's own type. A MethodPointerExpression fixes that to groovy.lang.Closure in its constructor, so the check never concerned the class the pointer is taken on, and its second argument was the whole expression text where assertStaticImportIsAllowed expects a member name.

Both modes were wrong, in opposite directions. Measured with the check enabled:

  disallowedImports = [java.lang.ProcessBuilder]
    new ProcessBuilder()             blocked
    ProcessBuilder.&new              allowed
    ProcessBuilder::new              allowed

  allowedImports = [java.util.ArrayList]
    ArrayList.&size                  refused

The deny list missed the pointer entirely, since nothing names Closure in one. The allow list refused every pointer, including pointers to a class it allowed, because Closure is not in an allow list either. So the check both let through what it was meant to stop and stopped what it was meant to allow.

Ask about the class the pointer is taken on, unwrapping arrays through the same helper the method call branch uses, and pass the method name rather than the expression text.

This changes behaviour in both directions, each toward what the flag documents: a denied target is now refused, and a pointer to an allowed target is now permitted where it was refused before.

An existing assertion covered java.util.LinkedList.&size under an allow list, and passed only because Closure was absent from that list; it passes after this change too, now for the reason it appears to be testing.