### PR TITLE
GROOVY-12342: report, and document, values composed into batch SQL as…

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -419,9 +419,19 @@ which it holds, and what its violation would look like.
   `PreparedStatement` bind parameters rather than string concatenation, so
   the idiomatic `sql.rows("select * from p where name = $name")` is
   parameterized. *Condition:* the GString/bind APIs are used (not a
-  hand-concatenated `String`). *Violation:* a GString placeholder reaching
-  the driver as literal SQL. CWE-89. *Indicative severity if violated:
-  High.* *(documented — verified in `groovy-sql`)*
+  hand-concatenated `String`). An API qualifies when it has a GString form
+  that binds; a SQL-accepting method with no such form is outside P1, and
+  a `GString` handed to one is coerced to text like any other argument.
+  `BatchingStatementWrapper.addBatch` inside `withBatch { … }` is the case
+  in the module: a JDBC `Statement` batch may hold different statements, so
+  there is nothing to bind against and no parameterized equivalent to
+  redirect callers to. Such a surface is not a P1 violation, but the
+  absence is a hazard where the surrounding module makes GString binding
+  the norm, so it must say so in its documentation and report the coercion
+  rather than perform it silently (GROOVY-12342). *Violation:* a GString
+  placeholder reaching the driver as literal SQL *from an API that has a
+  binding GString form*. CWE-89. *Indicative severity if violated: High.*
+  *(documented — verified in `groovy-sql`)*
 - **P2 — Hardened XML parsing by default.** `XmlParser`, `XmlSlurper`,
   `XmlUtil`, and the DOM/SAX/StAX/Transformer factories created via
   `groovy.xml.FactorySupport` enable `FEATURE_SECURE_PROCESSING`, disable

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/BatchingStatementWrapper.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/BatchingStatementWrapper.java
@@ -18,6 +18,7 @@
  */
 package groovy.sql;
 
+import groovy.lang.GString;
 import groovy.lang.GroovyObjectSupport;
 import org.codehaus.groovy.runtime.ArrayGroovyMethods;
 import org.codehaus.groovy.runtime.InvokerHelper;
@@ -43,6 +44,8 @@ public class BatchingStatementWrapper extends GroovyObjectSupport implements Aut
     protected Logger log;
     /** Accumulated update counts across delegate batch executions. */
     protected List<Integer> results;
