### PR TITLE
GROOVY-12360: GroovyDocWriter: keep generated pages inside the destin…

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/GroovyDocWriter.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/GroovyDocWriter.java
@@ -92,10 +92,31 @@ public class GroovyDocWriter {
     /**
      * Writes the HTML page for a single class doc if its visibility matches the configured scope.
      */
+    /**
+     * Whether a destination built from a documentation-derived name would land outside the
+     * destination directory. The name reaches here as a package path, and a {@code ..} segment
+     * in it — from a source argument or a source-path-relative file name — would otherwise let
+     * a page be written anywhere the process can write. The check is on the normalised paths, so
+     * it does not depend on the names having been sanitised earlier.
+     *
+     * @param destdir the destination directory
+     * @param destFileName the candidate output path below it
+     * @return whether the candidate resolves outside {@code destdir}
+     */
+    private static boolean escapesDestDir(String destdir, String destFileName) {
+        Path root = Paths.get(destdir).toAbsolutePath().normalize();
+        Path target = Paths.get(destFileName).toAbsolutePath().normalize();
+        return !target.startsWith(root);
+    }
+
     public void writeClassToOutput(GroovyClassDoc classDoc, String destdir) throws Exception {
         if (classDoc.isPublic() || classDoc.isProtected() && "true".equals(properties.getProperty("protectedScope")) ||
                 classDoc.isPackagePrivate() && "true".equals(properties.getProperty("packageScope")) || "true".equals(properties.getProperty("privateScope"))) {
             String destFileName = destdir + FS + classDoc.getFullPathName() + ".html";
+            if (escapesDestDir(destdir, destFileName)) {
+                log.warn("Skipping " + classDoc.getFullPathName() + ": documentation path escapes the destination directory");
+                return;
+            }
             log.debug("Generating " + destFileName);
             String renderedSrc = templateEngine.applyClassTemplates(classDoc);
             output.writeToOutput(destFileName, renderedSrc, properties.getProperty("fileEncoding"));
@@ -108,6 +129,10 @@ public class GroovyDocWriter {
     public void writePackages(GroovyRootDoc rootDoc, String destdir) throws Exception {
         for (GroovyPackageDoc packageDoc : rootDoc.specifiedPackages()) {
             if (new File(packageDoc.name()).isAbsolute()) continue;
+            if (escapesDestDir(destdir, destdir + FS + packageDoc.name())) {
+                log.warn("Skipping package " + packageDoc.name() + ": path escapes the destination directory");
+                continue;
+            }
             output.makeOutputArea(destdir + FS + packageDoc.name());
             writePackageToOutput(packageDoc, destdir);
             copyResourceFiles(packageDoc, destdir);

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/MockOutputTool.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/MockOutputTool.java
@@ -115,6 +115,16 @@ public class MockOutputTool implements OutputTool {
     }
 
     /**
+     * Returns every path written to by {@link #writeToOutput}, mapped to its content. The keys
+     * are the raw destination paths, so a test can assert none of them escape a directory.
+     *
+     * @return the written paths and their content
+     */
+    public Map<String, String> getOutputs() {
+        return output;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -154,6 +154,35 @@ public class GroovyDocToolTest extends GroovyTestCase {
     // GROOVY-3782 (stray-brace rendering bug): the old regex chain broke
     // `{@inheritDoc}` into bogus `{<DL><DT><B>inheritDoc:</B>...` HTML. The
     // GROOVY-11939 tokenizer refactor fixed that as a side-effect. Verify.
+    // A documentation path derived from a source argument or a source-path-relative file name
+    // may carry a ".." segment; the writer must not follow it out of the destination directory.
+    public void testClassPageDoesNotEscapeDestinationDirectory() throws Exception {
+        Path srcRoot = Files.createTempDirectory("groovydoc-traversal");
+        try {
+            Path pkg = Files.createDirectories(srcRoot.resolve("sub"));
+            Files.writeString(pkg.resolve("Pwned.groovy"), "class Pwned { }");
+
+            GroovyDocTool tool = makeHtmltool(new ArrayList<>(), null, new Properties(),
+                    new String[]{srcRoot.toString()});
+            // not found as a direct file, so resolved under the source path with its ".." kept
+            tool.add(List.of("../" + srcRoot.getFileName() + "/sub/Pwned.groovy"));
+
+            MockOutputTool output = new MockOutputTool();
+            tool.renderToOutput(output, MOCK_DIR);
+
+            for (String written : output.getOutputs().keySet()) {
+                Path resolved = Paths.get(written).toAbsolutePath().normalize();
+                Path root = Paths.get(MOCK_DIR).toAbsolutePath().normalize();
+                assertTrue("output escaped the destination directory: " + written,
+                        resolved.startsWith(root));
+            }
+        } finally {
+            try (Stream<Path> walk = Files.walk(srcRoot)) {
+                walk.sorted(Comparator.reverseOrder()).forEach(pth -> pth.toFile().delete());
+            }
+        }
+    }
+
     public void testInheritDocDoesNotLeaveStrayBrace() throws Exception {
         String base = "org/codehaus/groovy/tools/groovydoc/testfiles";
         htmlTool.add(List.of(base + "/ClassWithInheritDocStub.groovy"));


### PR DESCRIPTION
…ation directory

A class page was written to destdir + "/" + fullPathName + ".html", and a package page under destdir + "/" + packageDoc.name(), with the only guard being that the name is not absolute. The name is a package path, and it picks up a ".." segment when a source file is named through a source path with one — so a page could be written above the destination directory:

    fullPathName = ../srcroot/sub/Pwned
    -> <destdir>/../srcroot/sub/Pwned.html   written outside destdir

The absolute-only check is replaced by one that normalises the resolved path and confirms it stays within the destination directory, at both the class-page and package-page sites. A name that would escape is skipped with a warning rather than followed. The check is on the normalised paths, so it does not rely on names having been sanitised earlier, and a legitimate package like a/b/c still resolves within destdir and is unaffected.

The regression test builds a doc whose path carries "..", renders through a mock output tool, and asserts that nothing it wrote resolves outside the destination. It was confirmed to fail without the guard, writing to <destdir>/../.../Pwned.html.

MockOutputTool gains a getOutputs() accessor so the test can inspect every written path; it previously exposed only single-file lookup.