### PR TITLE
GROOVY-12378: @Log4j2: staticLocation option to emit compile-time cal…

### DIFF
--- a/src/main/java/groovy/util/logging/Log4j2.java
+++ b/src/main/java/groovy/util/logging/Log4j2.java
@@ -19,12 +19,16 @@
 package groovy.util.logging;
 
 import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyRuntimeException;
 import groovy.transform.Undefined;
+import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.TupleExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.transform.GroovyASTTransformationClass;
 import org.codehaus.groovy.transform.LogASTTransformation;
 
@@ -33,10 +37,14 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 
+import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.classX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.isInstanceOfX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.nullX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.ternaryX;
 
@@ -95,12 +103,42 @@ public @interface Log4j2 {
      */
     Class<? extends LogASTTransformation.LoggingStrategy> loggingStrategy() default Log4j2LoggingStrategy.class;
 
+    /**
+     * Whether logging statements hand Log4j 2 their source location, computed at
+     * compile time, instead of leaving it to be found by walking the stack at
+     * run time. With {@code true}, {@code log.info(msg)} becomes
+     * {@code log.atInfo().withLocation(location).log(msg)}, where {@code location}
+     * is a {@code StackTraceElement} for the statement held in a synthetic static
+     * field of the annotated class, naming the class, the enclosing method, the
+     * source file and the line of the statement. That location is correct however
+     * the call is dispatched -- through the Groovy runtime on a JVM, or inside a
+     * GraalVM native image, where stack walking otherwise reports runtime frames --
+     * and it spares Log4j 2 the stack walk that {@code %C}, {@code %M}, {@code %F}
+     * and {@code %L} patterns need.
+     * <p>
+     * Requires the {@code LogBuilder} API (Log4j 2.13 or later) on the compile
+     * classpath; compilation fails otherwise. Argument types are unknown when the
+     * transform runs, so a {@code Marker} first argument or a {@code Throwable}
+     * last argument is recognised, at run time, when it is passed as a variable
+     * (the usual {@code log.error("...", e)} shape); other expressions in those
+     * positions are logged as message parameters. Statements inside a closure
+     * name the enclosing method rather than the closure's {@code doCall}.
+     * Only statements made through the injected logger field are rewritten.
+     *
+     * @return {@code true} to supply locations at compile time
+     * @since 6.0.0
+     */
+    boolean staticLocation() default false;
+
     //
 
     /**
      * Logging strategy for Log4j 2.
      */
     class Log4j2LoggingStrategy extends LogASTTransformation.AbstractLoggingStrategyV2 {
+
+        private static final String LOG_BUILDER = "org.apache.logging.log4j.LogBuilder";
+        private static final String MARKER = "org.apache.logging.log4j.Marker";
 
         /**
          * Creates a Log4j 2 logging strategy.
@@ -147,6 +185,85 @@ public @interface Log4j2 {
             condition.setImplicitThis(false);
 
             return ternaryX(condition, originalExpression, nullX());
+        }
+
+        /**
+         * {@inheritDoc}
+         * <p>Requires Log4j 2.13's {@code LogBuilder} to be resolvable.
+         */
+        @Override
+        public String staticLocationUnsupportedReason() {
+            try {
+                classNode(LOG_BUILDER);
+                return null;
+            } catch (GroovyRuntimeException e) {
+                return LOG_BUILDER + " (Log4j 2.13 or later) is not on the compile classpath";
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         * <p>Emits {@code log.atLevel().withLocation(location).log(args)}. Argument
+         * types are unknown at compile time, so when a call has several arguments
+         * and its first or last one is a variable, that variable is tested at run
+         * time: a leading {@code Marker} goes through {@code withMarker} and a
+         * trailing {@code Throwable} through {@code withThrowable}, which the
+         * builder's {@code log} methods do not do on their own. Non-simple
+         * arguments keep the {@code isLevelEnabled} guard so they are not
+         * evaluated for a disabled level.
+         */
+        @Override
+        public Expression wrapLoggingMethodCallWithLocation(final Expression logVariable, final String methodName, final MethodCallExpression originalCall, final Expression location, final boolean guard) {
+            String level = methodName.substring(0, 1).toUpperCase(Locale.ENGLISH) + methodName.substring(1);
+            List<Expression> arguments = originalCall.getArguments() instanceof TupleExpression tuple
+                    ? tuple.getExpressions() : List.of(originalCall.getArguments());
+
+            Expression call = emitX(() -> builderX(logVariable, level, location), arguments);
+            call.setSourcePosition(originalCall);
+
+            if (!guard) return call;
+            MethodCallExpression condition = callX(logVariable, "is" + level + "Enabled", ArgumentListExpression.EMPTY_ARGUMENTS);
+            return ternaryX(condition, call, nullX());
+        }
+
+        /**
+         * Builds the {@code log(...)} call, branching at run time on a leading
+         * marker variable and then on a trailing throwable variable. Each branch
+         * gets its own builder expression tree; AST nodes must not be shared.
+         */
+        private Expression emitX(final Supplier<Expression> builder, final List<Expression> arguments) {
+            if (arguments.size() >= 2 && arguments.get(0) instanceof VariableExpression maybeMarker) {
+                List<Expression> rest = arguments.subList(1, arguments.size());
+                Expression marked = emitThrowableX(() -> callX(builder.get(), "withMarker", args(maybeMarker)), rest);
+                Expression plain = emitThrowableX(builder, arguments);
+                return ternaryX(isInstanceOfX(maybeMarker, classNode(MARKER)), marked, plain);
+            }
+            return emitThrowableX(builder, arguments);
+        }
+
+        private Expression emitThrowableX(final Supplier<Expression> builder, final List<Expression> arguments) {
+            int last = arguments.size() - 1;
+            if (arguments.size() >= 2 && arguments.get(last) instanceof VariableExpression maybeThrowable) {
+                List<Expression> init = arguments.subList(0, last);
+                Expression thrown = callX(callX(builder.get(), "withThrowable", args(maybeThrowable)), "log", args(init));
+                Expression plain = callX(builder.get(), "log", args(arguments));
+                return ternaryX(isInstanceOfX(maybeThrowable, ClassHelper.make(Throwable.class)), thrown, plain);
+            }
+            return callX(builder.get(), "log", args(arguments));
+        }
+
+        private static Expression builderX(final Expression logVariable, final String level, final Expression location) {
+            return callX(callX(logVariable, "at" + level), "withLocation", args(location));
+        }
+
+        private static MethodCallExpression callX(final Expression receiver, final String name, final Expression arguments) {
+            MethodCallExpression call = new MethodCallExpression(receiver, name, arguments);
+            call.setImplicitThis(false);
+            return call;
+        }
+
+        private static MethodCallExpression callX(final Expression receiver, final String name) {
+            return callX(receiver, name, ArgumentListExpression.EMPTY_ARGUMENTS);
         }
     }
 }

--- a/src/main/java/org/codehaus/groovy/transform/LogASTTransformation.java
+++ b/src/main/java/org/codehaus/groovy/transform/LogASTTransformation.java
@@ -30,6 +30,7 @@ import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.DynamicVariable;
 import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.ast.expr.Expression;
@@ -44,14 +45,22 @@ import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
 import java.lang.reflect.Method;
+import java.io.File;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.apache.groovy.ast.tools.VisibilityUtils.getVisibility;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.callThisX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.ctorX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.fieldX;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
 import static org.objectweb.asm.Opcodes.ACC_TRANSIENT;
 
 /**
@@ -101,9 +110,21 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
         if (!(targetClass instanceof ClassNode classNode))
             throw new GroovyBugError("Class annotation " + logAnnotation.getClassNode().getName() + " annotated no Class, this must not happen.");
 
+        final boolean staticLocation = lookupStaticLocation(logAnnotation);
+        if (staticLocation) {
+            String unsupported = loggingStrategy.staticLocationUnsupportedReason();
+            if (unsupported != null) {
+                addError("staticLocation is not supported by " + loggingStrategy.getClass().getName() + ": " + unsupported, logAnnotation);
+                return;
+            }
+        }
+        final String sourceFileName = new File(sourceUnit.getName()).getName();
+        final List<FieldNode> locationFields = new ArrayList<>();
+
         var transformer = new ClassCodeExpressionTransformer() {
             private boolean inClosure;
             private FieldNode logNode;
+            private String currentMethod = "<clinit>";
 
             @Override
             protected SourceUnit getSourceUnit() {
@@ -129,6 +150,55 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
                     return closure;
                 }
                 return super.transform(exp);
+            }
+
+            @Override
+            protected void visitConstructorOrMethod(final MethodNode node, final boolean isConstructor) {
+                String previous = currentMethod;
+                currentMethod = isConstructor ? "<init>" : node.getName();
+                try {
+                    super.visitConstructorOrMethod(node, isConstructor);
+                } finally {
+                    currentMethod = previous;
+                }
+            }
+
+            @Override
+            public void visitField(final FieldNode node) {
+                String previous = currentMethod;
+                currentMethod = node.isStatic() ? "<clinit>" : "<init>";
+                try {
+                    super.visitField(node);
+                } finally {
+                    currentMethod = previous;
+                }
+            }
+
+            @Override
+            public void visitObjectInitializerStatements(final ClassNode node) {
+                String previous = currentMethod;
+                currentMethod = "<init>";
+                try {
+                    super.visitObjectInitializerStatements(node);
+                } finally {
+                    currentMethod = previous;
+                }
+            }
+
+            /**
+             * A compile-time {@code StackTraceElement} for a logging statement, held in a
+             * synthetic static field of the annotated class (GROOVY-12378). The field is
+             * registered only once the strategy accepts the rewrite, and fields are added
+             * after the traversal, since a statement in a field initializer is visited
+             * while the class's field list is being iterated.
+             */
+            private FieldNode locationFieldFor(final MethodCallExpression mce, final ClassNode owner) {
+                String name = "$log$loc$" + (locationFields.size() + 1);
+                Expression init = ctorX(ClassHelper.make(StackTraceElement.class), args(
+                        constX(owner.getName()), constX(currentMethod), constX(sourceFileName), constX(mce.getLineNumber())));
+                FieldNode field = new FieldNode(name, ACC_STATIC | ACC_FINAL | ACC_SYNTHETIC, ClassHelper.make(StackTraceElement.class), owner, init);
+                field.setSynthetic(true);
+                return field;
             }
 
             @Override
@@ -171,8 +241,19 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
                     variableExpression.setAccessedVariable(logNode);
                 }
 
+                boolean simpleArguments = usesSimpleMethodArgumentsOnly(mce);
+                if (staticLocation) {
+                    FieldNode location = locationFieldFor(mce, logNode.getOwner());
+                    Expression withLocation = loggingStrategy.wrapLoggingMethodCallWithLocation(
+                            receiver, methodName, mce, fieldX(location), !simpleArguments);
+                    if (withLocation != null) {
+                        locationFields.add(location);
+                        return withLocation;
+                    }
+                }
+
                 // do not bother with guard if we have "simple" args since there are no savings
-                if (usesSimpleMethodArgumentsOnly(mce)) return null;
+                if (simpleArguments) return null;
 
                 return loggingStrategy.wrapLoggingMethodCall(receiver, methodName, mce);
             }
