### PR TITLE
GROOVY-12354: Indy: reflective cold tier off by default on a JVM, on …

### DIFF
--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/ColdReflectiveMethodHandleWrapper.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/ColdReflectiveMethodHandleWrapper.java
@@ -33,7 +33,9 @@ import java.lang.reflect.Modifier;
 
 /**
  * Experimental reflective cold-tier wrapper, guarded by the
- * {@code groovy.indy.cold.reflection} system property.
+ * {@code groovy.indy.cold.reflection} system property: off by default on a
+ * JVM, on for AOT-linked sites (see {@code IndyInterface#coldReflectionEnabled}
+ * for the caller-location trade-off behind that default).
  * <p>
  * The regular cold tier builds a fully guarded MethodHandle chain on the
  * first invocation of every receiver shape — paying the one-time LambdaForm

--- a/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyInterface.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v8/IndyInterface.java
@@ -56,13 +56,14 @@ public class IndyInterface {
     private static final long INDY_FALLBACK_THRESHOLD = SystemUtil.getLongSafe("groovy.indy.fallback.threshold", 1_000L);
     private static final long INDY_FALLBACK_CUTOFF = SystemUtil.getLongSafe("groovy.indy.fallback.cutoff", 100L);
     /**
-     * Dispatch plain method calls reflectively while a call site is cold,
-     * deferring all MethodHandle chain construction (and its one-time
-     * LambdaForm cost) to hit-count promotion. See
-     * {@link ColdReflectiveMethodHandleWrapper}. On by default; set
-     * {@code -Dgroovy.indy.cold.reflection=false} to disable (opt-out).
+     * Whether plain method calls dispatch reflectively while a call site is
+     * cold ({@link ColdReflectiveMethodHandleWrapper}), deferring MethodHandle
+     * chain construction (and its one-time LambdaForm cost) to hit-count
+     * promotion. An explicit {@code groovy.indy.cold.reflection} setting wins;
+     * {@code null} means unset, in which case only AOT-linked sites use the
+     * tier (see {@link #coldReflectionEnabled}). Read once at class init.
      */
