### PR TITLE
GROOVY-12324: ChannelSelect: per-select preconditions for guarded choice

### DIFF
--- a/src/main/java/groovy/concurrent/ChannelSelect.java
+++ b/src/main/java/groovy/concurrent/ChannelSelect.java
@@ -23,6 +23,7 @@ import org.apache.groovy.runtime.async.GroovyPromise;
 import org.apache.groovy.runtime.async.SelectClaim;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -69,6 +70,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  * complete unilaterally; over buffered channels with space, each peer's send
  * offer commits immediately under its own select, and the two proceed down
  * different branches of the same session.
+ * <p>
+ * Any branch may also carry a precondition — the <em>guarded choice</em> of
+ * CSP — by passing one flag per offer to {@link #select(boolean...)}. A
+ * disabled offer is left unregistered while the enabled ones keep their
+ * positions, so a guard can be masked off without renumbering the branches
+ * around it.
  * <p>
  * Inspired by GPars' {@code Select} and Go's {@code select} statement
  * (whose send cases these offers mirror).
@@ -243,16 +250,69 @@ public final class ChannelSelect {
      * @return an awaitable result indicating which offer committed
      */
     public Awaitable<Result> select() {
-        int count = offers.size();
+        return select(registrationOrder(null));
+    }
+
+    /**
+     * Waits for the first offer that can complete among those its
+     * precondition enables: the guarded choice of the CSP literature, where
+     * a branch is masked off for this call without disturbing the others.
+     * <p>
+     * Flag {@code i} enables offer {@code i}. A disabled offer is not
+     * registered on its channel — nothing is consumed from it and nothing is
+     * sent to it — but it keeps its position, so {@link Result#getIndex()}
+     * still denotes the same branch whatever the mask. That positional
+     * stability is the point: dropping an offer from the argument list
+     * instead would silently renumber the branches after it.
+     *
+     * <pre>{@code
+     * // the classic bounded buffer: take input only while there is room,
+     * // answer requests only while there is something to hand over
+     * def sel = offers(receive(input), receive(request))
+     * while (true) {
+     *     def result = await sel.select(size < capacity, size > 0)
+     *     if (result.index == 0) { ... buffer result.value ... }
+     *     else                   { ... reply with the oldest value ... }
+     * }
+     * }</pre>
+     * <p>
+     * In every other respect this behaves as {@link #select()}: the enabled
+     * offers are scanned in the order the choice policy dictates, and exactly
+     * one commits.
+     *
+     * @param enabled one flag per offer, in offer order
+     * @return an awaitable result indicating which offer committed, or one
+     *         that fails with {@link IllegalStateException} if every offer is
+     *         disabled
+     * @throws IllegalArgumentException if the number of flags is not the
+     *         number of offers
+     * @since 6.0.0
+     */
+    public Awaitable<Result> select(boolean... enabled) {
+        Objects.requireNonNull(enabled, "enabled must not be null");
+        if (enabled.length != offers.size()) {
+            throw new IllegalArgumentException("Expected " + offers.size()
+                    + " precondition(s), one per offer, but got " + enabled.length);
+        }
+        int[] order = registrationOrder(enabled);
+        if (order.length == 0) {
+            CompletableFuture<Result> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new IllegalStateException("every offer of the select is disabled"));
+            return GroovyPromise.of(failed);
+        }
+        return select(order);
+    }
+
+    private Awaitable<Result> select(int[] order) {
+        int count = order.length;
         Winner winner = new Winner();
         AtomicInteger closedCount = new AtomicInteger();
-        Awaitable<?>[] branches = new Awaitable<?>[count];
+        Awaitable<?>[] branches = new Awaitable<?>[offers.size()];
 
         // a ready offer completes synchronously during registration, so the
         // registration order is the priority order: rotate it under fair(),
         // shuffle it under random() (a random start alone would favour a
         // ready offer by the run of not-ready offers before it)
-        int[] order = registrationOrder(count);
         for (int k = 0; k < count && !winner.isDone(); k++) {
             final int index = order[k];
             final Offer offer = offers.get(index);
@@ -272,7 +332,7 @@ public final class ChannelSelect {
                     // other channel has consumed a value and must compete for it now
                     if (claimable || winner.claim.tryCommit(future)) {
                         withdraw(branches); // losers registered so far, before the caller sees the result
-                        winner.complete(new Result(index, offer.send ? offer.value : value, offer.send)); // holding the claim, this cannot fail
+                        winner.complete(new Result(index, offer.send ? offer.value : value, offer.send, ch)); // holding the claim, this cannot fail
                     } else {
                         resend(ch, value);
                     }
@@ -289,26 +349,38 @@ public final class ChannelSelect {
         return GroovyPromise.of(winner);
     }
 
-    private int[] registrationOrder(int count) {
+    /**
+     * The offer indices to register, in registration order, omitting those
+     * the given preconditions disable ({@code null} enables every offer).
+     */
+    private int[] registrationOrder(boolean[] enabled) {
+        int count = offers.size();
         int[] order = new int[count];
+        int size = 0;
         switch (policy) {
             case PRIORITY -> {
-                for (int i = 0; i < count; i++) order[i] = i;
+                for (int i = 0; i < count; i++) {
+                    if (enabled == null || enabled[i]) order[size++] = i;
+                }
             }
             case FAIR -> {
                 int start = Math.floorMod(lastWinner.get() + 1, count);
-                for (int i = 0; i < count; i++) order[i] = (start + i) % count;
+                for (int i = 0; i < count; i++) {
+                    int index = (start + i) % count;
+                    if (enabled == null || enabled[index]) order[size++] = index;
+                }
             }
             case RANDOM -> { // Fisher-Yates: every ready offer is equally likely to be met first
                 ThreadLocalRandom random = ThreadLocalRandom.current();
                 for (int i = 0; i < count; i++) {
-                    int j = random.nextInt(i + 1);
-                    order[i] = order[j];
+                    if (enabled != null && !enabled[i]) continue;
+                    int j = random.nextInt(size + 1);
+                    order[size++] = order[j];
                     order[j] = i;
                 }
             }
         }
-        return order;
+        return size == count ? order : Arrays.copyOf(order, size);
     }
 
     private static void withdraw(Awaitable<?>[] branches) {
@@ -369,22 +441,36 @@ public final class ChannelSelect {
         private final int index;
         private final Object value;
         private final boolean send;
+        private final AsyncChannel<?> channel;
 
         /**
          * Creates a selection result.
          *
-         * @param index the zero-based index of the committed offer
-         * @param value the received value, or the sent value for a send offer
-         * @param send  whether the committed offer was a send
+         * @param index   the zero-based index of the committed offer
+         * @param value   the received value, or the sent value for a send offer
+         * @param send    whether the committed offer was a send
+         * @param channel the channel the committed offer transferred over
          */
-        Result(int index, Object value, boolean send) {
+        Result(int index, Object value, boolean send, AsyncChannel<?> channel) {
             this.index = index;
             this.value = value;
             this.send = send;
+            this.channel = channel;
         }
 
         /** The zero-based index of the offer that committed. */
         public int getIndex() { return index; }
+
+        /**
+         * The channel the committed offer transferred over: the one received
+         * from, or the one sent to. Lets a branch be recognised by identity
+         * rather than by position, which suits a select whose offers are
+         * assembled dynamically.
+         *
+         * @return the winning channel
+         * @since 6.0.0
+         */
+        public AsyncChannel<?> getChannel() { return channel; }
 
         /**
          * The transferred value: what arrived, for a receive offer; what was

--- a/src/spec/doc/_core-async-channels.adoc
+++ b/src/spec/doc/_core-async-channels.adoc
@@ -189,6 +189,38 @@ unilaterally; over buffered channels with space, each peer's send offer
 commits at once under its own select and the peers proceed down
 different branches of the same conversation.
 
+=== Preconditions
+
+Each branch may also carry a _precondition_ — the guarded choice of CSP.
+`select` takes one flag per offer: a disabled offer is not registered on
+its channel, so nothing is taken from it and nothing is sent to it, but
+it keeps its position, so `result.index` denotes the same branch whatever
+the mask:
+
+[source,groovy]
+----
+def sel = offers(receive(input), receive(request))
+while (true) {
+    def result = await sel.select(size < capacity, size > 0)  // <1>
+    if (result.index == 0) {
+        // room to spare: buffer result.value
+    } else {
+        // something to hand over: reply with the oldest value
+    }
+}
+----
+<1> take input only while there is room, answer requests only while there
+is something to hand over
+
+Dropping an offer from the argument list instead would renumber every
+branch after it, silently changing what an index denotes. Enabling no
+branch at all is a deadlock rather than a wait, so `select` fails with
+`IllegalStateException`; passing the wrong number of flags is an
+`IllegalArgumentException`.
+
+A branch can also be recognised by identity instead of by position:
+`result.channel` is the channel the winning offer transferred over.
+
 [[async-broadcast-channel]]
 == BroadcastChannel
 

--- a/src/test/groovy/groovy/concurrent/ChannelSelectTest.groovy
+++ b/src/test/groovy/groovy/concurrent/ChannelSelectTest.groovy
@@ -719,4 +719,201 @@ final class ChannelSelectTest {
             assert b.toString().contains('waitingReceivers=0')
         '''
     }
+
+    @Test
+    void testDisabledOfferIsNotRegisteredAndIndicesAreUnchanged() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def first = AsyncChannel.create(4)
+            def second = AsyncChannel.create(4)
+            first.send('f1'); second.send('s1')
+
+            // both ready, but the first branch is masked off: the second wins
+            // and still calls itself index 1
+            def sel = offers(receive(first), receive(second))
+            def result = await sel.select(false, true)
+            assert result.index == 1 && result.value == 's1'
+
+            // the disabled branch was never registered: nothing taken, no receiver left
+            assert first.bufferedSize == 1
+            assert first.toString().contains('waitingReceivers=0')
+
+            // unmasking it restores the priority order
+            assert (await sel.select(true, true)).index == 0
+        '''
+    }
+
+    @Test
+    void testDisabledSendOfferTransfersNothing() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def out = AsyncChannel.create(4)      // room to spare: the send would commit at once
+            def input = AsyncChannel.create(4)
+            input.send('i1')
+
+            def result = await offers(send(out, 'v'), receive(input)).select(false, true)
+            assert result.index == 1 && !result.send && result.value == 'i1'
+            assert out.bufferedSize == 0
+            assert out.toString().contains('waitingSenders=0')
+        '''
+    }
+
+    @Test
+    void testSelectWithEveryOfferDisabledFails() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelSelect
+            import static groovy.test.GroovyAssert.shouldFail
+
+            def a = AsyncChannel.create(4)
+            def b = AsyncChannel.create(4)
+            a.send('ready')
+
+            def sel = ChannelSelect.from(a, b)
+            shouldFail(IllegalStateException) {
+                await sel.select(false, false)
+            }
+            // the ready channel was left alone
+            assert a.bufferedSize == 1
+            assert a.toString().contains('waitingReceivers=0')
+        '''
+    }
+
+    @Test
+    void testSelectRejectsAPreconditionCountThatIsNotTheOfferCount() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelSelect
+            import static groovy.test.GroovyAssert.shouldFail
+
+            def sel = ChannelSelect.from(AsyncChannel.create(4), AsyncChannel.create(4))
+            shouldFail(IllegalArgumentException) { sel.select(true) }
+            shouldFail(IllegalArgumentException) { sel.select(true, true, true) }
+        '''
+    }
+
+    @Test
+    void testFairSelectRotatesAmongTheEnabledOffersOnly() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelSelect
+
+            def a = AsyncChannel.create(20)
+            def b = AsyncChannel.create(20)
+            def c = AsyncChannel.create(20)
+            for (i in 0..<10) { a.send('a'); b.send('b'); c.send('c') }
+
+            // b stays masked off, so the rotation alternates between a and c
+            def sel = ChannelSelect.from(a, b, c).fair()
+            def indices = (0..<6).collect { (await sel.select(true, false, true)).index }
+            assert indices.toSet() == [0, 2] as Set
+            assert indices.count { it == 0 } == 3 && indices.count { it == 2 } == 3
+            assert b.bufferedSize == 10
+        '''
+    }
+
+    @Test
+    void testSelectWaitsOnTheEnabledOffersWhileADisabledOneIsReady() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelSelect
+
+            def masked = AsyncChannel.create(4)
+            def live = AsyncChannel.create(4)
+            masked.send('ignored')
+
+            async { Thread.sleep(50); live.send('late') }
+            def result = await ChannelSelect.from(masked, live).select(false, true).orTimeoutMillis(5000)
+            assert result.index == 1 && result.value == 'late'
+            assert masked.bufferedSize == 1
+        '''
+    }
+
+    @Test
+    void testSelectFailsOnlyWhenEveryEnabledChannelIsClosed() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelClosedException
+            import groovy.concurrent.ChannelSelect
+            import static groovy.test.GroovyAssert.shouldFail
+
+            def open = AsyncChannel.create(4)
+            def closed = AsyncChannel.create(4)
+            closed.close()
+
+            // the open channel is masked off, so the closed one decides the result
+            shouldFail(ChannelClosedException) {
+                await ChannelSelect.from(open, closed).select(false, true).orTimeoutMillis(1000)
+            }
+        '''
+    }
+
+    @Test
+    void testResultNamesTheWinningChannel() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def input = AsyncChannel.create(4)
+            def output = AsyncChannel.create(4)
+            input.send('i1')
+
+            def received = await offers(receive(input), send(output, 'o1')).select()
+            assert received.channel.is(input) && received.value == 'i1'
+
+            def sent = await offers(receive(input), send(output, 'o1')).select(false, true)
+            assert sent.channel.is(output) && sent.send
+            assert (await output.receive()) == 'o1'
+        '''
+    }
+
+    @Test
+    void testGuardedBoundedBuffer() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelClosedException
+            import static groovy.concurrent.ChannelSelect.*
+            import static org.apache.groovy.runtime.async.AsyncSupport.await as awaitFor
+
+            // Kerridge's bounded buffer: accept input only while there is room,
+            // answer a request only while the buffer holds something
+            int capacity = 3
+            def input = AsyncChannel.create()       // rendezvous, so a producer past capacity really blocks
+            def request = AsyncChannel.create()
+            def reply = AsyncChannel.create()
+
+            def buffer = Thread.start {
+                def held = new LinkedList()
+                def sel = offers(receive(input), receive(request))
+                while (true) {
+                    try {
+                        def result = awaitFor(sel.select(held.size() < capacity, !held.isEmpty()))
+                        if (result.index == 0) held.addLast(result.value)
+                        else awaitFor(reply.send(held.removeFirst()))
+                    } catch (ChannelClosedException e) {
+                        break
+                    }
+                }
+            }
+
+            // a fourth value would block while the buffer is full, so interleave
+            for (i in 1..3) awaitFor(input.send(i))
+            awaitFor(request.send('next'))
+            assert awaitFor(reply.receive()) == 1
+            awaitFor(input.send(4))
+
+            for (expected in 2..4) {
+                awaitFor(request.send('next'))
+                assert awaitFor(reply.receive()) == expected
+            }
+
+            input.close(); request.close()
+            buffer.join(10_000)
+            assert !buffer.alive
+        '''
+    }
 }


### PR DESCRIPTION
select(boolean...) takes one flag per offer. A disabled offer is not registered on its channel and keeps its position, so a guard can be masked off without renumbering the branches around it — the guarded ALT of JCSP and GPars. Disabling every offer fails the result with IllegalStateException; a flag count other than the offer count is an IllegalArgumentException. Result.getChannel() names the winning channel so a branch can also be recognised by identity rather than position.