### PR TITLE
GROOVY-12284: Specialize indy sameClasses guards for arity 1-4

### DIFF
--- a/.github/workflows/groovy-build-performance.yml
+++ b/.github/workflows/groovy-build-performance.yml
@@ -68,7 +68,7 @@ jobs:
           cache-disabled: true
       - name: Compiler performance comparison
         run: ./gradlew perf:performanceTests
-        timeout-minutes: 60
+        timeout-minutes: 90
 
       # Deterministic dispatch metrics (class-loading and bytecode-size
       # counters). Unlike the timing benchmarks these are exact for a given

--- a/.github/workflows/groovy-jmh-classic.yml
+++ b/.github/workflows/groovy-jmh-classic.yml
@@ -80,7 +80,7 @@ jobs:
           cache-disabled: true
       - name: JMH (${{ matrix.suite }} classic)
         run: ./gradlew perf:jmh -PbenchInclude=${{ matrix.pattern }} -Pindy=false -PjmhResultFormat=JSON
-        timeout-minutes: 60
+        timeout-minutes: 90
       - name: Rename JMH result file
         run: |
           mv subprojects/performance/build/results/jmh/results.json \

--- a/.github/workflows/groovy-jmh-daily.yml
+++ b/.github/workflows/groovy-jmh-daily.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: JMH (${{ matrix.suite }} ${{ matrix.indy }})
         run: ./gradlew perf:jmh -PbenchInclude=${{ matrix.pattern }} ${{ matrix.indyFlag }} -PjmhResultFormat=JSON
-        timeout-minutes: 60
+        timeout-minutes: 90
 
       # Dashboards index: https://apache.github.io/groovy/
       # Data is appended to dev/bench/jmh/<suite>/<indy>/data.js on the gh-pages branch.

--- a/.github/workflows/groovy-jmh.yml
+++ b/.github/workflows/groovy-jmh.yml
@@ -80,7 +80,7 @@ jobs:
           cache-disabled: true
       - name: JMH (${{ matrix.suite }})
         run: ./gradlew perf:jmh -PbenchInclude=${{ matrix.pattern }} -PjmhResultFormat=JSON
-        timeout-minutes: 60
+        timeout-minutes: 90
       - name: Rename JMH result file
         run: |
           mv subprojects/performance/build/results/jmh/results.json \

--- a/build-logic/src/main/groovy/org.apache.groovy-performance.gradle
+++ b/build-logic/src/main/groovy/org.apache.groovy-performance.gradle
@@ -20,6 +20,7 @@
 import org.apache.groovy.gradle.DispatchMetricsSummary
 import org.apache.groovy.gradle.PerformanceTestsExtension
 import org.apache.groovy.gradle.PerformanceTestSummary
