### PR TITLE
GROOVY-12333: findBalancedGroups: bound the cost of deeply nested input

### DIFF
--- a/src/main/java/groovy/util/regex/BalancedGroup.java
+++ b/src/main/java/groovy/util/regex/BalancedGroup.java
@@ -74,20 +74,21 @@ public final class BalancedGroup {
             }
         };
 
-    private final String matchedString;
+    private final CharSequence source;
     private final int start;
     private final int end;
     private final int fullStart;
     private final int fullEnd;
     private final List<BalancedGroup> children;
     private BalancedGroup parent;
-    /** Nesting depth; set once when this node is attached as a child (O(1) {@link #getDepth()}). */
-    private int depth;
+    private static final int DEPTH_UNRESOLVED = -1;
+    /** Nesting depth, resolved on first request from the parent chain and then cached. */
+    private int depth = DEPTH_UNRESOLVED;
 
     /**
-     * Package-private constructor: builds a node with offsets relative to
-     * {@code matchedString} ({@code start = 0}, {@code end = matchedString.length()},
-     * and the same for the full span). Prefer {@link #find} for public use.
+     * Package-private constructor: builds a node whose text is its own source
+     * ({@code start = 0}, {@code end = matchedString.length()}, and the same for the full span).
+     * Prefer {@link #find} for public use.
      * Wires each child's parent link (one-shot: a child may not already have a parent).
      *
      * @param matchedString the text captured for this group (never {@code null})
@@ -105,30 +106,36 @@ public final class BalancedGroup {
      * Prefer {@link #find} for public use. Wires each child's parent link and depth
      * (one-shot: a child may not already have a parent).
      *
-     * @param matchedString the text captured for this group (never {@code null});
-     *                      may include or exclude boundary delimiters depending on
-     *                      {@link MatchOptions#includeEdges()}
-     * @param start         start index of {@code matchedString} in the source (inclusive)
-     * @param end           end index of {@code matchedString} in the source (exclusive)
+     * <p>
+     * The node keeps the source and slices its text on demand rather than holding a copy: in a
+     * deeply nested document the groups' spans overlap, so a copy per node makes retention
+     * quadratic in the nesting. The source must be effectively immutable for the node's lifetime,
+     * which {@link #find} guarantees by flattening its input to a {@code String} first.
+     *
+     * @param source        the text the offsets index into (never {@code null})
+     * @param start         start index of this group's text (inclusive); includes or excludes the
+     *                      boundary delimiters depending on {@link MatchOptions#includeEdges()}
+     * @param end           end index of this group's text (exclusive)
      * @param fullStart     start index of the full pair including open delimiter
      * @param fullEnd       end index of the full pair including close delimiter (exclusive)
      * @param children      immediate nested groups, or {@code null}/empty for a leaf
-     * @throws NullPointerException     if {@code matchedString} is {@code null}, or
+     * @throws NullPointerException     if {@code source} is {@code null}, or
      *                                  {@code children} contains {@code null}
-     * @throws IllegalArgumentException if ranges are invalid or a child already has a parent
+     * @throws IllegalArgumentException if ranges are invalid or out of bounds for {@code source},
+     *                                  or a child already has a parent
      */
