### PR TITLE
GROOVY-12341: sync GroovyPosixCommands with JLine's control-character…

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/jline/GroovyPosixCommands.java
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/apache/groovy/groovysh/jline/GroovyPosixCommands.java
@@ -228,7 +228,7 @@ public class GroovyPosixCommands {
             if (showWords) result.append(String.format("%8d", words));
             if (showChars) result.append(String.format("%8d", chars));
             if (showBytes) result.append(String.format("%8d", bytes));
-            result.append(" ").append(source.getName());
+            result.append(" ").append(stripControlChars(source.getName()));
 
             context.out().println(result);
             context.out().flush();
@@ -302,7 +302,7 @@ public class GroovyPosixCommands {
                 if (!first) {
                     context.out().println();
                 }
-                context.out().println("==> " + nis.getName() + " <==");
+                context.out().println("==> " + stripControlChars(nis.getName()) + " <==");
             }
             doHead(context, nis.getInputStream(), nbLines, nbBytes);
             first = false;
@@ -373,7 +373,7 @@ public class GroovyPosixCommands {
         }
         for (NamedInputStream nis : sources) {
             if (filenameHeader) {
-                context.out().println("==> " + nis.getName() + " <==");
+                context.out().println("==> " + stripControlChars(nis.getName()) + " <==");
             }
             tailInputStream(context, nis.getInputStream(), lines, bytes);
         }
@@ -548,7 +548,7 @@ public class GroovyPosixCommands {
                     suffix = "@";
                     try {
                         Path l = Files.readSymbolicLink(abs);
-                        link = " -> " + l.toString();
+                        link = " -> " + stripControlChars(l.toString());
                     } catch (IOException e) {
                         // ignore
                     }
@@ -566,7 +566,7 @@ public class GroovyPosixCommands {
                     suffix = "";
                 }
                 boolean addSuffix = opt.isSet("F");
-                return applyStyle(path.toString(), colors, type) + (addSuffix ? suffix : "") + link;
+                return applyStyle(stripControlChars(path.toString()), colors, type) + (addSuffix ? suffix : "") + link;
             }
 
             /**
@@ -728,7 +728,7 @@ public class GroovyPosixCommands {
             space = true;
             Path path = currentDir.resolve(entry.path);
             if (expanded.size() > 1) {
-                out.println(currentDir.relativize(path).toString() + ":");
+                out.println(stripControlChars(currentDir.relativize(path).toString()) + ":");
             }
             try (Stream<Path> pathStream = Files.list(path)) {
                 display.accept(Stream.concat(Stream.of(".", "..").map(path::resolve), pathStream)
@@ -898,7 +898,7 @@ public class GroovyPosixCommands {
                                     if (colored) {
                                         applyStyle(sbl, colors, "fn");
                                     }
-                                    sbl.append(src.getName());
+                                    sbl.append(stripControlChars(src.getName()));
                                     if (colored) {
                                         applyStyle(sbl, colors, "se");
                                     }
@@ -942,7 +942,7 @@ public class GroovyPosixCommands {
                                 if (colored) {
                                     applyStyle(sbl, colors, "fn");
                                 }
-                                sbl.append(src.getName());
+                                sbl.append(stripControlChars(src.getName()));
                                 if (colored) {
                                     applyStyle(sbl, colors, "se");
                                 }
@@ -967,7 +967,7 @@ public class GroovyPosixCommands {
                                 if (colored) {
                                     applyStyle(sbl, colors, "fn");
                                 }
-                                sbl.append(src.getName());
+                                sbl.append(stripControlChars(src.getName()));
                                 if (colored) {
                                     applyStyle(sbl, colors, "se");
                                 }
@@ -1020,7 +1020,7 @@ public class GroovyPosixCommands {
                                 if (colored) {
                                     applyStyle(sbl, colors, "fn");
                                 }
-                                sbl.append(src.getName());
+                                sbl.append(stripControlChars(src.getName()));
                                 if (colored) {
                                     applyStyle(sbl, colors, "se");
                                 }
@@ -1228,6 +1228,31 @@ public class GroovyPosixCommands {
             }
         }
         return false;
+    }
+
+    /**
+     * Removes control characters from text that is about to be written to the terminal.
+     * <p>
+     * File names, symlink targets and the like are data supplied by whoever created them, not text
+     * the user asked to render, so an escape sequence embedded in a name would otherwise be executed
+     * by the terminal &mdash; hiding output, spoofing what is displayed, or reaching an emulator bug.
+     * <p>
+     * Ported verbatim from JLine's {@code PosixCommands} (jline#2200), which this class is derived
+     * from, so that the two stay diffable. Upstream strips rather than quoting as coreutils does; the
+     * behaviour is matched deliberately rather than improved on, because divergence here is what
+     * caused this fix to be missed in the first place.
+     */
+    private static String stripControlChars(String s) {
+        if (s == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder(s.length());
+        s.codePoints().forEach(cp -> {
+            if (!Character.isISOControl(cp)) {
+                sb.appendCodePoint(cp);
+            }
+        });
+        return sb.toString();
     }
 
     private static Set<PosixFilePermission> getPermissionsFromFile(Path f) {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/apache/groovy/groovysh/jline/GroovyPosixCommandsTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/apache/groovy/groovysh/jline/GroovyPosixCommandsTest.groovy
@@ -80,6 +80,67 @@ class GroovyPosixCommandsTest {
         new String(out.toByteArray(), StandardCharsets.UTF_8).normalize()
     }
 
+    /** A name carrying an escape sequence the terminal would otherwise act on. */
+    private static final String HOSTILE_NAME = "ok\u001B[2Ktrap.txt"
+
+    /**
+     * What the name looks like once neutralised. Stripping removes the ESC that makes the sequence a
+     * command; the printable remainder stays and is inert, which is what upstream does. Note the
+     * output legitimately contains other ESCs of its own for colour, so the assertion has to name the
+     * injected sequence rather than look for ESC in general.
+     */
+    private static final String NEUTRALISED_NAME = 'ok[2Ktrap.txt'
+
+    // GROOVY-12341
+    @Test
+    void lsStripsControlCharactersFromFileNames() {
+        Files.writeString(tempDir.resolve(HOSTILE_NAME), 'x\n')
+        GroovyPosixCommands.ls(context(), ['/ls'] as Object[])
+        def output = stdout()
+
+        assert !output.contains('\u001B[2K')
+        assert output.contains(NEUTRALISED_NAME)
+    }
+
+    // GROOVY-12341
+    @Test
+    void lsStripsControlCharactersFromSymlinkTargets() {
+        Path target = Files.writeString(tempDir.resolve(HOSTILE_NAME), 'x\n')
+        try {
+            Files.createSymbolicLink(tempDir.resolve('link.txt'), target)
+        } catch (UnsupportedOperationException | IOException ignored) {
+            return // symlinks unavailable (e.g. Windows without privilege)
+        }
+        GroovyPosixCommands.ls(context(), ['/ls', '-l'] as Object[])
+
+        assert !stdout().contains('\u001B[2K')
+    }
+
+    // GROOVY-12341
+    @Test
+    void headAndGrepAndWcStripControlCharactersFromNames() {
+        // the same treatment upstream applies to every command that echoes a source name
+        Path file = Files.writeString(tempDir.resolve(HOSTILE_NAME), 'alpha\nbeta\n')
+        Path plain = Files.writeString(tempDir.resolve('plain.txt'), 'alpha\n')
+
+        GroovyPosixCommands.head(context(), ['/head', file.toString(), plain.toString()] as Object[])
+        GroovyPosixCommands.grep(context(), ['/grep', '--color=never', 'alpha', file.toString(), plain.toString()] as Object[])
+        GroovyPosixCommands.wc(context(), ['/wc', file.toString()] as Object[])
+        def output = stdout()
+
+        assert !output.contains('\u001B[2K')
+        assert output.contains(NEUTRALISED_NAME)
+    }
+
+    // GROOVY-12341
+    @Test
+    void ordinaryNamesAreUnchanged() {
+        Files.writeString(tempDir.resolve('ordinary-name.txt'), 'x\n')
+        GroovyPosixCommands.ls(context(), ['/ls'] as Object[])
+
+        assert stdout().contains('ordinary-name.txt')
+    }
+
     @Test
     void catReadsFileContents() {
         Path file = Files.writeString(tempDir.resolve('hello.txt'), "first line\nsecond line\n")


### PR DESCRIPTION
… fix

/ls wrote file names and symlink targets into styled terminal output as they came off disk. A name is data supplied by whoever created it, not text the user asked to render, so an escape sequence embedded in one is executed by the terminal - hiding output, spoofing what is displayed, or reaching an emulator bug. coreutils and BSD ls quote such characters for this reason.

JLine fixed this upstream in 4.4.1 (jline#2200) and Groovy does not receive it: GroovyPosixCommands is a fork, and Main.posixCommand dispatches /ls, /wc, /head, /tail and /grep to it, registering JLine's implementations only so their --help text can be read. Bumping the dependency upgrades code these commands never run. The helper and its ten call sites are therefore ported here, matching upstream one for one.

Ported rather than improved on, deliberately. Upstream strips the control characters; coreutils quotes them, which preserves the distinction between two names that differ only by what was stripped. Quoting may well be better, but rewriting it here is how this file drifted far enough to miss the fix in the first place - that argument belongs upstream, where everyone would get the result.

Stripping removes the ESC that makes a sequence a command and leaves the printable remainder, which is inert; the tests assert exactly that, since the surrounding output legitimately carries escapes of its own for colour.

jline#2052, which restricts getSources to local jar: archives, is not ported: this fork has no jar: branch to restrict. The lasting fix for both is to stop forking - see the register's note on teaching upstream getSources to read a variable, which would let this file be deleted and take this patch with it.