### PR TITLE
GROOVY-12287: HttpBuilder: retry once on a stale keep-alive connection

### DIFF
--- a/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpBuilder.groovy
+++ b/subprojects/groovy-http-builder/src/main/groovy/groovy/http/HttpBuilder.groovy
@@ -28,9 +28,12 @@ import java.net.URLEncoder
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.net.http.HttpTimeoutException
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
 
 /**
  * Tiny DSL over JDK {@link HttpClient}.
@@ -217,7 +220,7 @@ final class HttpBuilder {
         URI resolvedUri = resolveUri(uri, requestSpec.queryParameters)
         Map<String, String> headers = combinedHeaders(requestSpec)
         HttpRequest httpRequest = buildHopRequest(method, resolvedUri, headers, requestSpec.body, requestSpec.timeout)
-        CompletableFuture<HttpResponse<String>> future = client.sendAsync(httpRequest, requestSpec.bodyHandler)
+        CompletableFuture<HttpResponse<String>> future = sendAsync(httpRequest, requestSpec.bodyHandler)
         if (followRedirectsManually) {
             future = future.thenCompose { HttpResponse<String> response ->
                 followRedirectsAsync(method, httpRequest.uri(), response, headers,
@@ -317,7 +320,7 @@ final class HttpBuilder {
                                                     @DelegatesTo(value = RequestSpec, strategy = Closure.DELEGATE_FIRST)
                                                     final Closure<?> spec = null) {
         HttpRequest httpRequest = buildStreamRequest(method, uri, spec)
-        return client.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofPublisher())
+        return sendAsync(httpRequest, HttpResponse.BodyHandlers.ofPublisher())
                 .thenApply { HttpResponse response -> new HttpStreamResult(response) }
     }
 
@@ -392,13 +395,77 @@ final class HttpBuilder {
     private <T> HttpResponse<T> send(final String method, final HttpRequest httpRequest,
                                      final HttpResponse.BodyHandler<T> bodyHandler) {
         try {
-            return client.send(httpRequest, bodyHandler)
+            try {
+                return client.send(httpRequest, bodyHandler)
+            } catch (IOException first) {
+                // JDK HttpClient retries GET/HEAD on a stale keep-alive socket, but not
+                // PUT/POST/PATCH. Retry once so a peer that already closed the connection
+                // (common after a 3xx that did not send Connection: close) does not fail
+                // the follow-up hop, or the next call on the same builder.
+                if (!isRetryableConnectionFailure(first)) {
+                    throw first
+                }
+                try {
+                    return client.send(httpRequest, bodyHandler)
+                } catch (IOException second) {
+                    second.addSuppressed(first)
+                    throw second
+                }
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt()
             throw new RuntimeException("HTTP request " + method + " " + httpRequest.uri() + " was interrupted", e)
         } catch (IOException e) {
             throw new RuntimeException("I/O error during HTTP request " + method + " " + httpRequest.uri(), e)
         }
+    }
+
+    private <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            final HttpRequest httpRequest,
+            final HttpResponse.BodyHandler<T> bodyHandler) {
+        return client.sendAsync(httpRequest, bodyHandler).handle { HttpResponse<T> response, Throwable error ->
+            if (error == null) {
+                return CompletableFuture.completedFuture(response)
+            }
+            if (isRetryableConnectionFailure(error)) {
+                return client.sendAsync(httpRequest, bodyHandler)
+            }
+            CompletableFuture<HttpResponse<T>> failed = new CompletableFuture<>()
+            failed.completeExceptionally(error)
+            return failed
+        }.thenCompose { it }
+    }
+
+    /**
+     * True when the JDK client failed before reading any response bytes because the
+     * TCP connection was already gone — the case it retries for GET/HEAD but not
+     * for methods with a body.
+     */
+    private static boolean isRetryableConnectionFailure(final Throwable error) {
+        Throwable t = error
+        while ((t instanceof CompletionException || t instanceof ExecutionException) && t.cause != null) {
+            t = t.cause
+        }
+        for (Throwable cur = t; cur != null && cur != cur.cause; cur = cur.cause) {
+            if (cur instanceof InterruptedException || cur instanceof HttpTimeoutException) {
+                return false
+            }
+        }
+        for (Throwable cur = t; cur != null && cur != cur.cause; cur = cur.cause) {
+            String msg = cur.message
+            if (msg == null) {
+                continue
+            }
+            String m = msg.toLowerCase(Locale.ROOT)
+            if (m.contains('header parser received no bytes')
+                    || m.contains('broken pipe')
+                    || m.contains('connection reset')
+                    || m.contains('forcibly closed')
+                    || m.contains('connection was aborted')) {
+                return true
+            }
+        }
+        return false
     }
 
     /**
@@ -466,7 +533,7 @@ final class HttpBuilder {
             nextHeaders = nextBody != null ? contentTypeOnly(nextHeaders) : [:]
         }
         HttpRequest httpRequest = buildHopRequest(nextMethod, target, nextHeaders, nextBody, timeout)
-        return client.sendAsync(httpRequest, bodyHandler).thenCompose { HttpResponse<String> next ->
+        return sendAsync(httpRequest, bodyHandler).thenCompose { HttpResponse<String> next ->
             followRedirectsAsync(nextMethod, target, next, nextHeaders, nextBody, timeout, bodyHandler,
                     redirects + 1, origin, nextLeftOrigin)
         }

--- a/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderRedirectHeaderTest.groovy
+++ b/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderRedirectHeaderTest.groovy
@@ -60,12 +60,14 @@ class HttpBuilderRedirectHeaderTest {
 
         // The redirect target is passed as the query so one handler serves every case.
         origin.createContext('/redirect') { HttpExchange exchange ->
+            drainRequestBody(exchange)
             exchange.responseHeaders.add('Location', exchange.requestURI.query)
             exchange.sendResponseHeaders(302, -1)
             exchange.close()
         }
         // 307 variant: the method and body are preserved across the hop.
         origin.createContext('/redirect307') { HttpExchange exchange ->
+            drainRequestBody(exchange)
             exchange.responseHeaders.add('Location', exchange.requestURI.query)
             exchange.sendResponseHeaders(307, -1)
             exchange.close()
@@ -82,6 +84,7 @@ class HttpBuilderRedirectHeaderTest {
         }
         // Second hop for the return-to-origin case.
         elsewhere.createContext('/bounce') { HttpExchange exchange ->
+            drainRequestBody(exchange)
             exchange.responseHeaders.add('Location', URLDecoder.decode(exchange.requestURI.query, 'UTF-8'))
             exchange.sendResponseHeaders(302, -1)
             exchange.close()
@@ -101,6 +104,12 @@ class HttpBuilderRedirectHeaderTest {
         received.clear()
         arrivals.set(0)
         receivedBody = null
+    }
+
+    private static void drainRequestBody(HttpExchange exchange) {
+        exchange.requestBody.withCloseable { InputStream body ->
+            body.transferTo(OutputStream.nullOutputStream())
+        }
     }
 
     private static void record(HttpExchange exchange) {

--- a/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderStaleConnectionTest.groovy
+++ b/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderStaleConnectionTest.groovy
@@ -1,0 +1,127 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.http
+
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * JDK {@link java.net.http.HttpClient} retries GET/HEAD when a keep-alive
+ * connection is already closed, but not PUT/POST/PATCH. HttpBuilder retries
+ * that stale-connection failure once so a follow-up hop (or the next call on
+ * the same builder) is not failed by a peer that already dropped the socket.
+ */
+class HttpBuilderStaleConnectionTest {
+
+    @Test
+    void retriesPutOnceWhenThePeerDropsTheConnectionBeforeResponseHeaders() {
+        withDropFirstConnectionServer { int port, AtomicInteger connections ->
+            HttpBuilder http = HttpBuilder.http {
+                baseUri "http://127.0.0.1:${port}/"
+                connectTimeout Duration.ofSeconds(2)
+                requestTimeout Duration.ofSeconds(2)
+            }
+
+            HttpResult result = http.put('/') { json([a: 1]) }
+
+            assert result.status == 200
+            assert result.body == 'recovered'
+            assert connections.get() >= 2
+        }
+    }
+
+    @Test
+    void retriesPutAsyncOnceWhenThePeerDropsTheConnectionBeforeResponseHeaders() {
+        withDropFirstConnectionServer { int port, AtomicInteger connections ->
+            HttpBuilder http = HttpBuilder.http {
+                baseUri "http://127.0.0.1:${port}/"
+                connectTimeout Duration.ofSeconds(2)
+                requestTimeout Duration.ofSeconds(2)
+            }
+
+            HttpResult result = http.putAsync('/') { json([a: 1]) }.get()
+
+            assert result.status == 200
+            assert result.body == 'recovered'
+            assert connections.get() >= 2
+        }
+    }
+
+    private static void withDropFirstConnectionServer(Closure<?> body) {
+        ServerSocket listener = new ServerSocket()
+        listener.bind(new InetSocketAddress('127.0.0.1', 0))
+        AtomicInteger connections = new AtomicInteger()
+        Thread acceptor = Thread.startDaemon {
+            try {
+                while (!listener.closed) {
+                    Socket socket = listener.accept()
+                    int n = connections.incrementAndGet()
+                    Thread.startDaemon {
+                        socket.withCloseable { Socket s ->
+                            consumeHttpRequest(s.inputStream)
+                            if (n == 1) {
+                                return
+                            }
+                            byte[] payload = 'recovered'.getBytes(StandardCharsets.UTF_8)
+                            OutputStream out = s.outputStream
+                            out.write("HTTP/1.1 200 OK\r\nContent-Length: ${payload.length}\r\nConnection: close\r\n\r\n".bytes)
+                            out.write(payload)
+                            out.flush()
+                        }
+                    }
+                }
+            } catch (IOException ignored) {
+                // listener closed
+            }
+        }
+        try {
+            body.call(listener.localPort, connections)
+        } finally {
+            listener.close()
+            acceptor.join(1000)
+        }
+    }
+
+    private static void consumeHttpRequest(InputStream input) {
+        StringBuilder headers = new StringBuilder()
+        int seen = 0
+        int ch
+        while ((ch = input.read()) != -1) {
+            headers.append((char) ch)
+            if (ch == (int) '\r' && (seen == 0 || seen == 2)) {
+                seen++
+            } else if (ch == (int) '\n' && (seen == 1 || seen == 3)) {
+                seen++
+                if (seen == 4) {
+                    break
+                }
+            } else if (ch != (int) '\r') {
+                seen = 0
+            }
+        }
+        def matcher = headers.toString() =~ /(?i)Content-Length:\s*(\d+)/
+        int length = matcher.find() ? matcher.group(1).toInteger() : 0
+        if (length > 0) {
+            input.skipNBytes(length)
+        }
+    }
+}

