### PR TITLE
GROOVY-12337: groovy -i: keep the file's permissions across an in-pla…

### DIFF
--- a/src/main/java/groovy/ui/GroovyMain.java
+++ b/src/main/java/groovy/ui/GroovyMain.java
@@ -54,14 +54,18 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import static java.lang.System.Logger.Level.ERROR;
@@ -639,6 +643,10 @@ public class GroovyMain {
             }
         } else {
             boolean unnamedScratch = backupExtension == null || backupExtension.isEmpty();
+            // Read before the original is moved aside: the rewrite creates a new file at the same
+            // path, which would otherwise take the ambient umask and could widen access to content
+            // that was deliberately restricted. sed and perl preserve the mode for the same reason.
+            Set<PosixFilePermission> permissions = posixPermissionsOf(file.toPath());
             File backup;
             if (unnamedScratch) {
                 // unique sibling of the source: same-filesystem rename, and the
@@ -653,6 +661,7 @@ public class GroovyMain {
                     throw new IOException("unable to rename " + file + " to " + backup);
                 }
             }
+            createWithPermissions(file.toPath(), permissions);
             try (BufferedReader reader = new BufferedReader(new FileReader(backup));
                  PrintWriter writer = new PrintWriter(new FileWriter(file))) {
                 processReader(s, reader, writer);
@@ -660,6 +669,47 @@ public class GroovyMain {
             if (unnamedScratch) {
                 Files.deleteIfExists(backup.toPath());
             }
+        }
+    }
+
+    /**
+     * The POSIX permissions of an existing file, or {@code null} where the file system does not
+     * record them.
+     *
+     * @param path the file to inspect
+     * @return the permissions, or {@code null} when unavailable
+     */
+    private static Set<PosixFilePermission> posixPermissionsOf(final Path path) {
+        try {
+            return Files.getPosixFilePermissions(path);
+        } catch (IOException | UnsupportedOperationException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Creates the file that the in-place rewrite is about to fill, carrying the permissions the
+     * original had.
+     * <p>
+     * The file is created with those permissions rather than created and then adjusted, so its
+     * contents are never briefly readable by anyone the original excluded. Where permissions are
+     * unavailable, the file is left for the writer to create as before.
+     *
+     * @param path the file to create
+     * @param permissions the permissions to give it, or {@code null} to leave creation to the writer
+     * @throws IOException if the file cannot be created
+     */
+    private static void createWithPermissions(final Path path, final Set<PosixFilePermission> permissions)
+            throws IOException {
+        if (permissions == null) {
+            return;
+        }
+        try {
+            Files.createFile(path, PosixFilePermissions.asFileAttribute(permissions));
+        } catch (FileAlreadyExistsException e) {
+            Files.setPosixFilePermissions(path, permissions);
+        } catch (UnsupportedOperationException e) {
+            // no POSIX support after all; the writer creates the file
         }
     }
 

--- a/src/test/groovy/groovy/ui/GroovyMainTest.groovy
+++ b/src/test/groovy/groovy/ui/GroovyMainTest.groovy
@@ -210,6 +210,79 @@ assert new MyConcreteClass() != null"""
         }
     }
 
+    private static boolean posix() {
+        java.nio.file.FileSystems.default.supportedFileAttributeViews().contains('posix')
+    }
+
+    private static String modeOf(File f) {
+        java.nio.file.attribute.PosixFilePermissions.toString(
+            java.nio.file.Files.getPosixFilePermissions(f.toPath()))
+    }
+
+    private static void setMode(File f, String mode) {
+        java.nio.file.Files.setPosixFilePermissions(f.toPath(),
+            java.nio.file.attribute.PosixFilePermissions.fromString(mode))
+    }
+
+    // GROOVY-12337
+    @Test
+    void testInPlaceEditPreservesRestrictivePermissions() {
+        org.junit.jupiter.api.Assumptions.assumeTrue(posix())
+        def dir = File.createTempDir('groovy-main-inplace-perm-')
+        def file = new File(dir, 'secret.txt')
+        file.text = 'hello\n'
+        setMode(file, 'rw-------')
+        try {
+            GroovyMain.main('-i', '-p', '-e', 'line.toUpperCase()', file.absolutePath)
+
+            assert file.text.normalize() == 'HELLO\n'
+            // a rewrite must not widen access to content that was deliberately restricted
+            assert modeOf(file) == 'rw-------'
+        } finally {
+            dir.listFiles()?.each { it.delete() }
+            dir.delete()
+        }
+    }
+
+    // GROOVY-12337
+    @Test
+    void testInPlaceEditWithBackupExtensionPreservesPermissions() {
+        org.junit.jupiter.api.Assumptions.assumeTrue(posix())
+        def dir = File.createTempDir('groovy-main-inplace-bakperm-')
+        def file = new File(dir, 'secret.txt')
+        file.text = 'hello\n'
+        setMode(file, 'rw-------')
+        try {
+            GroovyMain.main('-i', '.bak', '-p', '-e', 'line.toUpperCase()', file.absolutePath)
+
+            assert modeOf(file) == 'rw-------'
+            // the moved-aside original keeps its own mode too
+            assert modeOf(new File(dir, 'secret.txt.bak')) == 'rw-------'
+        } finally {
+            dir.listFiles()?.each { it.delete() }
+            dir.delete()
+        }
+    }
+
+    // GROOVY-12337
+    @Test
+    void testInPlaceEditPreservesAnExecutableMode() {
+        org.junit.jupiter.api.Assumptions.assumeTrue(posix())
+        def dir = File.createTempDir('groovy-main-inplace-exec-')
+        def file = new File(dir, 'script.sh')
+        file.text = 'echo hi\n'
+        setMode(file, 'rwxr-x---')
+        try {
+            GroovyMain.main('-i', '-p', '-e', 'line.toUpperCase()', file.absolutePath)
+
+            // preserving means preserving, not just restricting
+            assert modeOf(file) == 'rwxr-x---'
+        } finally {
+            dir.listFiles()?.each { it.delete() }
+            dir.delete()
+        }
+    }
+
     @Test
     void testInPlaceEditWithBackupExtension() {
         def dir = File.createTempDir('groovy-main-inplace-bak-')


### PR DESCRIPTION
…ce edit

An in-place edit does not modify the file, it replaces it: the original is moved aside, either to a named backup or to a scratch sibling, and a new file is created at the same path. That new file took the ambient umask, so a file the user had restricted came back widened - 0600 content readable by the group and the world after a rewrite that was only meant to change its text. sed and perl preserve the mode for this reason.

The permissions are now read before the original is moved and applied to its replacement. They are applied at creation rather than afterwards, so the rewritten contents are never briefly readable by anyone the original excluded.

Preserving means preserving in both directions: an executable stays executable, not merely a private file staying private. Where the file system does not record POSIX permissions there is nothing to carry over and the writer creates the file as before.

Ownership is untouched. A process cannot in general give a file away, and the in-place edit already runs as the user who owns what it rewrites.