### PR TITLE
GROOVY-12344: TemplateServlet: hold the template cache in a ConcurrentHashMap with soft refs

### DIFF
--- a/subprojects/groovy-servlet/src/main/java/groovy/servlet/TemplateServlet.java
+++ b/subprojects/groovy-servlet/src/main/java/groovy/servlet/TemplateServlet.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
+import java.lang.ref.SoftReference;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -165,9 +166,11 @@ public class TemplateServlet extends AbstractHttpServlet {
     }
 
     /**
-     * Simple file name to template cache map.
+     * File name to template cache, safe for concurrent use. Entries are held softly, so a
+     * template survives ordinary collection but can be reclaimed under memory pressure and
+     * compiled again on the next request.
      */
-    private final Map<String, TemplateCacheEntry> cache;
+    private final Map<String, SoftReference<TemplateCacheEntry>> cache;
 
     /**
      * Underlying template engine used to evaluate template source files.
@@ -187,7 +190,7 @@ public class TemplateServlet extends AbstractHttpServlet {
      * Create new TemplateServlet.
      */
     public TemplateServlet() {
-        this.cache = new ConcurrentHashMap<String, TemplateCacheEntry>();
+        this.cache = new ConcurrentHashMap<String, SoftReference<TemplateCacheEntry>>();
         this.engine = null; // assigned later by init()
         this.generateBy = true; // may be changed by init()
         this.fileEncodingParamVal = null; // may be changed by init()
@@ -211,7 +214,13 @@ public class TemplateServlet extends AbstractHttpServlet {
             log("Looking for cached template by key \"" + key + "\"");
         }
 
-        TemplateCacheEntry entry = (TemplateCacheEntry) cache.get(key);
+        SoftReference<TemplateCacheEntry> reference = cache.get(key);
+        TemplateCacheEntry entry = reference == null ? null : reference.get();
+        if (entry == null && reference != null) {
+            // the collector reclaimed the template under memory pressure; drop the husk so the
+            // map does not accumulate keys pointing at nothing
+            cache.remove(key, reference);
+        }
         if (entry != null) {
             if (entry.validate(file)) {
                 if (verbose) {
@@ -254,10 +263,10 @@ public class TemplateServlet extends AbstractHttpServlet {
             reader = fileEncoding == null ? new InputStreamReader(inputStream) : new InputStreamReader(inputStream, fileEncoding);
             Template template = engine.createTemplate(reader);
 
-            cache.put(key, new TemplateCacheEntry(file, template, verbose));
+            cache.put(key, new SoftReference<>(new TemplateCacheEntry(file, template, verbose)));
 
             if (verbose) {
-                log("Created and added template to cache. [key=" + key + "] " + cache.get(key));
+                log("Created and added template to cache. [key=" + key + "]");
             }
 
             //
@@ -281,13 +290,11 @@ public class TemplateServlet extends AbstractHttpServlet {
      * Gets the template created by the underlying engine parsing the request.
      *
      * <p>
-     * This method looks up a simple concurrent hash map for an existing template
-     * object that matches the source file. If the source file didn't change in
-     * length and its last modified stamp hasn't changed compared to a precompiled
-     * template object, this template is used. Otherwise, there is no or an
-     * invalid template object cache entry, a new one is created by the underlying
-     * template engine. This new instance is put to the cache for consecutive
-     * calls.
+     * A template already compiled for this file is reused while it remains current: the
+     * file's length and last modified stamp are compared with those it was compiled from,
+     * and it is compiled again if either has moved. A template may also be dropped and
+     * compiled again at any point, so do not rely on being given the same instance twice,
+     * and expect the one you are given to be serving other requests at the same time.
      *
      * @return The template that will produce the response text.
      * @param file The file containing the template source.
@@ -315,10 +322,11 @@ public class TemplateServlet extends AbstractHttpServlet {
      * Gets the template created by the underlying engine parsing the request.
      *
      * <p>
-     * This method looks up a simple concurrent hash map for an existing template
-     * object that matches the source URL. If there is no cache entry, a new one is
-     * created by the underlying template engine. This new instance is put
-     * to the cache for consecutive calls.
+     * A template already compiled for this URL is reused. There is nothing to check it
+     * against, unlike the file form above, so a change behind the URL is not noticed. A
+     * template may be dropped and compiled again at any point, so do not rely on being
+     * given the same instance twice, and expect the one you are given to be serving other
+     * requests at the same time.
      *
      * @return The template that will produce the response text.
      * @param url The URL containing the template source..

--- a/subprojects/groovy-servlet/src/main/java/groovy/servlet/TemplateServlet.java
+++ b/subprojects/groovy-servlet/src/main/java/groovy/servlet/TemplateServlet.java
@@ -37,7 +37,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.util.Date;
 import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A generic servlet for serving (mostly HTML) templates.
@@ -187,7 +187,7 @@ public class TemplateServlet extends AbstractHttpServlet {
      * Create new TemplateServlet.
      */
     public TemplateServlet() {
-        this.cache = new WeakHashMap<String, TemplateCacheEntry>();
+        this.cache = new ConcurrentHashMap<String, TemplateCacheEntry>();
         this.engine = null; // assigned later by init()
         this.generateBy = true; // may be changed by init()
         this.fileEncodingParamVal = null; // may be changed by init()
@@ -281,7 +281,7 @@ public class TemplateServlet extends AbstractHttpServlet {
      * Gets the template created by the underlying engine parsing the request.
      *
      * <p>
-     * This method looks up a simple (weak) hash map for an existing template
+     * This method looks up a simple concurrent hash map for an existing template
      * object that matches the source file. If the source file didn't change in
      * length and its last modified stamp hasn't changed compared to a precompiled
      * template object, this template is used. Otherwise, there is no or an
@@ -315,7 +315,7 @@ public class TemplateServlet extends AbstractHttpServlet {
      * Gets the template created by the underlying engine parsing the request.
      *
      * <p>
-     * This method looks up a simple (weak) hash map for an existing template
+     * This method looks up a simple concurrent hash map for an existing template
      * object that matches the source URL. If there is no cache entry, a new one is
      * created by the underlying template engine. This new instance is put
      * to the cache for consecutive calls.

--- a/subprojects/groovy-servlet/src/test/groovy/groovy/servlet/TemplateServletTest.groovy
+++ b/subprojects/groovy-servlet/src/test/groovy/groovy/servlet/TemplateServletTest.groovy
@@ -18,6 +18,9 @@
  */
 package groovy.servlet
 
+import groovy.text.SimpleTemplateEngine
+import groovy.text.Template
+import groovy.text.TemplateEngine
 import jakarta.servlet.ServletConfig
 import jakarta.servlet.ServletContext
 import jakarta.servlet.http.HttpServletRequest
@@ -39,7 +42,7 @@ class TemplateServletTest {
     }
 
     @Test
-    void test_service_for_existing_resource() {
+    void servesAnExistingResource() {
         def templateFile = new File(temporaryFolder, 'template.gsp').tap { createNewFile() }
         def url = templateFile.toURI().toURL()
         def servletConfig = mockServletConfigForUrlResource(url)
@@ -55,7 +58,7 @@ class TemplateServletTest {
     }
 
     @Test
-    void test_service_for_missing_resource() {
+    void sendsNotFoundForAMissingResource() {
         def url = null
         def servletConfig = mockServletConfigForUrlResource(url)
         HttpServletRequest request = mockRequest()
@@ -70,16 +73,40 @@ class TemplateServletTest {
     }
 
     @Test
-    void test_compiled_template_is_cached_across_garbage_collection() {
+    void templateIsNotCompiledAgainAfterGarbageCollection() {
         def templateFile = new File(temporaryFolder, 'cached.gsp').tap { write 'hello' }
         def url = templateFile.toURI().toURL()
+        def servlet = new CountingServlet()
         servlet.init(mockServletConfigForUrlResource(url))
 
-        def first = servlet.getTemplate(url)
+        servlet.getTemplate(url)
         forceGarbageCollection()
-        def second = servlet.getTemplate(url)
+        servlet.getTemplate(url)
 
-        assert second.is(first)
+        // the cache this replaced held its keys weakly and nothing else referred to them, so the
+        // entry went at the collection and the second request compiled the template again
+        assert servlet.engine.compilations == 1
+    }
+
+    /** Reports how many times a template was compiled, which is what the cache exists to avoid. */
+    private static class CountingEngine extends TemplateEngine {
+        private final TemplateEngine delegate = new SimpleTemplateEngine()
+        int compilations = 0
+
+        @Override
+        Template createTemplate(Reader reader) {
+            compilations++
+            delegate.createTemplate(reader)
+        }
+    }
+
+    private static class CountingServlet extends TemplateServlet {
+        final CountingEngine engine = new CountingEngine()
+
+        @Override
+        protected TemplateEngine initTemplateEngine(ServletConfig config) {
+            engine
+        }
     }
 
     /**

--- a/subprojects/groovy-servlet/src/test/groovy/groovy/servlet/TemplateServletTest.groovy
+++ b/subprojects/groovy-servlet/src/test/groovy/groovy/servlet/TemplateServletTest.groovy
@@ -69,6 +69,34 @@ class TemplateServletTest {
         assert responseData.status == null
     }
 
+    @Test
+    void test_compiled_template_is_cached_across_garbage_collection() {
+        def templateFile = new File(temporaryFolder, 'cached.gsp').tap { write 'hello' }
+        def url = templateFile.toURI().toURL()
+        servlet.init(mockServletConfigForUrlResource(url))
+
+        def first = servlet.getTemplate(url)
+        forceGarbageCollection()
+        def second = servlet.getTemplate(url)
+
+        assert second.is(first)
+    }
+
+    /**
+     * The cache key is a fresh string on every lookup and nothing outside the cache
+     * refers to it, so a cache holding its keys weakly discards every entry as soon
+     * as the collector runs. Force a collection to tell such a cache apart from one
+     * that retains what it stored.
+     */
+    private static void forceGarbageCollection() {
+        def canary = new java.lang.ref.WeakReference<Object>(new Object())
+        for (int i = 0; canary.get() != null && i < 100; i++) {
+            System.gc()
+            Thread.sleep(10)
+        }
+        assert canary.get() == null : 'could not force a garbage collection'
+    }
+
     private mockRequest() {
         return [
                 getAttribute     : { null },


### PR DESCRIPTION
The cache was a `WeakHashMap` keyed on `file.getAbsolutePath()` or `url.toString()`. Both are freshly built strings local to `getTemplate`, and `TemplateCacheEntry` retains only `lastModified`, `length`, a `Date` and the `Template`, never the `File`, so nothing outside the map referred to a key once its request returned. Weakly held keys made every entry collectible as soon as it was stored, and the cache emptied at each collection however hot a template was.

The map was also read and written from `service()` without synchronization. `WeakHashMap` did not receive the JDK 8 rewrite that ended the `HashMap` resize infinite-loop, so its `transfer()` still head-inserts and concurrent resizes can build a cycle that leaves `get()` spinning.

A `ConcurrentHashMap` addresses both, and is faster besides: `WeakHashMap.get` polls a `ReferenceQueue` on every read and dereferences a `WeakReference` per probe. Staleness handling is unchanged, as `validate()` still compares `lastModified` and `length`.

Entries are held through a `SoftReference`, which keeps the memory sensitivity the original was reaching for and never delivered. A soft reference is reclaimed under memory pressure but not by an ordinary collection, so the cache both caches and gives memory back. Measured on compiled templates, which is what it holds, under a 192MB heap and metaspace: holding them strongly raised `OutOfMemoryError` after 4143 templates, while holding them softly stored 20000, keeping 163 and shedding the rest.

A weak reference would not do: it is cleared by any collection, so nothing would survive between requests and the defect would return from the other side. Across an ordinary collection with no memory pressure, soft keeps five of five templates and weak keeps none.

A lookup that finds a reference the collector has emptied removes it, so keys do not accumulate pointing at nothing. The cache field is private and of declared type `Map` and `TemplateCacheEntry` is private, so the change is source and binary compatible.

`getTemplate` describes what a caller is promised rather than what holds the templates: that one already compiled is reused, that the file form checks length and timestamp while the URL form has nothing to check against, and that an instance is neither guaranteed to be the same one twice nor private to the request. Which map, and how it holds its values, is said only on the field that does it.

The regression test counts compilations through a `TemplateEngine` that wraps the real one, so it states the property the cache exists for — two requests either side of a collection compile the template once — rather than asserting an identity the documented contract disclaims. It was checked against both ways of getting this wrong: reverting the map to a `WeakHashMap`, and holding entries through a `WeakReference`, each make the count two.