-    BalancedGroup(String matchedString, int start, int end, int fullStart, int fullEnd,
+    BalancedGroup(CharSequence source, int start, int end, int fullStart, int fullEnd,
                   List<BalancedGroup> children) {
-        this.matchedString = Objects.requireNonNull(matchedString, "matchedString");
+        this.source = Objects.requireNonNull(source, "source");
         if (start < 0 || end < start) {
             throw new IllegalArgumentException("invalid match range: [" + start + ", " + end + ")");
         }
         if (fullStart < 0 || fullEnd < fullStart) {
             throw new IllegalArgumentException("invalid full range: [" + fullStart + ", " + fullEnd + ")");
         }
-        if (end - start != matchedString.length()) {
+        if (end > source.length()) {
             throw new IllegalArgumentException(
-                "matchedString length " + matchedString.length() + " != range length " + (end - start));
+                "match range [" + start + ", " + end + ") exceeds source length " + source.length());
         }
         this.start = start;
         this.end = end;
@@ -143,21 +150,32 @@ public final class BalancedGroup {
                     throw new IllegalArgumentException("child BalancedGroup already has a parent");
                 }
                 child.parent = this;
-                // Bottom-up assembly: this node may later be attached under a grandparent,
-                // so depth is assigned (and cascaded) here and again when we are attached.
-                child.assignDepth(this.depth + 1);
+                // A depth read before assembly finished is cached against a parent chain that is
+                // about to change; drop it so it resolves against the new one. find() never reads a
+                // depth while assembling, so nothing is cached yet on that path.
+                if (child.depth != DEPTH_UNRESOLVED) {
+                    child.clearResolvedDepths();
+                }
             }
         }
     }
 
     /**
-     * Sets this node's depth and cascades to descendants. Invoked only during the
-     * one-shot parent-wiring phase of construction (tree is not yet published).
+     * Drops the cached depth of this node and of every descendant holding one. Iterative, and
+     * prunes at any node that never had its depth read.
      */
-    private void assignDepth(int newDepth) {
-        this.depth = newDepth;
-        for (BalancedGroup child : children) {
-            child.assignDepth(newDepth + 1);
+    private void clearResolvedDepths() {
+        Deque<BalancedGroup> pending = new ArrayDeque<>();
+        pending.push(this);
+        while (!pending.isEmpty()) {
+            BalancedGroup node = pending.pop();
+            if (node.depth == DEPTH_UNRESOLVED) {
+                continue;
+            }
+            node.depth = DEPTH_UNRESOLVED;
+            for (BalancedGroup child : node.children) {
+                pending.push(child);
+            }
         }
     }
 
@@ -268,11 +286,10 @@ public final class BalancedGroup {
                 if (matchStart > matchEnd) {
                     matchStart = matchEnd;
                 }
-                String matchStr = source.substring(matchStart, matchEnd);
-
-                // Constructor wires child → parent links.
+                // Constructor wires child → parent links. The source is shared, not sliced per
+                // node: the groups' spans overlap, so a copy each would be quadratic in the nesting.
                 BalancedGroup completedNode = new BalancedGroup(
-                    matchStr, matchStart, matchEnd, openStart, closeEnd, openGroup.children());
+                    source, matchStart, matchEnd, openStart, closeEnd, openGroup.children());
                 stack.peek().addChild(completedNode);
             }
         }
