### PR TITLE
GROOVY-12311: --check must not stop before class generation

### DIFF
--- a/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/java/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -504,11 +504,16 @@ public class CompilerConfiguration {
 
     /**
      * The target compile phase: the last phase to be processed when
-     * {@link CompilationUnit#compile()} is called without an explicit phase
-     * (GROOVY-12204). Defaults to {@link Phases#ALL}. An earlier phase, such as
-     * {@link Phases#INSTRUCTION_SELECTION}, gives a check-only compilation
-     * which reports parse, resolution, and static type-checking errors without
-     * generating class files.
+     * {@link CompilationUnit#compile()} is called without an explicit phase.
+     * Defaults to {@link Phases#ALL}.
+     * <p>
+     * {@link Phases#CLASS_GENERATION} gives a check-only compilation: every check runs,
+     * but the class files are never written, because that happens in {@link Phases#OUTPUT}.
+     * This is what {@code groovyc --check} selects.
+     * <p>
+     * Earlier phases stop sooner and so report fewer errors. {@link Phases#INSTRUCTION_SELECTION}
+     * reports parse, resolution, and static type-checking errors, but not those raised
+     * during class verification or bytecode generation.
      */
     private int targetPhase = Phases.ALL;
 
@@ -1588,8 +1593,8 @@ public class CompilerConfiguration {
 
     /**
      * Gets the target compile phase: the last phase to be processed when
-     * {@link CompilationUnit#compile()} is called without an explicit phase
-     * (GROOVY-12204). Defaults to {@link Phases#ALL}.
+     * {@link CompilationUnit#compile()} is called without an explicit phase.
+     * Defaults to {@link Phases#ALL}.
      *
      * @return the target phase number, one of the {@link Phases} constants
      * @see #setTargetPhase(int)
@@ -1601,15 +1606,12 @@ public class CompilerConfiguration {
 
     /**
      * Sets the target compile phase: the last phase to be processed when
-     * {@link CompilationUnit#compile()} is called without an explicit phase
-     * (GROOVY-12204). Values outside
-     * the range of the {@link Phases} constants are clamped into range.
-     * Setting {@link Phases#INSTRUCTION_SELECTION} gives a check-only
-     * compilation, as used by the {@code groovyc --check} option: parse,
-     * resolution, and static type-checking errors are reported but no class
-     * files are generated. Callers that pass an explicit phase to
-     * {@link CompilationUnit#compile(int)}, such as the AST browser, are
-     * unaffected by this setting.
+     * {@link CompilationUnit#compile()} is called without an explicit phase.
+     * Values outside the range of the {@link Phases} constants are clamped into range.
+     * Setting {@link Phases#CLASS_GENERATION} gives a check-only
+     * compilation, as used by the {@code groovyc --check} option.
+     * Callers that pass an explicit phase to {@link CompilationUnit#compile(int)},
+     * such as the AST browser, are unaffected by this setting.
      *
      * @param targetPhase the target phase number, one of the {@link Phases} constants
      * @see #getTargetPhase()

--- a/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
+++ b/src/main/java/org/codehaus/groovy/tools/FileSystemCompiler.java
@@ -557,7 +557,7 @@ public class FileSystemCompiler {
         @Option(names = {"--type-checked"}, description = "Use TypeChecked")
         private boolean typeChecked;
 
-        @Option(names = {"--check"}, description = "Check sources for errors without generating class files (stops compilation after static analysis)")
+        @Option(names = {"--check"}, description = "Check sources for errors without writing class files (runs every check, including class verification and bytecode generation)")
         private boolean checkOnly;
 
         /**
@@ -583,7 +583,8 @@ public class FileSystemCompiler {
             configuration.setSourceEncoding(encoding);
             configuration.setScriptBaseClass(scriptBaseClass);
             if (checkOnly) {
-                configuration.setTargetPhase(Phases.INSTRUCTION_SELECTION);
+                // do all phases except OUTPUT so that all checks are performed.
+                configuration.setTargetPhase(Phases.CLASS_GENERATION);
             }
             if (tolerance > 0) {
                 configuration.setTolerance(tolerance);

--- a/src/spec/doc/tools-groovyc.adoc
+++ b/src/spec/doc/tools-groovyc.adoc
@@ -46,7 +46,7 @@ a number of command line switches:
 | | --encoding | Encoding of the source files | groovyc --encoding utf-8 script.groovy
 | | --help | Displays help for the command line groovyc tool | groovyc --help
 | -d | | Specify where to place generated class files. | groovyc -d target Person.groovy
-| | --check | Check sources for errors without generating class files (stops compilation after static analysis) | groovyc --check Person.groovy
+| | --check | Check sources for errors without writing class files. Every check runs, including class verification and bytecode generation. | groovyc --check Person.groovy
 | -v | --version | Displays the compiler version | groovyc -v
 | -e | --exception | Displays the stack trace in case of compilation error | groovyc -e script.groovy
 | -w | --warningLevel | Sets how many warnings are reported after a successful compile: `0` (none), `1` (likely errors, the default), `2` (possible errors) or `3` (all). See <<section-groovyc-warnings,Compiler warnings>>. | groovyc -w 2 MyClass.groovy

--- a/src/test/groovy/org/codehaus/groovy/tools/FileSystemCompilerTest.java
+++ b/src/test/groovy/org/codehaus/groovy/tools/FileSystemCompilerTest.java
@@ -212,6 +212,41 @@ public class FileSystemCompilerTest {
         assertTrue(Files.exists(dir.resolve("CliCheckDemo.class")), "sanity: without --check the class file is written");
     }
 
+    // GROOVY-12311: --check stops after CLASS_GENERATION, so errors raised by class
+    // verification — which runs in that phase — must be reported rather than missed
+    @Test
+    public void testCheckCommandLineOptionReportsVerifierErrors(@TempDir Path dir) throws Exception {
+        File file = dir.resolve("CliVerifyDemo.groovy").toFile();
+        Files.write(file.toPath(), "class CliVerifyDemo { def foo() { 1 }\n def foo() { 2 } }".getBytes(StandardCharsets.UTF_8));
+
+        Exception e = assertThrows(Exception.class, () ->
+                FileSystemCompiler.commandLineCompile(new String[] {"--check", "-d", dir.toString(), file.getPath()}));
+        assertTrue(e.getMessage().contains("Repetitive method name/signature"),
+                "expected the verifier error but got: " + e.getMessage());
+        assertFalse(Files.exists(dir.resolve("CliVerifyDemo.class")), "--check must not write class files");
+
+        // control: a full compile rejects the same source, so --check agrees with it
+        assertThrows(Exception.class, () ->
+                FileSystemCompiler.commandLineCompile(new String[] {"-d", dir.toString(), file.getPath()}));
+    }
+
+    // GROOVY-12311: an earlier target phase remains selectable, and because config scripts are
+    // processed last it overrides --check. This is the only route back to a shallower check, so
+    // the ordering it depends on is pinned here.
+    @Test
+    public void testConfigScriptOverridesCheckTargetPhase(@TempDir Path dir) throws Exception {
+        File file = dir.resolve("CliPhaseDemo.groovy").toFile();
+        Files.write(file.toPath(), "class CliPhaseDemo { def foo() { 1 }\n def foo() { 2 } }".getBytes(StandardCharsets.UTF_8));
+        File script = dir.resolve("phase.groovy").toFile();
+        Files.write(script.toPath(), ("configuration.targetPhase = "
+                + "org.codehaus.groovy.control.Phases.INSTRUCTION_SELECTION").getBytes(StandardCharsets.UTF_8));
+
+        // stopping before CLASS_GENERATION skips verification, so the duplicate method goes unseen
+        FileSystemCompiler.commandLineCompile(new String[] {
+                "--check", "--configscript", script.getPath(), "-d", dir.toString(), file.getPath()});
+        assertFalse(Files.exists(dir.resolve("CliPhaseDemo.class")), "an earlier phase still writes no class files");
+    }
+
     @Test
     public void testDeleteRecursiveDoesNotFollowSymlink() throws Exception {
         File base = Files.createTempDirectory("deleteRecursiveSymlink").toFile();


### PR DESCRIPTION
--check selected Phases.INSTRUCTION_SELECTION, so it reported success for sources that do not compile. Class verification and bytecode generation are both registered at Phases.CLASS_GENERATION, which the cutoff excluded, and each reports errors the earlier phases cannot: duplicate method signatures, illegal modifier combinations, abstract/final conflicts, and the direct field access diagnostics from StaticTypesCallSiteWriter.

The two ideas behind --check — check without producing an artefact, and stop at a phase — line up at CLASS_GENERATION rather than before it. Bytecode is built in memory there; the class files are written in the OUTPUT phase that follows, and suppressing that is all a check needs. Selecting an earlier phase does not check less thoroughly for free, it just misses errors.

--check now does more work than it did, since it generates bytecode it discards. That is the cost of its result being trustworthy.

Earlier phases remain selectable through CompilerConfiguration.setTargetPhase and a compiler configuration script. Config scripts are processed after the option is applied, so a script overrides --check; the new test pins that, since it is the only route back to a shallower check.