### PR TITLE
GROOVY-12339: opt the remaining serializable closures into the cycle check

### DIFF
--- a/src/main/java/groovy/lang/Closure.java
+++ b/src/main/java/groovy/lang/Closure.java
@@ -38,6 +38,7 @@ import org.codehaus.groovy.runtime.metaclass.PackedClosureMetaClass;
 
 import java.io.IOException;
 import java.io.InvalidObjectException;
+import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.io.Writer;
@@ -1360,6 +1361,30 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
         @Override
         public int getResolveStrategy() {
             return Closure.this.getResolveStrategy();
+        }
+
+        /**
+         * Reports the enclosing closure so the cycle check reaches it.
+         * <p>
+         * The constructor passes it as {@code owner} as well, so for an instance this class built
+         * the two are the same object and the walk merely meets it twice, which it tolerates. They
+         * are separate fields on the wire though, and every forwarding method above reads this one
+         * rather than {@code owner}, so a forged stream that made only this one self-referential
+         * would recurse on the first forwarded call while leaving an owner walk none the wiser.
+         */
+        @Override
+        protected Object[] additionalReferences() {
+            return new Object[]{Closure.this};
+        }
+
+        /**
+         * Rejects a deserialized closure whose references form a cycle, which would otherwise
+         * recurse indefinitely on invocation. See {@link Closure#checkForReferenceCycle}.
+         */
+        @Serial
+        private Object readResolve() throws ObjectStreamException {
+            Closure.checkForReferenceCycle(this);
+            return this;
         }
     }
 

--- a/src/main/java/org/apache/groovy/util/Closures.java
+++ b/src/main/java/org/apache/groovy/util/Closures.java
@@ -20,6 +20,7 @@ package org.apache.groovy.util;
 
 import groovy.lang.Closure;
 
+import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -157,6 +158,26 @@ public class Closures {
         public Boolean call(Object... args) {
             return test((T) args[0]);
         }
+
+        /**
+         * Exposes the wrapped Predicate, which the call methods dispatch to but which is held outside the
+         * {@code owner}/{@code delegate}/{@code thisObject} references the cycle check walks by default.
+         * Only {@code Closure}-valued links are followed, so a plain Predicate contributes nothing.
+         */
+        @Override
+        protected Object[] additionalReferences() {
+            return new Object[]{delegate};
+        }
+
+        /**
+         * Rejects a deserialized closure whose references form a cycle, which would otherwise recurse
+         * indefinitely on invocation. See {@link Closure#checkForReferenceCycle}.
+         */
+        @Serial
+        private Object readResolve() throws ObjectStreamException {
+            Closure.checkForReferenceCycle(this);
+            return this;
+        }
     }
 
     /**
@@ -191,6 +212,26 @@ public class Closures {
         @SuppressWarnings("unchecked")
         public R call(Object... args) {
             return apply((T) args[0]);
+        }
+
+        /**
+         * Exposes the wrapped Function, which the call methods dispatch to but which is held outside the
+         * {@code owner}/{@code delegate}/{@code thisObject} references the cycle check walks by
+         * default. Only {@code Closure}-valued links are followed, so a plain Function contributes nothing.
+         */
+        @Override
+        protected Object[] additionalReferences() {
+            return new Object[]{delegate};
+        }
+
+        /**
+         * Rejects a deserialized closure whose references form a cycle, which would otherwise recurse
+         * indefinitely on invocation. See {@link Closure#checkForReferenceCycle}.
+         */
+        @Serial
+        private Object readResolve() throws ObjectStreamException {
+            Closure.checkForReferenceCycle(this);
+            return this;
         }
     }
 
@@ -228,6 +269,26 @@ public class Closures {
         public Void call(Object... args) {
             accept((T) args[0]);
             return null;
+        }
+
+        /**
+         * Exposes the wrapped Consumer, which the call methods dispatch to but which is held outside the
+         * {@code owner}/{@code delegate}/{@code thisObject} references the cycle check walks by
+         * default. Only {@code Closure}-valued links are followed, so a plain Consumer contributes nothing.
+         */
+        @Override
+        protected Object[] additionalReferences() {
+            return new Object[]{delegate};
+        }
+
+        /**
+         * Rejects a deserialized closure whose references form a cycle, which would otherwise recurse
+         * indefinitely on invocation. See {@link Closure#checkForReferenceCycle}.
+         */
+        @Serial
+        private Object readResolve() throws ObjectStreamException {
+            Closure.checkForReferenceCycle(this);
+            return this;
         }
     }
 }