-    private static final boolean INDY_COLD_REFLECTION = SystemUtil.getBooleanSafe("groovy.indy.cold.reflection", true);
+    private static final Boolean INDY_COLD_REFLECTION = readColdReflectionFlag();
 
     /**
      * Flags for method and property calls.
@@ -761,7 +762,7 @@ public class IndyInterface {
 
         Selector selector = Selector.getSelector(callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, arguments);
 
-        if (INDY_COLD_REFLECTION && allowColdReflection && callID == CallType.METHOD.getOrderNumber()) {
+        if (allowColdReflection && callID == CallType.METHOD.getOrderNumber() && coldReflectionEnabled(callSite)) {
             MethodHandleWrapper cold = ColdReflectiveMethodHandleWrapper.tryBuild(
                     selector, callSite, sender, methodName, callID, safeNavigation, thisCall, spreadCall, arguments);
             if (cold != null) {
@@ -780,6 +781,30 @@ public class IndyInterface {
                 selector.method,
                 selector.cache
         );
+    }
+
+    private static Boolean readColdReflectionFlag() {
+        String value = SystemUtil.getSystemPropertySafe("groovy.indy.cold.reflection");
+        return value == null ? null : Boolean.parseBoolean(value);
+    }
+
+    /**
+     * Resolves the reflective cold-tier policy for a call site.
+     * <p>
+     * On a JVM the tier is off unless {@code groovy.indy.cold.reflection=true}
+     * is set: while a site is cold it leaves reflection and Groovy runtime
+     * frames between caller and target, so logging frameworks, {@code StackWalker}
+     * and stack traces report the wrong caller until the site promotes, or
+     * forever for rarely hit sites (GROOVY-12354). For an AOT-linked site
+     * (GraalVM native image, or {@code groovy.indy.aot.link=true}) the tier is
+     * the steady state — method-handle chains would run in the native
+     * MethodHandle interpreter — so it stays on unless the property disables it.
+     *
+     * @param callSite the site being linked
+     * @return {@code true} if the site may use the reflective cold tier
+     */
+    static boolean coldReflectionEnabled(CacheableCallSite callSite) {
+        return INDY_COLD_REFLECTION != null ? INDY_COLD_REFLECTION : callSite.isAotLinked();
     }
 
     /**

--- a/src/spec/doc/invokedynamic-support.adoc
+++ b/src/spec/doc/invokedynamic-support.adoc
@@ -105,3 +105,101 @@ Independently of the jar version that you use (and after having exchanged the ja
 |===
 
 So even if you use the indy jar, if you don't use the invokedynamic flag at compile time, then the compiled classes will use the "old" format.
+
+== Runtime properties
+
+=== The reflective cold tier and caller location
+
+Each dynamic call site is linked lazily. Normally even the first calls at a site run through a
+fully guarded `MethodHandle` chain, so nothing but hidden `LambdaForm` frames sits between the
+calling method and the target. The _reflective cold tier_ (`groovy.indy.cold.reflection`) instead
+dispatches plain instance method calls through `java.lang.reflect.Method.invoke` until the site has
+been hit `groovy.indy.optimize.threshold` times (default 1000), and only then builds the
+`MethodHandle` chain. It saves the one-time LambdaForm cost of shapes that are never hot.
+
+The default depends on where the site links:
+
+* On a JVM the tier is *off*. While a site is on the tier, reflection and Groovy runtime frames sit
+  between the caller and the target, so anything that inspects the call stack sees the wrong caller:
+  the `%C`, `%M`, `%F` and `%L` patterns of Log4j2 and Logback, the source class and method of
+  `java.util.logging`, `StackWalker` and `Throwable` stack traces. A site called fewer than the
+  threshold times, such as a rarely hit `warn` or `error` statement, would report the wrong location
+  for the life of the application.
+* For an AOT-linked site, that is inside a GraalVM native image (or when
+  `-Dgroovy.indy.aot.link=true` forces AOT link mode on a JVM), the tier is *on* and is the steady
+  state: a native image cannot retarget call sites and would otherwise run every `MethodHandle` chain
+  in its MethodHandle interpreter at microseconds per call.
+
+Setting the property explicitly overrides the default in either environment:
+
+----
+-Dgroovy.indy.cold.reflection=true    # use the tier on a JVM (opt in)
+-Dgroovy.indy.cold.reflection=false   # keep the MethodHandle path even in a native image
+----
+
+The property is read once when `IndyInterface` initialises, so pass it on the command line rather
+than setting it from code.
+
+==== Caller location with the tier enabled
+
+If you enable the tier on a JVM, or you run a native image, the following keep caller locations
+correct. Statically compiled code (`@CompileStatic`) needs none of them, since it calls targets
+directly.
+
+`java.util.logging`:: The JDK skips additional packages when inferring the caller if they are listed
+in `jdk.logger.packages`. On a JVM pass it at run time:
++
+----
+-Djdk.logger.packages=org.codehaus.groovy,groovy.lang
+----
++
+Alternatively use the `logp` methods, which take an explicit source class and method.
+
+Logback:: Logback skips its _framework packages_ when computing caller data. The list is only
+configurable programmatically, and its default contains just `org.codehaus.groovy.runtime`, so add
+the reflection and MOP packages before logging starts:
++
+[source,groovy]
+----
+import ch.qos.logback.classic.LoggerContext
+import org.slf4j.LoggerFactory
+
+def context = (LoggerContext) LoggerFactory.getILoggerFactory()
+context.frameworkPackages.addAll([
+    'jdk.internal.reflect', 'java.lang.reflect', 'sun.reflect',
+    'org.codehaus.groovy.', 'groovy.lang.'
+])
+----
+
+Log4j2:: Log4j2 has no equivalent skip list; its location is always the frame following the logger's
+own class. Use `@CompileStatic` for the classes whose log locations matter.
+
+Stack traces:: `org.codehaus.groovy.runtime.StackTraceUtils.sanitize` and `deepSanitize` already
+strip every frame the tier adds. Groovy's own caller lookup,
+`org.codehaus.groovy.reflection.ReflectionUtils.getCallingClass`, ignores the MOP packages and
+is unaffected on a JVM.
+
+==== Native images
+
+Inside a GraalVM native image the picture differs in two ways, and both apply whether the tier is
+on or off, so disabling it there gains nothing:
+
+* GraalVM runs dynamically built `MethodHandle` chains in an interpreter whose frames
+  (`com.oracle.svm.core.methodhandles.*`, `java.lang.invoke.LambdaForm$NamedFunction`) are visible
+  to `StackWalker` and to stack traces, unlike HotSpot's hidden `LambdaForm` frames.
+* Its reflection accessor is `com.oracle.svm.core.reflect.SubstrateMethodAccessor`, not a
+  `jdk.internal.reflect` class, so package lists written for HotSpot do not match it.
+
+The same two workarounds hold once those packages are included:
+
+`java.util.logging`:: The package list is captured in a static initialiser that GraalVM runs at
+image build time, so a run-time `-D` is ignored. Pass it to `native-image` when building:
++
+----
+native-image -Djdk.logger.packages=org.codehaus.groovy,groovy.lang,com.oracle.svm.core.methodhandles,com.oracle.svm.core.reflect,java.lang.invoke ...
+----
+
+Logback:: Add `com.oracle.svm.core.reflect`, `com.oracle.svm.core.methodhandles` and
+`java.lang.invoke` to the framework packages shown above.
+
+Log4j2:: No workaround; use `@CompileStatic` where locations matter.

--- a/src/test/groovy/org/codehaus/groovy/vmplugin/v8/ColdReflectionDefaultTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/vmplugin/v8/ColdReflectionDefaultTest.groovy
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.vmplugin.v8
+
+import org.apache.groovy.runtime.indy.AotDispatch
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.jupiter.api.parallel.Resources
+
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * GROOVY-12354: with {@code groovy.indy.cold.reflection} unset, the reflective
+ * cold tier is used only by AOT-linked sites. On a JVM it would leave
+ * reflection and Groovy frames between caller and target while a site is
+ * cold, misreporting the caller to loggers and stack walkers. The explicit
+ * on/off settings are covered by the fresh-JVM
+ * {@code ColdReflectionParityTest} in the performance subproject, since the
+ * property is read once at {@code IndyInterface} class init.
+ */
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
+final class ColdReflectionDefaultTest {
+
+    private static CacheableCallSite siteLinkedWithAot(boolean aot) {
+        String previous = System.getProperty(AotDispatch.FORCE_PROPERTY)
+        if (aot) System.setProperty(AotDispatch.FORCE_PROPERTY, 'true')
+        else System.clearProperty(AotDispatch.FORCE_PROPERTY)
+        try {
+            new CacheableCallSite(MethodType.methodType(Object, Object[]), MethodHandles.lookup())
+        } finally {
+            if (previous != null) {
+                System.setProperty(AotDispatch.FORCE_PROPERTY, previous)
+            } else {
+                System.clearProperty(AotDispatch.FORCE_PROPERTY)
+            }
+        }
+    }
+
+    @Test
+    void 'with the property unset only AOT-linked sites use the reflective cold tier'() {
+        assumeTrue(System.getProperty('groovy.indy.cold.reflection') == null,
+                'groovy.indy.cold.reflection is set for this JVM; the default cannot be observed')
+        assertFalse(IndyInterface.coldReflectionEnabled(siteLinkedWithAot(false)), 'JVM site must not use the tier by default')
+        assertTrue(IndyInterface.coldReflectionEnabled(siteLinkedWithAot(true)), 'AOT-linked site must use the tier by default')
+    }
+}

