### PR TITLE
GROOVY-12316: compose the parser DFA cache threshold with the GC canary

### DIFF
--- a/src/main/java/org/apache/groovy/parser/antlr4/internal/atnmanager/AtnManager.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/internal/atnmanager/AtnManager.java
@@ -26,7 +26,20 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * Manage ATN to avoid memory leak
+ * Manage ATN to avoid memory leak.
+ * <p>
+ * Two independent mechanisms drop the shared DFA cache, and they compose:
+ * <ul>
+ * <li>a <em>GC canary</em> — the softly referenced {@link AtnWrapper}. Its collection
+ *     signals memory pressure, so the cache is dropped when the next parse observes the
+ *     cleared reference. Active unless clearing is switched off entirely.</li>
+ * <li>a <em>parse counter</em> — clears every {@code groovy.antlr4.cache.threshold}
+ *     parses, bounding the cache deterministically rather than waiting for the collector.
+ *     Off by default.</li>
+ * </ul>
+ * The two used to be mutually exclusive: setting a threshold silently switched the canary
+ * off, so a value chosen to bound growth removed the only mechanism that responded to
+ * actual memory pressure and could make matters worse (GROOVY-12142).
  */
 public abstract class AtnManager {
     private static final ReentrantReadWriteLock RRWL = new ReentrantReadWriteLock(true);
@@ -34,19 +47,38 @@ public abstract class AtnManager {
     public static final ReentrantReadWriteLock.ReadLock READ_LOCK = RRWL.readLock();
     private static final String DFA_CACHE_THRESHOLD_OPT = "groovy.antlr4.cache.threshold";
     private static final long DFA_CACHE_THRESHOLD;
+    private static final boolean GC_CANARY_ENABLED;
     private SoftReference<AtnWrapper> atnWrapperSoftReference;
 
     static {
         long t = SystemUtil.getLongSafe(DFA_CACHE_THRESHOLD_OPT, 0L);
-        if (t < 0) {
-            t = Long.MAX_VALUE;
-        }
-
-        DFA_CACHE_THRESHOLD = t;
+        // A negative threshold has always meant "never clear the DFA cache". Preserve that
+        // escape hatch explicitly: it now switches off both mechanisms, because the canary
+        // is no longer implied by a zero threshold.
+        GC_CANARY_ENABLED = gcCanaryEnabled(t);
+        DFA_CACHE_THRESHOLD = counterThreshold(t);
     }
 
-    private static boolean isSmartCleanupEnabled() {
-        return 0 == DFA_CACHE_THRESHOLD;
+    /**
+     * Whether the GC canary is active for the given raw threshold. Only an explicit
+     * negative value ("never clear") switches it off; in particular a positive threshold
+     * leaves it on, so the two mechanisms compose.
+     */
+    static boolean gcCanaryEnabled(final long rawThreshold) {
+        return rawThreshold >= 0;
+    }
+
+    /** Parses between deterministic clears for the given raw threshold; 0 means off. */
+    static long counterThreshold(final long rawThreshold) {
+        return Math.max(rawThreshold, 0L);
+    }
+
+    /**
+     * Whether the parse counter is active. Zero (the default) leaves the GC canary as the
+     * only mechanism; any positive value adds a deterministic ceiling on top of it.
+     */
+    private static boolean isThresholdCleanupEnabled() {
+        return 0 != DFA_CACHE_THRESHOLD;
     }
 
     public ATN getATN() {
@@ -78,7 +110,7 @@ public abstract class AtnManager {
                 // defining class loader for the life of the JVM, leaking every
                 // container redeployment (GROOVY-12142).
                 atnWrapper = createAtnWrapper();
-                if (shouldClearDfaCache() && isSmartCleanupEnabled()) {
+                if (shouldClearDfaCache() && GC_CANARY_ENABLED) {
                     atnWrapper.clearDFA();
                 }
                 atnWrapperSoftReference = new SoftReference<>(atnWrapper);
@@ -98,7 +130,7 @@ public abstract class AtnManager {
         }
 
         public ATN checkAndClear() {
-            if (!shouldClearDfaCache() || isSmartCleanupEnabled()) {
+            if (!shouldClearDfaCache() || !isThresholdCleanupEnabled()) {
                 return atn;
             }
 

--- a/src/test/groovy/bugs/Groovy12142.groovy
+++ b/src/test/groovy/bugs/Groovy12142.groovy
@@ -50,6 +50,125 @@ final class Groovy12142 {
         assertTrue(rogue.isEmpty(), "runtime spawned loader-pinning threads: ${rogue*.name}")
     }
 
+    /**
+     * The parse-count threshold and the GC canary must compose. They were mutually
+     * exclusive, so setting {@code groovy.antlr4.cache.threshold} to bound the cache
+     * silently switched off the only mechanism that responds to memory pressure.
+     */
+    @Test
+    void testThresholdAndGcCanaryCompose() {
+        // default: canary only, no deterministic ceiling
+        assertTrue(gcCanaryEnabled(0L), 'canary must be on by default')
+        assertEquals(0L, counterThreshold(0L), 'counter must be off by default')
+
+        // a positive threshold adds a ceiling and must NOT disable the canary
+        assertTrue(gcCanaryEnabled(25L), 'a threshold must not switch off the GC canary')
+        assertEquals(25L, counterThreshold(25L))
+
+        // a negative threshold remains the explicit "never clear" escape hatch
+        assertFalse(gcCanaryEnabled(-1L), 'a negative threshold must disable clearing entirely')
+        assertEquals(0L, counterThreshold(-1L), 'a negative threshold must not clear on a counter')
+    }
+
+    /**
+     * With the default configuration the parser DFA cache must actually be released once
+     * the JVM has cleared soft references — the state a heap-constrained build reaches
+     * immediately before OutOfMemoryError.
+     */
+    @Test
+    void testParserDfaCacheIsReleasedAfterSoftReferenceClearing() {
+        (1..12).each { n -> parseVariedSource(n) }
+        int populated = parserDfaStateCount()
+        assertTrue(populated > 0, 'precondition: parsing must populate the parser DFA cache')
+
+        forceSoftReferenceClearing()
+        new GroovyShell().parse('1') // the clear happens on the next parse
+
+        int afterClear = parserDfaStateCount()
+        assertTrue(afterClear < populated,
+                "parser DFA cache must shrink after soft references are cleared, was $populated now $afterClear")
+    }
+
+    /**
+     * End-to-end guard for the composition, in a forked JVM because the threshold is read
+     * into a static final at class-init. With a threshold set but not yet reached, the only
+     * thing that can clear the cache is the GC canary — which a threshold used to disable.
+     */
+    @Test
+    void testThresholdSetStillAllowsGcCanaryToClearCache() {
+        def javaBin = new File(System.getProperty('java.home'), 'bin/java').absolutePath
+        def proc = [javaBin, '-Xmx256m', '-Dgroovy.antlr4.cache.threshold=25',
+                    '-cp', System.getProperty('java.class.path'),
+                    'bugs.Groovy12142$ThresholdCanaryProbe'].execute()
+        def out = new StringBuilder(), err = new StringBuilder()
+        proc.waitForProcessOutput(out, err)
+        assertEquals(0, proc.exitValue(),
+                "a set threshold must not disable the GC canary (exit=${proc.exitValue()})\nout: $out\nerr: $err")
+    }
+
+    /**
+     * Runs in a forked JVM with {@code groovy.antlr4.cache.threshold=25}. Parses fewer times
+     * than the threshold, so the deterministic counter cannot fire; any shrink is the canary.
+     * Exit 0 = cache released, 1 = not released, 2 = scaffolding failed to populate it.
+     */
+    static class ThresholdCanaryProbe {
+        static void main(String[] args) {
+            (1..12).each { n -> parseVariedSource(n) }
+            int populated = parserDfaStateCount()
+            if (populated <= 0) System.exit(2)
+
+            forceSoftReferenceClearing()
+            new GroovyShell().parse('1') // the canary is observed on the next parse
+
+            int afterClear = parserDfaStateCount()
+            System.err.println("populated=$populated afterClear=$afterClear")
+            System.exit(afterClear < populated ? 0 : 1)
+        }
+    }
+
+    /** Counts live states in the shared parser DFA cache. */
+    private static int parserDfaStateCount() {
+        def atn = org.apache.groovy.parser.antlr4.GroovyParser._ATN
+        def dfas = atn.decisionToDFA.findAll { it != null }
+        dfas.isEmpty() ? 0 : (int) dfas.sum { it.states.size() }
+    }
+
+    private static void parseVariedSource(int n) {
+        new GroovyShell().parse """
+            class Varied$n {
+                static final Map<String, List<Integer>> SEED = [a: [1, 2, $n], b: [$n, 5]]
+                def run$n(input) {
+                    def acc = new HashMap<String, List<Integer>>()
+                    def cl = { String k, List<Integer> xs -> xs.collect { it * $n }.findAll { it % 2 == 0 } }
+                    def (first, second) = [acc.size(), SEED.size()]
+                    def out = SEED.collectEntries { k, xs -> [(k): cl(k, xs)] }
+                    def msg = "n=\${first} m=\${second} -> \${out?.size() ?: 0}"
+                    def branch = switch (second) {
+                        case 0 -> 'zero'
+                        case 1..5 -> "small \$msg"
+                        default -> out.keySet().sort()
+                    }
+                    return first > $n ? out*.key : [*out.values(), *SEED.b].flatten()
+                }
+            }
+        """
+    }
+
+    private static boolean gcCanaryEnabled(long raw) {
+        (boolean) invokeAtnManagerPolicy('gcCanaryEnabled', raw)
+    }
+
+    private static long counterThreshold(long raw) {
+        (long) invokeAtnManagerPolicy('counterThreshold', raw)
+    }
+
+    private static Object invokeAtnManagerPolicy(String name, long raw) {
+        def m = Class.forName('org.apache.groovy.parser.antlr4.internal.atnmanager.AtnManager')
+                .getDeclaredMethod(name, long)
+        m.accessible = true
+        m.invoke(null, raw)
+    }
+
     @Test
     void testMapBasedClassValueComputesOncePerClassAndSupportsRemove() {
         def computations = []


### PR DESCRIPTION
AtnManager has two mechanisms for dropping the shared parser DFA cache, but they were mutually exclusive. isSmartCleanupEnabled() is defined as DFA_CACHE_THRESHOLD == 0, and the canary clear was guarded by shouldClearDfaCache() && isSmartCleanupEnabled(), so setting any positive groovy.antlr4.cache.threshold switched the GC canary off.

Since the threshold is the documented knob for bounding DFA cache growth, reaching for it to reduce memory use silently removed the only mechanism that responds to actual memory pressure. This was hit in practice: a user chasing an OOM on 5.1.1 under Maven at -Xmx128m set threshold=200 as a mitigation, which made 5.1.0 start OOMing too because it disabled the valve that had been keeping it alive.

Derive two independent switches from the raw property instead of overloading one: GC_CANARY_ENABLED (t >= 0) and DFA_CACHE_THRESHOLD (max(t, 0)). Behaviour changes only for a positive threshold, which now keeps the canary as well as the counter. Zero (the default) is unchanged, so there is no throughput cost for users who do not set the property, and a negative value remains the explicit "never clear" escape hatch — it now switches off both mechanisms, since the canary is no longer implied by a zero threshold.

The forked-JVM test fails without the fix: with threshold=25 and only 12 parses the counter cannot fire, and after the JVM clears soft references the parser DFA state count goes 478 -> 486 instead of dropping.

This does not on its own close the 5.1.1 memory regression. At the default the canary is still only observed on the parse path, so under a tight heap the cache can go unreclaimed until an OOM that arrives mid-parse.