### PR TITLE
GROOVY-12326: ChannelSelect: guard an offer directly with receive(c).…

### DIFF
--- a/src/main/java/groovy/concurrent/ChannelSelect.java
+++ b/src/main/java/groovy/concurrent/ChannelSelect.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 
 /**
  * Selects the first offer that can complete among multiple
@@ -72,10 +73,16 @@ import java.util.concurrent.atomic.AtomicInteger;
  * different branches of the same session.
  * <p>
  * Any branch may also carry a precondition — the <em>guarded choice</em> of
- * CSP — by passing one flag per offer to {@link #select(boolean...)}. A
- * disabled offer is left unregistered while the enabled ones keep their
- * positions, so a guard can be masked off without renumbering the branches
- * around it.
+ * CSP — either written onto the offer itself with
+ * {@link Offer#when(BooleanSupplier)} or passed positionally to
+ * {@link #select(boolean...)}. A disabled offer is left unregistered while
+ * the enabled ones keep their positions, so a guard can be masked off
+ * without renumbering the branches around it.
+ *
+ * <pre>{@code
+ * def result = await offers(receive(input).when { size < capacity },
+ *                           receive(request).when { size > 0 }).select()
+ * }</pre>
  * <p>
  * Inspired by GPars' {@code Select} and Go's {@code select} statement
  * (whose send cases these offers mirror).
@@ -159,7 +166,7 @@ public final class ChannelSelect {
         if (!(channel instanceof DefaultAsyncChannel)) {
             throw new IllegalArgumentException("send offers require a channel created by AsyncChannel.create");
         }
-        return new Offer(channel, value, true);
+        return new Offer(channel, value, true, null);
     }
 
     /**
@@ -173,7 +180,7 @@ public final class ChannelSelect {
      */
     public static Offer receive(AsyncChannel<?> channel) {
         Objects.requireNonNull(channel, "channel must not be null");
-        return new Offer(channel, null, false);
+        return new Offer(channel, null, false, null);
     }
 
     /**
@@ -238,7 +245,9 @@ public final class ChannelSelect {
      * and sends nothing.
      * <p>
      * If every offer's channel is closed, the result fails with
-     * {@link ChannelClosedException}.
+     * {@link ChannelClosedException}. If every offer is guarded off (see
+     * {@link Offer#when(BooleanSupplier)}) there is nothing to wait for and
+     * the result fails with {@link IllegalStateException}.
      * <p>
      * Only channels created by {@link AsyncChannel#create} take part in the
      * claim protocol that makes this possible. Any other {@code AsyncChannel}
@@ -250,7 +259,7 @@ public final class ChannelSelect {
      * @return an awaitable result indicating which offer committed
      */
     public Awaitable<Result> select() {
-        return select(registrationOrder(null));
+        return start(registrationOrder(null));
     }
 
     /**
@@ -258,12 +267,13 @@ public final class ChannelSelect {
      * precondition enables: the guarded choice of the CSP literature, where
      * a branch is masked off for this call without disturbing the others.
      * <p>
-     * Flag {@code i} enables offer {@code i}. A disabled offer is not
-     * registered on its channel — nothing is consumed from it and nothing is
-     * sent to it — but it keeps its position, so {@link Result#getIndex()}
-     * still denotes the same branch whatever the mask. That positional
-     * stability is the point: dropping an offer from the argument list
-     * instead would silently renumber the branches after it.
+     * Flag {@code i} enables offer {@code i}, and is conjoined with any guard
+     * the offer carries of its own: an offer is registered only if both hold.
+     * A disabled offer is not registered on its channel — nothing is consumed
+     * from it and nothing is sent to it — but it keeps its position, so
+     * {@link Result#getIndex()} still denotes the same branch whatever the
+     * mask. That positional stability is the point: dropping an offer from
+     * the argument list instead would silently renumber the branches after it.
      *
      * <pre>{@code
      * // the classic bounded buffer: take input only while there is room,
@@ -286,6 +296,7 @@ public final class ChannelSelect {
      *         disabled
      * @throws IllegalArgumentException if the number of flags is not the
      *         number of offers
+     * @see Offer#when(BooleanSupplier)
      * @since 6.0.0
      */
     public Awaitable<Result> select(boolean... enabled) {
@@ -294,17 +305,16 @@ public final class ChannelSelect {
             throw new IllegalArgumentException("Expected " + offers.size()
                     + " precondition(s), one per offer, but got " + enabled.length);
         }
-        int[] order = registrationOrder(enabled);
-        if (order.length == 0) {
+        return start(registrationOrder(enabled));
+    }
+
+    private Awaitable<Result> start(int[] order) {
+        int count = order.length;
+        if (count == 0) {
             CompletableFuture<Result> failed = new CompletableFuture<>();
             failed.completeExceptionally(new IllegalStateException("every offer of the select is disabled"));
             return GroovyPromise.of(failed);
         }
-        return select(order);
-    }
-
-    private Awaitable<Result> select(int[] order) {
-        int count = order.length;
         Winner winner = new Winner();
         AtomicInteger closedCount = new AtomicInteger();
         Awaitable<?>[] branches = new Awaitable<?>[offers.size()];
@@ -351,7 +361,8 @@ public final class ChannelSelect {
 
     /**
      * The offer indices to register, in registration order, omitting those
-     * the given preconditions disable ({@code null} enables every offer).
+     * disabled by the positional preconditions ({@code null} enables every
+     * position) or by a guard the offer carries.
      */
     private int[] registrationOrder(boolean[] enabled) {
         int count = offers.size();
@@ -360,20 +371,20 @@ public final class ChannelSelect {
         switch (policy) {
             case PRIORITY -> {
                 for (int i = 0; i < count; i++) {
-                    if (enabled == null || enabled[i]) order[size++] = i;
+                    if (isEnabled(i, enabled)) order[size++] = i;
                 }
             }
             case FAIR -> {
                 int start = Math.floorMod(lastWinner.get() + 1, count);
                 for (int i = 0; i < count; i++) {
                     int index = (start + i) % count;
-                    if (enabled == null || enabled[index]) order[size++] = index;
+                    if (isEnabled(index, enabled)) order[size++] = index;
                 }
             }
             case RANDOM -> { // Fisher-Yates: every ready offer is equally likely to be met first
                 ThreadLocalRandom random = ThreadLocalRandom.current();
                 for (int i = 0; i < count; i++) {
-                    if (enabled != null && !enabled[i]) continue;
+                    if (!isEnabled(i, enabled)) continue;
                     int j = random.nextInt(size + 1);
                     order[size++] = order[j];
                     order[j] = i;
@@ -381,6 +392,17 @@ public final class ChannelSelect {
             }
         }
         return size == count ? order : Arrays.copyOf(order, size);
+    }
+
+    /**
+     * Whether offer {@code index} takes part in this select: its positional
+     * precondition and its own guard must both hold. Each guard is consulted
+     * once per {@link #select()} call, in offer order under
+     * {@link Policy#PRIORITY} and {@link Policy#RANDOM} and in rotation order
+     * under {@link Policy#FAIR}.
+     */
+    private boolean isEnabled(int index, boolean[] enabled) {
+        return (enabled == null || enabled[index]) && offers.get(index).isEnabled();
     }
 
     private static void withdraw(Awaitable<?>[] branches) {
@@ -407,11 +429,56 @@ public final class ChannelSelect {
         private final AsyncChannel<?> channel;
         private final Object value;
         private final boolean send;
+        /** the guard, or {@code null} when the offer is unconditional */
+        private final BooleanSupplier guard;
 
-        private Offer(AsyncChannel<?> channel, Object value, boolean send) {
+        private Offer(AsyncChannel<?> channel, Object value, boolean send, BooleanSupplier guard) {
             this.channel = channel;
             this.value = value;
             this.send = send;
+            this.guard = guard;
+        }
+
+        /**
+         * Returns a copy of this offer guarded by {@code condition}: the
+         * precondition written onto the branch itself, as occam, Ada, Erlang
+         * and Kotlin write it, rather than passed positionally to
+         * {@link ChannelSelect#select(boolean...)}.
+         *
+         * <pre>{@code
+         * def sel = offers(receive(input).when { size < capacity },
+         *                  receive(request).when { size > 0 })
+         * def result = await sel.select()
+         * }</pre>
+         * <p>
+         * The condition is evaluated afresh on every {@link
+         * ChannelSelect#select()} call — that is why it is a supplier and not
+         * a boolean — so one guarded select may be held and reused as the
+         * state it guards on changes. When it does not hold, the offer is not
+         * registered on its channel: nothing is taken from it and nothing is
+         * sent to it, and the remaining offers keep their positions, so
+         * {@link Result#getIndex()} denotes the same branch either way.
+         * <p>
+         * Guards conjoin: over a second {@code when} both conditions must
+         * hold, as must the corresponding flag of a
+         * {@link ChannelSelect#select(boolean...)} call. If no offer of a
+         * select is enabled the result fails with
+         * {@link IllegalStateException}, since there is nothing left to wait
+         * for.
+         *
+         * @param condition the guard, consulted once per select
+         * @return a guarded copy of this offer
+         * @since 6.0.0
+         */
+        public Offer when(BooleanSupplier condition) {
+            Objects.requireNonNull(condition, "condition must not be null");
+            BooleanSupplier outer = guard;
+            return new Offer(channel, value, send,
+                    outer == null ? condition : () -> outer.getAsBoolean() && condition.getAsBoolean());
+        }
+
+        boolean isEnabled() {
+            return guard == null || guard.getAsBoolean();
         }
     }
 

--- a/src/spec/doc/_core-async-channels.adoc
+++ b/src/spec/doc/_core-async-channels.adoc
@@ -192,31 +192,50 @@ different branches of the same conversation.
 === Preconditions
 
 Each branch may also carry a _precondition_ — the guarded choice of CSP.
-`select` takes one flag per offer: a disabled offer is not registered on
-its channel, so nothing is taken from it and nothing is sent to it, but
-it keeps its position, so `result.index` denotes the same branch whatever
-the mask:
+`when` writes the guard onto the offer itself, as occam, Ada, Erlang and
+Kotlin do:
 
 [source,groovy]
 ----
-def sel = offers(receive(input), receive(request))
+def sel = offers(receive(input).when { held.size() < capacity },   // <1>
+                 receive(request).when { !held.isEmpty() })        // <2>
 while (true) {
-    def result = await sel.select(size < capacity, size > 0)  // <1>
+    def result = await sel.select()
     if (result.index == 0) {
-        // room to spare: buffer result.value
+        held.addLast(result.value)
     } else {
-        // something to hand over: reply with the oldest value
+        await reply.send(held.removeFirst())
     }
 }
 ----
-<1> take input only while there is room, answer requests only while there
-is something to hand over
+<1> take input only while there is room
+<2> answer a request only while there is something to hand over
 
-Dropping an offer from the argument list instead would renumber every
-branch after it, silently changing what an index denotes. Enabling no
+A guarded-off offer is not registered on its channel, so nothing is taken
+from it and nothing is sent to it, but it keeps its position, so
+`result.index` denotes the same branch either way. Dropping an offer from
+the argument list instead would renumber every branch after it, silently
+changing what an index denotes.
+
+The guard is a closure rather than a boolean because it is consulted
+afresh on every `select` call — that is what lets one select be built
+once and reused as the state it guards on changes. `when` returns a
+guarded copy, leaving the original offer alone, and guards conjoin: over
+a second `when`, both must hold.
+
+`select` also accepts the same preconditions positionally, one flag per
+offer, which suits a mask computed as a whole:
+
+[source,groovy]
+----
+def result = await sel.select(held.size() < capacity, !held.isEmpty())
+----
+
+A flag is conjoined with whatever guard its offer carries — both must
+hold for the offer to be registered — and passing a number of flags other
+than the number of offers is an `IllegalArgumentException`. Enabling no
 branch at all is a deadlock rather than a wait, so `select` fails with
-`IllegalStateException`; passing the wrong number of flags is an
-`IllegalArgumentException`.
+`IllegalStateException`.
 
 A branch can also be recognised by identity instead of by position:
 `result.channel` is the channel the winning offer transferred over.

--- a/src/test/groovy/groovy/concurrent/ChannelSelectTest.groovy
+++ b/src/test/groovy/groovy/concurrent/ChannelSelectTest.groovy
@@ -916,4 +916,196 @@ final class ChannelSelectTest {
             assert !buffer.alive
         '''
     }
+
+    @Test
+    void testGuardedOfferIsNotRegisteredAndIndicesAreUnchanged() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def first = AsyncChannel.create(4)
+            def second = AsyncChannel.create(4)
+            first.send('f1'); second.send('s1')
+
+            // both ready, but the first branch is guarded off: the second wins
+            // and still calls itself index 1
+            def result = await offers(receive(first).when { false }, receive(second)).select()
+            assert result.index == 1 && result.value == 's1'
+
+            // the guarded branch was never registered: nothing taken, no receiver left
+            assert first.bufferedSize == 1
+            assert first.toString().contains('waitingReceivers=0')
+        '''
+    }
+
+    @Test
+    void testGuardIsConsultedOnEverySelect() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def a = AsyncChannel.create(20)
+            def b = AsyncChannel.create(20)
+            for (i in 0..<4) { a.send('a' + i); b.send('b' + i) }
+
+            // one held select whose guard tracks changing state
+            boolean takeA = false
+            def sel = offers(receive(a).when { takeA }, receive(b))
+
+            assert (await sel.select()).value == 'b0'
+            takeA = true
+            assert (await sel.select()).value == 'a0'
+            takeA = false
+            assert (await sel.select()).value == 'b1'
+            takeA = true
+            assert (await sel.select()).value == 'a1'
+        '''
+    }
+
+    @Test
+    void testGuardedSendOfferTransfersNothing() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def out = AsyncChannel.create(4)      // room to spare: the send would commit at once
+            def input = AsyncChannel.create(4)
+            input.send('i1')
+
+            def result = await offers(send(out, 'v').when { false }, receive(input)).select()
+            assert result.index == 1 && !result.send && result.value == 'i1'
+            assert out.bufferedSize == 0
+            assert out.toString().contains('waitingSenders=0')
+        '''
+    }
+
+    @Test
+    void testGuardsConjoinWithEachOtherAndWithThePreconditionMask() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def a = AsyncChannel.create(20)
+            def b = AsyncChannel.create(20)
+            for (i in 0..<6) { a.send('a' + i); b.send('b' + i) }
+
+            // chained guards must both hold
+            boolean one = true, two = true
+            def sel = offers(receive(a).when { one }.when { two }, receive(b))
+            assert (await sel.select()).index == 0
+            two = false
+            assert (await sel.select()).index == 1
+            two = true; one = false
+            assert (await sel.select()).index == 1
+
+            // an enabled guard is still overridden by a false mask flag
+            one = true
+            assert (await sel.select(false, true)).index == 1
+            assert (await sel.select(true, true)).index == 0
+        '''
+    }
+
+    @Test
+    void testSelectWithEveryOfferGuardedOffFails() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+            import static groovy.test.GroovyAssert.shouldFail
+
+            def a = AsyncChannel.create(4)
+            def b = AsyncChannel.create(4)
+            a.send('ready')
+
+            def sel = offers(receive(a).when { false }, receive(b).when { false })
+            shouldFail(IllegalStateException) { await sel.select() }
+            shouldFail(IllegalStateException) { await sel.select(true, true) }
+
+            // the ready channel was left alone
+            assert a.bufferedSize == 1
+            assert a.toString().contains('waitingReceivers=0')
+        '''
+    }
+
+    @Test
+    void testGuardedOfferIsReusableAndLeavesTheOriginalUnguarded() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def a = AsyncChannel.create(20)
+            def b = AsyncChannel.create(20)
+            for (i in 0..<2) { a.send('a' + i); b.send('b' + i) }
+
+            def plain = receive(a)
+            def guarded = plain.when { false }        // when() copies, it does not mutate
+
+            assert (await offers(guarded, receive(b)).select()).index == 1
+            assert (await offers(plain, receive(b)).select()).index == 0
+        '''
+    }
+
+    @Test
+    void testFairSelectRotatesAmongTheUnguardedOffersOnly() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def a = AsyncChannel.create(20)
+            def b = AsyncChannel.create(20)
+            def c = AsyncChannel.create(20)
+            for (i in 0..<10) { a.send('a'); b.send('b'); c.send('c') }
+
+            // b stays guarded off, so the rotation alternates between a and c
+            def sel = offers(receive(a), receive(b).when { false }, receive(c)).fair()
+            def indices = (0..<6).collect { (await sel.select()).index }
+            assert indices.toSet() == [0, 2] as Set
+            assert indices.count { it == 0 } == 3 && indices.count { it == 2 } == 3
+            assert b.bufferedSize == 10
+        '''
+    }
+
+    @Test
+    void testGuardedBoundedBufferWithWhen() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelClosedException
+            import static groovy.concurrent.ChannelSelect.*
+            import static org.apache.groovy.runtime.async.AsyncSupport.await as awaitFor
+
+            // the same bounded buffer, with the guards written onto the branches
+            int capacity = 3
+            def input = AsyncChannel.create()       // rendezvous
+            def request = AsyncChannel.create()
+            def reply = AsyncChannel.create()
+            def held = new LinkedList()
+
+            def buffer = Thread.start {
+                def sel = offers(receive(input).when { held.size() < capacity },
+                                 receive(request).when { !held.isEmpty() })
+                while (true) {
+                    try {
+                        def result = awaitFor(sel.select())
+                        if (result.index == 0) held.addLast(result.value)
+                        else awaitFor(reply.send(held.removeFirst()))
+                    } catch (ChannelClosedException e) {
+                        break
+                    }
+                }
+            }
+
+            for (i in 1..3) awaitFor(input.send(i))
+            awaitFor(request.send('next'))
+            assert awaitFor(reply.receive()) == 1
+            awaitFor(input.send(4))
+
+            for (expected in 2..4) {
+                awaitFor(request.send('next'))
+                assert awaitFor(reply.receive()) == expected
+            }
+
+            input.close(); request.close()
+            buffer.join(10_000)
+            assert !buffer.alive
+        '''
+    }
 }


### PR DESCRIPTION
…when(cond)

Offer.when(BooleanSupplier) writes the precondition onto the branch it belongs to, as occam, Ada, Erlang and Kotlin do, instead of leaving the association to the position of a flag. It returns a guarded copy, so offers stay immutable and reusable, and guards conjoin — with each other and with the flags of select(boolean...).

The condition is a supplier rather than a boolean because it is consulted once per select() call: that is what lets a guarded select be built once and reused as the state it guards on changes. A guarded-off offer is not registered on its channel and keeps its position, and a select with no enabled offer fails with IllegalStateException whether the offers were disabled by guard or by flag.