### PR TITLE
GROOVY-12355: STC: infer division and group arithmetic from the runti…

### DIFF
--- a/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/java/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -6009,15 +6009,21 @@ trying: for (ClassNode[] signature : signatures) {
             switch (op) {
               case DIVIDE:
               case DIVIDE_EQUAL:
-                // divisions may produce different results depending on operand types
-                if (isFloatingCategory(leftRedirect) || isFloatingCategory(rightRedirect)) {
+                // divisions may produce different results depending on operand types;
+                // the runtime uses floating-point math when either operand is a Float
+                // or Double, wrapper or primitive, and BigDecimal math for integral,
+                // BigInteger and BigDecimal operands (GROOVY-12355)
+                if (isFloatingCategory(getUnwrapper(leftRedirect)) || isFloatingCategory(getUnwrapper(rightRedirect))) {
                     if (!isPrimitiveType(leftRedirect) || !isPrimitiveType(rightRedirect)) {
                         return Double_TYPE;
                     }
                     return double_TYPE;
                 }
                 if (DIVIDE == op) {
-                    return BigDecimal_TYPE;
+                    if (isBigDecCategory(getUnwrapper(leftRedirect)) && isBigDecCategory(getUnwrapper(rightRedirect))) {
+                        return BigDecimal_TYPE;
+                    }
+                    return Number_TYPE; // an operand of unknown category may be a Double or Float at runtime
                 }
                 // falls through
               case MOD:
@@ -6039,6 +6045,13 @@ trying: for (ClassNode[] signature : signatures) {
      * Returns the result type for grouped numeric operations such as addition.
      */
     protected static ClassNode getGroupOperationResultType(final ClassNode a, final ClassNode b) {
+        if (!isDoubleCategory(getUnwrapper(a)) || !isDoubleCategory(getUnwrapper(b))) {
+            // an operand typed as Number (or a Number subtype outside every category) may
+            // hold any category at runtime: a floating-point partner still decides the
+            // result, otherwise only Number is certain (GROOVY-12355)
+            if (isFloatingCategory(getUnwrapper(a)) || isFloatingCategory(getUnwrapper(b))) return Double_TYPE;
+            return Number_TYPE;
+        }
         if (isBigIntCategory(a) && isBigIntCategory(b)) return BigInteger_TYPE;
         if (isBigDecCategory(a) && isBigDecCategory(b)) return BigDecimal_TYPE;
         if (isBigDecimalType(a) || isBigDecimalType(b)) return BigDecimal_TYPE;

--- a/src/spec/doc/_working-with-numbers.adoc
+++ b/src/spec/doc/_working-with-numbers.adoc
@@ -304,6 +304,10 @@ if either operand is a `float` or `double`, and a `BigDecimal` result otherwise
 (when both operands are any combination of an integral type `short`, `char`, `byte`, `int`, `long`,
 `BigInteger` or `BigDecimal`).
 
+Under static type checking, the inferred type of a division follows the same rule from the
+static types of the operands. An operand typed as `Number` may hold a `Float` or `Double` at
+runtime as well as any of the other types, so a division involving one is inferred as `Number`.
+
 `BigDecimal` division is performed with the `divide()` method if the division is exact
 (i.e. yielding a result that can be represented within the bounds of the same precision and scale),
 or using a `MathContext` with a http://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html#precision()[precision]

--- a/src/test/groovy/groovy/transform/stc/TypeInferenceSTCTest.groovy
+++ b/src/test/groovy/groovy/transform/stc/TypeInferenceSTCTest.groovy
@@ -1835,6 +1835,92 @@ class TypeInferenceSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-12355
+    @Test
+    void testDivisionInference() {
+        // the runtime divides with floating-point math when either operand is a
+        // Float or Double, and with BigDecimal math for the other known categories;
+        // an operand typed as Number may be either, so the result is only a Number
+        [['Number',     'Number',     'Number'],
+         ['Number',     'int',        'Number'],
+         ['Integer',    'Number',     'Number'],
+         ['Double',     'Integer',    'Double'],
+         ['Integer',    'Double',     'Double'],
+         ['Float',      'Float',      'Double'],
+         ['double',     'Integer',    'Double'],
+         ['double',     'Number',     'Double'],
+         ['double',     'int',        'double'],
+         ['float',      'float',      'double'],
+         ['Integer',    'Integer',    'BigDecimal'],
+         ['int',        'int',        'BigDecimal'],
+         ['Long',       'BigInteger', 'BigDecimal'],
+         ['BigDecimal', 'Integer',    'BigDecimal'],
+         ['BigInteger', 'BigDecimal', 'BigDecimal']
+        ].each { left, right, result ->
+            assertScript """
+                def m($left a, $right b) {
+                    @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                        def type = node.rightExpression.getNodeMetaData(INFERRED_TYPE)
+                        assert type == make($result) : '$left / $right'
+                    })
+                    def r = a / b
+                    r
+                }
+            """
+        }
+    }
+
+    // GROOVY-12355
+    @Test
+    void testGroupOperationInferenceWithNumberOperand() {
+        // an operand typed as Number may hold any category at runtime, so only a
+        // floating-point partner decides the result; otherwise it is a Number
+        [['Number', 'int',        '+', 'Number'],
+         ['int',    'Number',     '*', 'Number'],
+         ['Number', 'Number',     '-', 'Number'],
+         ['Number', 'BigDecimal', '+', 'Number'],
+         ['Number', 'BigInteger', '*', 'Number'],
+         ['Number', 'double',     '*', 'Double'],
+         ['Double', 'Number',     '+', 'Double'],
+         ['Number', 'float',      '-', 'Double']
+        ].each { left, right, operator, result ->
+            assertScript """
+                def m($left a, $right b) {
+                    @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                        def type = node.rightExpression.getNodeMetaData(INFERRED_TYPE)
+                        assert type == make($result) : '$left $operator $right'
+                    })
+                    def r = a $operator b
+                    r
+                }
+            """
+        }
+        assertScript '''
+            def m(Number a, int b) { (a * b).intValue() }
+            assert m(1.5d, 8) == 12 // was ClassCastException: Double cannot be cast to Integer
+            assert m(1.5, 8) == 12
+            assert m(3, 8) == 24
+        '''
+    }
+
+    // GROOVY-12355
+    @Test
+    void testDivisionOfNumberOrWrapperFloatingOperandsAtRuntime() {
+        assertScript '''
+            def nn(Number a, Number b) { a / b }
+            def di(Double a, Integer b) { a / b }
+            def nnChain(Number a, Number b) { ((a / b) * 8).intValue() }
+            def diChain(Double a, Integer b) { ((a / b) * 8).intValue() }
+
+            assert nn(1.5d, 2) == 0.75d && nn(1.5d, 2) instanceof Double
+            assert nn(3, 2) == 1.5 && nn(3, 2) instanceof BigDecimal
+            assert di(1.5d, 2) == 0.75d && di(1.5d, 2) instanceof Double
+            assert nnChain(1.5d, 2) == 6 // was ClassCastException: Double cannot be cast to BigDecimal
+            assert nnChain(3, 2) == 12
+            assert diChain(1.5d, 2) == 6
+        '''
+    }
+
     @Test
     void testNumberPrefixPlusPlusInference() {
         [Byte:'Integer',

--- a/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/BugsStaticCompileTest.groovy
@@ -134,12 +134,12 @@ final class BugsStaticCompileTest extends BugsSTCTest implements StaticCompilati
         '''
     }
 
-    // GROOVY-
+    // GROOVY-5539
     @Test
     void testPowerShouldNotThrowVerifyError() {
         assertScript '''
             int squarePlusOne(int num) {
-                num ** num + 1
+                (num ** num + 1).intValue() // the sum of a power (a Number) and an int is a Number (GROOVY-12355)
             }
             assert squarePlusOne(2) == 5
         '''


### PR DESCRIPTION
…me's number categories

The runtime divides with floating-point math when either operand is a Float or Double, wrapper or primitive, and with BigDecimal math for integral, BigInteger and BigDecimal operands. The type checker only recognised primitive float and double, so Double / Integer was inferred as BigDecimal, and an operand typed as Number, whose runtime category is unknown, was inferred as BigDecimal too. Statically compiled code then cast the Double the runtime produced and failed.

Unwrap before testing the floating category, and infer BigDecimal only when both operands belong to a category that divides that way; a Number operand yields Number. The group operations had the same blind spot from the other side: they took the category of whichever operand they recognised, so Number * int was int. An operand of unknown category now yields Number unless a floating-point partner decides the result, as it does at runtime.

An arithmetic result that could not be typed before may now be a Number where it was an int or BigDecimal, so code that assigned it to a narrower type needs an explicit conversion, as the GROOVY-5539 test now shows. StringUtil.bar with Double arguments works without change.