### PR TITLE
GROOVY-12359: deleteDir: treat junctions and other special nodes as l…

### DIFF
--- a/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/java/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -64,6 +64,9 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.LinkOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1724,16 +1727,24 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
      * <li>false, when it is called for a file which isn't a directory</li>
      * <li>false, when directory couldn't be deleted</li>
      * </ul>
+     * <p>
+     * A symbolic link is removed as the link itself; its target is never entered. The same
+     * holds for any node that is neither a regular file nor a directory, such as a Windows
+     * directory junction: it is never entered, so what it points at is never touched.
      *
      * @param self a File
      * @return true if the file doesn't exist or deletion was successful
      * @since 1.6.0
      */
     public static boolean deleteDir(final File self) {
-        if (Files.isSymbolicLink(self.toPath())) {
-            // never follow a symbolic link into its target; remove the link itself.
-            // Note: Files.isSymbolicLink does not detect Windows directory junctions
-            // (reparse points), which are therefore still traversed.
+        final BasicFileAttributes attrs;
+        try {
+            attrs = Files.readAttributes(self.toPath(), BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        } catch (IOException e) {
+            return !self.exists();
+        }
+        if (attrs.isSymbolicLink()) {
+            // never follow a symbolic link into its target; remove the link itself
             try {
                 Files.delete(self.toPath());
                 return true;
@@ -1741,9 +1752,10 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
                 return false;
             }
         }
-        if (!self.exists())
-            return true;
-        if (!self.isDirectory())
+        if (attrs.isOther() || !attrs.isDirectory())
+            // a plain file is not a directory, and neither is anything reporting isOther:
+            // a Windows junction or other reparse point, a pipe, a socket, a device.
+            // A junction in particular is never entered, so its target is never touched.
             return false;
 
         File[] files = self.listFiles();
@@ -1754,8 +1766,9 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
         // delete contained files
         boolean result = true;
         for (File file : files) {
-            if (Files.isSymbolicLink(file.toPath())) {
-                // remove the link itself; do not recurse through it into the target
+            if (isLinkLike(file.toPath())) {
+                // a symbolic link, junction, or other special node: remove the node itself,
+                // never what it points at or represents
                 try {
                     Files.delete(file.toPath());
                 } catch (IOException e) {
@@ -1775,6 +1788,23 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
             result = false;
 
         return result;
+    }
+
+    /**
+     * Whether the node should be removed as itself rather than entered or opened: a symbolic
+     * link, or anything reporting {@code isOther} — a Windows junction or other reparse point,
+     * a pipe, a socket, a device.
+     *
+     * @param path the node, examined without following links
+     * @return whether to treat it as a leaf
+     */
+    private static boolean isLinkLike(final Path path) {
+        try {
+            BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            return attrs.isSymbolicLink() || attrs.isOther();
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/test/groovy/org/codehaus/groovy/runtime/DirectoryDeleteTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/runtime/DirectoryDeleteTest.groovy
@@ -31,6 +31,76 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue
  */
 class DirectoryDeleteTest {
 
+    // A junction is created without privilege on Windows, unlike a symbolic link, so it is
+    // the link form an unprivileged local user can plant. It must be removed as a node and
+    // never entered. Junctions only exist on Windows, so these run nowhere else; the
+    // symbolic-link tests below cover the same property for POSIX.
+    @Test
+    void junctionInsideTreeIsRemovedNotEntered() {
+        assumeTrue(System.getProperty('os.name').containsIgnoreCase('windows'),
+                'junctions are a Windows construct')
+        def base = Files.createTempDirectory('junction_')
+        def outside = Files.createDirectory(base.resolve('outside'))
+        def survivor = outside.resolve('survivor.txt')
+        survivor.toFile().write('keep')
+        def tree = Files.createDirectory(base.resolve('tree'))
+        def junction = tree.resolve('junction')
+        def proc = ['cmd', '/c', 'mklink', '/J', junction.toString(), outside.toString()].execute()
+        assumeTrue(proc.waitFor() == 0, 'could not create a junction')
+
+        assert tree.toFile().deleteDir()
+        assert !Files.exists(tree, LinkOption.NOFOLLOW_LINKS)
+        assert survivor.toFile().text == 'keep'
+        base.toFile().deleteDir()
+    }
+
+    @Test
+    void deleteDirOnAJunctionRefusesAndLeavesTheTargetAlone() {
+        assumeTrue(System.getProperty('os.name').containsIgnoreCase('windows'),
+                'junctions are a Windows construct')
+        def base = Files.createTempDirectory('junctionSelf_')
+        def outside = Files.createDirectory(base.resolve('outside'))
+        def survivor = outside.resolve('survivor.txt')
+        survivor.toFile().write('keep')
+        def junction = base.resolve('junction')
+        def proc = ['cmd', '/c', 'mklink', '/J', junction.toString(), outside.toString()].execute()
+        assumeTrue(proc.waitFor() == 0, 'could not create a junction')
+
+        // a junction is not a directory to this method, and is never entered
+        assert !junction.toFile().deleteDir()
+        assert survivor.toFile().text == 'keep'
+        base.toFile().deleteDir()
+    }
+
+    // The same guard covers every node reporting isOther, which on POSIX includes a named
+    // pipe — giving the new branch coverage on the platforms the build actually runs on.
+    @Test
+    void namedPipeInsideTreeIsDeletedWithIt() {
+        assumeTrue(!System.getProperty('os.name').containsIgnoreCase('windows'),
+                'mkfifo is a POSIX tool')
+        def base = Files.createTempDirectory('fifo_')
+        def tree = Files.createDirectory(base.resolve('tree'))
+        def fifo = tree.resolve('pipe')
+        assumeTrue(['mkfifo', fifo.toString()].execute().waitFor() == 0, 'could not create a fifo')
+
+        assert tree.toFile().deleteDir()
+        assert !Files.exists(tree, LinkOption.NOFOLLOW_LINKS)
+        base.toFile().deleteDir()
+    }
+
+    @Test
+    void deleteDirOnANamedPipeRefusesAndLeavesIt() {
+        assumeTrue(!System.getProperty('os.name').containsIgnoreCase('windows'),
+                'mkfifo is a POSIX tool')
+        def base = Files.createTempDirectory('fifoSelf_')
+        def fifo = base.resolve('pipe')
+        assumeTrue(['mkfifo', fifo.toString()].execute().waitFor() == 0, 'could not create a fifo')
+
+        assert !fifo.toFile().deleteDir()   // not a directory
+        assert Files.exists(fifo, LinkOption.NOFOLLOW_LINKS)
+        base.toFile().deleteDir()
+    }
+
     @Test
     void testDeleteDir(){
         def file = File.createTempFile("deleteDirTest", "")

--- a/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
+++ b/subprojects/groovy-nio/src/main/java/org/apache/groovy/nio/extensions/NioExtensions.java
@@ -63,6 +63,7 @@ import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
@@ -1387,6 +1388,10 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
      * <li>false, when it is called for a file which isn't a directory</li>
      * <li>false, when directory couldn't be deleted</li>
      * </ul>
+     * <p>
+     * A symbolic link is removed as the link itself; its target is never entered. The same
+     * holds for any node that is neither a regular file nor a directory, such as a Windows
+     * directory junction: it is never entered, so what it points at is never touched.
      * </p>
      *
      * @param self a Path
@@ -1394,10 +1399,14 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
      * @since 2.3.0
      */
     public static boolean deleteDir(final Path self) {
-        if (Files.isSymbolicLink(self)) {
-            // never follow a symbolic link into its target; remove the link itself.
-            // Note: Files.isSymbolicLink does not detect Windows directory junctions
-            // (reparse points), which are therefore still traversed.
+        final BasicFileAttributes selfAttrs;
+        try {
+            selfAttrs = Files.readAttributes(self, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        } catch (IOException e) {
+            return !Files.exists(self);
+        }
+        if (selfAttrs.isSymbolicLink()) {
+            // never follow a symbolic link into its target; remove the link itself
             try {
                 Files.delete(self);
                 return true;
@@ -1405,18 +1414,21 @@ public class NioExtensions extends DefaultGroovyMethodsSupport {
                 return false;
             }
         }
-
-        if (!Files.exists(self))
-            return true;
-
-        if (!Files.isDirectory(self))
+        if (selfAttrs.isOther() || !selfAttrs.isDirectory())
+            // a plain file is not a directory, and neither is anything reporting isOther:
+            // a Windows junction or other reparse point, a pipe, a socket, a device.
+            // A junction in particular is never entered, so its target is never touched.
             return false;
 
         // delete contained files
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(self)) {
             for (Path path : stream) {
-                // do not follow a symbolic link into its target; delete the link itself
-                if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+                BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                if (attrs.isSymbolicLink() || attrs.isOther()) {
+                    // a symbolic link, junction, or other special node: remove the node itself,
+                    // never what it points at or represents
+                    Files.delete(path);
+                } else if (attrs.isDirectory()) {
                     if (!deleteDir(path)) {
                         return false;
                     }

--- a/subprojects/groovy-nio/src/test/groovy/org/apache/groovy/nio/extensions/NioExtensionsTest.groovy
+++ b/subprojects/groovy-nio/src/test/groovy/org/apache/groovy/nio/extensions/NioExtensionsTest.groovy
@@ -726,6 +726,50 @@ class NioExtensionsTest extends Specification {
         !Files.exists(folder)
     }
 
+    def testDeleteDirRemovesAJunctionWithoutEnteringIt() {
+        setup:
+        if (!System.getProperty('os.name').containsIgnoreCase('windows')) {
+            throw new TestAbortedException('junctions are a Windows construct')
+        }
+        def base = Files.createTempDirectory(tempDir.toPath(), 'junction_')
+        def outside = Files.createDirectory(base.resolve('outside'))
+        def survivor = outside.resolve('survivor.txt')
+        Files.write(survivor, 'keep'.bytes)
+        def tree = Files.createDirectory(base.resolve('tree'))
+        def junction = tree.resolve('junction')
+        if (['cmd', '/c', 'mklink', '/J', junction.toString(), outside.toString()].execute().waitFor() != 0) {
+            throw new TestAbortedException('could not create a junction')
+        }
+
+        when:
+        def result = tree.deleteDir()
+
+        then:
+        result
+        !Files.exists(tree, LinkOption.NOFOLLOW_LINKS)
+        new String(Files.readAllBytes(survivor)) == 'keep'
+    }
+
+    def testDeleteDirDeletesANamedPipeInsideTheTree() {
+        setup:
+        if (System.getProperty('os.name').containsIgnoreCase('windows')) {
+            throw new TestAbortedException('mkfifo is a POSIX tool')
+        }
+        def base = Files.createTempDirectory(tempDir.toPath(), 'fifo_')
+        def tree = Files.createDirectory(base.resolve('tree'))
+        def fifo = tree.resolve('pipe')
+        if (['mkfifo', fifo.toString()].execute().waitFor() != 0) {
+            throw new TestAbortedException('could not create a fifo')
+        }
+
+        when:
+        def result = tree.deleteDir()
+
+        then:
+        result
+        !Files.exists(tree, LinkOption.NOFOLLOW_LINKS)
+    }
+
     def testDeleteDirDoesNotFollowSymlink() {
         setup:
         def base = Files.createTempDirectory(tempDir.toPath(), 'symlink_')


### PR DESCRIPTION
…eaves

Since GROOVY-12125 a symbolic link inside a tree being deleted is removed as the link itself and never entered. The guard was Files.isSymbolicLink, which does not report a Windows directory junction, so a junction was still traversed and the contents of its target deleted. A junction is the link form that matters most there: mklink /J needs no privilege, where a Windows symbolic link needs one most users do not hold, and it is planted in advance rather than raced.

Both implementations, File.deleteDir and the groovy-nio Path.deleteDir, now read each node's attributes without following links and treat anything that is neither a regular file nor a directory as a leaf: a symbolic link is removed as before, and a junction or other reparse point, a pipe, a socket or a device is removed as the node it is, never entered or opened. Handed such a node directly, deleteDir returns false as it does for any non-directory, and does not touch what the node points at.

On POSIX the visible behaviour is unchanged — a pipe inside a tree was deleted before and still is, now through the leaf branch, which is covered by new mkfifo tests that run on the platforms the build runs on. The junction behaviour cannot be exercised on those platforms, so the Windows-gated tests are the verification rather than a formality: they create a junction with mklink /J, which succeeds unprivileged on the CI runners, delete the enclosing tree, and assert the target's contents survive. Until they have run on Windows CI, the junction half of this change is implemented to the documented attribute behaviour, not demonstrated.