### PR TITLE
GROOVY-12370: GroovyDocWriter: do not copy a symbolic link out of a resource directory

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/GroovyDocWriter.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/GroovyDocWriter.java
@@ -28,7 +28,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.LinkOption;
 import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -142,6 +144,13 @@ public class GroovyDocWriter {
     private void copyTree(Path srcDir, Path dstDir) {
         try (Stream<Path> stream = Files.walk(srcDir)) {
             stream.forEach(srcFile -> {
+                if (isLinkLike(srcFile)) {
+                    // do not follow a link out of the resource tree: copying it would place the
+                    // content of whatever it points at, which may be outside the source, into the
+                    // published documentation
+                    log.warn("Skipping " + srcFile + ": symbolic links are not copied into the documentation");
+                    return;
+                }
                 Path rel = srcDir.relativize(srcFile);
                 Path dstFile = dstDir.resolve(rel);
                 try {
@@ -156,6 +165,23 @@ public class GroovyDocWriter {
             });
         } catch (IOException e) {
             log.warn("Failed to walk " + srcDir + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Whether the path is a symbolic link or other reparse point &mdash; a Windows junction, say.
+     * Such a node is not copied into the documentation, because copying it would follow it to
+     * content that may lie outside the resource tree the author meant to publish.
+     *
+     * @param path the path, examined without following links
+     * @return whether it should be skipped rather than copied
+     */
+    private static boolean isLinkLike(final Path path) {
+        try {
+            BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            return attrs.isSymbolicLink() || attrs.isOther();
+        } catch (IOException e) {
+            return false;
         }
     }
 

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -370,6 +370,46 @@ public class GroovyDocToolTest extends GroovyTestCase {
                 doc.contains(secretText));
     }
 
+    // A symbolic link inside a package's doc-files/ directory must not be followed when the
+    // directory is mirrored into the output: copying it would place the content of whatever it
+    // points at, possibly outside the source tree, into the published documentation.
+    public void testDocFilesSymlinkIsNotCopiedIntoOutput() throws Exception {
+        String pkg = "org/codehaus/groovy/tools/groovydoc/testfiles/docfiles";
+        Path tmp = Files.createTempDirectory("docfiles-symlink-");
+        Path pkgDir = tmp.resolve(pkg);
+        Path docFiles = Files.createDirectories(pkgDir.resolve("doc-files"));
+        Files.writeString(pkgDir.resolve("Documented.groovy"),
+                "package " + pkg.replace('/', '.') + "\nclass Documented {}\n");
+
+        String secret = "TOP_SECRET_CREDENTIAL_VALUE";
+        Path secretFile = Files.writeString(tmp.resolve("secret.txt"), secret);
+        Files.writeString(docFiles.resolve("note.txt"), "a real asset"); // positive control
+        try {
+            Files.createSymbolicLink(docFiles.resolve("leak.txt"), secretFile);
+        } catch (IOException | UnsupportedOperationException e) {
+            return; // symbolic links unavailable on this platform (e.g. Windows without privilege)
+        }
+
+        GroovyDocTool tool = new GroovyDocTool(
+                new FileSystemResourceManager("src/main/resources"),
+                new String[]{tmp.toString()},
+                GroovyDocTemplateInfo.DEFAULT_DOC_TEMPLATES,
+                GroovyDocTemplateInfo.DEFAULT_PACKAGE_TEMPLATES,
+                GroovyDocTemplateInfo.DEFAULT_CLASS_TEMPLATES,
+                new ArrayList<>(), null, new Properties());
+        tool.add(List.of(pkg + "/Documented.groovy"));
+        MockOutputTool output = new MockOutputTool();
+        tool.renderToOutput(output, MOCK_DIR);
+
+        String docFilesOut = MOCK_DIR + "/" + pkg + "/doc-files/";
+        // the symlink is not copied, so its target content never reaches the output
+        assertNull("a doc-files symlink was copied into the output",
+                output.getText(docFilesOut + "leak.txt"));
+        // a real asset in the same directory still is
+        assertEquals("a real doc-files asset should still be copied",
+                "a real asset", output.getText(docFilesOut + "note.txt"));
+    }
+
     /** Renders one class from a temporary source tree and returns its page. */
     private String renderSingle(Path sourcePath, String pkg, String simpleName) throws Exception {
         GroovyDocTool tool = new GroovyDocTool(


### PR DESCRIPTION
A package's doc-files/ and snippet-files/ directories are mirrored into the output verbatim. The mirror walked the tree and copied each entry with Files.copy, which follows a symbolic link and copies the content of its target. A link pointing outside the source tree therefore placed that outside content into the published documentation:

    doc-files/leak.txt -> ../../../secret/passwd
    published as doc-files/leak.txt containing the secret

A link, or other reparse point such as a Windows junction, is now skipped with a warning rather than followed, so only the files actually inside the resource directory are published. An ordinary file beside the link is copied as before.

The regression test puts a symbolic link to a file outside the tree into a package's doc-files/, renders, and asserts the link was not copied while a real asset in the same directory was; it was confirmed to copy the link's target content without the guard.