--- a/src/main/java/org/codehaus/groovy/runtime/memoize/Memoize.java
+++ b/src/main/java/org/codehaus/groovy/runtime/memoize/Memoize.java
@@ -20,6 +20,7 @@ package org.codehaus.groovy.runtime.memoize;
 
 import groovy.lang.Closure;
 
+import java.io.ObjectStreamException;
 import java.io.Serial;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
@@ -147,6 +148,25 @@ public abstract class Memoize {
         public V doCall(final Object... args) {
             return call(args);
         }
+
+        /**
+         * Exposes the memoized closure, which {@code call} dispatches to but which is held outside the
+         * {@code owner}/{@code delegate}/{@code thisObject} references the cycle check walks by default.
+         */
+        @Override
+        protected Object[] additionalReferences() {
+            return new Object[]{closure};
+        }
+
+        /**
+         * Rejects a deserialized closure whose references form a cycle, which would otherwise recurse
+         * indefinitely on invocation. See {@link Closure#checkForReferenceCycle}.
+         */
+        @Serial
+        private Object readResolve() throws ObjectStreamException {
+            Closure.checkForReferenceCycle(this);
+            return this;
+        }
     }
 
     private static class SoftReferenceMemoizeFunction<V> extends MemoizeFunction<V> {
@@ -187,6 +207,17 @@ public abstract class Memoize {
         private static void cleanUpNullReferences(final MemoizeCache<Object, Object> cache, final ReferenceQueue queue) {
             while(queue.poll() != null) {}  //empty the reference queue
             cache.cleanUpNullReferences();
+        }
+
+        /**
+         * Declared again rather than inherited: {@code readResolve} is private, so it is not inherited
+         * and a subclass that does not declare its own is deserialized unchecked.
+         * See {@link Closure#checkForReferenceCycle}.
+         */
+        @Serial
+        private Object readResolve() throws ObjectStreamException {
+            Closure.checkForReferenceCycle(this);
+            return this;
         }
     }
 }

--- a/src/test/groovy/groovy/lang/ClosureSerializationCycleTest.groovy
+++ b/src/test/groovy/groovy/lang/ClosureSerializationCycleTest.groovy
@@ -18,10 +18,14 @@
  */
 package groovy.lang
 
+import org.apache.groovy.util.Closures
 import org.codehaus.groovy.runtime.CurriedClosure
 import org.junit.jupiter.api.Test
 
 import java.io.InvalidObjectException
+import java.util.function.Consumer
+import java.util.function.Function
+import java.util.function.Predicate
 
 import static groovy.test.GroovyAssert.shouldFail
 
@@ -140,6 +144,68 @@ final class ClosureSerializationCycleTest {
         assert err.message.contains('additionalReferences() must not return null')
     }
 
