### PR TITLE
GROOVY-12361: CachedMethod DirectInvoker: decline hidden declaring cl…

### DIFF
--- a/src/main/java/org/apache/groovy/internal/runtime/invoke/InvokerFactory.java
+++ b/src/main/java/org/apache/groovy/internal/runtime/invoke/InvokerFactory.java
@@ -104,6 +104,13 @@ public final class InvokerFactory {
             return null;
         }
         try {
+            if (!allTypesNameable(method.getCachedMethod())) {
+                // A hidden class (e.g. a ProxyGeneratorAdapter proxy) cannot be named
+                // in bytecode. Every step's trampoline would define and initialise
+                // fine but fail with NoClassDefFoundError once its CHECKCAST /
+                // INVOKE* / invokeExact descriptor resolves on first use (GROOVY-12361).
+                return null;
+            }
             return defineSteps(method);
         } catch (Exception | LinkageError ignored) {
             // Sticky-fail expected define/link/access problems, including
@@ -132,6 +139,33 @@ public final class InvokerFactory {
             return false;
         }
         return !AndroidSupport.isRunningAndroid();
+    }
+
+    /**
+     * Whether every type the trampoline bytecode must name — declaring class,
+     * return type and parameter types (array components included) — can be
+     * resolved by name, i.e. none of them is a hidden class (GROOVY-12361).
+     *
+     * @param m the candidate
+     * @return {@code true} when a trampoline can legally reference all types
+     */
+    static boolean allTypesNameable(final Method m) {
+        if (!nameable(m.getDeclaringClass()) || !nameable(m.getReturnType())) {
+            return false;
+        }
+        for (Class<?> p : m.getParameterTypes()) {
+            if (!nameable(p)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean nameable(Class<?> type) {
+        while (type.isArray()) {
+            type = type.getComponentType();
+        }
+        return !type.isHidden();
     }
 
     /**

--- a/src/main/java/org/apache/groovy/internal/runtime/invoke/InvokerFactory.java
+++ b/src/main/java/org/apache/groovy/internal/runtime/invoke/InvokerFactory.java
@@ -54,7 +54,12 @@ import java.lang.reflect.Modifier;
  *       loader can resolve {@link DirectInvoker} — never for bootstrap hosts.</li>
  * </ol>
  *
- * Failures sticky-return {@code null}; they must not propagate to
+ * <p>Before any step, a member whose declaring class, return type or a
+ * parameter type is a hidden class is declined outright (GROOVY-12361): every
+ * encoding names those types in the constant pool, so the trampoline would
+ * define but throw {@code NoClassDefFoundError} on first invoke.
+ *
+ * <p>Failures sticky-return {@code null}; they must not propagate to
  * {@code CachedMethod.invoke}.
  *
  * @since 6.0.0
@@ -103,14 +108,15 @@ public final class InvokerFactory {
         if (method.isCallerSensitive() || Modifier.isAbstract(method.getModifiers())) {
             return null;
         }
+        if (!allTypesNameable(method)) {
+            // Policy decline, not a define failure: a hidden class (e.g. a
+            // ProxyGeneratorAdapter proxy) cannot be named in bytecode. Every
+            // step's trampoline would define and initialise fine but fail with
+            // NoClassDefFoundError once its CHECKCAST / INVOKE* / invokeExact
+            // descriptor resolves on first use (GROOVY-12361).
+            return null;
+        }
         try {
-            if (!allTypesNameable(method.getCachedMethod())) {
-                // A hidden class (e.g. a ProxyGeneratorAdapter proxy) cannot be named
-                // in bytecode. Every step's trampoline would define and initialise
-                // fine but fail with NoClassDefFoundError once its CHECKCAST /
-                // INVOKE* / invokeExact descriptor resolves on first use (GROOVY-12361).
-                return null;
-            }
             return defineSteps(method);
         } catch (Exception | LinkageError ignored) {
             // Sticky-fail expected define/link/access problems, including
@@ -146,14 +152,17 @@ public final class InvokerFactory {
      * return type and parameter types (array components included) — can be
      * resolved by name, i.e. none of them is a hidden class (GROOVY-12361).
      *
-     * @param m the candidate
+     * Reads the same types {@link #isPubliclyInvocableFromInvokerFactory} does,
+     * without forcing accessibility on the underlying {@link Method}.
+     *
+     * @param method the candidate
      * @return {@code true} when a trampoline can legally reference all types
      */
-    static boolean allTypesNameable(final Method m) {
-        if (!nameable(m.getDeclaringClass()) || !nameable(m.getReturnType())) {
+    static boolean allTypesNameable(final CachedMethod method) {
+        if (!nameable(method.getDeclaringClass().getTheClass()) || !nameable(method.getReturnType())) {
             return false;
         }
-        for (Class<?> p : m.getParameterTypes()) {
+        for (Class<?> p : method.getNativeParameterTypes()) {
             if (!nameable(p)) {
                 return false;
             }

--- a/src/test/groovy/org/apache/groovy/internal/runtime/invoke/InvokerFactoryTest.groovy
+++ b/src/test/groovy/org/apache/groovy/internal/runtime/invoke/InvokerFactoryTest.groovy
@@ -474,8 +474,53 @@ final class InvokerFactoryTest {
     }
 
     // -------------------------------------------------------------------------
-    // Forced Step 3 through defineSteps (hidden non-public nestmate)
+    // Hidden hosts (GROOVY-12361): no step may bind a hidden declaring class
     // -------------------------------------------------------------------------
+
+    @Test
+    void testTryCreateDeclinesPublicHiddenHost() {
+        // The ProxyGeneratorAdapter shape: a public hidden nestmate whose public
+        // method is a Step 1 candidate. Its trampoline would CHECKCAST the
+        // receiver to the hidden class name, which no loader can resolve, so it
+        // defines fine but throws NoClassDefFoundError on first invoke.
+        byte[] bytes = emitStringPingClass(
+                'org/apache/groovy/internal/runtime/invoke/PublicHiddenHost',
+                'ping', 'hidden-pong', true)
+        Class<?> hiddenHost = HiddenClassDefiner.tryDefineNestmate(InvokerFactory.LOOKUP, bytes, true)
+        assertNotNull(hiddenHost)
+        assertTrue((Boolean) Class.getMethod('isHidden').invoke(hiddenHost))
+        Method ping = javaGetMethod(hiddenHost, 'ping')
+        assertTrue(InvokerFactory.isPubliclyInvocableFromInvokerFactory(cm(ping)))
+        assertFalse(InvokerFactory.allTypesNameable(ping))
+
+        assertNull(InvokerFactory.tryCreate(cm(ping)), 'hidden declaring class must not get a trampoline')
+        // the reflective path keeps working
+        Object host = ((Class) hiddenHost).getConstructor().newInstance()
+        assertEquals('hidden-pong', cm(ping).invoke(host, new Object[0]))
+    }
+
+    @Test
+    void testHiddenProxyStaysInvocablePastThreshold() {
+        // End-to-end: a map-coerced proxy of a superclass on Groovy's own loader
+        // is a hidden class; before GROOVY-12361 the call after the threshold
+        // failed with NoClassDefFoundError from the generated trampoline.
+        String old = System.getProperty(InvokerFactory.PROPERTY_THRESHOLD)
+        System.setProperty(InvokerFactory.PROPERTY_THRESHOLD, '0')
+        try {
+            Object proxy = [name: { 'circle' }] as HiddenProxyBase
+            assertTrue((Boolean) Class.getMethod('isHidden').invoke(proxy.getClass()))
+            CachedMethod name = CachedMethod.find(javaGetMethod(proxy.getClass(), 'name'))
+            assertNotNull(name)
+            3.times { assertEquals('circle', name.invoke(proxy, new Object[0])) }
+        } finally {
+            if (old == null) System.clearProperty(InvokerFactory.PROPERTY_THRESHOLD)
+            else System.setProperty(InvokerFactory.PROPERTY_THRESHOLD, old)
+        }
+    }
+
+    static abstract class HiddenProxyBase {
+        abstract String name()
+    }
 
     @Test
     void testDefineStepsFallsThroughToClassDataForHiddenNonPublicHost() {
@@ -493,13 +538,17 @@ final class InvokerFactoryTest {
 
         Method ping = javaGetMethod(hiddenHost, 'ping')
         assertFalse(InvokerFactory.isPubliclyInvocableFromInvokerFactory(cm(ping)))
-        DirectInvoker di = InvokerFactory.tryCreate(cm(ping))
-        assertNotNull(di, 'Step 3 classData must succeed when Steps 1–2 cannot')
+        // GROOVY-12361: tryCreate declines any hidden host, since even the classData
+        // trampoline names the hidden type in its invokeExact descriptor and would
+        // throw NoClassDefFoundError on first invoke.
+        assertNull(InvokerFactory.tryCreate(cm(ping)), 'hidden host must not get a trampoline')
+        // Step 3 can still be driven directly (definition succeeds; only resolution
+        // on invoke would fail), which is what the remaining classData tests rely on.
+        DirectInvoker di = InvokerFactory.tryCreateClassData(cm(ping))
+        assertNotNull(di, 'Step 3 classData definition itself must succeed')
         assertTrue(di.class.hidden)
         assertSame(InvokerFactory, di.class.nestHost)
-        // The trampoline CHECKCASTs the receiver to the hidden host name, which is
-        // not Class.forName-loadable — do not invoke. Production CachedMethods
-        // wrap ordinary types; this fixture exists to force the Step 3 fall-through.
+        // Do not invoke: the CHECKCAST to the hidden host name cannot resolve.
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/groovy/org/apache/groovy/internal/runtime/invoke/InvokerFactoryTest.groovy
+++ b/src/test/groovy/org/apache/groovy/internal/runtime/invoke/InvokerFactoryTest.groovy
@@ -491,7 +491,7 @@ final class InvokerFactoryTest {
         assertTrue((Boolean) Class.getMethod('isHidden').invoke(hiddenHost))
         Method ping = javaGetMethod(hiddenHost, 'ping')
         assertTrue(InvokerFactory.isPubliclyInvocableFromInvokerFactory(cm(ping)))
-        assertFalse(InvokerFactory.allTypesNameable(ping))
+        assertFalse(InvokerFactory.allTypesNameable(cm(ping)))
 
         assertNull(InvokerFactory.tryCreate(cm(ping)), 'hidden declaring class must not get a trampoline')
         // the reflective path keeps working
@@ -500,21 +500,30 @@ final class InvokerFactoryTest {
     }
 
     @Test
+    @ResourceLock(Resources.SYSTEM_PROPERTIES)
     void testHiddenProxyStaysInvocablePastThreshold() {
-        // End-to-end: a map-coerced proxy of a superclass on Groovy's own loader
-        // is a hidden class; before GROOVY-12361 the call after the threshold
-        // failed with NoClassDefFoundError from the generated trampoline.
-        String old = System.getProperty(InvokerFactory.PROPERTY_THRESHOLD)
-        System.setProperty(InvokerFactory.PROPERTY_THRESHOLD, '0')
+        // End-to-end through the CachedMethod.invoke hook: a map-coerced proxy of
+        // a superclass on Groovy's own loader is a hidden class; before
+        // GROOVY-12361 the call after the threshold failed with
+        // NoClassDefFoundError from the generated trampoline.
+        String previous = System.getProperty(InvokerFactory.PROPERTY_THRESHOLD)
         try {
+            System.setProperty(InvokerFactory.PROPERTY_THRESHOLD, '0')
             Object proxy = [name: { 'circle' }] as HiddenProxyBase
             assertTrue((Boolean) Class.getMethod('isHidden').invoke(proxy.getClass()))
-            CachedMethod name = CachedMethod.find(javaGetMethod(proxy.getClass(), 'name'))
-            assertNotNull(name)
-            3.times { assertEquals('circle', name.invoke(proxy, new Object[0])) }
+            CachedMethod name = new CachedMethod(javaGetMethod(proxy.getClass(), 'name'))
+            // first call crosses the threshold and must sticky-decline generation
+            assertEquals('circle', name.invoke(proxy, new Object[0]))
+            def attempted = CachedMethod.getDeclaredField('invokerAttempted')
+            attempted.accessible = true
+            assertTrue((Boolean) attempted.get(name), 'generation must have been attempted and declined')
+            def invokerField = CachedMethod.getDeclaredField('invoker')
+            invokerField.accessible = true
+            assertNull(invokerField.get(name), 'hidden proxy must stay on the reflective path')
+            // and the reflective path keeps serving subsequent calls
+            2.times { assertEquals('circle', name.invoke(proxy, new Object[0])) }
         } finally {
-            if (old == null) System.clearProperty(InvokerFactory.PROPERTY_THRESHOLD)
-            else System.setProperty(InvokerFactory.PROPERTY_THRESHOLD, old)
+            restoreProperty(InvokerFactory.PROPERTY_THRESHOLD, previous)
         }
     }
 
@@ -523,7 +532,7 @@ final class InvokerFactoryTest {
     }
 
     @Test
-    void testDefineStepsFallsThroughToClassDataForHiddenNonPublicHost() {
+    void testTryCreateDeclinesNonPublicHiddenHost() {
         byte[] bytes = emitStringPingClass(
                 'org/apache/groovy/internal/runtime/invoke/Step3HiddenHost',
                 'ping', 'step3-pong', false)
@@ -538,17 +547,12 @@ final class InvokerFactoryTest {
 
         Method ping = javaGetMethod(hiddenHost, 'ping')
         assertFalse(InvokerFactory.isPubliclyInvocableFromInvokerFactory(cm(ping)))
-        // GROOVY-12361: tryCreate declines any hidden host, since even the classData
-        // trampoline names the hidden type in its invokeExact descriptor and would
-        // throw NoClassDefFoundError on first invoke.
+        // GROOVY-12361: a non-public hidden host is not a Step 1/2 candidate, so a
+        // Step 1-only patch would let it reach Step 3, whose classData trampoline
+        // names the hidden type in its invokeExact descriptor and would throw
+        // NoClassDefFoundError on first invoke. tryCreate must decline outright.
+        assertFalse(InvokerFactory.allTypesNameable(cm(ping)))
         assertNull(InvokerFactory.tryCreate(cm(ping)), 'hidden host must not get a trampoline')
-        // Step 3 can still be driven directly (definition succeeds; only resolution
-        // on invoke would fail), which is what the remaining classData tests rely on.
-        DirectInvoker di = InvokerFactory.tryCreateClassData(cm(ping))
-        assertNotNull(di, 'Step 3 classData definition itself must succeed')
-        assertTrue(di.class.hidden)
-        assertSame(InvokerFactory, di.class.nestHost)
-        // Do not invoke: the CHECKCAST to the hidden host name cannot resolve.
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
…asses

The generated trampoline names the declaring class, the return type and the parameter types in its bytecode (CHECKCAST, INVOKE*, or the classData invokeExact descriptor). A hidden class cannot be resolved by name, so the trampoline for e.g. a ProxyGeneratorAdapter proxy defined and initialised fine but threw NoClassDefFoundError on first invoke once the method passed the generation threshold. tryCreate now sticky-declines when any of those types is hidden, keeping the reflective path.