--- a/subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/DynamicDispatchColdBench.java
+++ b/subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/DynamicDispatchColdBench.java
@@ -94,25 +94,25 @@ public class DynamicDispatchColdBench {
 
     /**
      * As {@link #dynamicMono_groovy} but with the reflective cold tier
-     * explicitly disabled (GROOVY-12137). The tier is on by default, so the
-     * plain variant measures the shipping (enabled) cold path and this is the
-     * disabled baseline for the cold-dispatch A/B.
+     * explicitly enabled (GROOVY-12137). The tier is off by default on a JVM
+     * (GROOVY-12354), so the plain variant measures the shipping cold path and
+     * this is the enabled side of the cold-dispatch A/B.
      * @return the computed sum
      */
     @Benchmark
-    @Fork(value = 25, jvmArgsAppend = "-Dgroovy.indy.cold.reflection=false")
+    @Fork(value = 25, jvmArgsAppend = "-Dgroovy.indy.cold.reflection=true")
     public int dynamicMono_groovyColdReflect() {
         return new DynamicDispatchCold().monoSum(n);
     }
 
     /**
      * As {@link #dynamicPoly_groovy} but with the reflective cold tier
-     * explicitly disabled (GROOVY-12137) — the disabled baseline for the
-     * polymorphic cold-dispatch A/B (the tier is on by default).
+     * explicitly enabled (GROOVY-12137) — the enabled side of the polymorphic
+     * cold-dispatch A/B (the tier is off by default on a JVM, GROOVY-12354).
      * @return the computed sum
      */
     @Benchmark
-    @Fork(value = 25, jvmArgsAppend = "-Dgroovy.indy.cold.reflection=false")
+    @Fork(value = 25, jvmArgsAppend = "-Dgroovy.indy.cold.reflection=true")
     public int dynamicPoly_groovyColdReflect() {
         return new DynamicDispatchCold().polySum(n);
     }

--- a/subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/dispatch/CallsiteBench.java
+++ b/subprojects/performance/src/jmh/groovy/org/apache/groovy/bench/dispatch/CallsiteBench.java
@@ -48,15 +48,15 @@ public class CallsiteBench {
 
     /**
      * Monomorphic dispatch via Groovy dynamic with the reflective cold tier
-     * explicitly disabled (GROOVY-12137). The tier is on by default, so the
-     * plain {@link #dispatch_1_monomorphic_groovy} measures the shipping
-     * (enabled) behaviour and this variant is the disabled baseline; steady
-     * state must match either way (the hot path is identical after promotion).
+     * explicitly enabled (GROOVY-12137). The tier is off by default on a JVM
+     * (GROOVY-12354), so the plain {@link #dispatch_1_monomorphic_groovy}
+     * measures the shipping behaviour and this variant is the enabled side;
+     * steady state must match either way (the hot path is identical after promotion).
      * @param state the monomorphic receiver state
      * @param bh the blackhole for consuming results
      */
     @Benchmark
-    @Fork(value = 2, jvmArgsAppend = "-Dgroovy.indy.cold.reflection=false")
+    @Fork(value = 2, jvmArgsAppend = "-Dgroovy.indy.cold.reflection=true")
     public void dispatch_1_monomorphic_groovyColdReflect(MonomorphicState state, Blackhole bh) {
         Callsite.dispatch(state.receivers, bh);
     }
@@ -93,15 +93,16 @@ public class CallsiteBench {
 
     /**
      * Polymorphic dispatch (3 types) via Groovy dynamic with the reflective
-     * cold tier explicitly disabled (GROOVY-12137) — the disabled baseline
-     * against the default-on {@link #dispatch_3_polymorphic_groovy}. Polymorphic
-     * sites never reach the consecutive-hit promotion, so the enabled variant
-     * exercises the per-wrapper cumulative promotion; steady state must match.
+     * cold tier explicitly enabled (GROOVY-12137) — the enabled side against
+     * the default {@link #dispatch_3_polymorphic_groovy} (tier off on a JVM,
+     * GROOVY-12354). Polymorphic sites never reach the consecutive-hit
+     * promotion, so this variant exercises the per-wrapper cumulative
+     * promotion; steady state must match.
      * @param state the polymorphic receiver state
      * @param bh the blackhole for consuming results
      */
     @Benchmark
-    @Fork(value = 2, jvmArgsAppend = "-Dgroovy.indy.cold.reflection=false")
+    @Fork(value = 2, jvmArgsAppend = "-Dgroovy.indy.cold.reflection=true")
     public void dispatch_3_polymorphic_groovyColdReflect(PolymorphicState state, Blackhole bh) {
         Callsite.dispatch(state.receivers, bh);
     }

--- a/subprojects/performance/src/test/groovy/org/apache/groovy/perf/ColdReflectionParityTest.groovy
+++ b/subprojects/performance/src/test/groovy/org/apache/groovy/perf/ColdReflectionParityTest.groovy
@@ -25,7 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * Standing parity guard for the reflective cold tier (GROOVY-12137,
- * {@code groovy.indy.cold.reflection}, on by default). The tier's fast path
+ * {@code groovy.indy.cold.reflection}; off by default on a JVM, on for
+ * AOT-linked sites — GROOVY-12354). The tier's fast path
  * dispatches via {@code java.lang.reflect.Method.invoke} while the normal
  * path uses MethodHandles, so its unique risk is behavioural divergence
  * between those two invocation mechanisms (e.g. primitive-return box identity,
@@ -73,11 +74,21 @@ class ColdReflectionParityTest {
         assertEquals(0, firedOff, "reflective cold tier fired $firedOff times when disabled; expected none")
     }
 
+    @Test
+    void coldReflectionDefaultIsAotOnly() {
+        // property unset: a plain JVM never fires the tier (GROOVY-12354); the same
+        // JVM with AOT link mode forced links every site through it
+        int firedJvm = countColdDispatches(runCorpus(null, true))
+        int firedAot = countColdDispatches(runCorpus(null, true, ['-Dgroovy.indy.aot.link=true']))
+        assertEquals(0, firedJvm, "reflective cold tier fired $firedJvm times on a JVM with the property unset; expected none")
+        assertTrue(firedAot >= 50, "reflective cold tier fired only $firedAot times on AOT-linked sites with the property unset; expected broad exercise")
+    }
+
     private static int countColdDispatches(String log) {
         log.readLines().count { it.contains('using reflective cold tier') }
     }
 
-    private static String runCorpus(boolean coldReflection, boolean logging = false) {
+    private static String runCorpus(Boolean coldReflection, boolean logging = false, List<String> extraArgs = []) {
         def corpus = File.createTempFile('cold-reflection-parity', '.groovy')
         corpus.deleteOnExit()
         corpus.bytes = ColdReflectionParityTest.getResourceAsStream(CORPUS_RESOURCE).bytes
@@ -85,9 +96,10 @@ class ColdReflectionParityTest {
         def java = new File(System.getProperty('java.home'), 'bin/java').absolutePath
         def cp = System.getProperty('java.class.path')
         def cmd = [java, '-cp', cp]
-        // pin the state explicitly (the flag is opt-out / on by default), so
-        // the off case actively disables and the test does not rely on the default
-        cmd << "-Dgroovy.indy.cold.reflection=${coldReflection}".toString()
+        // pin the state explicitly when asked, so the on/off cases do not depend on
+        // the default; null leaves the property unset to exercise the default itself
+        if (coldReflection != null) cmd << "-Dgroovy.indy.cold.reflection=${coldReflection}".toString()
+        cmd.addAll(extraArgs)
         if (logging) cmd << '-Dgroovy.indy.logging=true'
         cmd += ['groovy.ui.GroovyMain', corpus.absolutePath]
 


### PR DESCRIPTION
…for AOT-linked sites

While a call site is on the reflective cold tier, reflection and Groovy runtime frames sit between caller and target, so logging frameworks, StackWalker and stack traces report the wrong caller until the site promotes, or forever for rarely hit sites. Groovy 5 reported the caller correctly from the first call, so the on-by-default tier was a regression.

An explicit groovy.indy.cold.reflection setting still wins. When unset, only AOT-linked sites (GraalVM native image, or groovy.indy.aot.link) use the tier, where it is the steady state. The JMH A/B forks now enable the tier rather than disable it, and the invokedynamic docs describe the property, its defaults, and the logger-side workarounds for JVM and native-image users.