@@ -319,7 +336,7 @@ public final class BalancedGroup {
      *         delimiters depending on {@link MatchOptions#includeEdges()}
      */
     public String getMatchedString() {
-        return matchedString;
+        return source.subSequence(start, end).toString();
     }
 
     /**
@@ -389,11 +406,30 @@ public final class BalancedGroup {
 
     /**
      * Nesting depth of this node (0 for a root).
-     * Computed once when the parent link is wired; O(1).
+     * <p>
+     * Resolved from the parent chain on first request and cached, along with every ancestor walked
+     * on the way, so resolving the depth of every node in a tree costs O(n) overall and any single
+     * node is O(1) once resolved. Assigning eagerly during construction would instead re-walk each
+     * subtree every time it is attached to a new parent, which the bottom-up assembly in
+     * {@link #find} does once per closing delimiter &mdash; quadratic in the nesting. The walk is
+     * iterative because a deeply nested document must not consume a stack frame per level.
      *
      * @return the number of ancestors
      */
     public int getDepth() {
+        if (depth != DEPTH_UNRESOLVED) {
+            return depth;
+        }
+        Deque<BalancedGroup> pending = new ArrayDeque<>();
+        BalancedGroup node = this;
+        while (node.depth == DEPTH_UNRESOLVED && node.parent != null) {
+            pending.push(node);
+            node = node.parent;
+        }
+        int resolved = node.depth == DEPTH_UNRESOLVED ? (node.depth = 0) : node.depth;
+        while (!pending.isEmpty()) {
+            pending.pop().depth = ++resolved;
+        }
         return depth;
     }
 
@@ -404,7 +440,7 @@ public final class BalancedGroup {
      */
     @Override
     public String toString() {
-        return matchedString;
+        return source.subSequence(start, end).toString();
     }
 
     /**

--- a/src/test/groovy/bugs/Groovy12333.groovy
+++ b/src/test/groovy/bugs/Groovy12333.groovy
@@ -1,0 +1,133 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package bugs
+
+import groovy.util.regex.BalancedGroup
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * GROOVY-12333: findBalancedGroups resolves nesting depth without recursing over each subtree.
+ *
+ * find() assembles the tree bottom-up, so a node is attached to a new parent once per enclosing
+ * delimiter. Assigning depth eagerly re-walked the whole subtree on every attach, which is
+ * quadratic in the nesting and recursed one frame per level.
+ */
+final class Groovy12333 {
+
+    private static String chain(int depth) {
+        '(' * depth + ')' * depth
+    }
+
+    private static BalancedGroup innermost(BalancedGroup group) {
+        BalancedGroup node = group
+        while (!node.children.isEmpty()) node = node.children[0]
+        node
+    }
+
+    /** Runs on a deliberately small stack, so recursion per nesting level shows up as a failure. */
+    private static void onSmallStack(Closure body) {
+        Throwable failure = null
+        Thread thread = new Thread(null, { try { body() } catch (Throwable t) { failure = t } }, 'small-stack', 128 * 1024)
+        thread.start()
+        thread.join()
+        if (failure != null) throw failure
+    }
+
+    @Test
+    void testDeeplyNestedInputResolvesWithoutRecursingPerLevel() {
+        // depth 3000 overflows a 128KB stack once anything walks the tree a frame at a time
+        onSmallStack {
+            int depth = 3000
+            List<BalancedGroup> roots = chain(depth).findBalancedGroups(/\(/, /\)/)
+
+            assertEquals(1, roots.size())
+            assertEquals(0, roots[0].depth)
+            assertEquals(depth - 1, innermost(roots[0]).depth)
+        }
+    }
+
+    @Test
+    void testDeeplyNestedInputDoesNotRetainOverlappingCopies() {
+        // Groups nest, so their spans overlap; a copy of its own text per node made retention
+        // quadratic in the nesting -- 64KB of nesting held ~990MB, and enough of it exhausted the
+        // heap before anything could read the result.
+        int depth = 50000
+        List<BalancedGroup> roots = chain(depth).findBalancedGroups(/\(/, /\)/)
+
+        assertEquals(1, roots.size())
+        assertEquals(depth * 2, roots[0].matchedString.length())
+        assertEquals('()', innermost(roots[0]).matchedString)
+    }
+
+    @Test
+    void testMatchedStringIsSlicedFromTheSource() {
+        BalancedGroup root = 'noise (a(b)c) noise'.findBalancedGroups(/\(/, /\)/)[0]
+
+        assertEquals('(a(b)c)', root.matchedString)
+        assertEquals('(b)', root.children[0].matchedString)
+        // repeated reads are equal but need not be the same instance
+        assertEquals(root.matchedString, root.matchedString)
+        assertEquals(6, root.start)
+        assertEquals(13, root.end)
+    }
+
+    @Test
+    void testDepthIsCorrectAtEveryLevel() {
+        BalancedGroup node = '((((a))))'.findBalancedGroups(/\(/, /\)/)[0]
+        for (int expected = 0; expected < 4; expected++) {
+            assertEquals(expected, node.depth)
+            if (expected < 3) node = node.children[0]
+        }
+        assertTrue(node.children.isEmpty())
+    }
+
+    @Test
+    void testDepthIsStableWhenReadRepeatedlyAndOutOfOrder() {
+        // resolution caches into the nodes it walks past, so order of access must not matter
+        BalancedGroup root = chain(500).findBalancedGroups(/\(/, /\)/)[0]
+        BalancedGroup deep = innermost(root)
+
+        assertEquals(499, deep.depth)   // deepest first, resolving the whole chain
+        assertEquals(0, root.depth)
+        assertEquals(499, deep.depth)   // and again, from the cache
+        assertEquals(1, root.children[0].depth)
+    }
+
+    @Test
+    void testSiblingsShareDepthIndependently() {
+        List<BalancedGroup> roots = '(a)((b))(c)'.findBalancedGroups(/\(/, /\)/)
+
+        assertEquals(3, roots.size())
+        roots.each { assertEquals(0, it.depth) }
+        assertEquals(1, roots[1].children[0].depth)
+        assertTrue(roots[0].children.isEmpty())
+    }
+
+    @Test
+    void testDepthAfterOrphanPromotion() {
+        // dangling opener: completed children are promoted outward, so their depth changes
+        List<BalancedGroup> roots = '(A (B) (C(D)'.findBalancedGroups(/\(/, /\)/)
+
+        assertTrue(roots.size() >= 1)
+        roots.each { assertEquals(0, it.depth) }
+    }
+}

--- a/src/test/groovy/groovy/util/regex/BalancedGroupConstructorTest.groovy
+++ b/src/test/groovy/groovy/util/regex/BalancedGroupConstructorTest.groovy
@@ -49,7 +49,7 @@ final class BalancedGroupConstructorTest {
 
         assertThrows(IllegalArgumentException, () -> new BalancedGroup('other', [child]))
         assertThrows(NullPointerException, () -> new BalancedGroup(null, null))
-        assertThrows(IllegalArgumentException, () -> new BalancedGroup('ab', 0, 1, 0, 1, null)) // length mismatch
+        assertThrows(IllegalArgumentException, () -> new BalancedGroup('ab', 0, 3, 0, 3, null)) // past end of source
         assertThrows(IllegalArgumentException, () -> new BalancedGroup('a', -1, 1, 0, 1, null))
     }
 
@@ -71,7 +71,8 @@ final class BalancedGroupConstructorTest {
         assertEquals(4, leaf.fullEnd)
         assertEquals(0, leaf.depth)
 
-        BalancedGroup absolute = new BalancedGroup('xy', 10, 12, 8, 15, null)
+        // offsets index into the source the node keeps, so the source must span them
+        BalancedGroup absolute = new BalancedGroup('0123456789xy---', 10, 12, 8, 15, null)
         assertEquals('xy', absolute.matchedString)
         assertEquals(10, absolute.start)
         assertEquals(12, absolute.end)


### PR DESCRIPTION
A few hundred KB of nested delimiters cost tens of seconds, then died - with a StackOverflowError if the stack ran out first, otherwise by exhausting the heap. Two independent quadratics, both in the nesting.

Depth was assigned eagerly during assembly. find() builds bottom-up, so a node is attached to a new parent once per enclosing delimiter, and each attach re-walked the whole subtree beneath it to restamp depths - quadratic, and one stack frame per level. Depth is now resolved from the parent chain when first asked for and cached, along with every ancestor walked on the way, so resolving a whole tree costs O(n) and any node is O(1) once resolved. The walk is iterative, so nesting no longer consumes stack. A chain 20,000 deep goes from 3646ms to 51ms, and one 10,000 deep whose depths are never read from 853ms to 4ms.

Attaching a node whose depth was already read caches it against a parent chain that is about to change, so the attach drops the cached depths beneath it. That walk is iterative too, prunes at any node whose depth was never read, and does not run during find(), which reads no depths while assembling.

Each node also held its own copy of its matched text. Groups nest, so their spans overlap and those copies duplicate most of the document once per level: 64KB of nesting retained about 990MB. A node now keeps the source and slices on demand, which is what the start/end offsets it already carried were for, so retention is proportional to the input - the same 64KB now retains 2MB. Reading every group's text costs what it did; reading one group's text repeatedly now slices each time rather than returning a stored copy, about 2ns per call.

The package-private six-argument constructor consequently takes the source rather than the already-sliced text, and its offsets index into it. Passing text detached from its offsets is no longer meaningful, so the range check that compared them is now a bounds check against the source. find() is the only production caller and always had the source to hand; it no longer allocates a substring per group.

The source must be effectively immutable for as long as a node lives. find() already flattens its input to a String before matching, which guarantees that.