### PR TITLE
GROOVY-12348: JmxBuilder: listen where the connector was asked to listen

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -90,7 +90,7 @@ not deployed as a network service of its own. The shapes that matter:
 | **Embedded runtime** | An application puts `groovy-*` jars on its classpath and calls Groovy APIs (GDK methods, `groovy.sql.Sql`, parsers, builders) and/or evaluates Groovy it authored. |
 | **Dynamic evaluation host** | An application uses `GroovyShell`, `Eval`, `GroovyClassLoader`, `GroovyScriptEngine`, JSR-223 (`groovy-jsr223`), or the template engines to run Groovy decided at runtime. |
 | **Build / compile** | `groovyc`, the Gradle/Maven integrations, and AST transforms compile developer-authored source. |
-| **Interactive / CLI tools** | `groovy`, `groovysh`, `groovyConsole`, `groovydoc`, `groovy-servlet` run on inputs the operator provides. |
+| **Interactive / CLI tools** | `groovy`, `groovysh`, `groovyConsole`, `groovydoc`, `groovy-servlet` run on inputs the operator provides. `groovy -l` and `JmxBuilder`'s connector server belong here too: they take those inputs from a socket rather than a terminal, bound to loopback unless the operator widens them ([§7](#7-adversary-model)). |
 
 ### Caller roles
 
@@ -385,12 +385,28 @@ single "remote attacker." The adversaries that matter:
 - **A local user on a shared host.** Can read predictable or
   world-readable artifacts that Groovy tooling writes (the class of issue
   behind CVE-2020-17521).
