### PR TITLE
GROOVY-12343: AsyncChannel.after: a timer channel as a select branch

### DIFF
--- a/src/main/java/groovy/concurrent/AsyncChannel.java
+++ b/src/main/java/groovy/concurrent/AsyncChannel.java
@@ -21,7 +21,11 @@ package groovy.concurrent;
 import org.apache.groovy.runtime.async.AsyncSupport;
 import org.apache.groovy.runtime.async.DefaultAsyncChannel;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -72,6 +76,63 @@ public interface AsyncChannel<T> extends Iterable<T> {
      */
     static <T> AsyncChannel<T> create(int capacity) {
         return new DefaultAsyncChannel<>(capacity);
+    }
+
+    /**
+     * Creates a timer channel: a capacity-1 channel that delivers a single
+     * value, the {@link Instant} at which it fired, once {@code millis} has
+     * elapsed from this call, and then closes.
+     * <p>
+     * Its purpose is to make a deadline a branch of a {@link ChannelSelect},
+     * the way Go's {@code time.After} does, rather than an exception thrown
+     * around the whole select by {@link Awaitable#orTimeout(long, TimeUnit)}:
+     * <pre>{@code
+     * def result = await ChannelSelect.from(work, AsyncChannel.after(100)).select()
+     * if (result.index == 1) {
+     *     // timed out: result.value is the Instant the timer fired
+     * }
+     * }</pre>
+     * As a channel, a timer composes with everything a select offers: several
+     * timers give per-branch deadlines, a timer may be guarded with
+     * {@link ChannelSelect.Offer#when}, and {@link ChannelSelect#fair()} and
+     * {@link ChannelSelect#random()} treat it like any other ready branch.
+     * <p>
+     * The clock starts now, not at the first receive, so a timer created
+     * once and reused across selects is a fixed deadline shared by every
+     * round. For a per-round timeout that re-arms on each call of a select
+     * that is held and reused, use the timer offer
+     * {@link ChannelSelect#after(long)} instead. A timer that loses a select keeps
+     * its value: it fires all the same and holds the instant until received.
+     * Once the value has been taken, further receives fail with
+     * {@link ChannelClosedException} rather than waiting forever, and
+     * {@link #isClosed()} reports that the timer has fired. Closing a timer
+     * before it fires cancels it. A delay that is not positive has already
+     * elapsed, so the channel is returned already holding its instant: it
+     * is ready at once, which suits a deadline computed from an absolute
+     * time that has already passed.
+     *
+     * @param millis how long to wait before firing, in milliseconds
+     * @return a channel that delivers the firing instant and then closes
+     * @see #after(Duration)
+     * @see ChannelSelect
+     * @since 6.0.0
+     */
+    static AsyncChannel<Instant> after(long millis) {
+        return DefaultAsyncChannel.after(millis, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Creates a timer channel that fires once {@code duration} has elapsed;
+     * see {@link #after(long)}.
+     *
+     * @param duration how long to wait before firing
+     * @return a channel that delivers the firing instant and then closes
+     * @throws NullPointerException if duration is null
+     * @since 6.0.0
+     */
+    static AsyncChannel<Instant> after(Duration duration) {
+        Objects.requireNonNull(duration, "duration must not be null");
+        return DefaultAsyncChannel.after(duration.toNanos(), TimeUnit.NANOSECONDS);
     }
 
     /** Returns this channel's buffer capacity. */

--- a/src/main/java/groovy/concurrent/ChannelSelect.java
+++ b/src/main/java/groovy/concurrent/ChannelSelect.java
@@ -22,12 +22,15 @@ import org.apache.groovy.runtime.async.DefaultAsyncChannel;
 import org.apache.groovy.runtime.async.GroovyPromise;
 import org.apache.groovy.runtime.async.SelectClaim;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 
@@ -84,6 +87,23 @@ import java.util.function.BooleanSupplier;
  *                           receive(request).when { size > 0 }).select()
  * }</pre>
  * <p>
+ * A deadline is just another branch. The timer offer {@link #after(long)}
+ * arms a fresh timer on every {@link #select()} call, so a select held
+ * across rounds waits for work, but not forever, and keeps its choice
+ * policy state while it does:
+ *
+ * <pre>{@code
+ * def sel = offers(receive(work), after(100)).fair()
+ * while (true) {
+ *     def result = await sel.select()
+ *     if (result.timeout) { ... nothing arrived this round ... }
+ * }
+ * }</pre>
+ *
+ * For a fixed deadline across rounds, receive from a timer channel
+ * instead: {@link AsyncChannel#after(long)} starts its clock when it is
+ * created and delivers the instant it fired.
+ * <p>
  * Inspired by GPars' {@code Select} and Go's {@code select} statement
  * (whose send cases these offers mirror).
  *
@@ -94,15 +114,21 @@ public final class ChannelSelect {
     /** How to choose when several offers are ready at the same time. */
     private enum Policy { PRIORITY, FAIR, RANDOM }
 
+    /** What an offer does when it commits. */
+    private enum Kind { SEND, RECEIVE, TIMER }
+
     private final List<Offer> offers;
     private final Policy policy;
     /** index of the last winner; only maintained under {@link Policy#FAIR} */
     private final AtomicInteger lastWinner;
+    /** how many offers are timers, so a select without any allocates nothing for them */
+    private final int timerCount;
 
     private ChannelSelect(List<Offer> offers, Policy policy) {
         this.offers = offers;
         this.policy = policy;
         this.lastWinner = policy == Policy.FAIR ? new AtomicInteger(-1) : null;
+        this.timerCount = (int) offers.stream().filter(o -> o.kind == Kind.TIMER).count();
     }
 
     /**
@@ -166,7 +192,7 @@ public final class ChannelSelect {
         if (!(channel instanceof DefaultAsyncChannel)) {
             throw new IllegalArgumentException("send offers require a channel created by AsyncChannel.create");
         }
-        return new Offer(channel, value, true, null);
+        return new Offer(channel, value, Kind.SEND, 0, null);
     }
 
     /**
@@ -180,7 +206,67 @@ public final class ChannelSelect {
      */
     public static Offer receive(AsyncChannel<?> channel) {
         Objects.requireNonNull(channel, "channel must not be null");
-        return new Offer(channel, null, false, null);
+        return new Offer(channel, null, Kind.RECEIVE, 0, null);
+    }
+
+    /**
+     * An offer that commits once {@code millis} has elapsed from the start
+     * of the {@link #select()} call it takes part in: a timeout as a branch
+     * of the choice, rather than an exception thrown around it by
+     * {@link Awaitable#orTimeout(long, TimeUnit)}. It commits with the
+     * {@link Instant} at which it fired.
+     * <p>
+     * Semantically it is a receive from a timer channel that the select
+     * creates and, if the offer loses, cancels on every call — the
+     * difference from {@code receive(AsyncChannel.after(millis))}, whose
+     * clock starts once, when the channel is created. The timer offer is
+     * therefore the "wait for work, but not forever" branch of a select
+     * that is held and reused, where it re-arms each round while the
+     * instance keeps its {@link #fair()} rotation. The channel form is
+     * the fixed deadline shared by every round. Like any other offer it
+     * may be guarded with {@link Offer#when}; a guarded-off timer offer
+     * arms nothing.
+     * <p>
+     * A timer offer with a positive delay is never ready at the moment of
+     * registration, so among offers that are ready at once the choice
+     * policy considers only the channel offers; the timer commits only when
+     * no channel offer could before it fired. A delay that is not positive
+     * has already elapsed, so that offer is ready at registration and takes
+     * part in the choice among ready offers like any other: under the
+     * default priority it wins if listed before every ready channel offer
+     * and loses to one listed before it, and {@link #fair()} rotates over it.
+     * Listed last, {@code after(0)} is therefore the {@code default} clause
+     * of Go's {@code select}: take a transfer if one can complete at once,
+     * otherwise proceed without waiting.
+     *
+     * <pre>{@code
+     * def result = await offers(receive(work), after(0)).select()
+     * if (result.timeout) { ... nothing was ready ... }
+     * }</pre>
+     *
+     * @param millis how long to wait, in milliseconds, from the start of
+     *               each select call
+     * @return the timer offer
+     * @see #after(Duration)
+     * @see Result#isTimeout()
+     * @since 6.0.0
+     */
+    public static Offer after(long millis) {
+        return new Offer(null, null, Kind.TIMER, TimeUnit.MILLISECONDS.toNanos(millis), null);
+    }
+
+    /**
+     * An offer that commits once {@code duration} has elapsed from the
+     * start of the select call it takes part in; see {@link #after(long)}.
+     *
+     * @param duration how long to wait from the start of each select call
+     * @return the timer offer
+     * @throws NullPointerException if duration is null
+     * @since 6.0.0
+     */
+    public static Offer after(Duration duration) {
+        Objects.requireNonNull(duration, "duration must not be null");
+        return new Offer(null, null, Kind.TIMER, duration.toNanos(), null);
     }
 
     /**
@@ -242,7 +328,9 @@ public final class ChannelSelect {
      * result (for example through
      * {@link Awaitable#orTimeout(long, java.util.concurrent.TimeUnit)})
      * withdraws the pending offers, so a timed-out select consumes nothing
-     * and sends nothing.
+     * and sends nothing. To take a timeout as a branch instead of an
+     * exception, add a timer offer from {@link #after(long)} or receive
+     * from a timer channel from {@link AsyncChannel#after(long)}.
      * <p>
      * If every offer's channel is closed, the result fails with
      * {@link ChannelClosedException}. If every offer is guarded off (see
@@ -318,6 +406,8 @@ public final class ChannelSelect {
         Winner winner = new Winner();
         AtomicInteger closedCount = new AtomicInteger();
         Awaitable<?>[] branches = new Awaitable<?>[offers.size()];
+        // the timers armed for this call, closed (and so cancelled) with the losers
+        AsyncChannel<?>[] timers = timerCount == 0 ? null : new AsyncChannel<?>[offers.size()];
 
         // a ready offer completes synchronously during registration, so the
         // registration order is the priority order: rotate it under fair(),
@@ -326,23 +416,28 @@ public final class ChannelSelect {
         for (int k = 0; k < count && !winner.isDone(); k++) {
             final int index = order[k];
             final Offer offer = offers.get(index);
-            AsyncChannel<?> ch = offer.channel;
+            final boolean timer = offer.kind == Kind.TIMER;
+            final AsyncChannel<?> ch = timer
+                    ? DefaultAsyncChannel.after(offer.delayNanos, TimeUnit.NANOSECONDS)
+                    : offer.channel;
             final boolean claimable = ch instanceof DefaultAsyncChannel;
             @SuppressWarnings("unchecked")
-            Awaitable<?> branch = offer.send
+            Awaitable<?> branch = offer.kind == Kind.SEND
                     ? ((DefaultAsyncChannel<Object>) ch).sendIfUnclaimed(offer.value, winner.claim)
                     : claimable
                         ? ((DefaultAsyncChannel<?>) ch).receiveIfUnclaimed(winner.claim)
                         : ch.receive();
             branches[index] = branch;
+            if (timer) timers[index] = ch;
             CompletableFuture<?> future = branch.toCompletableFuture();
             future.whenComplete((value, error) -> {
                 if (error == null) {
                     // a claimable channel committed the claim as it completed; any
                     // other channel has consumed a value and must compete for it now
                     if (claimable || winner.claim.tryCommit(future)) {
-                        withdraw(branches); // losers registered so far, before the caller sees the result
-                        winner.complete(new Result(index, offer.send ? offer.value : value, offer.send, ch)); // holding the claim, this cannot fail
+                        withdraw(branches, timers); // losers registered so far, before the caller sees the result
+                        winner.complete(new Result(index, offer.kind == Kind.SEND ? offer.value : value,
+                                offer.kind, timer ? null : ch)); // holding the claim, this cannot fail
                     } else {
                         resend(ch, value);
                     }
@@ -353,7 +448,7 @@ public final class ChannelSelect {
         }
         // branches registered after the win, and cancellation of the result itself
         winner.whenComplete((result, error) -> {
-            withdraw(branches);
+            withdraw(branches, timers);
             if (result != null && lastWinner != null) lastWinner.set(result.index);
         });
         return GroovyPromise.of(winner);
@@ -405,9 +500,23 @@ public final class ChannelSelect {
         return (enabled == null || enabled[index]) && offers.get(index).isEnabled();
     }
 
-    private static void withdraw(Awaitable<?>[] branches) {
+    /**
+     * Withdraws every registered branch, and closes every timer armed for
+     * the call so its scheduled firing is cancelled. Branches go first: a
+     * timer's receive is then already cancelled when the close would fail
+     * it, so the close counts no spurious closed branch. Closing takes the
+     * timer's lock, which is safe from inside another channel's delivery
+     * because a firing timer does only lock-free work while it holds it and
+     * never takes another channel's lock.
+     */
+    private static void withdraw(Awaitable<?>[] branches, AsyncChannel<?>[] timers) {
         for (Awaitable<?> branch : branches) {
             if (branch != null) branch.cancel();
+        }
+        if (timers != null) {
+            for (AsyncChannel<?> timer : timers) {
+                if (timer != null) timer.close();
+            }
         }
     }
 
@@ -419,23 +528,27 @@ public final class ChannelSelect {
 
     /**
      * One branch of a select: an input guard created by
-     * {@link #receive(AsyncChannel)}, or an output guard created by
-     * {@link #send(AsyncChannel, Object)}. Immutable and freely reusable
-     * across selects.
+     * {@link #receive(AsyncChannel)}, an output guard created by
+     * {@link #send(AsyncChannel, Object)}, or a timeout created by
+     * {@link #after(long)}. Immutable and freely reusable across selects.
      *
      * @since 6.0.0
      */
     public static final class Offer {
+        /** the channel operated on, or {@code null} for a timer */
         private final AsyncChannel<?> channel;
         private final Object value;
-        private final boolean send;
+        private final Kind kind;
+        /** the timer delay; meaningful only when {@link #kind} is {@link Kind#TIMER} */
+        private final long delayNanos;
         /** the guard, or {@code null} when the offer is unconditional */
         private final BooleanSupplier guard;
 
-        private Offer(AsyncChannel<?> channel, Object value, boolean send, BooleanSupplier guard) {
+        private Offer(AsyncChannel<?> channel, Object value, Kind kind, long delayNanos, BooleanSupplier guard) {
             this.channel = channel;
             this.value = value;
-            this.send = send;
+            this.kind = kind;
+            this.delayNanos = delayNanos;
             this.guard = guard;
         }
 
@@ -473,7 +586,7 @@ public final class ChannelSelect {
         public Offer when(BooleanSupplier condition) {
             Objects.requireNonNull(condition, "condition must not be null");
             BooleanSupplier outer = guard;
-            return new Offer(channel, value, send,
+            return new Offer(channel, value, kind, delayNanos,
                     outer == null ? condition : () -> outer.getAsBoolean() && condition.getAsBoolean());
         }
 
@@ -507,21 +620,23 @@ public final class ChannelSelect {
     public static final class Result {
         private final int index;
         private final Object value;
-        private final boolean send;
+        private final Kind kind;
         private final AsyncChannel<?> channel;
 
         /**
          * Creates a selection result.
          *
          * @param index   the zero-based index of the committed offer
-         * @param value   the received value, or the sent value for a send offer
-         * @param send    whether the committed offer was a send
-         * @param channel the channel the committed offer transferred over
+         * @param value   the received value, the sent value for a send offer,
+         *                or the firing instant for a timer offer
+         * @param kind    what the committed offer did
+         * @param channel the channel the committed offer transferred over, or
+         *                {@code null} for a timer offer
          */
-        Result(int index, Object value, boolean send, AsyncChannel<?> channel) {
+        Result(int index, Object value, Kind kind, AsyncChannel<?> channel) {
             this.index = index;
             this.value = value;
-            this.send = send;
+            this.kind = kind;
             this.channel = channel;
         }
 
@@ -532,16 +647,22 @@ public final class ChannelSelect {
          * The channel the committed offer transferred over: the one received
          * from, or the one sent to. Lets a branch be recognised by identity
          * rather than by position, which suits a select whose offers are
-         * assembled dynamically.
+         * assembled dynamically. A timer offer transfers over no channel of
+         * the caller's, so for a timeout this is {@code null}: a select that
+         * carries a timer offer and dispatches on the channel must test
+         * {@link #isTimeout()} first, and dereference the channel only when
+         * that is {@code false}.
          *
-         * @return the winning channel
+         * @return the winning channel, or {@code null} for a timeout
+         * @see #isTimeout()
          * @since 6.0.0
          */
-        public AsyncChannel<?> getChannel() { return channel; }
+        public /*@Nullable*/ AsyncChannel<?> getChannel() { return channel; }
 
         /**
          * The transferred value: what arrived, for a receive offer; what was
-         * sent, for a send offer.
+         * sent, for a send offer; the {@link Instant} it fired, for a timer
+         * offer.
          */
         @SuppressWarnings("unchecked")
         public <T> T getValue() { return (T) value; }
@@ -551,7 +672,16 @@ public final class ChannelSelect {
          *
          * @since 6.0.0
          */
-        public boolean isSend() { return send; }
+        public boolean isSend() { return kind == Kind.SEND; }
+
+        /**
+         * Whether the committed offer was a timer created by
+         * {@link ChannelSelect#after(long)}: the select timed out, and
+         * {@link #getValue()} is the instant at which it did.
+         *
+         * @since 6.0.0
+         */
+        public boolean isTimeout() { return kind == Kind.TIMER; }
 
         /**
          * Returns a diagnostic representation of this selection result.
@@ -560,7 +690,11 @@ public final class ChannelSelect {
          */
         @Override
         public String toString() {
-            return "SelectResult[" + (send ? "sent to channel=" : "channel=") + index + ", value=" + value + "]";
+            return switch (kind) {
+                case SEND -> "SelectResult[sent to channel=" + index + ", value=" + value + "]";
+                case RECEIVE -> "SelectResult[channel=" + index + ", value=" + value + "]";
+                case TIMER -> "SelectResult[timeout=" + index + ", at=" + value + "]";
+            };
         }
     }
 }

--- a/src/main/java/org/apache/groovy/runtime/async/AsyncExecutors.java
+++ b/src/main/java/org/apache/groovy/runtime/async/AsyncExecutors.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -86,12 +87,7 @@ final class AsyncExecutors {
     private static final AtomicReference<Executor> defaultExecutor =
             new AtomicReference<>(createDefaultExecutor());
 
-    private static final ScheduledExecutorService SCHEDULER =
-            Executors.newSingleThreadScheduledExecutor(r -> {
-                Thread t = new Thread(r, "groovy-async-scheduler");
-                t.setDaemon(true);
-                return t;
-            });
+    private static final ScheduledExecutorService SCHEDULER = createScheduler();
 
     private AsyncExecutors() { }
 
@@ -121,6 +117,24 @@ final class AsyncExecutors {
 
     private static Executor createDefaultExecutor() {
         return VIRTUAL_THREADS_AVAILABLE ? VIRTUAL_THREAD_EXECUTOR : FALLBACK_EXECUTOR;
+    }
+
+    /**
+     * A single daemon scheduler thread. Cancelled tasks are removed from
+     * the delay queue at once rather than on expiry: a timeout that its task
+     * beat, or a timer branch of a select that lost its round, otherwise
+     * leaves a stale entry queued for the whole of its delay, and a busy
+     * loop with long deadlines would accumulate them. The handle is
+     * unconfigurable, as the {@link Executors} factory's is.
+     */
+    private static ScheduledExecutorService createScheduler() {
+        ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(1, r -> {
+            Thread t = new Thread(r, "groovy-async-scheduler");
+            t.setDaemon(true);
+            return t;
+        });
+        scheduler.setRemoveOnCancelPolicy(true);
+        return Executors.unconfigurableScheduledExecutorService(scheduler);
     }
 
     private static int getIntegerSafe(String name, int defaultValue) {

--- a/src/main/java/org/apache/groovy/runtime/async/DefaultAsyncChannel.java
+++ b/src/main/java/org/apache/groovy/runtime/async/DefaultAsyncChannel.java
@@ -23,6 +23,7 @@ import groovy.concurrent.Awaitable;
 import groovy.concurrent.ChannelClosedException;
 import groovy.transform.Internal;
 
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
@@ -30,6 +31,8 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -66,6 +69,8 @@ public final class DefaultAsyncChannel<T> implements AsyncChannel<T> {
     private final Deque<PendingOp<T>> waitingReceivers = new ConcurrentLinkedDeque<>();
     private final int capacity;
     private volatile boolean closed;
+    /** run once, outside the lock, by the call that closes the channel; {@code null} for none */
+    private volatile Runnable onClose;
 
     public DefaultAsyncChannel() {
         this(0);
@@ -76,6 +81,41 @@ public final class DefaultAsyncChannel<T> implements AsyncChannel<T> {
             throw new IllegalArgumentException("channel capacity must not be negative: " + capacity);
         }
         this.capacity = capacity;
+    }
+
+    /**
+     * Creates a timer channel: a capacity-1 channel that delivers one value,
+     * the {@link Instant} at which it fired, once {@code delay} has elapsed
+     * from this call, and then closes. Closing the channel before it fires
+     * cancels the timer, so a timer that is no longer wanted holds no
+     * scheduler slot. A delay that is not positive has already elapsed, so
+     * the channel is returned already holding its instant and closed: it is
+     * ready to a receiver or a select at once, with no scheduler hop.
+     * <p>
+     * Implementation of {@link AsyncChannel#after(long)}; not part of the
+     * channel contract.
+     *
+     * @param delay how long to wait before firing
+     * @param unit  the unit of {@code delay}
+     * @return the timer channel
+     */
+    @Internal
+    public static DefaultAsyncChannel<Instant> after(long delay, TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit must not be null");
+        DefaultAsyncChannel<Instant> timer = new DefaultAsyncChannel<>(1);
+        if (delay <= 0) {
+            timer.send(Instant.now());
+            timer.close();
+            return timer;
+        }
+        ScheduledFuture<?> firing = AsyncExecutors.getScheduler().schedule(() -> {
+            // the only sender into a capacity-1 buffer: the send buffers or
+            // delivers at once, never parks, and only fails if already closed
+            timer.send(Instant.now());
+            timer.close();
+        }, delay, unit);
+        timer.onClose = () -> firing.cancel(false);
+        return timer;
     }
 
     // ---- Query ----------------------------------------------------------
@@ -251,11 +291,13 @@ public final class DefaultAsyncChannel<T> implements AsyncChannel<T> {
             for (PendingSend<T> sender; (sender = waitingSenders.pollFirst()) != null; ) {
                 sender.completion.completeExceptionally(closedForSend());
             }
-
-            return true;
         } finally {
             lock.unlock();
         }
+
+        Runnable hook = onClose;
+        if (hook != null) hook.run();
+        return true;
     }
 
     // ---- Iterable (for await / for loop) --------------------------------

--- a/src/spec/doc/_core-async-channels.adoc
+++ b/src/spec/doc/_core-async-channels.adoc
@@ -240,6 +240,94 @@ branch at all is a deadlock rather than a wait, so `select` fails with
 A branch can also be recognised by identity instead of by position:
 `result.channel` is the channel the winning offer transferred over.
 
+=== Timeouts
+
+A deadline can be a branch of the select, as it is in Go, Rust, Clojure
+and Kotlin, instead of an exception thrown around the whole select by
+`orTimeout`. There are two forms, one for a timeout that re-arms on every
+round and one for a fixed deadline.
+
+The _timer offer_ `after` arms a fresh timer each time `select` is called
+and commits, with the `Instant` it fired, if no channel offer could
+commit first. It is the "wait for work, but not forever" branch of a
+select that is built once and reused, and because the timer lives inside
+the call, the held instance keeps its `fair()` rotation from round to
+round:
+
+[source,groovy]
+----
+import static groovy.concurrent.ChannelSelect.*
+
+def sel = offers(receive(work), after(100)).fair()
+while (true) {
+    def result = await sel.select()
+    if (result.timeout) {
+        // nothing arrived within 100 ms of this call: result.value is the Instant
+    } else {
+        handle(result.value)
+    }
+}
+----
+
+A timer offer that loses its round is cancelled with the other losing
+branches, so it leaves nothing armed. It reports `result.timeout` rather
+than a channel: `result.channel` is `null` for a timeout, and `result.index`
+still names the branch. So a select that carries a timer offer and
+dispatches on `result.channel` must test `result.timeout` first, as the
+loop above does. Like any offer it can be guarded with `when`, and
+a guarded-off timer offer arms nothing. Several timer offers give
+per-branch deadlines.
+
+A timer offer with a positive delay is never ready at the moment the
+select registers its offers, so the choice policy considers only the
+channel offers that are ready at once; the timer commits only when none
+was. A delay that is not positive has already elapsed, so that offer is
+ready at registration and the policy treats it like any other ready
+branch: priority takes whichever is listed first, and `fair()` rotates
+over it. Listed last, `after(0)` is the `default` clause of Go's
+`select` — take a transfer if one can complete at once, otherwise
+proceed without waiting:
+
+[source,groovy]
+----
+def result = await offers(receive(work), after(0)).select()
+if (result.timeout) {
+    // nothing was ready; do something else and come back
+}
+----
+
+The _timer channel_ `AsyncChannel.after` is the fixed-deadline form: a
+capacity-1 channel that delivers one value, the `Instant` it fired, once
+the given delay has elapsed from its creation, and then closes, as Go's
+`time.After` does. Received from within a select, it is a deadline shared
+by every round that selects on it:
+
+[source,groovy]
+----
+def deadline = AsyncChannel.after(5000)
+def sel = ChannelSelect.from(work, deadline)
+while (true) {
+    def result = await sel.select()
+    if (result.index == 1) break    // five seconds since the deadline was set
+    handle(result.value)
+}
+----
+
+Because it is an ordinary channel, a timer channel composes with
+everything a channel does: it can be guarded with `when`, and once fired
+`fair()` and `random()` treat it like any other ready channel. A timer
+channel that loses a select keeps its value: it fires all the same and
+holds the instant until received. Once that value has been taken, further
+receives fail with `ChannelClosedException` rather than waiting forever,
+and `isClosed()` reports that the timer has fired. Closing a timer channel
+before it fires cancels it.
+
+Both forms accept a `java.time.Duration` in place of milliseconds, and in
+both a delay that is not positive has already elapsed: the timer channel
+is created already holding its instant, and the timer offer is ready at
+registration. That suits a deadline computed from an absolute time that
+has already passed.
+
 [[async-broadcast-channel]]
 == BroadcastChannel
 

--- a/src/spec/doc/core-async-await.adoc
+++ b/src/spec/doc/core-async-await.adoc
@@ -529,6 +529,12 @@ type, e.g. `AtomicInteger` for a shared counter, or thread-safe types from
 | `AsyncChannel.create(n)`
 | Create a buffered (or unbuffered) channel for inter-task communication.
 
+| `ChannelSelect.after(ms)`
+| Timer offer: a `ChannelSelect` branch that re-arms each round and commits with the `Instant` it fired.
+
+| `AsyncChannel.after(ms)`
+| Timer channel: delivers the `Instant` it fired, then closes. A fixed deadline as a `ChannelSelect` branch.
+
 | `AsyncScope.withScope { ... }`
 | Structured concurrency — all children complete (or are cancelled) on scope exit.
 

--- a/src/test/groovy/groovy/concurrent/ChannelSelectTest.groovy
+++ b/src/test/groovy/groovy/concurrent/ChannelSelectTest.groovy
@@ -1108,4 +1108,363 @@ final class ChannelSelectTest {
             assert !buffer.alive
         '''
     }
+
+    // GROOVY-12343: a deadline as a branch of the select
+
+    @Test
+    void testTimerBranchWinsAQuietSelect() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelSelect
+            import java.time.Instant
+
+            def work = AsyncChannel.create(4)
+            def before = Instant.now()
+            def result = await ChannelSelect.from(work, AsyncChannel.after(50)).select()
+
+            assert result.index == 1
+            assert result.value instanceof Instant
+            assert !result.value.isBefore(before)
+            assert work.toString().contains('waitingReceivers=0')
+        '''
+    }
+
+    @Test
+    void testDataBeatsTheTimerAndTheTimerStillFires() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelClosedException
+            import groovy.concurrent.ChannelSelect
+            import java.time.Instant
+
+            def work = AsyncChannel.create(4)
+            def timer = AsyncChannel.after(100)
+            async { Thread.sleep(20); work.send('done') }
+
+            def result = await ChannelSelect.from(work, timer).select()
+            assert result.index == 0 && result.value == 'done'
+
+            // the losing timer was withdrawn, not consumed: it fires all the
+            // same, holds its instant until received, and then closes
+            assert !timer.closed
+            def fired = await timer.receive()
+            assert fired instanceof Instant
+            assert timer.closed
+            try {
+                await timer.receive()
+                assert false
+            } catch (ChannelClosedException expected) {
+            }
+        '''
+    }
+
+    @Test
+    void testPerBranchDeadlines() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def fast = AsyncChannel.create()
+            def slow = AsyncChannel.create()
+            def sel = offers(receive(fast), receive(AsyncChannel.after(30)),
+                             receive(slow), receive(AsyncChannel.after(2000)))
+
+            def result = await sel.select()
+            assert result.index == 1
+        '''
+    }
+
+    @Test
+    void testTimerCreatedOnceIsAFixedDeadlineAcrossSelects() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelSelect
+
+            def work = AsyncChannel.create(16)
+            def deadline = AsyncChannel.after(200)
+            def sel = ChannelSelect.from(work, deadline)
+
+            async {
+                for (i in 0..<3) { work.send(i); Thread.sleep(10) }
+            }
+
+            def received = []
+            while (true) {
+                def result = await sel.select()
+                if (result.index == 1) break
+                received << result.value
+            }
+            assert received == [0, 1, 2]
+            assert deadline.closed
+        '''
+    }
+
+    @Test
+    void testGuardedTimerIsNotRegisteredWhileItsGuardIsOff() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def work = AsyncChannel.create(4)
+            def timer = AsyncChannel.after(10)
+            boolean armed = false
+            def sel = offers(receive(work), receive(timer).when { armed })
+
+            Thread.sleep(30)     // the timer has fired and holds its instant
+            async { Thread.sleep(20); work.send('x') }
+            def first = await sel.select()
+            assert first.index == 0 && first.value == 'x'
+            assert timer.bufferedSize == 1
+
+            armed = true
+            def second = await sel.select()
+            assert second.index == 1
+            assert timer.bufferedSize == 0
+        '''
+    }
+
+    @Test
+    void testFairSelectServesAFiredTimerLikeAnyReadyBranch() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelSelect
+
+            def busy = AsyncChannel.create(8)
+            for (i in 0..<8) busy.send(i)
+            def timer = AsyncChannel.after(0)
+            Thread.sleep(30)
+
+            // busy never runs dry, yet the fired timer is served within n calls
+            def sel = ChannelSelect.from(busy, timer).fair()
+            def indices = (0..<4).collect { (await sel.select()).index }
+            assert indices.count { it == 1 } == 1
+        '''
+    }
+
+    @Test
+    void testClosingATimerBeforeItFiresCancelsIt() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import groovy.concurrent.ChannelClosedException
+
+            def timer = AsyncChannel.after(50)
+            assert timer.close()
+            assert !timer.close()
+            Thread.sleep(100)
+            assert timer.bufferedSize == 0
+            try {
+                await timer.receive()
+                assert false
+            } catch (ChannelClosedException expected) {
+            }
+        '''
+    }
+
+    @Test
+    void testDurationAndNegativeDelays() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import java.time.Duration
+            import java.time.Instant
+
+            def before = Instant.now()
+            def byDuration = await AsyncChannel.after(Duration.ofMillis(20)).receive()
+            assert byDuration instanceof Instant && !byDuration.isBefore(before)
+
+            // a deadline that has already passed is created already fired
+            def overdue = AsyncChannel.after(-1000)
+            assert overdue.bufferedSize == 1 && overdue.closed
+            assert (await overdue.receive()) instanceof Instant
+            def zero = AsyncChannel.after(Duration.ZERO)
+            assert zero.bufferedSize == 1 && zero.closed
+            assert (await zero.receive()) instanceof Instant
+
+            try {
+                AsyncChannel.after((Duration) null)
+                assert false
+            } catch (NullPointerException expected) {
+            }
+        '''
+    }
+
+    // GROOVY-12343: the timer offer re-arms on every select call
+
+    @Test
+    void testTimerOfferWinsAQuietSelect() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import java.time.Instant
+            import static groovy.concurrent.ChannelSelect.*
+
+            def work = AsyncChannel.create(4)
+            def before = Instant.now()
+            def result = await offers(receive(work), after(50)).select()
+
+            assert result.index == 1
+            assert result.timeout && !result.send
+            assert result.channel == null
+            assert result.value instanceof Instant
+            assert !result.value.isBefore(before)
+            assert result.toString().startsWith('SelectResult[timeout=1, at=')
+            assert work.toString().contains('waitingReceivers=0')
+        '''
+    }
+
+    @Test
+    void testTimerOfferReArmsOnEveryRound() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def work = AsyncChannel.create()
+            def sel = offers(receive(work), after(150))
+
+            // each round's value arrives well inside the round's own deadline
+            // but well past the first round's: a fixed deadline would time out
+            async {
+                for (i in 0..<4) { Thread.sleep(60); work.send(i) }
+            }
+            def received = (0..<4).collect {
+                def result = await sel.select()
+                assert !result.timeout && result.channel.is(work)
+                result.value
+            }
+            assert received == [0, 1, 2, 3]
+
+            // and a round in which nothing arrives times out
+            def result = await sel.select()
+            assert result.timeout && result.index == 1
+        '''
+    }
+
+    @Test
+    void testElapsedTimerOfferIsReadyAtRegistrationAndThePolicyDecides() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def work = AsyncChannel.create(4)
+            work.send('ready')
+
+            // listed last, after(0) is Go's default clause: a ready channel wins...
+            def result = await offers(receive(work), after(0)).select()
+            assert result.index == 0 && result.value == 'ready'
+
+            // ...and with nothing ready the select completes without waiting
+            def polled = offers(receive(work), after(0)).select()
+            assert polled.toCompletableFuture().isDone()
+            assert (await polled).timeout
+            assert work.toString().contains('waitingReceivers=0')
+
+            // listed first, the elapsed timer is the ready offer with priority
+            work.send('ready')
+            result = await offers(after(0), receive(work)).select()
+            assert result.timeout && result.index == 0
+            assert work.bufferedSize == 1
+        '''
+    }
+
+    @Test
+    void testFairSelectRotatesOverAnElapsedTimerOffer() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def work = AsyncChannel.create(8)
+            for (i in 0..<8) work.send(i)
+
+            def sel = offers(receive(work), after(0)).fair()
+            def indices = (0..<4).collect { (await sel.select()).index }
+            assert indices == [0, 1, 0, 1]
+            assert work.bufferedSize == 6
+        '''
+    }
+
+    @Test
+    void testFairRotationSurvivesATimedOutRound() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def a = AsyncChannel.create(4)
+            def c = AsyncChannel.create(4)
+            def sel = offers(receive(a), after(20), receive(c)).fair()
+
+            a.send('a1'); c.send('c1')
+            assert (await sel.select()).index == 0      // starts at a
+            assert (await sel.select()).index == 2      // rotation: c, the timer is not ready
+            assert (await sel.select()).timeout          // nothing ready: the timer fires
+
+            // the rotation continues from the timer's branch, so c is served
+            // before a even though a is listed first
+            a.send('a2'); c.send('c2')
+            assert (await sel.select()).index == 2
+            assert (await sel.select()).index == 0
+        '''
+    }
+
+    @Test
+    void testGuardedTimerOfferArmsNothing() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import java.util.concurrent.TimeoutException
+            import static groovy.concurrent.ChannelSelect.*
+
+            def work = AsyncChannel.create(4)
+            boolean armed = false
+            def sel = offers(receive(work), after(10).when { armed })
+
+            // with the timer guarded off the select waits on work alone
+            try {
+                await sel.select().orTimeoutMillis(100)
+                assert false
+            } catch (TimeoutException expected) {
+            }
+            assert work.toString().contains('waitingReceivers=0')
+
+            armed = true
+            def result = await sel.select()
+            assert result.timeout && result.index == 1
+        '''
+    }
+
+    @Test
+    void testPerBranchTimerOffersAndDurations() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import java.time.Duration
+            import static groovy.concurrent.ChannelSelect.*
+
+            def fast = AsyncChannel.create()
+            def slow = AsyncChannel.create()
+            def sel = offers(receive(fast), after(Duration.ofMillis(30)),
+                             receive(slow), after(Duration.ofSeconds(2)))
+
+            def result = await sel.select()
+            assert result.timeout && result.index == 1
+
+            try {
+                after((Duration) null)
+                assert false
+            } catch (NullPointerException expected) {
+            }
+        '''
+    }
+
+    @Test
+    void testTimerOfferWithinPositionalPreconditions() {
+        assertScript '''
+            import groovy.concurrent.AsyncChannel
+            import static groovy.concurrent.ChannelSelect.*
+
+            def work = AsyncChannel.create(4)
+            def sel = offers(receive(work), after(10))
+            work.send('x')
+
+            // the timer masked off: the value is taken
+            assert (await sel.select(true, false)).value == 'x'
+            // work masked off: only the timer can commit
+            assert (await sel.select(false, true)).timeout
+        '''
+    }
 }


### PR DESCRIPTION
A deadline can now be a branch of a ChannelSelect rather than an exception thrown around it by orTimeout. AsyncChannel.after(millis) and after(Duration) create a capacity-1 channel that delivers the Instant it fired and then closes, in the manner of Go's time.After. Being an ordinary built-in channel it takes part in the claim protocol, so a losing timer is withdrawn rather than consumed, and it composes with per-branch deadlines, when() guards, fair() and random().

The clock starts at creation. A timer that has delivered its value closes, so a second receive fails with ChannelClosedException instead of waiting forever. Closing a timer before it fires cancels the scheduled task; a negative delay fires at once, which suits deadlines computed from an absolute time already passed.