--- a/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderTest.groovy
+++ b/subprojects/groovy-http-builder/src/test/groovy/groovy/http/HttpBuilderTest.groovy
@@ -95,6 +95,7 @@ class HttpBuilderTest {
             exchange.responseBody.withCloseable { it.write(bytes) }
         }
         server.createContext('/redirect-me') { exchange ->
+            drainRequestBody(exchange)
             exchange.responseHeaders.add('Location', '/redirect-target')
             exchange.sendResponseHeaders(302, -1)
             exchange.close()
@@ -572,9 +573,22 @@ class HttpBuilderTest {
 
     private void redirect(String path, int status, String location) {
         server.createContext(path) { exchange ->
+            // Consume the body first. HttpServer's sendResponseHeaders(status, -1)
+            // closes the exchange immediately; if the request body was never read,
+            // that close drops the TCP connection without sending Connection: close.
+            // JDK HttpClient then reuses the dead connection for the next hop and
+            // does not retry PUT/POST/PATCH — producing a flaky
+            // "HTTP/1.1 header parser received no bytes" / Broken pipe failure.
+            drainRequestBody(exchange)
             exchange.responseHeaders.add('Location', location)
             exchange.sendResponseHeaders(status, -1)
             exchange.close()
+        }
+    }
+
+    private static void drainRequestBody(exchange) {
+        exchange.requestBody.withCloseable { InputStream body ->
+            body.transferTo(OutputStream.nullOutputStream())
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-12287