+    /** Whether the interpolation warning has already been logged for this wrapper. */
+    private boolean interpolationWarned;
 
     /**
      * Creates a batching wrapper for a statement.
@@ -80,6 +83,13 @@ public class BatchingStatementWrapper extends GroovyObjectSupport implements Aut
 
     /**
      * Adds a SQL command to the current batch.
+     * <p>
+     * The command is used as SQL text. Unlike the query methods on {@link Sql}, a {@link GString}
+     * passed here is <b>not</b> converted into {@code PreparedStatement} placeholders: a JDBC
+     * {@link Statement} batch may hold different statements, so there is nothing to bind against.
+     * Interpolating an untrusted value therefore composes it into the SQL. To bind values, batch
+     * against a single statement with {@link Sql#withBatch(String, groovy.lang.Closure)}, whose
+     * wrapper takes parameters rather than text.
      *
      * @param sql the SQL command to add
      * @throws SQLException if the command cannot be added
@@ -87,6 +97,85 @@ public class BatchingStatementWrapper extends GroovyObjectSupport implements Aut
     public void addBatch(String sql) throws SQLException {
         delegate.addBatch(sql);
         incrementBatchCount();
+    }
+
+    /**
+     * Adds a SQL command to the current batch, composed from a {@link GString}.
+     * <p>
+     * Present so the coercion is visible rather than silent: the {@code GString} is rendered to text
+     * and added as SQL, and a warning is logged the first time this happens with an interpolated
+     * value that is not a {@link Sql#expand deliberate expansion}. It is not rejected, because a
+     * {@link Statement} batch has no parameterised equivalent to redirect callers to &mdash; batching
+     * heterogeneous statements, generated DDL or identifiers that cannot be bound are all legitimate
+     * uses of this method.
+     *
+     * @param sql the SQL command to add
+     * @throws SQLException if the command cannot be added
+     * @since 6.0.0
+     */
+    public void addBatch(GString sql) throws SQLException {
+        warnIfInterpolated(sql);
+        addBatch(render(sql));
+    }
+
+    /**
+     * Renders the command to text, substituting the value behind any {@link Sql#expand deliberate
+     * expansion} rather than the marker object itself, as {@link Sql#asSql} does. A command with no
+     * expansions renders exactly as the {@code GString} would on its own, leaving the long-standing
+     * behaviour of this method untouched.
+     *
+     * @param sql the command to render
+     * @return the SQL text
+     */
+    private static String render(GString sql) {
+        Object[] values = sql.getValues();
+        boolean expanded = false;
+        for (Object value : values) {
+            if (value instanceof ExpandedVariable) {
+                expanded = true;
+                break;
+            }
+        }
+        if (!expanded) {
+            return sql.toString();
+        }
+        String[] strings = sql.getStrings();
+        StringBuilder buffer = new StringBuilder();
+        for (int i = 0; i < strings.length; i++) {
+            buffer.append(strings[i]);
+            if (i < values.length) {
+                Object value = values[i];
+                buffer.append(value instanceof ExpandedVariable ? ((ExpandedVariable) value).getObject() : value);
+            }
+        }
+        return buffer.toString();
+    }
+
+    /**
+     * Logs, at most once per wrapper, that a value has been composed into batch SQL as text.
+     * <p>
+     * Mirrors what {@link Sql#asSql} does when it inlines rather than binds: wherever Groovy puts a
+     * dynamic value into SQL text, it says so. A {@code GString} with no values, or whose values are
+     * all {@link ExpandedVariable}, is deliberate and passes quietly.
+     *
+     * @param sql the command being added
+     */
+    private void warnIfInterpolated(GString sql) {
+        if (interpolationWarned) {
+            return;
+        }
+        for (Object value : sql.getValues()) {
+            if (!(value instanceof ExpandedVariable)) {
+                log.warning("A dynamic expression (one starting with $) was composed into batch SQL as text. " +
+                        "A JDBC Statement batch cannot bind parameters, so the value is part of the statement " +
+                        "and an untrusted value here is a SQL injection vulnerability. To bind values, batch " +
+                        "against a single statement using Sql.withBatch(String, Closure). If the interpolation " +
+                        "is deliberate, wrap the value in Sql.expand(...) to say so and silence this warning. " +
+                        "The statement so far is: " + sql);
+                interpolationWarned = true;
+                return;
+            }
+        }
     }
 
     /**

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
@@ -183,6 +183,14 @@ import static org.apache.groovy.sql.extensions.SqlExtensions.toRowResult;
  * <code>sql.firstRow("select * from PersonTable where SurnameColumn = $userInput")</code>
  * or the named parameter variants discussed next.
  * <p>
+ * That conversion belongs to the query methods on this class. It does <b>not</b> apply to
+ * {@link groovy.sql.BatchingStatementWrapper#addBatch(String) addBatch} inside
+ * <code>withBatch { ... }</code>: a JDBC <code>Statement</code> batch may hold different statements,
+ * so there is nothing to bind against and the command is used as SQL text. An interpolated value
+ * there is composed into the statement, and Groovy logs a warning saying so. To bind values in a
+ * batch, batch against a single statement with {@link #withBatch(String, Closure)}, whose wrapper
+ * takes parameters instead of text.
+ * <p>
  * When using the GString variants, do <b>not</b> surround an interpolated expression with SQL quotes,
  * e.g. <code>sql.firstRow("select * from PersonTable where SurnameColumn = '$userInput'")</code>.
  * Such quoting prevents Groovy from using a JDBC PreparedStatement placeholder for the value and would
@@ -4152,6 +4160,12 @@ public class Sql implements AutoCloseable {
      * }
      * </pre>
      *
+     * <p>
+     * The commands added inside the closure are used as SQL <b>text</b>. A GString interpolated
+     * there is composed into the statement rather than bound, because a JDBC <code>Statement</code>
+     * batch may hold different statements and so has nothing to bind against; Groovy logs a warning
+     * when that happens. Use {@link #withBatch(String, Closure)} to bind values instead.
+     *
      * @param closure the closure containing batch and optionally other statements
      * @return an array of update counts containing one element for each
      *         command in the batch.  The elements of the array are ordered according
@@ -4195,6 +4209,12 @@ public class Sql implements AutoCloseable {
      *     ...
      * }
      * </pre>
+     *
+     * <p>
+     * The commands added inside the closure are used as SQL <b>text</b>. A GString interpolated
+     * there is composed into the statement rather than bound, because a JDBC <code>Statement</code>
+     * batch may hold different statements and so has nothing to bind against; Groovy logs a warning
+     * when that happens. Use {@link #withBatch(String, Closure)} to bind values instead.
      *
      * @param batchSize partition the batch into batchSize pieces, i.e. after batchSize
      *                  <code>addBatch()</code> invocations, call <code>executeBatch()</code> automatically;

--- a/subprojects/groovy-sql/src/test/groovy/groovy/sql/SqlBatchInterpolationTest.groovy
+++ b/subprojects/groovy-sql/src/test/groovy/groovy/sql/SqlBatchInterpolationTest.groovy
@@ -1,0 +1,129 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.sql
+
+import groovy.test.GroovyTestCase
+
+import javax.sql.DataSource
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+
+import static groovy.sql.SqlTestConstants.DB_DATASOURCE
+import static groovy.sql.SqlTestConstants.DB_DS_KEY
+import static groovy.sql.SqlTestConstants.DB_PASSWORD
+import static groovy.sql.SqlTestConstants.DB_URL_PREFIX
+import static groovy.sql.SqlTestConstants.DB_USER
+
+/**
+ * A JDBC Statement batch may hold different statements, so it has nothing to bind against and
+ * addBatch takes SQL text. A GString interpolated there is composed into the statement rather than
+ * bound - unlike every query method on Sql. That is not rejected, because heterogeneous batches,
+ * generated DDL and identifiers that cannot be bound are legitimate uses with no parameterised
+ * equivalent, but it is reported so it is not silent.
+ */
+class SqlBatchInterpolationTest extends GroovyTestCase {
+
+    Sql sql
+    private Logger logger
+    private List<LogRecord> records
+    private Handler handler
+
+    void setUp() {
+        DataSource ds = DB_DATASOURCE.newInstance(
+                (DB_DS_KEY): DB_URL_PREFIX + getMethodName(),
+                user: DB_USER, password: DB_PASSWORD)
+        sql = new Sql(ds.connection)
+        sql.execute('CREATE TABLE person ( id INTEGER, firstname VARCHAR(10), PRIMARY KEY (id))')
+
+        records = []
+        handler = new Handler() {
+            void publish(LogRecord r) { records << r }
+            void flush() {}
+            void close() {}
+        }
+        logger = Logger.getLogger('groovy.sql.Sql')
+        logger.addHandler(handler)
+    }
+
+    void tearDown() {
+        logger?.removeHandler(handler)
+        sql?.close()
+    }
+
+    private List<String> warnings() {
+        records.findAll { it.level == Level.WARNING }*.message
+    }
+
+    // GROOVY-12342
+    void testInterpolatedValueIsReportedNotRejected() {
+        def name = "Jean"
+        def result = sql.withBatch { stmt ->
+            stmt.addBatch("insert into PERSON (id, firstname) values (1, '$name')")
+        }
+
+        // the statement still runs: this is a warning, not a rejection
+        assert result == [1]
+        assert sql.rows('SELECT * FROM PERSON').size() == 1
+        assert warnings().any { it.contains('composed into batch SQL as text') }
+    }
+
+    // GROOVY-12342
+    void testWarningIsLoggedOncePerBatch() {
+        sql.withBatch { stmt ->
+            (1..3).each { i -> stmt.addBatch("insert into PERSON (id, firstname) values ($i, 'n$i')") }
+        }
+
+        assert warnings().count { it.contains('composed into batch SQL as text') } == 1
+    }
+
+    // GROOVY-12342
+    void testConstantSqlIsNotReported() {
+        sql.withBatch { stmt ->
+            stmt.addBatch("insert into PERSON (id, firstname) values (1, 'fixed')")
+        }
+
+        assert warnings().findAll { it.contains('composed into batch SQL as text') }.isEmpty()
+    }
+
+    // GROOVY-12342
+    void testDeliberateExpansionIsNotReported() {
+        // Sql.expand marks interpolation the caller meant, as it does for the query methods
+        def table = Sql.expand('PERSON')
+        sql.withBatch { stmt ->
+            stmt.addBatch("insert into $table (id, firstname) values (1, 'fixed')")
+        }
+
+        assert sql.rows('SELECT * FROM PERSON').size() == 1
+        assert warnings().findAll { it.contains('composed into batch SQL as text') }.isEmpty()
+    }
+
+    // GROOVY-12342
+    void testParameterisedBatchRemainsTheBindingForm() {
+        // withBatch(sql, closure) binds, and says nothing
+        def result = sql.withBatch('insert into PERSON (id, firstname) values (?, ?)') { ps ->
+            ps.addBatch([1, 'Jean'])
+            ps.addBatch([2, 'Lino'])
+        }
+
+        assert result == [1, 1]
+        assert warnings().findAll { it.contains('composed into batch SQL as text') }.isEmpty()
+    }
+}