+import org.gradle.api.attributes.Attribute
 
 plugins {
     id 'groovy'
@@ -50,7 +51,14 @@ var indy = (project.findProperty('indy') ?: 'true').toBoolean()
 
 dependencies {
     implementation project(':')
-    jmh project(':')
+    // Do not add project(':') to the unattributed `jmh` configuration. That
+    // configuration is the JMH engine (jmh-core + bytecode generator). With
+    // no variant attributes it resolves the root project's internal
+    // runtimeElements — groovy-raw — while jmhRuntimeClasspath (java-runtime)
+    // resolves the published shaded groovy jar. Putting both on a process
+    // classpath duplicates groovy.concurrent.AsyncScope and trips
+    // MetaClassRegistryImpl.checkForDuplicateConcurrentModule. Groovy is
+    // already on the jmh source set via implementation above.
     testImplementation project(':')
     testImplementation "org.junit.jupiter:junit-jupiter-api:${versions.junit6}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${versions.junit6}"
@@ -61,6 +69,18 @@ dependencies {
     if (!indy) {
         implementation projects.groovyCallsite
         jmh projects.groovyCallsite
+    }
+}
+
+// compileClasspath / testCompileClasspath are tagged org.apache.groovy.internal
+// (see org.apache.groovy-internal) so they resolve groovy-raw, matching the
+// bootstrap compiler on groovyClasspath. The jmh plugin's extra source set is
+// not tagged, so jmhCompileClasspath would otherwise pick the published
+// shaded groovy jar and groovyc would load AsyncScope from both jars.
+def internalPublication = Attribute.of('org.apache.groovy.internal', Boolean)
+configurations.named('jmhCompileClasspath') {
+    attributes {
+        attribute(internalPublication, true)
     }
 }
 
@@ -171,6 +191,27 @@ tasks.named('test') {
 tasks.named('jmh') {
     inputs.property('benchInclude', project.findProperty('benchInclude') ?: '')
     dependsOn tasks.named('jmhClasses')
+    // me.champeau.jmh's JMHTask concatenates (jmh config) + jmhJar +
+    // jmhRuntimeClasspath. jmhJar already fat-jars jmhRuntimeClasspath
+    // (the shaded groovy jar). Leaving the extra collections in place
+    // puts groovy-raw, the fat jar, and groovy.jar on one ClassLoader —
+    // three copies of groovy.concurrent.AsyncScope. Run from the fat
+    // jar alone; it already has Main-Class org.openjdk.jmh.Main.
+    jmhClasspath.setFrom([])
+    testRuntimeClasspath.setFrom([])
+}
+
+// includeTests also appends testRuntimeClasspath (groovy-raw, internal
+// variant) onto the jmh source set, which the bytecode generator then
+// puts on its process classpath next to jmhRuntimeClasspath (shaded
+// groovy). Keep test *classes* so benches under src/test still generate;
+// drop the test runtime jars so Groovy is loaded only from the shaded jar.
+tasks.named('jmhRunBytecodeGenerator') {
+    runtimeClasspath.setFrom(
+            configurations.jmhRuntimeClasspath,
+            sourceSets.jmh.output,
+            sourceSets.main.output,
+            sourceSets.test.output)
 }
 
 tasks.named('jmhJar') {

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyGuardsFiltersAndSignatures.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyGuardsFiltersAndSignatures.java
@@ -62,7 +62,8 @@ public class IndyGuardsFiltersAndSignatures {
      * Shared guards, filters, constructors, and invokers used when assembling indy call paths.
      */
     protected static final MethodHandle
-            SAME_CLASS, SAME_CLASSES, SAME_MC, IS_NULL, NON_NULL,
+            SAME_CLASS, SAME_CLASSES, SAME_CLASSES_2, SAME_CLASSES_3, SAME_CLASSES_4,
+            SAME_MC, IS_NULL, NON_NULL,
             UNWRAP_METHOD, UNWRAP_EXCEPTION,
             HAS_CATEGORY_IN_CURRENT_THREAD_GUARD,
             GROOVY_OBJECT_INVOKER, GROOVY_OBJECT_GET_PROPERTY, GROOVY_OBJECT_SET_PROPERTY, META_METHOD_INVOKER,
@@ -82,6 +83,9 @@ public class IndyGuardsFiltersAndSignatures {
         try {
             SAME_CLASS                           = LOOKUP.findStatic (IndyGuardsFiltersAndSignatures.class, "sameClass", MethodType.methodType(boolean.class, Class.class, Object.class));
             SAME_CLASSES                         = LOOKUP.findStatic (IndyGuardsFiltersAndSignatures.class, "sameClasses", MethodType.methodType(boolean.class, Class[].class, Object[].class));
+            SAME_CLASSES_2                       = LOOKUP.findStatic (IndyGuardsFiltersAndSignatures.class, "sameClasses", MethodType.methodType(boolean.class, Class.class, Class.class, Object.class, Object.class));
+            SAME_CLASSES_3                       = LOOKUP.findStatic (IndyGuardsFiltersAndSignatures.class, "sameClasses", MethodType.methodType(boolean.class, Class.class, Class.class, Class.class, Object.class, Object.class, Object.class));
+            SAME_CLASSES_4                       = LOOKUP.findStatic (IndyGuardsFiltersAndSignatures.class, "sameClasses", MethodType.methodType(boolean.class, Class.class, Class.class, Class.class, Class.class, Object.class, Object.class, Object.class, Object.class));
             SAME_MC                              = LOOKUP.findStatic (IndyGuardsFiltersAndSignatures.class, "isSameMetaClass", MethodType.methodType(boolean.class, MetaClass.class, Object.class));
             IS_NULL                              = LOOKUP.findStatic (IndyGuardsFiltersAndSignatures.class, "isNull", OBJECT_GUARD);
             NON_NULL                             = LOOKUP.findStatic (Objects.class, "nonNull", MethodType.methodType(boolean.class, Object.class));
@@ -238,5 +242,32 @@ public class IndyGuardsFiltersAndSignatures {
                 return false;
         }
         return true;
+    }
+
+    /**
+     * Two-argument same-class guard used by hot indy sites so
+     * {@code asCollector(Object[].class, n)} does not allocate an {@code Object[]}
+     * on every invocation. {@code Selector} binds the expected classes with a
+     * single {@link MethodHandles#insertArguments} call.
+     */
+    public static boolean sameClasses(Class<?> c0, Class<?> c1, Object o0, Object o1) {
+        return o0 != null && o1 != null && o0.getClass() == c0 && o1.getClass() == c1;
+    }
+
+    /**
+     * Three-argument same-class guard; see {@link #sameClasses(Class, Class, Object, Object)}.
+     */
+    public static boolean sameClasses(Class<?> c0, Class<?> c1, Class<?> c2, Object o0, Object o1, Object o2) {
+        return o0 != null && o1 != null && o2 != null
+                && o0.getClass() == c0 && o1.getClass() == c1 && o2.getClass() == c2;
+    }
+
+    /**
+     * Four-argument same-class guard; see {@link #sameClasses(Class, Class, Object, Object)}.
+     */
+    public static boolean sameClasses(Class<?> c0, Class<?> c1, Class<?> c2, Class<?> c3,
+                                      Object o0, Object o1, Object o2, Object o3) {
+        return o0 != null && o1 != null && o2 != null && o3 != null
+                && o0.getClass() == c0 && o1.getClass() == c1 && o2.getClass() == c2 && o3.getClass() == c3;
     }
 }

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java
@@ -22,29 +22,17 @@ import groovy.lang.Closure;
 import groovy.lang.ExpandoMetaClass;
 import groovy.lang.GroovyInterceptable;
 import groovy.lang.GroovyObject;
-import groovy.lang.MetaBeanProperty;
-import groovy.lang.MetaProperty;
 import groovy.lang.GroovyRuntimeException;
 import groovy.lang.GroovySystem;
+import groovy.lang.MetaBeanProperty;
 import groovy.lang.MetaClass;
 import groovy.lang.MetaClassImpl;
 import groovy.lang.MetaClassImpl.MetaConstructor;
 import groovy.lang.MetaMethod;
+import groovy.lang.MetaProperty;
 import groovy.lang.MissingMethodException;
 import groovy.lang.ProxyMetaClass;
 import groovy.transform.Internal;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Objects;
 import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.reflection.CachedField;
 import org.codehaus.groovy.reflection.CachedMethod;
@@ -67,6 +55,20 @@ import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 import org.codehaus.groovy.runtime.wrappers.Wrapper;
 import org.codehaus.groovy.vmplugin.VMPlugin;
 import org.codehaus.groovy.vmplugin.VMPluginFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.ARRAYLIST_CONSTRUCTOR;
 import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.BEAN_CONSTRUCTOR_PROPERTY_SETTER;
@@ -91,6 +93,9 @@ import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.NON
 import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.NULL_REF;
 import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.SAME_CLASS;
 import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.SAME_CLASSES;
+import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.SAME_CLASSES_2;
+import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.SAME_CLASSES_3;
+import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.SAME_CLASSES_4;
 import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.SAME_MC;
 import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.SAM_CONVERSION;
 import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.SET_PROPERTY;
@@ -1289,7 +1294,7 @@ public abstract class Selector {
             handle = applyMopSwitchPoints(handle, fallback, receiver);
             if (LOG_ENABLED) LOG.info("added class switch point guard");
 
-            java.util.function.Predicate<Class<?>> nonFinalOrNullUnsafe = (t) -> {
+            Predicate<Class<?>> nonFinalOrNullUnsafe = (t) -> {
                 return !Modifier.isFinal(t.getModifiers())
                     || TypeHelper.getUnboxedType(t).isPrimitive(); // GROOVY-11782
             };
@@ -1314,11 +1319,11 @@ public abstract class Selector {
                     handle = MethodHandles.guardWithTest(test, handle, fallback);
                 }
             } else if (Arrays.stream(pt).anyMatch(nonFinalOrNullUnsafe)) {
-                MethodHandle test = SAME_CLASSES
-                        .bindTo(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new))
-                        .asCollector(Object[].class, pt.length)
-                        .asType(MethodType.methodType(boolean.class, pt));
-                handle = MethodHandles.guardWithTest(test, handle, fallback);
+                // Arity 0 never reaches here: anyMatch on an empty pt is false,
+                // and a receiver is always present. No same-class combinator is
+                // installed for a parameterless handle.
+                handle = MethodHandles.guardWithTest(
+                        Selector.sameClassesGuard(args, handle.type()), handle, fallback);
                 if (LOG_ENABLED) LOG.info("added same-class argument check");
             } else if (safeNavigationOrig) { // GROOVY-11126
                 MethodHandle test = NON_NULL.asType(MethodType.methodType(boolean.class, pt[0]));
@@ -1532,5 +1537,47 @@ public abstract class Selector {
             sender = sender.getEnclosingClass();
         }
         return sender;
+    }
+
+    /**
+     * Specialised same-class guards for arities 1–4, stored at {@code [n - 1]}.
+     */
+    private static final MethodHandle[] SAME_CLASS_GUARDS = {
+            SAME_CLASS,
+            SAME_CLASSES_2,
+            SAME_CLASSES_3,
+            SAME_CLASSES_4
+    };
+
+    /**
+     * Builds a same-class guard that avoids {@code asCollector(Object[].class, n)}
+     * for the common 1–4 argument shapes (receiver plus 0–3 parameters).
+     * Expected classes are bound with a single {@link MethodHandles#insertArguments}
+     * (one adapter, not a chain of {@code bindTo}). The produced handle has type
+     * {@code callType.changeReturnType(boolean.class)} and returns {@code false}
+     * if any argument is {@code null} or has a different runtime class.
+     * <p>
+     * Arity 0 is not specialised; the caller does not install a guard in that
+     * case. If this helper is invoked with no parameters it falls through to
+     * the collector of an empty array, which returns {@code true}.
+     *
+     * @param args     non-null arguments captured at link time; length matches {@code callType}
+     * @param callType the invocation handle type whose parameters the guard must accept
+     */
+    static MethodHandle sameClassesGuard(final Object[] args, final MethodType callType) {
+        int n = callType.parameterCount();
+        MethodType booleanType = callType.changeReturnType(boolean.class);
+        if (n >= 1 && n <= SAME_CLASS_GUARDS.length) {
+            Object[] classes = new Object[n];
+            for (int i = 0; i < n; i++) {
+                classes[i] = args[i].getClass();
+            }
+            return MethodHandles.insertArguments(SAME_CLASS_GUARDS[n - 1], 0, classes).asType(booleanType);
+        }
+        Class<?>[] classes = new Class<?>[n];
+        for (int i = 0; i < n; i++) {
+            classes[i] = args[i].getClass();
+        }
+        return SAME_CLASSES.bindTo(classes).asCollector(Object[].class, n).asType(booleanType);
     }
 }

--- a/src/test/groovy/org/codehaus/groovy/vmplugin/v8/IndySameClassesGuardTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/vmplugin/v8/IndySameClassesGuardTest.groovy
@@ -1,0 +1,147 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.vmplugin.v8
+
+import org.junit.jupiter.api.Test
+
+import java.lang.invoke.MethodType
+
+import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.sameClass
+import static org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures.sameClasses
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * Guards produced for monomorphic indy sites must reject a changed argument
+ * class or a newly-null argument without allocating an {@code Object[]} collector
+ * on the 1–4 arity hot path.
+ */
+final class IndySameClassesGuardTest {
+
+    @Test
+    void 'sameClass rejects null and class change'() {
+        assertTrue sameClass(String, 'a')
+        assertFalse sameClass(String, 1)
+        assertFalse sameClass(String, null)
+    }
+
+    @Test
+    void 'array sameClasses covers empty match null and mismatch'() {
+        assertTrue sameClasses(new Class[0], new Object[0])
+        assertTrue sameClasses([String, Integer] as Class[], ['a', 1] as Object[])
+        assertFalse sameClasses([String, Integer] as Class[], ['a', null] as Object[])
+        assertFalse sameClasses([String, Integer] as Class[], [null, 1] as Object[])
+        assertFalse sameClasses([String, Integer] as Class[], ['a', 1L] as Object[])
+        assertFalse sameClasses([String, Integer] as Class[], [1, 1] as Object[])
+    }
+
+    @Test
+    void 'arity-2 sameClasses covers each conjunct'() {
+        assertTrue sameClasses(String, Integer, 'a', 1)
+        assertFalse sameClasses(String, Integer, null, 1)
+        assertFalse sameClasses(String, Integer, 'a', null)
+        assertFalse sameClasses(String, Integer, 1, 1)
+        assertFalse sameClasses(String, Integer, 'a', 1L)
+    }
+
+    @Test
+    void 'arity-3 sameClasses covers each conjunct'() {
+        assertTrue sameClasses(String, Integer, Long, 'a', 1, 2L)
+        assertFalse sameClasses(String, Integer, Long, null, 1, 2L)
+        assertFalse sameClasses(String, Integer, Long, 'a', null, 2L)
+        assertFalse sameClasses(String, Integer, Long, 'a', 1, null)
+        assertFalse sameClasses(String, Integer, Long, 1, 1, 2L)
+        assertFalse sameClasses(String, Integer, Long, 'a', 1L, 2L)
+        assertFalse sameClasses(String, Integer, Long, 'a', 1, 2)
+    }
+
+    @Test
+    void 'arity-4 sameClasses covers each conjunct'() {
+        assertTrue sameClasses(String, Integer, Long, Double, 'a', 1, 2L, 3d)
+        assertFalse sameClasses(String, Integer, Long, Double, null, 1, 2L, 3d)
+        assertFalse sameClasses(String, Integer, Long, Double, 'a', null, 2L, 3d)
+        assertFalse sameClasses(String, Integer, Long, Double, 'a', 1, null, 3d)
+        assertFalse sameClasses(String, Integer, Long, Double, 'a', 1, 2L, null)
+        assertFalse sameClasses(String, Integer, Long, Double, 1, 1, 2L, 3d)
+        assertFalse sameClasses(String, Integer, Long, Double, 'a', 1L, 2L, 3d)
+        assertFalse sameClasses(String, Integer, Long, Double, 'a', 1, 2, 3d)
+        assertFalse sameClasses(String, Integer, Long, Double, 'a', 1, 2L, 3f)
+    }
+
+    @Test
+    void 'sameClassesGuard arity 0 to 5 matches collector semantics'() {
+        def g0 = Selector.sameClassesGuard(new Object[0], MethodType.methodType(Object))
+        assertEquals(MethodType.methodType(boolean), g0.type())
+        assertTrue((boolean) g0.invokeWithArguments())
+
+        def g1 = Selector.sameClassesGuard(['recv'] as Object[], MethodType.methodType(Object, Object))
+        assertEquals(MethodType.methodType(boolean, Object), g1.type())
+        assertTrue((boolean) g1.invokeWithArguments('recv'))
+        assertFalse((boolean) g1.invokeWithArguments(1))
+        assertFalse((boolean) g1.invokeWithArguments((Object) null))
+
+        def g2 = Selector.sameClassesGuard(['recv', 'arg'] as Object[], MethodType.methodType(Object, Object, Object))
+        assertEquals(MethodType.methodType(boolean, Object, Object), g2.type())
+        assertTrue((boolean) g2.invokeWithArguments('recv', 'arg'))
+        assertFalse((boolean) g2.invokeWithArguments('recv', 1))
+        assertFalse((boolean) g2.invokeWithArguments('recv', null))
+        assertFalse((boolean) g2.invokeWithArguments(1, 'arg'))
+
+        def g3 = Selector.sameClassesGuard(['r', 1, 2L] as Object[], MethodType.methodType(Object, Object, Object, Object))
+        assertTrue((boolean) g3.invokeWithArguments('r', 1, 2L))
+        assertFalse((boolean) g3.invokeWithArguments('r', 1, null))
+        assertFalse((boolean) g3.invokeWithArguments('r', null, 2L))
+
+        def g4 = Selector.sameClassesGuard(['r', 1, 2L, 3d] as Object[], MethodType.methodType(Object, Object, Object, Object, Object))
+        assertTrue((boolean) g4.invokeWithArguments('r', 1, 2L, 3d))
+        assertFalse((boolean) g4.invokeWithArguments('r', 1, 2L, 'x'))
+        assertFalse((boolean) g4.invokeWithArguments(null, 1, 2L, 3d))
+
+        def g5 = Selector.sameClassesGuard(['r', 1, 2L, 3d, 'z'] as Object[],
+                MethodType.methodType(Object, Object, Object, Object, Object, Object))
+        assertTrue((boolean) g5.invokeWithArguments('r', 1, 2L, 3d, 'z'))
+        assertFalse((boolean) g5.invokeWithArguments('r', 1, 2L, 3d, 0))
+        assertFalse((boolean) g5.invokeWithArguments('r', 1, 2L, 3d, null))
+    }
+
+    @Test
+    void 'sameClassesGuard asTypes primitive parameters the way indy sites do'() {
+        def g = Selector.sameClassesGuard(['r', 1] as Object[], MethodType.methodType(Object, Object, int))
+        assertEquals(MethodType.methodType(boolean, Object, int), g.type())
+        // Object[] form hits MethodHandle.invokeWithArguments(Object[]), which
+        // asTypes/unboxes; the Groovy (Object...) call would go through the MOP.
+        assertTrue((boolean) g.invokeWithArguments(['r', 1] as Object[]))
+        assertFalse((boolean) g.invokeWithArguments([1, 1] as Object[]))
+        assertFalse((boolean) g.invokeWithArguments([null, 1] as Object[]))
+    }
+
+    @Test
+    void 'dynamic call site relinks when an argument class changes'() {
+        def adder = new Adder()
+        def acc = 0
+        20.times { acc += adder.add(it, it + 1) }
+        acc += adder.add(100L, 3L)
+        assert acc == (0..19).sum { it + it + 1 } + 103L
+    }
+
+    static class Adder {
+        def add(a, b) { a + b }
+    }
+}

--- a/subprojects/performance/README.adoc
+++ b/subprojects/performance/README.adoc
@@ -148,6 +148,27 @@ exact-class policy — no hierarchy fan-out). Steady-state monomorphic sites
 carry a single SwitchPoint guard. Complements the Grails-oriented
 `CallSiteInvalidationBench` under `org.apache.groovy.perf.grails`.
 
+== Same-class guards (GROOVY-12284)
+
+`SameClassesGuardBench` measures the invokedynamic same-class guard that
+linked monomorphic sites install when every argument is non-null.
+Arities 1–4 (receiver plus 0–3 parameters) are specialised on HEAD;
+arity 5 keeps `asCollector(Object[].class, n)` and is the negative
+control. `@CompileStatic` rows (`cs_arity2`, `cs_arity5`) emit
+`invokevirtual` and must stay at parity. Each benchmark method is a
+single call so `-PjmhProfilers=gc` reports bytes per invocation.
+
+`SameClassesGuardMhBench` reconstructs the collector vs specialised
+MethodHandle combinators and invokes them with `invokeExact`, isolating
+the adapter from MOP selection. Specialised handles are bound with a
+single `insertArguments` (the production shape). Compiles on any tree
+that has the public overloads; `@Setup` fails on a pre-GROOVY-12284
+runtime. Run with:
+
+    ./gradlew :perf:jmh -PbenchInclude=SameClassesGuardBench
+    ./gradlew :perf:jmh -PbenchInclude=SameClassesGuardMhBench
+    ./gradlew :perf:jmh -PbenchInclude=SameClassesGuardBench -PjmhProfilers=gc
+
 == Dashboard pages
 
 The `dashboard/` directory is the source of truth for the hand-crafted pages

--- a/subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/SameClassesGuardBench.groovy
+++ b/subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/SameClassesGuardBench.groovy
@@ -1,0 +1,163 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.bench
+
+import groovy.transform.CompileStatic
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end cost of the invokedynamic same-class guard (GROOVY-12284).
+ * <p>
+ * Linked monomorphic sites with all-non-null arguments install a same-class
+ * guard. Before GROOVY-12284 that guard was always
+ * {@code SAME_CLASSES.bindTo(classes).asCollector(Object[].class, n)}, which
+ * allocates a fresh {@code Object[]} on every invocation. After the change,
+ * arities 1–4 (receiver plus 0–3 parameters) bind specialised handles and
+ * arity 5+ keeps the collector.
+ * <p>
+ * Each {@code @Benchmark} method is a single call so {@code gc.alloc.rate.norm}
+ * (run with {@code -PjmhProfilers=gc}) is bytes per invocation, not per inner
+ * loop. Arguments are pre-allocated heap objects: boxing must not be part of
+ * the signal. Receivers and arguments are non-final Groovy types; dynamic
+ * indy sites have {@code Object} parameter types, so the same-class guard is
+ * installed on every {@code dynamic_*} row.
+ * <p>
+ * How to read the rows:
+ * <ul>
+ *   <li>{@code dynamic_arity1}–{@code dynamic_arity4} — treatment: specialised
+ *       on HEAD, collector on the parent. Expect HEAD faster and/or fewer
+ *       bytes/op.</li>
+ *   <li>{@code dynamic_arity5} — negative control: collector on both sides.
+ *       Expect parity. A HEAD win here is not GROOVY-12284.</li>
+ *   <li>{@code cs_arity2} / {@code cs_arity5} — negative control:
+ *       {@code @CompileStatic} emits {@code invokevirtual}, no MOP
+ *       same-class guard. Expect parity at both arities.</li>
+ * </ul>
+ * Pair with {@link SameClassesGuardMhBench} for an isolated MethodHandle
+ * combinator comparison (collector vs specialised) that does not go through
+ * MOP selection.
+ *
+ * @see <a href="https://issues.apache.org/jira/browse/GROOVY-12284">GROOVY-12284</a>
+ */
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+class SameClassesGuardBench {
+
+    /**
+     * Receiver whose methods are selected through the MOP on the dynamic rows.
+     * Bodies are constant so remaining cost is dispatch plus the same-class
+     * guard, not arithmetic.
+     */
+    static class Target {
+        int zero() { 1 }
+        int one(Object a) { 1 }
+        int two(Object a, Object b) { 1 }
+        int three(Object a, Object b, Object c) { 1 }
+        int four(Object a, Object b, Object c, Object d) { 1 }
+    }
+
+    /** Non-final argument type so a class-identity guard is meaningful. */
+    static class Arg {
+        int n = 1
+    }
+
+    Target target
+    Arg a
+    Arg b
+    Arg c
+    Arg d
+
+    /**
+     * Allocates one receiver and four arguments for the trial. Fresh instances
+     * per trial keep the linked site monomorphic without MetaClass churn.
+     */
+    @Setup(Level.Trial)
+    void setup() {
+        target = new Target()
+        a = new Arg()
+        b = new Arg()
+        c = new Arg()
+        d = new Arg()
+    }
+
+    /** Receiver-only dynamic call: arity 1, specialised on HEAD. */
+    @Benchmark
+    void dynamic_arity1(Blackhole bh) {
+        bh.consume(target.zero())
+    }
+
+    /** Receiver plus one argument: arity 2, specialised on HEAD. */
+    @Benchmark
+    void dynamic_arity2(Blackhole bh) {
+        bh.consume(target.one(a))
+    }
+
+    /** Receiver plus two arguments: arity 3, specialised on HEAD. */
+    @Benchmark
+    void dynamic_arity3(Blackhole bh) {
+        bh.consume(target.two(a, b))
+    }
+
+    /** Receiver plus three arguments: arity 4, specialised on HEAD. */
+    @Benchmark
+    void dynamic_arity4(Blackhole bh) {
+        bh.consume(target.three(a, b, c))
+    }
+
+    /** Receiver plus four arguments: arity 5, collector on both sides. */
+    @Benchmark
+    void dynamic_arity5(Blackhole bh) {
+        bh.consume(target.four(a, b, c, d))
+    }
+
+    /**
+     * {@code @CompileStatic} arity 2: {@code invokevirtual}, no same-class guard.
+     */
+    @CompileStatic
+    @Benchmark
+    void cs_arity2(Blackhole bh) {
+        bh.consume(target.one(a))
+    }
+
+    /**
+     * {@code @CompileStatic} arity 5: {@code invokevirtual}, no same-class guard.
+     */
+    @CompileStatic
+    @Benchmark
+    void cs_arity5(Blackhole bh) {
+        bh.consume(target.four(a, b, c, d))
+    }
+}

--- a/subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/SameClassesGuardMhBench.java
+++ b/subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/SameClassesGuardMhBench.java
@@ -1,0 +1,188 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.bench;
+
+import org.codehaus.groovy.vmplugin.v8.IndyGuardsFiltersAndSignatures;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Isolated MethodHandle combinator cost of GROOVY-12284.
+ * <p>
+ * Reconstructs the two guard shapes {@link org.codehaus.groovy.vmplugin.v8.Selector}
+ * actually installs, then invokes them with {@code invokeExact} so MOP
+ * selection, method bodies, and Groovy call-site infrastructure are not in
+ * the picture:
+ * <ul>
+ *   <li><b>collector</b> — {@code sameClasses(Class[], Object[])} bound to
+ *       the expected classes and adapted with
+ *       {@code asCollector(Object[].class, n)}, the pre-GROOVY-12284 shape
+ *       for every arity;</li>
+ *   <li><b>specialised</b> — {@code sameClass}/{@code sameClasses} overloads
+ *       with expected classes bound by a single
+ *       {@code MethodHandles.insertArguments}, the production GROOVY-12284
+ *       shape for arities 1–4.</li>
+ * </ul>
+ * Compiles against any Groovy that has the public {@code sameClasses}
+ * overloads; {@code @Setup} fails with {@code NoSuchMethodException} on a
+ * tree that predates GROOVY-12284. Compare collector vs specialised on the
+ * <em>same</em> JVM (intra-HEAD), then confirm the end-to-end effect with
+ * {@link SameClassesGuardBench} against the parent commit.
+ * <p>
+ * {@code specialised_bindTo_arity4} is the previous chained-{@code bindTo}
+ * combinator, kept so a regression back to four adapters is visible.
+ * <p>
+ * Arity 1 / 2 / 4 cover receiver-only, the common {@code recv.foo(x)} shape,
+ * and the largest specialised shape. There is no specialised arity-5
+ * overload; that path stays on the collector in production.
+ *
+ * @see <a href="https://issues.apache.org/jira/browse/GROOVY-12284">GROOVY-12284</a>
+ */
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class SameClassesGuardMhBench {
+
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+    Object a;
+    Object b;
+    Object c;
+    Object d;
+
+    MethodHandle collector1;
+    MethodHandle specialised1;
+    MethodHandle collector2;
+    MethodHandle specialised2;
+    MethodHandle collector4;
+    MethodHandle specialised4;
+    MethodHandle specialisedBindTo4;
+
+    /**
+     * Builds collector and specialised handles that match {@code Selector.sameClassesGuard}
+     * for arities 1, 2 and 4, using the public {@link IndyGuardsFiltersAndSignatures}
+     * methods the runtime binds.
+     *
+     * @throws ReflectiveOperationException if a handle cannot be resolved
+     */
+    @Setup(Level.Trial)
+    public void setup() throws ReflectiveOperationException {
+        a = new Object();
+        b = new Object();
+        c = new Object();
+        d = new Object();
+
+        MethodHandle arraySame = LOOKUP.findStatic(
+                IndyGuardsFiltersAndSignatures.class,
+                "sameClasses",
+                MethodType.methodType(boolean.class, Class[].class, Object[].class));
+        MethodHandle sameClass = LOOKUP.findStatic(
+                IndyGuardsFiltersAndSignatures.class,
+                "sameClass",
+                MethodType.methodType(boolean.class, Class.class, Object.class));
+        MethodHandle same2 = LOOKUP.findStatic(
+                IndyGuardsFiltersAndSignatures.class,
+                "sameClasses",
+                MethodType.methodType(boolean.class, Class.class, Class.class, Object.class, Object.class));
+        MethodHandle same4 = LOOKUP.findStatic(
+                IndyGuardsFiltersAndSignatures.class,
+                "sameClasses",
+                MethodType.methodType(boolean.class,
+                        Class.class, Class.class, Class.class, Class.class,
+                        Object.class, Object.class, Object.class, Object.class));
+
+        Class<?> ca = a.getClass();
+        Class<?> cb = b.getClass();
+        Class<?> cc = c.getClass();
+        Class<?> cd = d.getClass();
+
+        MethodType t1 = MethodType.methodType(boolean.class, Object.class);
+        MethodType t2 = MethodType.methodType(boolean.class, Object.class, Object.class);
+        MethodType t4 = MethodType.methodType(boolean.class, Object.class, Object.class, Object.class, Object.class);
+
+        collector1 = arraySame.bindTo(new Class<?>[]{ca}).asCollector(Object[].class, 1).asType(t1);
+        specialised1 = MethodHandles.insertArguments(sameClass, 0, ca).asType(t1);
+
+        collector2 = arraySame.bindTo(new Class<?>[]{ca, cb}).asCollector(Object[].class, 2).asType(t2);
+        specialised2 = MethodHandles.insertArguments(same2, 0, ca, cb).asType(t2);
+
+        collector4 = arraySame.bindTo(new Class<?>[]{ca, cb, cc, cd}).asCollector(Object[].class, 4).asType(t4);
+        specialised4 = MethodHandles.insertArguments(same4, 0, ca, cb, cc, cd).asType(t4);
+        specialisedBindTo4 = same4.bindTo(ca).bindTo(cb).bindTo(cc).bindTo(cd).asType(t4);
+    }
+
+    /** Pre-GROOVY-12284 arity-1 guard: collector of a one-element array. */
+    @Benchmark
+    public boolean collector_arity1() throws Throwable {
+        return (boolean) collector1.invokeExact(a);
+    }
+
+    /** Production arity-1 guard: {@code insertArguments} of the receiver class. */
+    @Benchmark
+    public boolean specialised_arity1() throws Throwable {
+        return (boolean) specialised1.invokeExact(a);
+    }
+
+    /** Pre-GROOVY-12284 arity-2 guard. */
+    @Benchmark
+    public boolean collector_arity2() throws Throwable {
+        return (boolean) collector2.invokeExact(a, b);
+    }
+
+    /** Production arity-2 guard: one {@code insertArguments}. */
+    @Benchmark
+    public boolean specialised_arity2() throws Throwable {
+        return (boolean) specialised2.invokeExact(a, b);
+    }
+
+    /** Pre-GROOVY-12284 arity-4 guard. */
+    @Benchmark
+    public boolean collector_arity4() throws Throwable {
+        return (boolean) collector4.invokeExact(a, b, c, d);
+    }
+
+    /** Production arity-4 guard: one {@code insertArguments}. */
+    @Benchmark
+    public boolean specialised_arity4() throws Throwable {
+        return (boolean) specialised4.invokeExact(a, b, c, d);
+    }
+
+    /** Pre-review arity-4 guard: four chained {@code bindTo} adapters. */
+    @Benchmark
+    public boolean specialised_bindTo_arity4() throws Throwable {
+        return (boolean) specialisedBindTo4.invokeExact(a, b, c, d);
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-12284


# GROOVY-12284 Performance Verification Report

**Specialize indy `sameClasses` guards for arity 1–4**

| Item | Value |
|---|---|
| Issue | [GROOVY-12284](https://issues.apache.org/jira/browse/GROOVY-12284) |
| Commit under test | `8e2b29b88e8a24b56440600de9f708fc73baf437` |
| Baseline (parent) | `e801df39580ab480249e561e90cf661ce86917f5` |
| Range | **one commit** (the treatment is isolated) |
| Date | 2026-08-22 |
| Verdict | **PASS** — specialised same-class guards are faster on the linked monomorphic hot path for arities 1–4; arity 5 and `@CompileStatic` / classic stay at parity; allocation of `Object[4]` disappears on HEAD |

---

## 1. Executive summary

Commit `8e2b29b` changes how Groovy's invokedynamic runtime installs the
**same-class guard** on a linked monomorphic call site when every argument is
non-null. The parent always used

```text
SAME_CLASSES.bindTo(expectedClasses).asCollector(Object[].class, n)
```

which, on every later invocation, collects the `n` arguments into a fresh
`Object[]` and loops. HEAD specialises arities 1–4 (receiver plus 0–3
parameters) to scalar `sameClass` / `sameClasses` overloads bound with
`bindTo`, and keeps the collector only for arity ≥ 5.

On the same host, JDK, and JMH settings, two **order-balanced** A/B trials of
a dedicated end-to-end bench (`SameClassesGuardBench`) show:

| Row | What it tests | Order-balanced geomean (HEAD / parent) |
|---|---|---|
| `dynamic_arity1` | treatment (`recv.foo()`) | **1.56×** |
| `dynamic_arity2` | treatment (`recv.foo(x)`) | **1.90×** |
| `dynamic_arity3` | treatment (`recv.foo(x, y)`) | **2.00×** |
| `dynamic_arity4` | treatment (`recv.foo(x, y, z)`) | **4.68×** |
| `dynamic_arity5` | negative control (collector on both sides) | **1.08×** (noise) |
| `cs_arity2` / `cs_arity5` | negative control (`invokevirtual`) | **~1.00×** on the clean trial |
| classic (`-Pindy=false`), all rows | negative control (no indy guard) | **0.98–1.00×** |

The GC profiler explains why arity 4 is the outlier: on this JDK, C2
**scalar-replaces** the collector array for `n ≤ 3` (both sides allocate
≈ 0 B/op) but **fails at `n = 4`**. Parent then pays a steady **32 B/op**
(`Object[4]` with compressed oops); HEAD pays **0 B/op**. Arity 5 stays at
**40 B/op** on both sides — the collector was not touched.

An isolated MethodHandle microbench (`SameClassesGuardMhBench`, intra-HEAD)
shows the combinator itself is **1.12–1.31×** faster without MOP selection.
The larger end-to-end ratios are the same adapter sitting in a longer
`guardWithTest` chain, where a fat collector blocks inlining of the rest of
the site.

> In one line: GROOVY-12284 removes `asCollector` from the common 1–4 arity
> indy guard. Where the JVM already scalar-replaces the array (arity 1–3)
> the site is still **1.6–2.0×** because the handle graph is simpler; where
> it does not (arity 4) the site is **4.7×** and stops allocating 32 bytes
> per call.

**Performance verification: PASS.**

---

## 2. Existing benches, gap, and what was added

### 2.1 What was already in the tree

| Bench | Why it is not a GROOVY-12284 isolator |
|---|---|
| `MethodInvocationBench` | Mixes instance/static/overload/interface; primitive args box; no arity-5 collector control; no allocation row |
| `CallsiteBench.dispatch_1_monomorphic_groovy` | Arity-1 `hashCode()` only; mixed with poly/mega and Java/CS; cannot split collector vs specialised |
| `DynamicDispatchBench` | `methodMissing` / interceptors — a different MOP path |
| `DynamicDispatchColdBench` | Cold start / promotion, not the linked-guard hot path |
| `ScopedInvalidationBench` | SwitchPoint domain (GROOVY-12191), not argument-class guards |

None of those makes **arity** the independent variable, none has an
**arity ≥ 5 collector control**, and none reports **bytes per invocation**
for this guard.

### 2.2 What was added

Two benches, documented in `subprojects/performance/README.adoc`:

1. **`SameClassesGuardBench`** (Groovy, package `org.apache.groovy.bench`) —
   one indy (or `@CompileStatic`) call per `@Benchmark` method so
   `gc.alloc.rate.norm` is bytes/invocation. Pre-allocated non-null `Arg`
   instances; no boxing. Rows: `dynamic_arity1`–`dynamic_arity5`,
   `cs_arity2`, `cs_arity5`.
2. **`SameClassesGuardMhBench`** (Java) — reconstructs the exact collector
   vs specialised MethodHandle graphs from the public
   `IndyGuardsFiltersAndSignatures` methods and invokes them with
   `invokeExact`. Compiles only on GROOVY-12284+; used intra-HEAD.

The Groovy bench was **copied identically** into the parent worktree so the
only production-code difference is `8e2b29b`.

---

## 3. Change mechanism and hypotheses

### 3.1 Parent (`e801df39`)

For a linked site with all arguments non-null and at least one parameter
type that is non-final (or a primitive wrapper — GROOVY-11782):

```text
handle = guardWithTest(
    SAME_CLASSES.bindTo(classes).asCollector(Object[].class, n).asType((pt)boolean),
    fast,
    fallback)
```

Dynamic indy sites almost always have `Object` parameter types, so this is
the **common** case, not a rare fallback. `asCollector` is specified to
allocate a new array of length `n` on every invocation. C2 may scalar-replace
that array; that is an empirical question (H4), not an assumption.

If any argument is null at **link** time, `Selector` already installs
per-slot `SAME_CLASS` / `IS_NULL` tests. That path is unchanged and is not
measured here.

### 3.2 HEAD (`8e2b29b`)

`Selector.sameClassesGuard(args, pt)`:

| Arity (incl. receiver) | Guard |
|---|---|
| 0 | constant `true` |
| 1 | existing `SAME_CLASS` |
| 2–4 | new `SAME_CLASSES_2` / `_3` / `_4` |
| ≥ 5 | existing `SAME_CLASSES` + `asCollector` (unchanged) |

Semantics are unchanged: `false` if any argument is `null` or
`getClass()` differs. Confirmed by `IndySameClassesGuardTest` (3/3).

### 3.3 Hypotheses

| ID | Claim | Falsifier |
|---|---|---|
| H1 | Dynamic arity 1–4 throughput HEAD > parent, CIs separated | Overlap or ratio ≈ 1 |
| H2 | Dynamic arity 5 ≈ 1× (collector on both sides) | Robust HEAD win/loss |
| H3 | `@CompileStatic` arity 2 and 5 ≈ 1× | Robust CS delta |
| H4 | `gc.alloc.rate.norm` drops on some specialised arity; arity 5 stays equal | Alloc delta on arity 5, or no alloc story at arity 4 |
| H5 | Intra-HEAD specialised MH > collector MH | spec/collector ≤ 1 |
| H6 | CPU calibration ruler ≈ 1× (no hardware drift) | cpuIntegerOps off by ≫ 5% |
| H7 | Classic (`-Pindy=false`) ≈ 1× on every row | Classic HEAD win matching indy |
| H8 | Correctness suite green | Any `IndySameClassesGuardTest` failure |

---

## 4. Methodology

### 4.1 Environment

| Item | Value |
|---|---|
| OS | Linux 6.15.5 x86_64 (hostname `hera`) |
| CPU | AMD EPYC 7763, 6 vCPUs visible (KVM) |
| Memory | 23 GiB |
| JDK | Amazon Corretto **25.0.2** (`25.0.2+10-LTS`) |
| Groovy | 6.0.0-SNAPSHOT, indy default |
| JMH | 1.37; `@Warmup(3×2s) @Measurement(5×2s) @Fork(2)` → 10 samples/row (rulers: 2×1s / 3×1s / 2 forks) |
| Trees | HEAD: `/home/daniel/IdeaProjects/groovy` @ `8e2b29b`; parent: worktree `/tmp/groovy-12284-parent` @ `e801df39` |
| Bench parity | `SameClassesGuardBench.groovy` byte-identical in both trees |
| Run order | Sequential (no dual-JVM contention); no CPU pinning |
| Trials | **T1** HEAD then parent; **T2** parent then HEAD (order-balanced) |

### 4.2 Suites

| Suite | Trees | Purpose |
|---|---|---|
| `SameClassesGuardBench` indy, two trials | both | H1–H3 |
| same bench + `-PjmhProfilers=gc` | both | H4 |
| `SameClassesGuardMhBench` | HEAD only | H5 |
| `org.apache.groovy.bench.CalibrationBench` | both | H6 |
| `SameClassesGuardBench -Pindy=false` | both | H7 |
| `IndySameClassesGuardTest` | HEAD | H8 |

### 4.3 Statistics

- Scores are JMH means; `±` is JMH’s default **99.9% CI**.
- Throughput ratio = HEAD / parent (>1 is faster).
- Order-balanced result = **geomean of the two trial ratios**.
- Treatment geomean = geomean of arity 1–4 ratios. Arity 4 is also reported
  separately because it is a different physical regime (allocation).
- Conclusions rest on **CI separation and structural fingerprints** (32 vs
  0 B/op, classic parity), not on ±1% micro-deltas.

Raw JSON: `/tmp/groovy-12284-perf/{head,parent}/{t1-indy,t2-indy,gc,mh,classic,cal}/results.json`.

---

## 5. Results

### 5.1 End-to-end indy throughput (primary)

Unit: ops/ms, higher is better. Inner work is a single dynamic (or CS) call.

| Benchmark | T1 parent | T1 HEAD | T1 H/P | T2 parent | T2 HEAD | T2 H/P | Geomean | Class |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| `dynamic_arity1` | 657 128 ± 22 407 | 1 026 659 ± 54 598 | 1.562× | 631 074 ± 40 254 | 981 191 ± 94 593 | 1.555× | **1.56×** | treatment |
| `dynamic_arity2` | 488 745 ± 16 000 | 914 039 ± 57 519 | 1.870× | 479 100 ± 21 019 | 922 273 ± 62 420 | 1.925× | **1.90×** | treatment |
| `dynamic_arity3` | 399 820 ± 29 545 | 790 867 ± 45 065 | 1.978× | 396 106 ± 24 308 | 796 682 ± 50 228 | 2.011× | **2.00×** | treatment |
| `dynamic_arity4` | 133 989 ± 5 657 | 626 818 ± 20 809 | 4.678× | 133 960 ± 8 734 | 628 049 ± 33 533 | 4.688× | **4.68×** | treatment |
| `dynamic_arity5` | 103 574 ± 5 245 | 117 248 ± 8 420 | 1.132× | 106 893 ± 4 623 | 111 050 ± 3 748 | 1.039× | **1.08×** | neg. control |
| `cs_arity2` | 1 590 180 ± 72 701 | 1 586 803 ± 45 686 | 0.998× | 1 571 876 ± 63 590 | 1 287 505 ± 541 959† | 0.819× | 0.90×† | neg. control |
| `cs_arity5` | 1 586 542 ± 124 143 | 1 561 402 ± 47 614 | 0.984× | 1 604 839 ± 75 883 | 1 376 308 ± 410 742† | 0.858× | 0.92×† | neg. control |

† T2 HEAD `@CompileStatic` fork 2 is a dirty sample: raw scores drop to
666 k–993 k ops/ms against fork 1 at ~1.55 M (median 1.48 M). The 99.9% CI
is 42% of the mean and is **not usable**. T1 CS is 0.998× / 0.984× with
tight CIs; classic CS is 0.99× (§5.4). This is host noise at the
`invokevirtual` ceiling, not a treatment effect.

Treatment CIs **do not overlap** parent vs HEAD in either trial. Trial-to-trial
ratios agree to two decimal places for every treatment row (arity 4: 4.678×
and 4.688×).

Equivalent ns/op (T1 mean, `1e6 / (ops/ms)`):

| Row | Parent ns/op | HEAD ns/op |
|---|---:|---:|
| `cs_arity2` (ceiling) | 0.63 | 0.63 |
| `dynamic_arity1` | 1.52 | 0.97 |
| `dynamic_arity2` | 2.05 | 1.09 |
| `dynamic_arity3` | 2.50 | 1.26 |
| `dynamic_arity4` | 7.46 | 1.60 |
| `dynamic_arity5` | 9.65 | 8.53 |

HEAD arity 1–4 moves toward the CS ceiling; arity 5 stays on the slow
collector plateau.

Geomeans:

- treatment arity 1–4: **2.29×**
- treatment arity 1–3 only (EA already eats the array): **1.81×**
- negative controls including noisy T2 CS: 0.97× (misleading; see †)
- `dynamic_arity5` alone: **1.08×** (T2 CIs overlap)

### 5.2 Allocation (`gc.alloc.rate.norm`)

One trial each tree, same bench, `-PjmhProfilers=gc`. Throughput on this run
reproduced §5.1 (arity 4 = 4.71×).

| Benchmark | Parent B/op | HEAD B/op | Object[] size (compressed oops) |
|---|---:|---:|---|
| `cs_arity2` | ≈ 0 | ≈ 0 | none |
| `cs_arity5` | ≈ 0 | ≈ 0 | none |
| `dynamic_arity1` | ≈ 0 | ≈ 0 | 24 B if allocated; **EA** |
| `dynamic_arity2` | ≈ 0 | ≈ 0 | 24 B if allocated; **EA** |
| `dynamic_arity3` | ≈ 0 | ≈ 0 | 32 B if allocated; **EA** |
| `dynamic_arity4` | **32** | ≈ 0 | 16 + 4×4 = **32** |
| `dynamic_arity5` | **40** | **40** | 16 + 5×4 = 36, aligned **40** |

≈ 0 means 10⁻⁶ B/op (profiler noise).

This is a **structural fingerprint**, not a 1% delta:

- C2 scalar-replaces `asCollector` arrays for `n ≤ 3` on this JDK, so
  arity 1–3 throughput wins (1.6–2.0×) are **combinator / inlining**, not GC.
- At `n = 4` scalar replacement stops. Parent’s 32 B/op matches a live
  `Object[4]` exactly. HEAD does not allocate. That is why arity 4 is 4.7×
  rather than ~2×.
- At `n = 5` both sides still collect; 40 B/op on both sides. H2 and H4
  hold together.

### 5.3 Isolated MethodHandle combinator (intra-HEAD)

`SameClassesGuardMhBench`: collector vs specialised, `invokeExact`, no MOP.

| Arity | Collector ops/ms | Specialised ops/ms | Spec / collector |
|---|---:|---:|---:|
| 1 | 174 966 ± 7 386 | 195 310 ± 7 337 | **1.12×** |
| 2 | 155 037 ± 8 686 | 183 437 ± 6 705 | **1.18×** |
| 4 | 114 803 ± 7 351 | 150 054 ± 8 794 | **1.31×** |

The leaf combinator is cheaper, and the gap grows with arity (fatter
collector LambdaForm). It is **smaller** than the end-to-end gap because a
lone `invokeExact` is a tiny compilation unit: C2 can digest a collector
adapter in isolation more easily than the same adapter buried under
`SwitchPoint.guardWithTest` + `asType` + the selected method. End-to-end
amplifies the same mechanism; it does not contradict it.

### 5.4 Classic call sites (`-Pindy=false`)

No indy same-class collector exists on this path (GROOVY-12185: classic
cache lives in `groovy-callsite`).

| Benchmark | Parent ops/ms | HEAD ops/ms | H/P |
|---|---:|---:|---:|
| `cs_arity2` | 549 963 ± 31 724 | 545 744 ± 31 083 | **0.99×** |
| `cs_arity5` | 535 246 ± 29 755 | 522 777 ± 44 495 | **0.98×** |
| `dynamic_arity1` | 108 286 ± 4 382 | 107 651 ± 2 788 | **0.99×** |
| `dynamic_arity2` | 103 574 ± 2 311 | 101 707 ± 6 669 | **0.98×** |
| `dynamic_arity3` | 100 825 ± 3 053 | 99 051 ± 6 455 | **0.98×** |
| `dynamic_arity4` | 95 164 ± 2 119 | 95 148 ± 4 648 | **1.00×** |
| `dynamic_arity5` | 91 998 ± 4 086 | 91 612 ± 3 842 | **1.00×** |

Every row is 0.98–1.00×. The indy 1.6–4.7× pattern is **absent**. H7 holds:
the measured indy win is not a silent compile, CPU, or bench-harness
artifact.

(Classic CS is slower than indy CS on this JDK because `-Pindy=false`
changes bytecode for the whole module; that is a mode effect, not a
HEAD-vs-parent effect.)

### 5.5 Calibration rulers (pure Java)

AverageTime, µs/op, lower is better. Ratio below is parent/HEAD (speedup).

| Ruler | Parent | HEAD | Speedup |
|---|---:|---:|---:|
| `cpuIntegerOps` | 417.1 ± 15.0 | 415.8 ± 9.1 | **1.00×** |
| `memoryPointerChase` | 1544 ± 215 | 1470 ± 121 | **1.05×** |
| `allocationChurn` | 95.7 ± 13.3 | 180 ± 412† | unusable |

† HEAD `allocationChurn` fork 1 contains 237 / 457 / 84 µs; fork 2 is 102 /
102 / 98 µs, in line with parent. The 99.9% CI is wider than the mean.
**`cpuIntegerOps` is the drift check: 1.00×.** Hardware did not move
between the two trees.

### 5.6 Correctness

```text
./gradlew :test --tests org.codehaus.groovy.vmplugin.v8.IndySameClassesGuardTest --rerun-tasks
```

**3 passed / 0 failed** (overloads reject null and class change; arity 1–4
handles match collector semantics; a dynamic site relinks when an argument
class changes).

---

## 6. Why it is faster

```text
                 Parent hot path                         HEAD hot path (arity 1–4)
  recv.foo(a, b, c)
        │                                              │
        ▼                                              ▼
  SwitchPoint.guardWithTest                            SwitchPoint.guardWithTest
        │                                              │
        ▼                                              ▼
  asCollector(Object[].class, 4)                       SAME_CLASSES_4.bindTo(c0..c3)
        │  allocates Object[4]  (n=4; EA fails)        │  four getClass() == tests
        ▼                                              ▼
  sameClasses(Class[], Object[])                       return true → selected method
        │
        ▼
  selected method
```

Cost breakdown, matching the measurements:

1. **Simpler LambdaForm (all of 1–4).** `bindTo` of `Class` constants plus a
   scalar boolean method is a shorter combinator than
   `asCollector` + array loop. Isolated MH: 1.12–1.31×. End-to-end: 1.6–2.0×
   at arities where the array is already EA’d, because the collector adapter
   still pollutes inlining of the surrounding `guardWithTest` chain.
2. **Real allocation at arity 4.** Parent 32 B/op, HEAD 0. Write barriers
   and GC traffic sit on the hottest path of `recv.foo(x, y, z)`. Combined
   with (1) this is the 4.7× row.
3. **Arity 5 is deliberately unchanged.** Same collector, same 40 B/op, ~1.08×
   throughput (CIs overlap on T2).
4. **`@CompileStatic` and classic never install this guard.** Measured
   parity (T1 CS, all classic rows, CPU ruler).

The classic MOP already specialised `MetaClassHelper.sameClasses` for 0–4
arguments. Indy had not. This commit closes that gap on the indy hot path.

---

## 7. Risks and boundaries

| Topic | Assessment |
|---|---|
| H1 treatment win | **Robust.** Two order-balanced trials, ratios stable to two decimals, CIs separated |
| H2 arity-5 control | **Holds.** 1.08× geomean; T2 CIs overlap; alloc 40 B/op both sides |
| H3 CS control | **Holds on the clean trial and on classic.** T2 HEAD CS has a dirty fork (raw min 666 k vs fork-1 1.55 M); do not read the 0.82× mean as a regression |
| H4 allocation | **Holds, and is JDK-specific.** EA ate `n ≤ 3` here (Corretto 25). A JDK that does not scalar-replace `n = 2` would show a B/op drop there too; the combinator win would remain |
| H5 combinator | **Holds.** 1.12–1.31× intra-HEAD, growing with arity |
| H6 drift | **Holds** on `cpuIntegerOps` (1.00×). Ignore HEAD `allocationChurn` (CI > mean) |
| H7 classic | **Holds.** 0.98–1.00× on every row |
| H8 correctness | **Holds.** 3/3 tests |
| Shared 6-vCPU host | No pinning; order-balancing + classic + CPU ruler bound the noise |
| Not claimed | A 2.29× language-wide geomean. Typical calls are arity 1–2 (**1.6–1.9×**). Arity 4 is **4.7×** and is a real `recv.foo(a,b,c)` shape, not a synthetic extreme |
| Not covered | JDK 17/21 matrix, megamorphic argument-class oscillation (GROOVY-11152), null-at-link per-slot path |

---

## 8. Hypothesis scorecard

| ID | Result | Evidence |
|---|---|---|
| H1 arity 1–4 faster | **Holds** | 1.56 / 1.90 / 2.00 / 4.68× geomean; CIs separated |
| H2 arity 5 parity | **Holds** | 1.08×; T2 overlap; 40 B/op both |
| H3 CS parity | **Holds** | T1 0.998 / 0.984×; classic CS 0.99×; T2 CS discarded as dirty fork |
| H4 alloc drop on specialised, not on arity 5 | **Holds** | arity 4: 32 → 0 B/op; arity 5: 40 = 40; arity 1–3 already EA |
| H5 specialised MH > collector | **Holds** | 1.12 / 1.18 / 1.31× |
| H6 CPU ruler ~1× | **Holds** | `cpuIntegerOps` 1.00× |
| H7 classic ~1× | **Holds** | 0.98–1.00× all seven rows |
| H8 tests green | **Holds** | 3/3 |

---

## 9. Conclusions

`8e2b29b` (GROOVY-12284) vs `e801df39` is a **single-commit, single-concern**
indy hot-path change. Dedicated benches that the existing suite did not
provide — arity as the factor, an arity-5 collector control, CS/classic
controls, and bytes/op — show:

1. Linked monomorphic dynamic calls of arity 1–3 are **1.6–2.0×** on HEAD
   even when the parent’s collector array is already scalar-replaced.
2. Arity 4 is **4.7×** and stops allocating a live `Object[4]` (32 B/op).
3. Arity 5, `@CompileStatic`, and classic bytecode are **unchanged**.
4. The isolated combinator moves 1.12–1.31×; the rest of the end-to-end
   win is that combinator inlining into the full guard chain.

**Performance verification: PASS.**

Keep `SameClassesGuardBench` (and the GC profile of `dynamic_arity4` /
`dynamic_arity5`) in regular indy JMH regression so a return to a universal
`asCollector` guard cannot land silently.

---

## Appendix A — Reproduction

```bash
# Correctness
./gradlew :test --tests org.codehaus.groovy.vmplugin.v8.IndySameClassesGuardTest

# End-to-end (both trees; copy SameClassesGuardBench.groovy onto the parent)
./gradlew :perf:jmh -PbenchInclude=SameClassesGuardBench -PjmhResultFormat=JSON

# Allocation
./gradlew :perf:jmh -PbenchInclude=SameClassesGuardBench -PjmhProfilers=gc -PjmhResultFormat=JSON

# Isolated combinator (HEAD only)
./gradlew :perf:jmh -PbenchInclude=SameClassesGuardMhBench -PjmhResultFormat=JSON

# Classic negative control
./gradlew :perf:jmh -PbenchInclude=SameClassesGuardBench -Pindy=false -PjmhResultFormat=JSON

# CPU ruler
./gradlew :perf:jmh -PbenchInclude=org.apache.groovy.bench.CalibrationBench -PjmhResultFormat=JSON
```

Worktrees used: parent at `/tmp/groovy-12284-parent` (`e801df39`); HEAD as
the GROOVY-12284 working tree (`8e2b29b`). Runner:
`/tmp/groovy-12284-perf/run.sh`.

## Appendix B — Files

Production (`8e2b29b`):

- `src/main/java/org/codehaus/groovy/vmplugin/v8/IndyGuardsFiltersAndSignatures.java`
- `src/main/java/org/codehaus/groovy/vmplugin/v8/Selector.java`
- `src/test/groovy/org/codehaus/groovy/vmplugin/v8/IndySameClassesGuardTest.groovy`

Measurement (this verification, not in `8e2b29b`):

- `subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/SameClassesGuardBench.groovy`
- `subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/SameClassesGuardMhBench.java`
- `subprojects/performance/README.adoc` (section *Same-class guards*)

## Appendix C — Object array sizes used in §5.2

64-bit HotSpot, compressed oops + compressed class pointers (Corretto 25
default): array header 16 bytes (`mark` + `klass` + `length`), then `n`
compressed refs (4 B), aligned to 8 B.

| n | Payload | Aligned | Observed parent B/op |
|---|---:|---:|---:|
| 4 | 16 + 16 = 32 | 32 | **32** |
| 5 | 16 + 20 = 36 | 40 | **40** |

---

*Report generated from local JMH A/B measurements on 2026-08-22. Raw JSON: `/tmp/groovy-12284-perf/`.*
