### PR TITLE
GROOVY-12309: Preserve Object[] closure call semantics

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesClosureWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesClosureWriter.java
@@ -220,7 +220,8 @@ public class StaticTypesClosureWriter extends ClosureWriter {
             throw new GroovyBugError("Expected to find one (1) doCall method on generated closure, but found " + doCalls.size());
         }
         MethodNode doCallMethod = doCalls.get(0);
-        if (methods.isEmpty() && doCallMethod.getParameters().length == 1) {
+        if (methods.isEmpty() && doCallMethod.getParameters().length == 1
+                && !doCallMethod.getParameters()[0].getType().isArray()) {
             createDirectCallMethod(closureClass, doCallMethod);
         }
         MethodTargetCompletionVisitor visitor = new MethodTargetCompletionVisitor(doCallMethod);

--- a/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/StaticCompileClosureCallTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/StaticCompileClosureCallTest.groovy
@@ -122,6 +122,20 @@ final class StaticCompileClosureCallTest extends AbstractBytecodeTestCase {
         '''
     }
 
+    // GROOVY-12309
+    @Test
+    void testClosureCallWithObjectArrayParameter() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            class Foo {
+                static Object[] foo() {
+                    { Object[] args -> args }.call(new Object[] {'foo'})
+                }
+            }
+            assert Foo.foo() == ['foo'] as Object[]
+        '''
+    }
+
     @Test
     void testWriteSharedVariableInClosure() {
         def bytecode = compile([method:'m'],'''


### PR DESCRIPTION
Avoid generating a direct call(Object[]) override for a statically compiled closure with an Object[] parameter. The override collides with Closure.call(Object...) and allows Closure.call(Object) to wrap the argument array before dispatch.

Add a regression test for calling such a closure with an Object[] argument.

Assisted-by: Hermes Agent (Nous Research)