+    // GROOVY-12339
+    @Test
+    void testWritableClosureCycleRejected() {
+        // asWritable() wraps the closure it writes through as its owner, so a forged owner cycle
+        // recurses on the first call or render
+        byte[] bytes = Holder.serializeCyclicWritable()
+        def err = shouldFail(InvalidObjectException) { deserialize(bytes) }
+        assert err.message.contains('cycle')
+    }
+
+    // GROOVY-12339
+    @Test
+    void testWritableClosureCyclicOuterRejected() {
+        byte[] bytes = Holder.serializeWritableWithCyclicOuter()
+        def err = shouldFail(InvalidObjectException) { deserialize(bytes) }
+        assert err.message.contains('cycle')
+    }
+
+    // GROOVY-12339
+    @Test
+    void testMemoizedClosureCycleRejected() {
+        // the memoized closure is held in a 'closure' field, outside the default walk
+        byte[] bytes = Holder.serializeCyclicMemoized()
+        def err = shouldFail(InvalidObjectException) { deserialize(bytes) }
+        assert err.message.contains('cycle')
+    }
+
+    // GROOVY-12339
+    @Test
+    void testSoftReferenceMemoizedClosureCycleRejected() {
+        // readResolve is private and therefore not inherited: the subclass needs its own
+        byte[] bytes = Holder.serializeCyclicSoftMemoized()
+        def err = shouldFail(InvalidObjectException) { deserialize(bytes) }
+        assert err.message.contains('cycle')
+    }
+
+    // GROOVY-12339
+    @Test
+    void testFunctionalHybridClosureCyclesRejected() {
+        // PredicateClosure/FunctionClosure/ConsumerClosure each dispatch through a 'delegate'
+        // field outside the default walk
+        ['Predicate', 'Function', 'Consumer'].each { kind ->
+            byte[] bytes = Holder."serializeCyclic${kind}Closure"()
+            def err = shouldFail(InvalidObjectException) { deserialize(bytes) }
+            assert err.message.contains('cycle'), kind
+        }
+    }
+
+    // GROOVY-12339
+    @Test
+    void testLegitimateMemoizedClosureRoundTrips() {
+        byte[] bytes = Holder.serializeMemoized()
+        assert deserialize(bytes).call(4) == 8
+    }
+
+    // GROOVY-12339
+    @Test
+    void testLegitimateFunctionalHybridRoundTrips() {
+        byte[] bytes = Holder.serializePredicateClosure()
+        assert deserialize(bytes).call(4) == true
+    }
+
     @Test
     void testLegitimateTrampolineRoundTrips() {
         byte[] bytes = Holder.serializeTrampoline()
@@ -213,6 +279,64 @@ final class ClosureSerializationCycleTest {
             def trampoline = { x -> x }.trampoline()
             setDeclaredField(trampoline, 'original', trampoline)
             serialize(trampoline)
+        }
+
+        static byte[] serializeWritableWithCyclicOuter() {
+            // the synthetic outer reference the forwarding methods read, forged to point at the
+            // wrapper itself while owner is left acyclic
+            def writable = { x -> x }.asWritable()
+            setDeclaredField(writable, 'this$0', writable)
+            serialize(writable)
+        }
+
+        static byte[] serializeCyclicWritable() {
+            def writable = { x -> x }.asWritable()
+            setDeclaredField(writable, 'owner', writable)
+            setDeclaredField(writable, 'delegate', writable)
+            serialize(writable)
+        }
+
+        static byte[] serializeMemoized() {
+            serialize({ x -> x * 2 }.memoize())
+        }
+
+        static byte[] serializeCyclicMemoized() {
+            def memoized = { x -> x * 2 }.memoize()
+            setDeclaredField(memoized, 'closure', memoized)
+            serialize(memoized)
+        }
+
+        static byte[] serializeCyclicSoftMemoized() {
+            // A real instance cannot be serialized: it holds a non-transient ReferenceQueue. A forged
+            // gadget stream is hand-written and under no such constraint, so the unserializable fields
+            // are cleared here to produce the stream an attacker would simply author.
+            def memoized = { x -> x * 2 }.memoizeAtLeast(4)
+            setDeclaredField(memoized, 'queue', null)
+            setDeclaredField(memoized, 'lruProtectionStorage', null)
+            setDeclaredField(memoized, 'closure', memoized)
+            serialize(memoized)
+        }
+
+        static byte[] serializePredicateClosure() {
+            serialize(Closures.from({ n -> n % 2 == 0 } as Predicate))
+        }
+
+        static byte[] serializeCyclicPredicateClosure() {
+            def pc = Closures.from({ n -> n % 2 == 0 } as Predicate)
+            setDeclaredField(pc, 'delegate', pc)
+            serialize(pc)
+        }
+
+        static byte[] serializeCyclicFunctionClosure() {
+            def fc = Closures.from({ n -> n * 2 } as Function)
+            setDeclaredField(fc, 'delegate', fc)
+            serialize(fc)
+        }
+
+        static byte[] serializeCyclicConsumerClosure() {
+            def cc = Closures.from({ n -> } as Consumer)
+            setDeclaredField(cc, 'delegate', cc)
+            serialize(cc)
         }
 
         static byte[] serializeCurriedOverNullRefsClosure() {


### PR DESCRIPTION
The 6.0.0 deserialization cycle check is opt-in per class, deliberately: Closure.checkForReferenceCycle is a static helper rather than a hook, because a hook would have to be protected to reach generated subclasses and would force every subclass declaring the idiomatic private readResolve to widen it. CurriedClosure, ComposedClosure, TrampolineClosure and MethodClosure opted in. Six serializable closures did not, and a forged owner cycle in any of them deserializes unchecked and recurses on first use.

WritableClosure needs only the readResolve: the closure it writes through is its owner, which the default walk already reaches. The memoize wrappers and the functional hybrids also override additionalReferences, because each dispatches through a field - closure, delegate - that the owner/delegate/thisObject walk does not see. Only Closure-valued links are followed, so a hybrid wrapping a plain lambda contributes nothing.

SoftReferenceMemoizeFunction declares its own readResolve rather than relying on its superclass, since a private readResolve is not inherited and a subclass without one is read unchecked. It cannot itself be serialized, holding a non-transient ReferenceQueue, but that does not put it out of reach: a gadget stream is authored rather than produced by serializing a live object, so the test clears those fields to write the stream an attacker would simply compose.

Closures.java is the notable case: it shipped in 6.0.0, the same release as the check, without opting in. Its three hybrids are new API rather than pre-existing classes the rollout missed.