### PR DESCRIPTION
… text

Inside withBatch { ... } the wrapper's only SQL-accepting method takes a String, so a GString handed to it is coerced and its values become part of the statement. Every query method on Sql binds the same idiom, and the class documentation said so without qualification, so the one surface where it does not hold read exactly like the ones where it does.

It is documented rather than rejected. A JDBC Statement batch may hold different statements, which is why it takes text and has nothing to bind against, and there is no parameterized equivalent to send callers to: batching heterogeneous statements, generated DDL, and identifiers that cannot be bound are all legitimate here. The module's own SqlBatchTest uses this idiom. Rejecting would remove a capability with no replacement, which is the same test applied to the quoted-expression case that is rejected precisely because removing the quotes costs nothing.

So: an addBatch(GString) overload that renders and adds the command as before, and logs once per batch when a value was composed in that was not marked with Sql.expand. That mirrors asSql, which warns whenever it inlines rather than binds; the difference is that inlining is the only option here, so there is no strict mode to fall back from. Deliberate interpolation marked with Sql.expand passes quietly and now substitutes the expanded value, which plain GString rendering did not do.

The documentation is the substance of the fix: the class-level guidance now carries the exception, both withBatch forms that hand out this wrapper say the commands are text, and addBatch says it on the method itself.

P1 gains the rule that settles the finding's disposition: an API qualifies when it has a GString form that binds, so this surface is outside P1 rather than violating it, and the obligation is to say so and report the coercion.