@@ -196,6 +277,9 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
 
         };
         transformer.visitClass(classNode);
+        for (FieldNode locationField : locationFields) {
+            classNode.addField(locationField);
+        }
 
         // GROOVY-6373: references to 'log' field are normally already FieldNodes by now, so revisit scoping
         new VariableScopeVisitor(sourceUnit, true).visitClass(classNode);
@@ -208,6 +292,11 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
         } else {
             return "log";
         }
+    }
+
+    private static boolean lookupStaticLocation(final AnnotationNode logAnnotation) {
+        Expression member = logAnnotation.getMember("staticLocation");
+        return member instanceof ConstantExpression constant && Boolean.TRUE.equals(constant.getValue());
     }
 
     private static String lookupCategoryName(final AnnotationNode logAnnotation) {
@@ -302,6 +391,40 @@ public class LogASTTransformation extends AbstractASTTransformation implements C
         }
 
         Expression wrapLoggingMethodCall(Expression logVariable, String methodName, Expression originalExpression);
+
+        /**
+         * Why {@link #wrapLoggingMethodCallWithLocation} cannot be used with this
+         * strategy in the current compilation, for the compile error reported when
+         * {@code staticLocation} is requested anyway. A strategy whose logging API
+         * accepts a caller-supplied location returns {@code null} when that API is
+         * resolvable, and names what is missing from the compile classpath when it
+         * is not. By default compile-time locations are not implemented.
+         *
+         * @return the reason compile-time locations are unavailable, or {@code null} if they are supported
+         * @since 6.0.0
+         */
+        default String staticLocationUnsupportedReason() {
+            return "it does not implement compile-time locations";
+        }
+
+        /**
+         * Rewrites a logging call so that the logging framework is handed the
+         * statement's location, computed at compile time, instead of walking the
+         * stack at run time (GROOVY-12378). Only called when
+         * {@link #staticLocationUnsupportedReason()} returned {@code null}.
+         *
+         * @param logVariable the logger expression
+         * @param methodName the logging method that was called, e.g. {@code info}
+         * @param originalCall the call as written; its arguments are the call's arguments
+         * @param location an expression yielding the {@code StackTraceElement} for the statement
+         * @param guard whether the arguments are worth guarding with a level check
+         *              (they are not all constants or variables)
+         * @return the replacement expression, or {@code null} to leave the call unchanged
+         * @since 6.0.0
+         */
+        default Expression wrapLoggingMethodCallWithLocation(Expression logVariable, String methodName, MethodCallExpression originalCall, Expression location, boolean guard) {
+            return null;
+        }
     }
 
     /**

--- a/src/spec/doc/invokedynamic-support.adoc
+++ b/src/spec/doc/invokedynamic-support.adoc
@@ -181,7 +181,13 @@ context.frameworkPackages.addAll([
 ----
 
 Log4j2:: Log4j2 has no equivalent skip list; its location is always the frame following the logger's
-own class. Use `@CompileStatic` for the classes whose log locations matter.
+own class. Its answer is a location supplied by the caller, which Groovy's `@Log4j2` transform can
+provide at compile time: `@Log4j2(staticLocation = true)` rewrites each logging statement to
+`log.at<Level>().withLocation(location).log(...)`, with the level of the original call, so
+`log.warn(msg)` becomes `log.atWarn().withLocation(location).log(msg)`, where `location` is a
+`StackTraceElement` for the statement held in a static field of the annotated class. That location is correct however the call is
+dispatched and costs no stack walk. It covers statements made through the injected field only; for a
+hand-declared logger, use `@CompileStatic` where locations matter.
 
 Stack traces:: The logger settings above change what a logger reports as the source; they do not
 remove the frames from exception stack traces. `org.codehaus.groovy.runtime.StackTraceUtils.sanitize`
@@ -212,7 +218,8 @@ native-image -Djdk.logger.packages=org.codehaus.groovy,groovy.lang,com.oracle.sv
 Logback:: Add `com.oracle.svm.core.reflect`, `com.oracle.svm.core.methodhandles` and
 `java.lang.invoke` to the framework packages shown above.
 
-Log4j2:: No workaround; use `@CompileStatic` where locations matter.
+Log4j2:: `@Log4j2(staticLocation = true)` as above, which needs no native-image settings; for a
+hand-declared logger, use `@CompileStatic` where locations matter.
 
 === DGM adapters in native images
 

--- a/subprojects/groovy-logging-test/src/test/groovy/groovy/util/logging/Log4j2Test.groovy
+++ b/subprojects/groovy-logging-test/src/test/groovy/groovy/util/logging/Log4j2Test.groovy
@@ -48,7 +48,8 @@ final class Log4j2Test {
         @Override
         void append(LogEvent ev) {
             // Log4j2 re-cycles log events so extract and store the relevant info
-            events.add([level: ev.level, message: ev.message.formattedMessage])
+            events.add([level: ev.level, message: ev.message.formattedMessage,
+                        source: ev.source, marker: ev.marker, thrown: ev.thrown])
         }
     }
 
@@ -356,5 +357,167 @@ final class Log4j2Test {
 
         assert appenderForCustomCategory.getEvents().size() == 1
         assert appender.getEvents().size() == 0
+    }
+
+    // GROOVY-12378 -------------------------------------------------------------
+
+    /** line number (1-based) of the first line of {@code source} containing {@code needle} */
+    private static int lineOf(String source, String needle) {
+        int idx = source.readLines().findIndexOf { it.contains(needle) }
+        assert idx >= 0 : "no line contains $needle"
+        idx + 1
+    }
+
+    /** each test compiles its own class: Log4j2 loggers are cached by name, and a
+     *  second appender registered under an existing name is ignored */
+    private static String staticLocationSource(String className) { '''
+        @groovy.util.logging.Log4j2(staticLocation = true)
+        class CLASSNAME {
+            static int evaluations = 0
+            static String expensive() { evaluations++; 'expensive' }
+
+            def instanceMethod() {
+                log.info('plain')                       // L1 simple arguments: no guard
+                log.warn("interpolated ${expensive()}") // L2 guarded
+                [1].each {
+                    log.error('from closure')            // L3 inside a closure
+                }
+            }
+            static void staticMethod() {
+                log.debug('static {}', 42)               // L4 parameterised
+            }
+            def withThrowable() {
+                try { throw new IllegalStateException('boom') } catch (e) { log.error('failed', e) }
+            }
+            def withMarker(org.apache.logging.log4j.Marker m) {
+                log.info(m, 'marked {}', 'x')
+            }
+            def withMarkerAndThrowable(org.apache.logging.log4j.Marker m, Throwable t) {
+                log.warn(m, 'both {}', 'y', t)
+            }
+        }
+    '''.replace('CLASSNAME', className) }
+
+    @Test
+    void testStaticLocationSuppliesCompileTimeLocations() {
+        String source = staticLocationSource('LocatedA')
+        Class clazz = new GroovyClassLoader().parseClass(source, 'LocatedA.groovy')
+        clazz.log.addAppender(appender)
+        clazz.log.setLevel(Level.ALL)
+        clazz.newInstance().instanceMethod()
+        clazz.staticMethod()
+
+        def events = appender.events
+        assert events*.message == ['plain', 'interpolated expensive', 'from closure', 'static 42']
+        assert events*.source*.className == ['LocatedA'] * 4
+        assert events*.source*.fileName == ['LocatedA.groovy'] * 4
+        assert events*.source*.methodName == ['instanceMethod', 'instanceMethod', 'instanceMethod', 'staticMethod']
+        assert events*.source*.lineNumber == ['L1', 'L2', 'L3', 'L4'].collect { lineOf(source, it) }
+
+        // one synthetic static final field per logging statement
+        def locations = clazz.declaredFields.findAll { it.name.startsWith('$log$loc$') }
+        assert locations.size() == 7
+        assert locations.every { isStatic(it.modifiers) && isFinal(it.modifiers) && it.synthetic && it.type == StackTraceElement }
+    }
+
+    @Test
+    void testStaticLocationKeepsGuardForNonSimpleArguments() {
+        Class clazz = new GroovyClassLoader().parseClass(staticLocationSource('LocatedB'), 'LocatedB.groovy')
+        clazz.log.addAppender(appender)
+        clazz.log.setLevel(Level.ERROR)
+        clazz.newInstance().instanceMethod()
+
+        assert clazz.evaluations == 0 : 'a disabled level must not evaluate the interpolated argument'
+        assert appender.events*.message == ['from closure']
+    }
+
+    @Test
+    void testStaticLocationThrowableAndMarker() {
+        Class clazz = new GroovyClassLoader().parseClass(staticLocationSource('LocatedC'), 'LocatedC.groovy')
+        clazz.log.addAppender(appender)
+        clazz.log.setLevel(Level.ALL)
+        def marker = org.apache.logging.log4j.MarkerManager.getMarker('GROOVY12378')
+        def instance = clazz.newInstance()
+        instance.withThrowable()
+        instance.withMarker(marker)
+        instance.withMarkerAndThrowable(marker, new IllegalArgumentException('bad'))
+
+        def events = appender.events
+        assert events.size() == 3
+        assert events[0].message == 'failed'
+        assert events[0].thrown instanceof IllegalStateException
+        assert events[0].source.methodName == 'withThrowable'
+        assert events[1].message == 'marked x'
+        assert events[1].marker == marker
+        assert events[1].thrown == null
+        assert events[1].source.methodName == 'withMarker'
+        assert events[2].message == 'both y'
+        assert events[2].marker == marker
+        assert events[2].thrown instanceof IllegalArgumentException
+        assert events[2].source.methodName == 'withMarkerAndThrowable'
+    }
+
+    @Test
+    void testStaticLocationWithCompileStatic() {
+        Class clazz = new GroovyClassLoader().parseClass('''
+            @groovy.transform.CompileStatic
+            @groovy.util.logging.Log4j2(staticLocation = true)
+            class LocatedStatic {
+                void run(String who) {
+                    log.info("hello $who")
+                    log.warn('plain')
+                }
+            }
+        ''', 'LocatedStatic.groovy')
+        clazz.log.addAppender(appender)
+        clazz.log.setLevel(Level.ALL)
+        clazz.newInstance().run('world')
+
+        def events = appender.events
+        assert events*.message == ['hello world', 'plain']
+        assert events*.source*.className == ['LocatedStatic', 'LocatedStatic']
+        assert events*.source*.methodName == ['run', 'run']
+        assert events*.source*.lineNumber == [6, 7]
+    }
+
+    @Test
+    void testStaticLocationOffLeavesCallsAlone() {
+        Class clazz = new GroovyClassLoader().parseClass('''
+            @groovy.util.logging.Log4j2
+            class NotLocated {
+                def run() { log.info('plain') }
+            }
+        ''', 'NotLocated.groovy')
+        assert !clazz.declaredFields.any { it.name.startsWith('$log$loc$') }
+    }
+
+    @Test
+    void testStaticLocationRejectedByStrategyWithoutSupport() {
+        // a Log-family annotation whose strategy does not support compile-time locations
+        def err = shouldFail(org.codehaus.groovy.control.MultipleCompilationErrorsException) {
+            new GroovyClassLoader().parseClass('''
+                @groovy.util.logging.Log4j2Test.NoLocationLog(staticLocation = true)
+                class Unsupported {
+                    def run() { log.info('plain') }
+                }
+            ''')
+        }
+        assert err.message.contains('staticLocation is not supported by ' + NoLocationStrategy.name + ': locations are looked up at run time here')
+    }
+
+    @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.SOURCE)
+    @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE)
+    @org.codehaus.groovy.transform.GroovyASTTransformationClass('org.codehaus.groovy.transform.LogASTTransformation')
+    static @interface NoLocationLog {
+        String value() default 'log'
+        String category() default org.codehaus.groovy.transform.LogASTTransformation.DEFAULT_CATEGORY_NAME
+        String visibilityId() default groovy.transform.Undefined.STRING
+        Class<? extends org.codehaus.groovy.transform.LogASTTransformation.LoggingStrategy> loggingStrategy() default NoLocationStrategy
+        boolean staticLocation() default false
+    }
+
+    static class NoLocationStrategy extends Log4j2.Log4j2LoggingStrategy {
+        NoLocationStrategy(GroovyClassLoader loader) { super(loader) }
+        @Override String staticLocationUnsupportedReason() { 'locations are looked up at run time here' }
     }
 }


### PR DESCRIPTION
…ler locations via LogBuilder.withLocation

Logging frameworks locate a statement's caller by walking the stack, and every frame Groovy's runtime inserts (metaclass dispatch, the reflective cold tier, GraalVM's method-handle interpreter in a native image) makes that answer wrong. Log4j2 offers no skip list but does let the caller supply the location. With staticLocation = true the transform rewrites log.info(msg) to log.atInfo().withLocation(loc).log(msg), where loc is a StackTraceElement for the statement held in a synthetic static field, so the location is correct however the call is dispatched and Log4j2 skips its stack walk. A leading Marker or trailing Throwable variable is routed through withMarker/withThrowable at run time, since the builder does not extract a message's throwable itself. Opt-in: the call shape changes and LogBuilder needs Log4j 2.13+, which the transform checks at compile time.