+- **A peer of a listener the operator started.** Two development tools
+  listen on a socket when asked to: `groovy -l`, which runs the operator's
+  script once per line received with the line supplied as the `line`
+  binding, and `JmxBuilder`'s connector server, which exposes an MBean
+  server. Both exist only where an operator started one, both bind the
+  loopback address unless given a wider one, and neither evaluates what a
+  peer sends as code. For `groovy -l` this is the data supplier above
+  reached over a socket Groovy opened rather than through the embedding
+  application, carrying the same capability and no more; what a peer
+  achieves is whatever the operator's script does with `line`, and a script
+  that evaluates it has opted into [§3](#3-out-of-scope-explicit-non-goals).
+  A connector server is the wider of the two: it offers whatever the MBean
+  server holds, and the default is the platform server, whose beans can dump
+  the heap and run diagnostic commands. Widening either past loopback puts
+  that within reach of any peer that can route to the port.
 
 **Capabilities the in-scope adversary has (closed list).** Supplying bytes
 to a data parser; supplying values bound as data (SQL parameters, template
 *bindings* — not template *text*); supplying oversized, deeply-nested, or
-syntactically adversarial *data*; and, for the local adversary, reading
-files on the shared host subject to OS permissions. **A finding that
+syntactically adversarial *data*; connecting to a listener the operator
+started and sending it lines or MBean requests; and, for the local
+adversary, reading files on the shared host subject to OS permissions. **A finding that
 requires any capability not on this list is out of model**
 ([§11b](#11b-scanner-calibration-default-downgrade-rules)).
 
@@ -499,6 +515,11 @@ Groovy does **not** claim, and you must not assume, any of the following.
   objects.** See [§3](#3-out-of-scope-explicit-non-goals).
 - **`SecurityManager`-based confinement.** The JDK `SecurityManager` is
   deprecated/removed; Groovy does not rely on it and neither can you.
+- **Authentication or transport security for the listeners.** Neither
+  `groovy -l` nor a `JmxBuilder` connector authenticates a peer by default,
+  and neither encrypts unless configured to. Binding loopback by default
+  limits who can arrive; beyond loopback the operator owns authentication,
+  and the port belongs behind whatever the deployment already uses.
 
 ### False friends — features that look like security but are not
 
@@ -508,7 +529,8 @@ Groovy does **not** claim, and you must not assume, any of the following.
 | `@ThreadInterrupt` / `@TimedInterrupt` / `@ConditionInterrupt` | Cooperative interruption checks woven into loops/methods to tame *runaway* (buggy) scripts | Cooperative and removable by the code being run; no defense against deliberately malicious scripts. |
 | `@CompileStatic` / `@TypeChecked` | Compile-time type checking for correctness and performance | Not a security control; statically-compiled code is exactly as privileged. |
 | `groovy.sql.Sql` (beyond P1) | Convenience SQL access | Only the GString/bind forms parameterize. A `String` you concatenate yourself, dynamic identifiers via `Sql.expand`, or `DataSet` table/column names, are **not** protected (CWE-89). |
-| The Groovy "shell"/console tools | Developer/operator conveniences | `groovysh`/`groovyConsole` run code with the user's full privileges; they are not multi-tenant or sandboxed. |
+| The Groovy "shell"/console tools | Developer/operator conveniences | `groovysh`/`groovyConsole` run code with the user's full privileges; they are not multi-tenant or sandboxed. `groovy -l` is the same kind of tool with a socket for an input channel instead of a terminal &mdash; an aid to experimenting with a line-driven script, not an application server. |
+| `JmxBuilder` connector servers | A development and experimentation aid | Every connector security property was assembled and discarded from 2008 until 2026, so no configuration produced a secured connector in that window and none can have been relied upon. It exposes an MBean server rather than being a managed service, and authenticates nobody unless told to. |
 
 Well-known attack classes Groovy does **not** defend against on the
 application's behalf: command injection from app-built command strings
@@ -575,6 +597,13 @@ If you embed or script with Groovy, **you** own these:
     your exposure, not Groovy's obligations** — a defect in a tool module is
     still a defect, and the interactive user is a caller role in this model
     ([§2](#2-scope-and-intended-use)), not an out-of-scope one.
+12. **If you start a listener, you own the exposure.** `groovy -l` and
+    `JmxBuilder` connector servers bind loopback unless you pass a wider
+    address, and neither authenticates anyone. Give one a reachable address
+    only where the peers are ones it is prepared to serve, and put
+    authentication in front of the port. A connector server reaches whatever
+    its MBean server holds, so prefer a purpose-built server over the
+    platform one when the port is not confined to the host.
 
 ---
 
@@ -682,9 +711,16 @@ carries a hardening obligation.
   classes (would create a deserialization surface that *is* in model).
 - Changing the secure-by-default XML posture (P2) or temp-artifact
   permissions (P4).
-- A new tool or subproject that accepts input over the network as a
-  service (would introduce a remote network adversary the current model
-  does not have).
+- A new tool or subproject that accepts input over the network **as a
+  service** (would introduce a remote network adversary the current model
+  does not have). `groovy -l` and `JmxBuilder` connector servers do not
+  meet this: they are development tools of the
+  [§9](#9-security-properties-the-project-does-not-provide) shell/console
+  family, bound to loopback by default, and their peer is covered by the
+  listener bullet in [§7](#7-adversary-model). What would meet it is a
+  surface accepting something richer — code, serialized objects, or
+  commands Groovy itself interprets rather than the operator's script — or
+  one listening beyond loopback by default.
 - Hardening of serializable runtime types (e.g. making closure fields
   transient, or removing `Serializable`) — would move some [§11a](#11a-known-non-findings-recurring-false-positives)
   items into scope as defense-in-depth.

--- a/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxServerConnectorFactory.groovy
+++ b/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxServerConnectorFactory.groovy
@@ -27,6 +27,8 @@ import javax.management.remote.rmi.RMIConnectorServer
 import javax.net.ssl.SSLContext
 import javax.rmi.ssl.SslRMIClientSocketFactory
 import javax.rmi.ssl.SslRMIServerSocketFactory
+import java.rmi.server.RMIClientSocketFactory
+import java.rmi.server.RMIServerSocketFactory
 
 /**
  * This is the server connector factory used for node JmxBuilder.connectorServer().  A call to this node
@@ -56,6 +58,11 @@ import javax.rmi.ssl.SslRMIServerSocketFactory
  * authenticate but has none of these would start open, so that combination is rejected rather
  * than accepted silently. Any other entry in {@code properties} is passed to the connector
  * environment unaltered.
+ * <p>
+ * An RMI connector listens on {@code host}, which is {@code localhost} unless given, so by
+ * default only clients on the same machine can reach it. Pass a wildcard address to listen on
+ * every interface. A connector exposes the MBean server to whoever can reach it and
+ * authenticates nobody unless configured to, so widening the host warrants authentication.
  *
  * @see javax.management.remote.JMXConnectorServer
  */
@@ -114,9 +121,11 @@ class JmxServerConnectorFactory extends AbstractFactory {
 
         MBeanServer server = (MBeanServer) fsb.getMBeanServer()
         JMXServiceURL serviceUrl = (url) ? new JMXServiceURL(url) : generateServiceUrl(protocol, host, port)
+        if (!url && protocol == "rmi") {
+            env = confineToHost(env, host)
+        }
         JMXConnectorServer connector = JMXConnectorServerFactory.newJMXConnectorServer(serviceUrl, env, server)
-
-
+        warnIfReachableAndOpen(env, url, host)
 
         return connector
     }
@@ -206,6 +215,123 @@ class JmxServerConnectorFactory extends AbstractFactory {
         props.clear()
 
         return env
+    }
+
+    /**
+     * Adds a server socket factory that binds the host the connector was asked for, so that a
+     * connector listens where its service URL says it does. Without one, the RMI object is
+     * exported on every interface whatever host the URL names, and {@code host} restricts only
+     * the registry the stub is bound into. A caller who supplied a socket factory keeps it, and
+     * a wildcard host is taken as a request to listen everywhere.
+     *
+     * @param env connector environment, possibly null
+     * @param host host the connector was asked to listen on
+     * @return the environment to create the connector with
+     */
+    private static Map confineToHost(Map env, String host) {
+        Map result = env != null ? env : new HashMap<String, Object>()
+        if (result.containsKey(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE)
+                || result.containsKey(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE)) {
+            return result
+        }
+        InetAddress address
+        try {
+            address = InetAddress.getByName(host)
+        } catch (UnknownHostException ignored) {
+            return result
+        }
+        if (address.isAnyLocalAddress()) {
+            return result
+        }
+        // both halves are needed: the server factory decides where the exported object listens,
+        // and the stub carries the client factory, which decides where a client dials. Binding
+        // without the second leaves clients dialling the host RMI advertises, where nothing listens.
+        result.put(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE, new BoundServerSocketFactory(address))
+        result.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, new BoundClientSocketFactory(address.hostAddress))
+        return result
+    }
+
+    /**
+     * Warns when a connector both accepts connections from other hosts and authenticates nobody.
+     * Staying quiet for a connector confined to loopback keeps the warning to the case where a
+     * peer other than the operator can reach it.
+     *
+     * @param env connector environment, possibly null
+     * @param url explicit service URL, if one was supplied
+     * @param host host the connector was asked to listen on
+     */
+    private static void warnIfReachableAndOpen(Map env, String url, String host) {
+        boolean authenticated = env != null && (env.get(JMXConnectorServer.AUTHENTICATOR) != null
+                || env.get("jmx.remote.x.password.file") != null
+                || env.get("jmx.remote.x.login.config") != null)
+        if (authenticated) {
+            return
+        }
+        boolean reachable = true
+        if (!url) {
+            try {
+                reachable = !InetAddress.getByName(host).isLoopbackAddress()
+            } catch (UnknownHostException ignored) {
+            }
+        }
+        if (reachable) {
+            System.err.println("warning: JMX connector on '${url ?: host}' accepts connections from other hosts " +
+                    "and authenticates nobody; it exposes the MBean server to any peer that can reach it")
+        }
+    }
+
+    /**
+     * Client socket factory that dials the address the connector was bound to. It travels to the
+     * client inside the stub, so it must be serializable.
+     */
+    private static class BoundClientSocketFactory implements RMIClientSocketFactory, Serializable {
+        private static final long serialVersionUID = 1L
+        private final String host
+
+        BoundClientSocketFactory(String host) {
+            this.host = host
+        }
+
+        @Override
+        Socket createSocket(String ignoredHost, int port) throws IOException {
+            return new Socket(host, port)
+        }
+
+        @Override
+        boolean equals(Object other) {
+            other instanceof BoundClientSocketFactory && ((BoundClientSocketFactory) other).host == host
+        }
+
+        @Override
+        int hashCode() {
+            host.hashCode()
+        }
+    }
+
+    /**
+     * Server socket factory that binds one address rather than every interface.
+     */
+    private static class BoundServerSocketFactory implements RMIServerSocketFactory {
+        private final InetAddress address
+
+        BoundServerSocketFactory(InetAddress address) {
+            this.address = address
+        }
+
+        @Override
+        ServerSocket createServerSocket(int port) throws IOException {
+            return new ServerSocket(port, 0, address)
+        }
+
+        @Override
+        boolean equals(Object other) {
+            other instanceof BoundServerSocketFactory && ((BoundServerSocketFactory) other).address == address
+        }
+
+        @Override
+        int hashCode() {
+            address.hashCode()
+        }
     }
 
     private JMXServiceURL generateServiceUrl(def protocol, def host, def port) {

--- a/subprojects/groovy-jmx/src/spec/doc/jmx.adoc
+++ b/subprojects/groovy-jmx/src/spec/doc/jmx.adoc
@@ -411,17 +411,26 @@ include::../test/JmxTest.groovy[tags=connector_server,indent=0]
 
 The snippet above returns an RMI connector that will start listening on port 9000. By default, the builder will internally generate URL **"service:jmx:rmi:///jndi/rmi://localhost:9000/jmxrmi"**.
 
-__NOTE: Sadly you are as likely to get something like the following when attempting to run the previous snippet of code (example is incomplete, see below):__
+The snippet on its own fails, because it does not create the RMI registry the connector binds
+its stub into:
 
 ----
-Caught: java.io.IOException: Cannot bind to URL [rmi://localhost:9000/jmxrmi]: javax.naming.ServiceUnavailableException [Root exception is java.rmi.ConnectException: Connection refused to host: localhost; nested exception is:
-?????? java.net.ConnectException: Connection refused]
-??
+Caught: java.io.IOException: Cannot bind to URL [rmi://localhost:9000/jmxrmi]:
+javax.naming.ServiceUnavailableException [Root exception is java.rmi.ConnectException:
+Connection refused to host: localhost; ...]
 ----
 
-__This occurs on Mac and Linux (CentOS 5) with Groovy 1.6 installed. Perhaps there were assumptions made about the configuration of the /etc/hosts file?__
+NOTE: __The corrected example, which creates the registry first, is shown below.__
 
-NOTE: __The correct example is shown below.__
+The connector listens on the host it was given, which is `localhost` unless you say otherwise,
+so by default only clients on the same machine can reach it. Pass a `host` to listen more
+widely -- `0.0.0.0` for every interface, or a single address to pick one.
+
+WARNING: A connector exposes the MBean server, and the default MBean server is the platform
+one, whose beans can dump the heap and run diagnostic commands. It authenticates nobody unless
+you configure it to, so a connector reachable from other hosts hands that to any peer that can
+reach the port. `JmxBuilder` is a development and experimentation aid; treat a connector left
+open the way you would treat an open shell on the host.
 
 **Connector Example (Corrected) - Connector Server**
 

--- a/subprojects/groovy-jmx/src/test/groovy/groovy/jmx/builder/JmxServerConnectorFactoryTest.groovy
+++ b/subprojects/groovy-jmx/src/test/groovy/groovy/jmx/builder/JmxServerConnectorFactoryTest.groovy
@@ -52,6 +52,63 @@ class JmxServerConnectorFactoryTest {
         JmxConnectorHelper.destroyRmiRegistry(rmi.registry)
     }
 
+    // GROOVY-12348: the exported RMI object must listen where the connector was asked to,
+    // rather than on every interface whatever host the service URL names.
+    @Test
+    void testConnectorConfinedToLoopbackByDefault() {
+        def factory = new JmxServerConnectorFactory()
+        def env = factory.confineToHost(null, 'localhost')
+
+        def ssf = env.get(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE)
+        assert ssf != null
+        def socket = ssf.createServerSocket(0)
+        try {
+            assert socket.inetAddress.loopbackAddress
+        } finally {
+            socket.close()
+        }
+    }
+
+    @Test
+    void testConfinementSuppliesBothHalves() {
+        // the stub carries the client factory; without it a client dials the host RMI
+        // advertises rather than the bound one, and finds nothing listening
+        def env = new JmxServerConnectorFactory().confineToHost(null, 'localhost')
+        assert env.get(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE) != null
+        assert env.get(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE) instanceof Serializable
+    }
+
+    @Test
+    void testWildcardHostIsLeftUnconfined() {
+        def env = new JmxServerConnectorFactory().confineToHost(null, '0.0.0.0')
+        assert env.get(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE) == null
+    }
+
+    @Test
+    void testSuppliedSocketFactoryIsKept() {
+        def mine = new SslRMIServerSocketFactory()
+        def env = new JmxServerConnectorFactory().confineToHost(
+                [(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE): mine], 'localhost')
+        assert env.get(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE).is(mine)
+    }
+
+    @Test
+    void testLoopbackConnectorStillServesLocalClients() {
+        def connector = builder.connectorServer(port: rmi.port)
+        connector.start()
+        try {
+            def client = JMXConnectorFactory.connect(
+                    new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:${rmi.port}/jmxrmi"), null)
+            try {
+                assert client.MBeanServerConnection.getMBeanCount() > 0
+            } finally {
+                client.close()
+            }
+        } finally {
+            connector.stop()
+        }
+    }
+
     // GROOVY-12270: authentication properties must land on the keys a connector server
     // consumes, not on the JDK management agent's names, which it ignores.
     @Test


### PR DESCRIPTION
connectorServer takes a host, defaulting to localhost, but it reached only the service URL. The authority before /jndi/ was left empty, which exports the RMI object on every interface, so host named the registry the stub was bound into and never restricted the listener. A connector asked for localhost was reachable from any host that could route to the port, and since the default MBean server is the platform one, that offered HotSpotDiagnostic.dumpHeap and the DiagnosticCommand operations to whoever arrived.

The connector now binds the host it was given. Both halves are needed: the server socket factory decides where the exported object listens, and the stub carries the client factory, which decides where a client dials. Binding without the second leaves clients dialling the host RMI advertises, where nothing is listening. A caller who supplied either factory keeps their own, so the SSL path is untouched, and a wildcard host still listens everywhere.

Starting a connector that both reaches other hosts and authenticates nobody now warns. A connector confined to loopback stays quiet, so the warning marks the case where a peer other than the operator can arrive.

The documentation recorded that its own example failed on Mac and CentOS 5 under Groovy 1.6 and wondered about /etc/hosts. The example fails because it does not create the RMI registry, which the corrected example below it already showed, so it now says that and describes what the connector exposes and to whom.