### PR TITLE
GROOVY-12294: STC: emit consistent category error for all use() overl…

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -6072,7 +6072,7 @@ trying: for (ClassNode[] signature : signatures) {
      */
     protected boolean areCategoryMethodCalls(final List<MethodNode> foundMethods, final String name, final ClassNode[] args) {
         boolean category = false;
-        if ("use".equals(name) && args != null && args.length == 2 && args[1].equals(CLOSURE_TYPE)) {
+        if ("use".equals(name) && args != null && args.length >= 2 && args[args.length - 1].equals(CLOSURE_TYPE)) {
             category = true;
             for (MethodNode method : foundMethods) {
                 if (!isDefaultExtension(method)) {
@@ -7178,7 +7178,7 @@ out:    for (ClassNode type : todo) {
      * Reports that categories cannot be used under static type checking.
      */
     protected void addCategoryMethodCallError(final Expression call) {
-        addStaticTypeError("Due to their dynamic nature, usage of categories is not possible with static type checking active", call);
+        addStaticTypeError("Due to their dynamic nature, usage of categories is not possible with static type checking active. Consider using an extension module, which is compatible with static type checking", call);
     }
 
     /**

--- a/src/spec/doc/core-domain-specific-languages.adoc
+++ b/src/spec/doc/core-domain-specific-languages.adoc
@@ -271,7 +271,7 @@ include::../test/BaseScriptSpecTest.groovy[tags=custom_run_parse,indent=0]
 
 In Groovy number types are considered equal to any other types. As such, it is possible to enhance numbers by adding
 properties or methods to them. This can be very handy when dealing with measurable quantities for example. Details about
-how existing classes can be enhanced in Groovy are found in the link:core-metaprogramming.html#_extension_modules[extension
+how existing classes can be enhanced in Groovy are found in the link:core-metaprogramming.html#extension-modules[extension
 modules] section or the link:core-metaprogramming.html#categories[categories] section.
 
 An illustration of this can be found in Groovy using the `TimeCategory`:

--- a/src/spec/doc/core-metaprogramming.adoc
+++ b/src/spec/doc/core-metaprogramming.adoc
@@ -406,6 +406,12 @@ first parameter. The target type class is given as an argument to the annotation
 [NOTE]
 There is a distinct section on `@Category` in the <<xform-Category,compile-time metaprogramming section>>.
 
+[NOTE]
+Because category methods are resolved dynamically at runtime, categories cannot be used in code under
+`@TypeChecked` or `@CompileStatic`; the type checker reports an error for `use` method calls.
+If you need statically checked code, consider an <<extension-modules,extension module>> instead,
+which provides methods in the same form as a category class but is compatible with type checking.
+
 === Metaclasses
 
 As explained earlier, Metaclasses play a central role in method resolution.
@@ -763,6 +769,7 @@ globally using the `ExpandoMetaClass.enableGlobally()` method before application
 include::../test/metaprogramming/ExpandoMetaClassTest.groovy[tags=emc_interface,indent=0]
 ----
 
+[[extension-modules]]
 === Extension modules
 ==== Extending existing classes
 

--- a/src/test/groovy/groovy/transform/stc/CategoriesSTCTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/CategoriesSTCTest.groovy
@@ -32,6 +32,29 @@ final class CategoriesSTCTest extends StaticTypeCheckingTestCase {
                 1.day
             }
         ''',
+        'Due to their dynamic nature, usage of categories is not possible with static type checking active. Consider using an extension module, which is compatible with static type checking',
+        'No such property: day for class: java.lang.Integer'
+    }
+
+    @Test // GROOVY-12294
+    void testShouldNotAllowCategoryListForm() {
+        shouldFailWithMessages '''import groovy.time.TimeCategory
+            use([TimeCategory]) {
+                1.day
+            }
+        ''',
+        'Due to their dynamic nature, usage of categories is not possible with static type checking active',
+        'No such property: day for class: java.lang.Integer'
+    }
+
+    @Test // GROOVY-12294
+    void testShouldNotAllowCategoryVarargsForm() {
+        shouldFailWithMessages '''import groovy.time.TimeCategory
+            import org.codehaus.groovy.runtime.StringGroovyMethods
+            use(TimeCategory, StringGroovyMethods) {
+                1.day
+            }
+        ''',
         'Due to their dynamic nature, usage of categories is not possible with static type checking active',
         'No such property: day for class: java.lang.Integer'
     }


### PR DESCRIPTION
…oads

The category error was keyed on exactly two arguments (category + closure), so the varargs form use(A, B) { ... } fell through to generic no-such-method/ property errors. Detect any use() call resolving to the DGM extension methods with a trailing closure. Also extend the error message to point at extension modules as the type-checking-compatible alternative, and document the limitation in the categories section of the metaprogramming guide.