### PR TITLE
GROOVY-12366: Ship native-image.properties and resource patterns in t…

### DIFF
--- a/build-logic/src/main/groovy/org.apache.groovy-common.gradle
+++ b/build-logic/src/main/groovy/org.apache.groovy-common.gradle
@@ -67,6 +67,7 @@ tasks.named('rat') {
                 '**/jquery-2.1.1.min.js', // MIT license as per NOTICE/LICENSE files
                 '**/dashboard/vendor/**', // third-party MIT JS vendored for the gh-pages perf dashboard only; excluded from source zip
                 '**/groovy/console/ui/icons/*.svg', // Material Symbols, Apache 2.0 (see credits.txt)
+                '**/META-INF/native-image/**/*.json', // GraalVM reachability metadata; JSON cannot carry a license header
                 '.classpath', '.project', '.settings/**', 'bin/**', // Eclipse files
                 'bootstrap/settings.gradle', // empty file
                 '**/hs_err_pid**.log', // sometimes left over error files

--- a/src/resources/META-INF/native-image/org.apache.groovy/groovy/native-image.properties
+++ b/src/resources/META-INF/native-image/org.apache.groovy/groovy/native-image.properties
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# GraalVM native-image picks this file up from the class path (GROOVY-12366).
+#
+# The classes below keep run-time state or read system properties in their
+# static initialisers and decide how dynamic dispatch links (the AOT link mode
+# of GROOVY-12234 detects a native image at run time). They must never be
+# initialised while the image is being built, even if the builder's class
+# initialisation simulation would otherwise consider them safe.
+#
+# Reflection metadata for Groovy's own runtime is not shipped yet (GROOVY-12365);
+# record it with the native-image agent. The resource patterns Groovy needs are
+# in resource-config.json next to this file.
+#
+# Caller location in java.util.logging inside a native image needs the
+# packages Groovy and GraalVM insert to be listed in jdk.logger.packages at
+# image build time; that property is a single value, so it is deliberately
+# left to the application (see the invokedynamic documentation).
+Args = --initialize-at-run-time=org.codehaus.groovy.vmplugin.v8.IndyInterface,org.codehaus.groovy.vmplugin.v8.CacheableCallSite,org.apache.groovy.runtime.indy.AotDispatch,org.apache.groovy.runtime.indy.IndyInvalidation,org.apache.groovy.util.HiddenClassDefiner,org.apache.groovy.internal.runtime.invoke.InvokerFactory,org.codehaus.groovy.control.XStreamUtils

--- a/src/resources/META-INF/native-image/org.apache.groovy/groovy/resource-config.json
+++ b/src/resources/META-INF/native-image/org.apache.groovy/groovy/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {"pattern": "\\QMETA-INF/dgminfo\\E"},
+      {"pattern": "\\QMETA-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule\\E"},
+      {"pattern": "\\QMETA-INF/services/org.codehaus.groovy.runtime.ExtensionModule\\E"}
+    ]
+  }
+}


### PR DESCRIPTION
…he groovy jar

GraalVM native-image reads META-INF/native-image/<group>/<artifact>/ native-image.properties from the class path. Pin run-time initialisation for the runtime classes that read system properties or hold link-time state (the AOT link mode detects a native image at run time), and ship the resource patterns Groovy's runtime needs (dgminfo, extension-module descriptor and service file), so a dynamic Groovy application no longer has to carry these in its own build. Reflection metadata is left to GROOVY-12365. The JSON metadata is excluded from RAT since it cannot carry a license header.