### PR TITLE
GROOVY-12368: groovy.ast=xml: give the AST dump the source file's per…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,11 @@ afterEvaluate {
 dependencies {
     // Classic call-site runtime for tests that compile with indy=false (GROOVY-11158)
     testRuntimeOnly projects.groovyCallsite
+    // the groovy.ast=xml AST dump uses XStream, an optional feature; supply it to the tests so
+    // XStreamUtils can be exercised (its permission handling in particular) rather than skipped
+    testRuntimeOnly "com.thoughtworks.xstream:xstream:${versions.xstream}", {
+        transitive = false
+    }
     // for internal CLI usage
     api "info.picocli:picocli:${versions.picocli}" // marked as api but manually excluded later in assemble.gradle - modules will use shaded version
     // for internal usage of things like Opcode

--- a/src/main/java/org/codehaus/groovy/control/XStreamUtils.java
+++ b/src/main/java/org/codehaus/groovy/control/XStreamUtils.java
@@ -24,7 +24,15 @@ import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.WARNING;
@@ -37,7 +45,10 @@ public abstract class XStreamUtils {
     private static final System.Logger LOGGER = System.getLogger(XStreamUtils.class.getName());
 
     /**
-     * Serializes the supplied AST object to an XML file next to the named source.
+     * Serializes the supplied AST object to an XML file next to the named source. The file is
+     * given the source file's permissions, so it exposes no more than the source already does;
+     * where there is no source file to match, or the filesystem has no POSIX permissions, the
+     * file is owner-only or left to the default respectively.
      *
      * @param name the source name or URI used to derive the XML file name
      * @param ast the AST object to serialize
@@ -53,6 +64,10 @@ public abstract class XStreamUtils {
                 LOGGER.log(WARNING, "File-name for writing {0} AST could not be determined!", name);
                 return;
             }
+            // the dump is a serialization of the source's AST, so it is no less sensitive than the
+            // source; give it the source file's permissions rather than the process umask, so it
+            // does not expose to others what the source kept to its owner
+            createWithPermissions(astFile.toPath(), astDumpPermissions(name));
             astFileWriter = new FileWriter(astFile, false);
             xstream.toXML(ast, astFileWriter);
             LOGGER.log(DEBUG, "Written AST to {0}.xml", name);
@@ -61,6 +76,51 @@ public abstract class XStreamUtils {
             LOGGER.log(WARNING, "Couldn''t write to " + name + ".xml", e);
         } finally {
             DefaultGroovyMethods.closeQuietly(astFileWriter);
+        }
+    }
+
+    /**
+     * The permissions to give the AST dump: the source file's own, so the dump exposes no more
+     * than the source already does. When there is no source file to match — a source compiled
+     * from a string, say — a debug dump defaults to owner-only rather than the process umask.
+     *
+     * @param name the source name or URI the dump sits beside
+     * @return the permissions, or {@code null} where POSIX permissions do not apply
+     */
+    private static Set<PosixFilePermission> astDumpPermissions(final String name) {
+        try {
+            File sourceFile = name.startsWith("file:") ? new File(URI.create(name)) : new File(name);
+            if (sourceFile.exists()) {
+                return Files.getPosixFilePermissions(sourceFile.toPath());
+            }
+            return EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+        } catch (IOException | UnsupportedOperationException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Creates the dump file carrying the given permissions, so its contents are never briefly
+     * readable by anyone those permissions exclude. Where they do not apply, creation is left to
+     * the writer as before.
+     *
+     * @param path the file to create
+     * @param permissions the permissions to give it, or {@code null} to leave creation to the writer
+     */
+    private static void createWithPermissions(final Path path, final Set<PosixFilePermission> permissions) {
+        if (permissions == null) {
+            return;
+        }
+        try {
+            Files.createFile(path, PosixFilePermissions.asFileAttribute(permissions));
+        } catch (FileAlreadyExistsException e) {
+            try {
+                Files.setPosixFilePermissions(path, permissions);
+            } catch (IOException | UnsupportedOperationException ignored) {
+                // best effort; the writer overwrites the existing file
+            }
+        } catch (IOException | UnsupportedOperationException e) {
+            // no POSIX support, or the file cannot be pre-created; the writer creates it
         }
     }
 

--- a/src/test/groovy/org/codehaus/groovy/control/XStreamUtilsTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/control/XStreamUtilsTest.groovy
@@ -1,0 +1,73 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.control
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFileAttributeView
+import java.nio.file.attribute.PosixFilePermission
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * The {@code groovy.ast=xml} AST dump is written beside its source; it should not expose to
+ * others what the source kept to its owner.
+ */
+class XStreamUtilsTest {
+
+    @TempDir
+    Path dir
+
+    private static boolean posixSupported(Path path) {
+        Files.getFileAttributeView(path, PosixFileAttributeView) != null
+    }
+
+    @Test
+    void dumpInheritsThePermissionsOfItsSource() {
+        Path source = dir.resolve('Private.groovy')
+        Files.writeString(source, 'println "hi"')
+        assumeTrue(posixSupported(source), 'POSIX file permissions not supported here')
+        Files.setPosixFilePermissions(source, EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE))
+
+        XStreamUtils.serialize(source.toString(), 'placeholder AST content')
+
+        Path dump = dir.resolve('Private.groovy.xml')
+        assert Files.exists(dump)
+        assert Files.getPosixFilePermissions(dump) == Files.getPosixFilePermissions(source)
+        assert !Files.getPosixFilePermissions(dump).contains(PosixFilePermission.OTHERS_READ)
+    }
+
+    @Test
+    void dumpForASourceWithoutAFileIsOwnerOnly() {
+        // a source compiled from a string has a name but no file to match, so the dump defaults
+        // to owner-only rather than the process umask
+        Path dump = dir.resolve('script_from_string.xml')
+        assumeTrue(posixSupported(dir), 'POSIX file permissions not supported here')
+
+        XStreamUtils.serialize(dir.resolve('script_from_string').toString(), 'placeholder AST content')
+
+        assert Files.exists(dump)
+        def perms = Files.getPosixFilePermissions(dump)
+        assert !perms.contains(PosixFilePermission.OTHERS_READ)
+        assert !perms.contains(PosixFilePermission.GROUP_READ)
+    }
+}


### PR DESCRIPTION
…missions

The groovy.ast=xml debug option writes a serialized AST to <source>.xml beside the source, through a FileWriter that creates the file at the process umask. A source the developer had kept to themselves produced a world-readable dump of its AST:

    -rw-------  Script.groovy
    -rw-r--r--  Script.groovy.xml

The dump is a serialization of that source's AST, so it is no less sensitive than the source. It is now created with the source file's own permissions, so it exposes no more than the source already does; a world-readable source still yields a world-readable dump, unchanged. Where there is no source file to match — a source compiled from a string — the dump defaults to owner-only rather than the umask; where the filesystem has no POSIX permissions, creation is left to the writer as before.

The file is created with the permissions rather than created and then adjusted, following the pattern used for in-place file rewrites, so its contents are never briefly readable by anyone those permissions exclude.

XStream is an optional feature, so a testRuntimeOnly dependency is added to let XStreamUtils be exercised; the test asserts the dump inherits a private source's permissions and was confirmed to fail without the change.