### PR TITLE
GROOVY-12338: StreamingSAXBuilder: reject comment and PI content that…

### DIFF
--- a/subprojects/groovy-xml/src/main/groovy/groovy/xml/StreamingSAXBuilder.groovy
+++ b/subprojects/groovy-xml/src/main/groovy/groovy/xml/StreamingSAXBuilder.groovy
@@ -33,6 +33,9 @@ class StreamingSAXBuilder extends AbstractStreamingBuilder {
 
     /** Closure backing {@code mkp.comment} for SAX handlers supporting lexical events. */
     def commentClosure = {doc, pendingNamespaces, namespaces, namespaceSpecificTags, prefix, attrs, body, contentHandler ->
+        // Checked before the handler type is consulted: a handler that is not a LexicalHandler drops
+        // the comment, and silently discarding malformed content is worse than reporting it.
+        checkCommentText(body)
         if (contentHandler instanceof LexicalHandler) {
             contentHandler.comment(body.toCharArray(), 0, body.size())
         }
@@ -41,9 +44,12 @@ class StreamingSAXBuilder extends AbstractStreamingBuilder {
     /** Closure backing {@code mkp.pi} for emitting processing instructions. */
     def piClosure = {doc, pendingNamespaces, namespaces, namespaceSpecificTags, prefix, attrs, body, contentHandler ->
         attrs.each {target, instruction ->
+            checkProcessingInstruction(target)
             if (instruction instanceof Map) {
+                // toMapStringClosure rejects '?>' in the names and values it assembles
                 contentHandler.processingInstruction(target, toMapStringClosure(instruction))
             } else {
+                checkProcessingInstruction(instruction)
                 contentHandler.processingInstruction(target, instruction)
             }
         }

--- a/subprojects/groovy-xml/src/test/groovy/groovy/xml/MarkupBuilderInjectionTest.groovy
+++ b/subprojects/groovy-xml/src/test/groovy/groovy/xml/MarkupBuilderInjectionTest.groovy
@@ -126,4 +126,64 @@ final class MarkupBuilderInjectionTest {
             new StreamingDOMBuilder().bind { mkp.comment('a -- b'); root('x') }()
         }
     }
+
+    /** Serialising SAX handler, so the emitted document can be inspected as text. */
+    private static saxHandlerTo(ByteArrayOutputStream out) {
+        def handler = javax.xml.transform.TransformerFactory.newInstance().newTransformerHandler()
+        handler.setResult(new javax.xml.transform.stream.StreamResult(out))
+        handler
+    }
+
+    // GROOVY-12338
+    @Test
+    void streamingSaxCommentRejectsCommentTerminator() {
+        assertThrows(GroovyRuntimeException) {
+            new StreamingSAXBuilder().bind { mkp.comment('legit --> <injected/>'); root('x') }(saxHandlerTo(new ByteArrayOutputStream()))
+        }
+        assertThrows(GroovyRuntimeException) {
+            new StreamingSAXBuilder().bind { mkp.comment('a -- b'); root('x') }(saxHandlerTo(new ByteArrayOutputStream()))
+        }
+        assertThrows(GroovyRuntimeException) {
+            new StreamingSAXBuilder().bind { mkp.comment('trailing hyphen-'); root('x') }(saxHandlerTo(new ByteArrayOutputStream()))
+        }
+    }
+
+    // GROOVY-12338
+    @Test
+    void streamingSaxCommentIsCheckedEvenWhenTheHandlerWouldDropIt() {
+        // a handler that is not a LexicalHandler discards comments; malformed content should still
+        // be reported rather than silently thrown away
+        def plainHandler = new org.xml.sax.helpers.DefaultHandler()
+        assertThrows(GroovyRuntimeException) {
+            new StreamingSAXBuilder().bind { mkp.comment('a -- b'); root('x') }(plainHandler)
+        }
+    }
+
+    // GROOVY-12338
+    @Test
+    void streamingSaxProcessingInstructionRejectsTerminator() {
+        assertThrows(GroovyRuntimeException) {
+            new StreamingSAXBuilder().bind { mkp.pi('xml-stylesheet': [href: 'a?><injected/>']); root('x') }(saxHandlerTo(new ByteArrayOutputStream()))
+        }
+        assertThrows(GroovyRuntimeException) {
+            new StreamingSAXBuilder().bind { mkp.pi('x?><injected/>': [href: 'a']); root('x') }(saxHandlerTo(new ByteArrayOutputStream()))
+        }
+        assertThrows(GroovyRuntimeException) {
+            new StreamingSAXBuilder().bind { mkp.pi('target': 'data?><injected/>'); root('x') }(saxHandlerTo(new ByteArrayOutputStream()))
+        }
+    }
+
+    // GROOVY-12338
+    @Test
+    void streamingSaxKeepsPlainCommentAndProcessingInstruction() {
+        def out = new ByteArrayOutputStream()
+        new StreamingSAXBuilder().bind {
+            mkp.pi('xml-stylesheet': [href: 'style.css', type: 'text/css'])
+            root { mkp.comment('plain > & < text') }
+        }(saxHandlerTo(out))
+        def result = out.toString()
+
+        assertTrue(result.contains('style.css'), result)
+        assertTrue(result.contains('plain'), result)
+    }
 }


### PR DESCRIPTION
… would break out

AbstractStreamingBuilder defines checkCommentText and checkProcessingInstruction, and StreamingMarkupBuilder and StreamingDOMBuilder both call them. StreamingSAXBuilder called neither, passing comment bodies and processing-instruction targets and data straight to the ContentHandler. Neither context supports escaping, so content carrying "-->" or "?>" closes the construct early and whatever follows is emitted as markup.

The two validators are now called here as well. The map-valued form of mkp.pi was already covered, because it is assembled by toMapStringClosure, which rejects "?>" in the names and values it writes; the gaps were the comment body, the instruction target, and the non-map instruction data.

Comment text is checked before the handler type is consulted. A handler that is not a LexicalHandler discards comments entirely, and silently discarding malformed content is worse than reporting it.

This rejects input that was previously accepted, but it was never well-formed XML: the specification forbids "--" within a comment, a comment ending in "-", and "?>" within a processing instruction. A ContentHandler need not serialise, so the check is stricter than a non-serialising sink requires; StreamingDOMBuilder, which builds a DOM rather than text, already rejects on the same grounds.