### PR TITLE
GROOVY-12379: native probe: cover groovy-nio, groovy-xml and groovy-json

### DIFF
--- a/.github/workflows/groovy-native-check.yml
+++ b/.github/workflows/groovy-native-check.yml
@@ -47,6 +47,9 @@ on:
       - 'src/main/java/groovy/lang/**'
       - 'src/resources/META-INF/native-image/**'
       - 'subprojects/tests-native/**'
+      - 'subprojects/groovy-nio/src/main/**'
+      - 'subprojects/groovy-xml/src/main/**'
+      - 'subprojects/groovy-json/src/main/**'
       - '.github/workflows/groovy-native-check.yml'
   pull_request:
     paths:
@@ -59,6 +62,9 @@ on:
       - 'src/main/java/groovy/lang/**'
       - 'src/resources/META-INF/native-image/**'
       - 'subprojects/tests-native/**'
+      - 'subprojects/groovy-nio/src/main/**'
+      - 'subprojects/groovy-xml/src/main/**'
+      - 'subprojects/groovy-json/src/main/**'
       - '.github/workflows/groovy-native-check.yml'
   schedule:
     - cron: '0 5 * * 1'  # weekly Monday 05:00 UTC

--- a/src/main/java/org/codehaus/groovy/tools/NativeImageMetadataGenerator.java
+++ b/src/main/java/org/codehaus/groovy/tools/NativeImageMetadataGenerator.java
@@ -88,6 +88,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.Executors;
 
 /**
@@ -278,6 +279,8 @@ public class NativeImageMetadataGenerator {
     private final Map<String, Map<String, EnumSet<Flag>>> entries = new TreeMap<>();
     /** Individually named methods, keyed like {@link #entries}, for JDK classes too big to register wholesale. */
     private final Map<String, Map<String, Set<String>>> methods = new TreeMap<>();
+    /** resource globs by condition: lookups the runtime performs that an exact-mode image must allow */
+    private final Map<String, Set<String>> resources = new TreeMap<>();
 
     /**
      * Writes the metadata file under {@code targetDirectory}.
@@ -312,16 +315,48 @@ public class NativeImageMetadataGenerator {
                                         String targetDirectory) throws IOException {
         File file = new File(targetDirectory, "META-INF/native-image/org.apache.groovy/" + artifactId + "/" + METADATA_FILE).getCanonicalFile();
         file.getParentFile().mkdirs();
-        Files.write(file.toPath(), generateForModule(instanceExtensions, staticExtensions).getBytes(StandardCharsets.UTF_8));
+        Files.write(file.toPath(), generateForModule(artifactId, instanceExtensions, staticExtensions).getBytes(StandardCharsets.UTF_8));
         return file.getPath();
     }
 
     static String generateForModule(List<Class<?>> instanceExtensions, List<Class<?>> staticExtensions) {
+        return generateForModule(null, instanceExtensions, staticExtensions);
+    }
+
+    static String generateForModule(String artifactId, List<Class<?>> instanceExtensions, List<Class<?>> staticExtensions) {
         NativeImageMetadataGenerator generator = new NativeImageMetadataGenerator();
         String registry = MetaClassRegistryImpl.class.getName();
         for (Class<?> extension : instanceExtensions) generator.scannedHolder(registry, extension);
         for (Class<?> extension : staticExtensions) generator.scannedHolder(registry, extension);
+        if ("groovy-xml".equals(artifactId)) generator.jaxpFactories();
         return generator.toJson();
+    }
+
+    /**
+     * What {@code groovy.xml.FactorySupport} does on every XML user's behalf:
+     * each JAXP {@code newInstance} first asks {@code ServiceLoader} for a
+     * provider, a resource lookup an exact-mode image must allow even though
+     * the JDK ships no such file, and then instantiates the JDK's default
+     * implementation by name.
+     */
+    private void jaxpFactories() {
+        String support = "groovy.xml.FactorySupport";
+        String[][] factories = {
+                {"javax.xml.parsers.SAXParserFactory", "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"},
+                {"javax.xml.parsers.DocumentBuilderFactory", "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"},
+                {"javax.xml.stream.XMLInputFactory", "com.sun.xml.internal.stream.XMLInputFactoryImpl"},
+                {"javax.xml.transform.TransformerFactory", "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl"},
+                {"javax.xml.validation.SchemaFactory", "com.sun.org.apache.xerces.internal.jaxp.validation.XMLSchemaFactory"},
+                {"javax.xml.xpath.XPathFactory", "com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl"},
+        };
+        for (String[] factory : factories) {
+            resource(support, "META-INF/services/" + factory[0]);
+            method(support, factory[1], "<init>");
+        }
+    }
+
+    private void resource(String condition, String glob) {
+        resources.computeIfAbsent(condition, k -> new TreeSet<>()).add(glob);
     }
 
     /**
@@ -572,7 +607,20 @@ public class NativeImageMetadataGenerator {
                 first = false;
             }
         }
-        json.append("\n  ]\n}\n");
+        json.append("\n  ]");
+        if (!resources.isEmpty()) {
+            json.append(",\n  \"resources\": [");
+            first = true;
+            for (Map.Entry<String, Set<String>> condition : resources.entrySet()) {
+                for (String glob : condition.getValue()) {
+                    json.append(first ? "\n" : ",\n").append("    {\"condition\": {\"typeReached\": \"").append(condition.getKey())
+                        .append("\"}, \"glob\": \"").append(glob).append("\"}");
+                    first = false;
+                }
+            }
+            json.append("\n  ]");
+        }
+        json.append("\n}\n");
         return json.toString();
     }
 

--- a/src/spec/doc/invokedynamic-support.adoc
+++ b/src/spec/doc/invokedynamic-support.adoc
@@ -273,8 +273,12 @@ Each Groovy module that registers extension methods through a descriptor (`groov
 `groovy-xml`, `groovy-dateutil`, `groovy-datetime`, `groovy-sql`, `groovy-swing`, `groovy-jsr223`,
 `groovy-ginq`, `groovy-macro` and `groovy-macro-library`) ships the equivalent for itself under
 `META-INF/native-image/org.apache.groovy/<module>/`: the extension classes the registry loads by
-name and scans, and the types in their signatures. Modules without a descriptor, `groovy-json` and
-`groovy-http-builder` among them, need none: what they reflect over is the application's data.
+name and scans, and the types in their signatures. `groovy-xml` adds what `FactorySupport` does for
+every XML user: the JAXP factory lookups, a `ServiceLoader` resource read that an exact-mode image
+must allow even though the JDK ships no such file, and the JDK's default implementations it then
+instantiates by name. `groovy-json` ships only the `ServiceLoader`-loaded string service its parser
+uses. Modules that reflect over nothing but the application's data, `groovy-http-builder` among
+them, need none.
 
 Every entry is conditional on the class that performs the access being reached, so an image pays
 only for what it uses; a statically compiled program that never links a dynamic call site carries

--- a/src/test/groovy/org/codehaus/groovy/tools/NativeImageMetadataTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/tools/NativeImageMetadataTest.groovy
@@ -244,6 +244,30 @@ final class NativeImageMetadataTest {
     }
 
     @Test
+    void xmlModuleMetadataCoversFactorySupportsJaxpLookups() {
+        // groovy-xml's FactorySupport asks ServiceLoader for each JAXP factory (a resource read an
+        // exact-mode image must allow though the JDK ships no such file) and then instantiates the
+        // JDK default implementation by name; both are conditional on FactorySupport being reached
+        def parsed = new JsonSlurper().parseText(NativeImageMetadataGenerator.generateForModule('groovy-xml', [], [])) as Map
+        def resources = parsed.resources as List<Map>
+        assert resources*.glob as Set == [
+                'META-INF/services/javax.xml.parsers.SAXParserFactory',
+                'META-INF/services/javax.xml.parsers.DocumentBuilderFactory',
+                'META-INF/services/javax.xml.stream.XMLInputFactory',
+                'META-INF/services/javax.xml.transform.TransformerFactory',
+                'META-INF/services/javax.xml.validation.SchemaFactory',
+                'META-INF/services/javax.xml.xpath.XPathFactory',
+        ] as Set
+        assert resources.every { it.condition.typeReached == 'groovy.xml.FactorySupport' }
+        def sax = (parsed.reflection as List<Map>).find { it.type == 'com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl' }
+        assert sax.condition.typeReached == 'groovy.xml.FactorySupport'
+        assert sax.methods*.name == ['<init>']
+
+        // other modules get no resources section at all
+        assert !(new JsonSlurper().parseText(NativeImageMetadataGenerator.generateForModule('groovy-nio', [], [])) as Map).containsKey('resources')
+    }
+
+    @Test
     void entriesAreUnique() {
         def keys = reflection().collect { [it.condition.typeReached, it.type] }
         assert keys.size() == (keys as Set).size()

--- a/subprojects/groovy-json/src/main/resources/META-INF/native-image/org.apache.groovy/groovy-json/reachability-metadata.json
+++ b/subprojects/groovy-json/src/main/resources/META-INF/native-image/org.apache.groovy/groovy-json/reachability-metadata.json
@@ -1,0 +1,45 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.groovy.json.internal.FastStringUtils"
+      },
+      "type": "org.apache.groovy.json.DefaultFastStringServiceFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "groovy.json.JsonTokenType"
+      },
+      "type": "groovy.json.JsonTokenType$1"
+    },
+    {
+      "condition": {
+        "typeReached": "groovy.json.JsonTokenType"
+      },
+      "type": "groovy.json.JsonTokenType$1BeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "groovy.json.JsonTokenType"
+      },
+      "type": "groovy.json.JsonTokenType$1Customizer"
+    },
+    {
+      "condition": {
+        "typeReached": "groovy.json.JsonTokenType"
+      },
+      "type": "groovy.runtime.metaclass.groovy.json.JsonTokenType$1MetaClass"
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/services/org.apache.groovy.json.FastStringServiceFactory"
+    }
+  ]
+}

--- a/subprojects/tests-native/build.gradle
+++ b/subprojects/tests-native/build.gradle
@@ -61,7 +61,14 @@ plugins {
 
 dependencies {
     implementation project(':')
+    // modules the probe exercises; their repackaged jars carry their own metadata
+    // (groovy-json ships none by design: what it reflects over is the application's data)
+    implementation projects.groovyNio
+    implementation projects.groovyXml
+    implementation projects.groovyJson
 }
+
+def probeModules = ['groovy-nio', 'groovy-xml', 'groovy-json']
 
 def graalvmHome = providers.gradleProperty('groovy.native.home')
         .orElse(providers.environmentVariable('GRAALVM_HOME'))
@@ -70,7 +77,9 @@ def graalvmBin = { String tool -> graalvmHome.map { "$it/bin/$tool" as String } 
 
 // what a Java user of org.apache.groovy:groovy gets: the repackaged jar, not the classes directory
 def coreJar = rootProject.tasks.named('repackageJar').flatMap { it.archiveFile }
-def probeClasspath = files(coreJar, sourceSets.main.output)
+def moduleJars = probeModules.collect { project(":$it").tasks.named('repackageJar').flatMap { it.archiveFile } }
+def groovyJars = files(coreJar, moduleJars)
+def probeClasspath = files(groovyJars, sourceSets.main.output)
 def nativeDir = layout.buildDirectory.dir('native')
 def agentDir = nativeDir.map { it.dir('agent') }
 def agentAllDir = nativeDir.map { it.dir('agent-all') }
@@ -83,6 +92,11 @@ def groovyOwned = { String type -> groovyPackages.any { type.startsWith(it) } }
 // Names the runtime looks up with a constant string, which the image builder
 // folds: the agent records them, the jar need not ship them.
 def foldedLookups = ['groovy.runtime.metaclass.CustomMetaClassCreationHandle'] as Set
+// Entries the JVM agent cannot record but --exact-reachability-metadata needs: Groovy's metaclass
+// creation runs the JavaBeans Introspector over the probe's receivers, and MethodDescriptor resolves
+// method parameter types by name; on a JVM those classes are still cached so no lookup happens,
+// in an image each must be registered. Kept across updateProbeMetadata like the proxy entries.
+def handListedTypes = ['java.nio.file.WatchEvent$Modifier'] as Set
 
 tasks.withType(Exec).configureEach {
     onlyIf('a GraalVM is configured (-Pgroovy.native.home or GRAALVM_HOME)') { graalvmPresent.get() }
@@ -93,6 +107,7 @@ def registerAgentRun = { String name, Provider<Directory> outputDir, boolean fil
         group = 'verification'
         description = "Runs the probe on the GraalVM JVM under the native-image agent${filtered ? ', recording Groovy callers only' : ''}"
         dependsOn rootProject.tasks.named('repackageJar'), classes
+        probeModules.each { dependsOn project(":$it").tasks.named('repackageJar') }
         inputs.files(probeClasspath)
         if (filtered) inputs.file(callerFilter)
         outputs.dir(outputDir)
@@ -141,8 +156,15 @@ def metadataByType = { File json ->
     byType
 }
 
-def shippedMetadata = { File jar ->
-    metadataByType(zipTree(jar).matching { include 'META-INF/native-image/org.apache.groovy/groovy/reachability-metadata.json' }.singleFile)
+// the union of what the groovy jar and the module jars on the probe classpath ship
+def shippedMetadata = { Iterable<File> jars ->
+    def byType = [:].withDefault { [:] }
+    jars.each { File jar ->
+        zipTree(jar).matching { include 'META-INF/native-image/org.apache.groovy/*/reachability-metadata.json' }.each { File json ->
+            metadataByType(json).each { type, flags -> byType[type].putAll(flags) }
+        }
+    }
+    byType
 }
 
 def checkNativeMetadata = tasks.register('checkNativeMetadata') {
@@ -150,7 +172,7 @@ def checkNativeMetadata = tasks.register('checkNativeMetadata') {
     description = 'Fails if the agent recorded a Groovy-owned reflective need the jar does not ship metadata for'
     dependsOn nativeAgentRun
     onlyIf('a GraalVM is configured (-Pgroovy.native.home or GRAALVM_HOME)') { graalvmPresent.get() }
-    inputs.files(coreJar)
+    inputs.files(groovyJars)
     inputs.dir(agentDir)
     doLast {
         def recording = agentDir.get().file('reachability-metadata.json').asFile
@@ -160,7 +182,7 @@ def checkNativeMetadata = tasks.register('checkNativeMetadata') {
                     "does not apply to Groovy 6); found: " + (agentDir.get().asFile.list() ?: []).join(', '))
         }
         def recorded = new JsonSlurper().parse(recording).reflection
-        def shipped = shippedMetadata(coreJar.get().asFile)
+        def shipped = shippedMetadata(groovyJars.files)
         def probeOwn = metadataByType(probeMetadata.asFile)
         def missing = []
         recorded.each { Map e ->
@@ -181,7 +203,7 @@ def checkNativeMetadata = tasks.register('checkNativeMetadata') {
             }
         }
         if (missing) {
-            throw new GradleException("The runtime needs reflection metadata the groovy jar does not ship; " +
+            throw new GradleException("The runtime needs reflection metadata the groovy jar and the module jars do not ship; " +
                     "extend NativeImageMetadataGenerator for:\n  " + missing.join('\n  '))
         }
         logger.lifecycle("checkNativeMetadata: ${recorded.size()} recorded entries, every Groovy-owned one is shipped")
@@ -192,8 +214,9 @@ def registerImage = { String suffix, boolean exact ->
     def image = nativeDir.map { it.file("probe$suffix") }
     def compile = tasks.register("nativeCompile$suffix", Exec) {
         group = 'verification'
-        description = "Builds the probe into a native image${exact ? ' with --exact-reachability-metadata' : ''}, with only the jar's metadata for Groovy's part"
+        description = "Builds the probe into a native image${exact ? ' with --exact-reachability-metadata' : ''}, with only the jars' metadata for Groovy's part"
         dependsOn rootProject.tasks.named('repackageJar'), classes
+        probeModules.each { dependsOn project(":$it").tasks.named('repackageJar') }
         inputs.files(probeClasspath)
         outputs.file(image)
         doFirst {
@@ -238,16 +261,17 @@ tasks.register('updateProbeMetadata') {
     onlyIf('a GraalVM is configured (-Pgroovy.native.home or GRAALVM_HOME)') { graalvmPresent.get() }
     doLast {
         def recorded = new JsonSlurper().parse(agentAllDir.get().file('reachability-metadata.json').asFile).reflection
-        def shipped = shippedMetadata(coreJar.get().asFile)
+        def shipped = shippedMetadata(groovyJars.files)
         // dynamic proxies the agent does not see: a closure coerced to a SAM parameter at a dynamic
         // call site is proxied through a method handle the agent does not instrument, so the
         // interfaces recorded here by hand are carried over from the current file
-        def proxies = probeMetadata.asFile.exists() ?
-                new JsonSlurper().parse(probeMetadata.asFile).reflection.findAll { !(it.type instanceof String) } : []
-        recorded = recorded + proxies.findAll { p -> !recorded.any { it.type == p.type } }
+        def previous = probeMetadata.asFile.exists() ? new JsonSlurper().parse(probeMetadata.asFile).reflection : []
+        def carried = previous.findAll { !(it.type instanceof String) || it.type in handListedTypes }
+        recorded = recorded + carried.findAll { p -> !recorded.any { it.type == p.type } }
         def keep = recorded.findAll { Map e ->
             def type = e.type
             if (!(type instanceof String)) return true // a dynamic proxy: which interfaces are coerced is the application's
+            if (type in handListedTypes) return true
             if (type in foldedLookups) return false
             if (!shipped.containsKey(type)) return true
             !(e.keySet() - ['type', 'condition']).every { covers(shipped[type], it, e) }

--- a/subprojects/tests-native/src/main/groovy/probe.groovy
+++ b/subprojects/tests-native/src/main/groovy/probe.groovy
@@ -25,7 +25,15 @@
 // Keep the marker lines: the build asserts on `PROBE OK`.
 
 import groovy.concurrent.AsyncScope
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
+import groovy.xml.MarkupBuilder
+import groovy.xml.XmlParser
+import groovy.xml.XmlSlurper
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 import static org.apache.groovy.runtime.async.AsyncSupport.await
 
@@ -75,6 +83,29 @@ def async = AsyncScope.withScope { scope ->
     await(a) + await(b)
 }
 
+// modules: groovy-nio (Path extensions), groovy-xml (parsers and a builder),
+// groovy-json (slurper and output over the application's own class)
+Path tmp = Files.createTempFile('probe', '.txt')
+tmp.text = 'one\ntwo\nthree\n'
+tmp << 'four\n'
+def lines = tmp.readLines()
+def counted = 0
+tmp.eachLine { counted++ }
+def firstLine = tmp.withReader { it.readLine() }
+Files.delete(tmp)
+
+def slurped = new XmlSlurper().parseText('<root><item id="1">alpha</item><item id="2">beta</item></root>')
+def itemNames = slurped.item.collect { it.text() }
+def parsed = new XmlParser().parseText('<root><item id="1">alpha</item><item id="2">beta</item></root>')
+def itemIds = parsed.item*.@id
+def writer = new StringWriter()
+new MarkupBuilder(writer).root { item(id: 3, 'gamma') }
+def built = writer.toString()
+
+def json = JsonOutput.toJson([point: p, names: names, nested: [ok: true]])
+def back = new JsonSlurper().parseText(json)
+def pretty = JsonOutput.prettyPrint(json)
+
 println "numbers=$numbers total=$total"
 println "words=$words"
 println "point=$p dyn=$dyn"
@@ -90,6 +121,12 @@ println "static=$statically"
 println "async=$async"
 println "captured=$captured floats=${floats.sum()}"
 println "metaClass=${p.metaClass.class.simpleName} methods=${p.metaClass.methods.size() > 0}"
+println "nio lines=$lines counted=$counted first=$firstLine"
+println "xml names=$itemNames ids=$itemIds built=${built.contains('gamma')}"
+println "json back=${back.point} pretty=${pretty.count('\n') > 0}"
+assert lines == ['one', 'two', 'three', 'four'] && counted == 4 && firstLine == 'one'
+assert itemNames == ['alpha', 'beta'] && itemIds == ['1', '2'] && built.contains('<item id=\'3\'>gamma</item>')
+assert back.point.x == 4 && back.point.y == 6 && back.names.size() == 3 && back.nested.ok == true
 assert total == 220 && curried(2) == 42 && p.x == 4
 assert person.greet() == 'hello, groovy' && sorted == [1, 2, 3] && statically == 45 && async == 42 && captured == 6 && floats.sum() == 4.0f
 println 'PROBE OK'

--- a/subprojects/tests-native/src/main/resources/META-INF/native-image/org.apache.groovy/tests-native/reachability-metadata.json
+++ b/subprojects/tests-native/src/main/resources/META-INF/native-image/org.apache.groovy/tests-native/reachability-metadata.json
@@ -168,6 +168,52 @@
             "type": "groovy.concurrent.Awaitable"
         },
         {
+            "type": "groovy.json.JsonOutput",
+            "methods": [
+                {
+                    "name": "prettyPrint",
+                    "parameterTypes": [
+                        "java.lang.String"
+                    ]
+                },
+                {
+                    "name": "toJson",
+                    "parameterTypes": [
+                        "java.util.Map"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "groovy.json.JsonOutputBeanInfo"
+        },
+        {
+            "type": "groovy.json.JsonOutputCustomizer"
+        },
+        {
+            "type": "groovy.json.JsonSlurper",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        
+                    ]
+                },
+                {
+                    "name": "parseText",
+                    "parameterTypes": [
+                        "java.lang.String"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "groovy.json.JsonSlurperBeanInfo"
+        },
+        {
+            "type": "groovy.json.JsonSlurperCustomizer"
+        },
+        {
             "type": "groovy.runtime.metaclass.Named$Trait$HelperMetaClass"
         },
         {
@@ -181,6 +227,39 @@
         },
         {
             "type": "groovy.runtime.metaclass.groovy.concurrent.AsyncScopeMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.json.JsonOutputMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.json.JsonSlurperMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.util.NodeListMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.util.NodeMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.xml.MarkupBuilderMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.xml.XmlParserMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.xml.XmlSlurperMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.xml.slurpersupport.NodeChildMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.groovy.xml.slurpersupport.NodeChildrenMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.java.io.BufferedReaderMetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.java.io.StringWriterMetaClass"
         },
         {
             "type": "groovy.runtime.metaclass.java.lang.BooleanMetaClass"
@@ -201,6 +280,9 @@
             "type": "groovy.runtime.metaclass.java.lang.StringMetaClass"
         },
         {
+            "type": "groovy.runtime.metaclass.java.nio.file.FilesMetaClass"
+        },
+        {
             "type": "groovy.runtime.metaclass.java.util.ArrayListMetaClass"
         },
         {
@@ -210,19 +292,34 @@
             "type": "groovy.runtime.metaclass.java.util.LinkedHashMapMetaClass"
         },
         {
+            "type": "groovy.runtime.metaclass.org.apache.groovy.json.internal.LazyMapMetaClass"
+        },
+        {
             "type": "groovy.runtime.metaclass.org.apache.groovy.runtime.async.AsyncSupportMetaClass"
         },
         {
             "type": "groovy.runtime.metaclass.org.apache.groovy.runtime.async.DefaultAsyncScopeMetaClass"
         },
         {
-            "type": "groovy.runtime.metaclass.probe$_run_closure10$_closure11MetaClass"
+            "type": "groovy.runtime.metaclass.probe$_run_closure10$_closure15MetaClass"
         },
         {
-            "type": "groovy.runtime.metaclass.probe$_run_closure10$_closure12MetaClass"
+            "type": "groovy.runtime.metaclass.probe$_run_closure10$_closure16MetaClass"
         },
         {
             "type": "groovy.runtime.metaclass.probe$_run_closure10MetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.probe$_run_closure11MetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.probe$_run_closure12MetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.probe$_run_closure13MetaClass"
+        },
+        {
+            "type": "groovy.runtime.metaclass.probe$_run_closure14MetaClass"
         },
         {
             "type": "groovy.runtime.metaclass.probe$_run_closure1MetaClass"
@@ -255,7 +352,187 @@
             "type": "groovy.runtime.metaclass.probeMetaClass"
         },
         {
+            "type": "groovy.runtime.metaclass.sun.nio.fs.UnixPathMetaClass"
+        },
+        {
+            "type": "groovy.util.BuilderSupport"
+        },
+        {
+            "type": "groovy.util.BuilderSupportBeanInfo"
+        },
+        {
+            "type": "groovy.util.BuilderSupportCustomizer"
+        },
+        {
+            "type": "groovy.util.NodeBeanInfo"
+        },
+        {
+            "type": "groovy.util.NodeCustomizer"
+        },
+        {
+            "type": "groovy.util.NodeList"
+        },
+        {
+            "type": "groovy.util.NodeListBeanInfo"
+        },
+        {
+            "type": "groovy.util.NodeListCustomizer"
+        },
+        {
+            "type": "groovy.xml.MarkupBuilder",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "java.io.Writer"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "groovy.xml.MarkupBuilderBeanInfo"
+        },
+        {
+            "type": "groovy.xml.MarkupBuilderCustomizer"
+        },
+        {
+            "type": "groovy.xml.XmlParser",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        
+                    ]
+                },
+                {
+                    "name": "parseText",
+                    "parameterTypes": [
+                        "java.lang.String"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "groovy.xml.XmlParserBeanInfo"
+        },
+        {
+            "type": "groovy.xml.XmlParserCustomizer"
+        },
+        {
+            "type": "groovy.xml.XmlSlurper",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        
+                    ]
+                },
+                {
+                    "name": "parseText",
+                    "parameterTypes": [
+                        "java.lang.String"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "groovy.xml.XmlSlurperBeanInfo"
+        },
+        {
+            "type": "groovy.xml.XmlSlurperCustomizer"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.GPathResult"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.GPathResult$1"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.GPathResultBeanInfo"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.GPathResultCustomizer"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.NodeChild",
+            "methods": [
+                {
+                    "name": "text",
+                    "parameterTypes": [
+                        
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "groovy.xml.slurpersupport.NodeChildBeanInfo"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.NodeChildCustomizer"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.NodeChildren"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.NodeChildrenBeanInfo"
+        },
+        {
+            "type": "groovy.xml.slurpersupport.NodeChildrenCustomizer"
+        },
+        {
             "type": "java.beans.PropertyVetoException"
+        },
+        {
+            "type": "java.io.BufferedReader",
+            "methods": [
+                {
+                    "name": "readLine",
+                    "parameterTypes": [
+                        
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "java.io.BufferedReaderBeanInfo"
+        },
+        {
+            "type": "java.io.BufferedReaderCustomizer"
+        },
+        {
+            "type": "java.io.ReaderBeanInfo"
+        },
+        {
+            "type": "java.io.ReaderCustomizer"
+        },
+        {
+            "type": "java.io.StringWriter",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        
+                    ]
+                },
+                {
+                    "name": "toString",
+                    "parameterTypes": [
+                        
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "java.io.StringWriterBeanInfo"
+        },
+        {
+            "type": "java.io.StringWriterCustomizer"
+        },
+        {
+            "type": "java.io.WriterBeanInfo"
+        },
+        {
+            "type": "java.io.WriterCustomizer"
         },
         {
             "type": "java.lang.Boolean",
@@ -334,6 +611,12 @@
             "type": "java.lang.String",
             "methods": [
                 {
+                    "name": "contains",
+                    "parameterTypes": [
+                        "java.lang.CharSequence"
+                    ]
+                },
+                {
                     "name": "split",
                     "parameterTypes": [
                         "java.lang.String"
@@ -354,10 +637,50 @@
             "type": "java.lang.StringCustomizer"
         },
         {
-            "type": "java.lang.reflect.Constructor[]"
+            "type": "java.nio.Buffer"
         },
         {
-            "type": "java.lang.reflect.TypeVariable[]"
+            "type": "java.nio.CharBuffer"
+        },
+        {
+            "type": "java.nio.file.DirectoryStream$Filter"
+        },
+        {
+            "type": "java.nio.file.FileVisitor"
+        },
+        {
+            "type": "java.nio.file.Files",
+            "methods": [
+                {
+                    "name": "createTempFile",
+                    "parameterTypes": [
+                        "java.lang.String",
+                        "java.lang.String",
+                        "java.nio.file.attribute.FileAttribute[]"
+                    ]
+                },
+                {
+                    "name": "delete",
+                    "parameterTypes": [
+                        "java.nio.file.Path"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "java.nio.file.FilesBeanInfo"
+        },
+        {
+            "type": "java.nio.file.FilesCustomizer"
+        },
+        {
+            "type": "java.nio.file.WatchService"
+        },
+        {
+            "type": "java.nio.file.attribute.FileAttribute"
+        },
+        {
+            "type": "java.nio.file.attribute.UserPrincipal"
         },
         {
             "type": "java.util.AbstractMapBeanInfo"
@@ -370,6 +693,9 @@
         },
         {
             "type": "java.util.ArrayListCustomizer"
+        },
+        {
+            "type": "java.util.Calendar"
         },
         {
             "type": "java.util.Date",
@@ -407,16 +733,25 @@
             "type": "java.util.Map$Entry[]"
         },
         {
-            "type": "java.util.concurrent.CompletionStage"
+            "type": "java.util.function.UnaryOperator"
         },
         {
-            "type": "java.util.function.UnaryOperator"
+            "type": "javax.xml.parsers.SAXParser"
         },
         {
             "type": "jdk.internal.jrtfs.JrtFileSystemProvider"
         },
         {
             "type": "jdk.internal.reflect.CallerSensitive"
+        },
+        {
+            "type": "org.apache.groovy.json.internal.LazyMap"
+        },
+        {
+            "type": "org.apache.groovy.json.internal.LazyMapBeanInfo"
+        },
+        {
+            "type": "org.apache.groovy.json.internal.LazyMapCustomizer"
         },
         {
             "type": "org.apache.groovy.runtime.async.AsyncSupport",
@@ -446,6 +781,36 @@
         },
         {
             "type": "org.codehaus.groovy.reflection.ParameterTypes"
+        },
+        {
+            "type": "org.xml.sax.Attributes"
+        },
+        {
+            "type": "org.xml.sax.ContentHandler"
+        },
+        {
+            "type": "org.xml.sax.DTDHandler"
+        },
+        {
+            "type": "org.xml.sax.EntityResolver"
+        },
+        {
+            "type": "org.xml.sax.ErrorHandler"
+        },
+        {
+            "type": "org.xml.sax.Locator"
+        },
+        {
+            "type": "org.xml.sax.XMLReader"
+        },
+        {
+            "type": "org.xml.sax.helpers.DefaultHandler"
+        },
+        {
+            "type": "org.xml.sax.helpers.DefaultHandlerBeanInfo"
+        },
+        {
+            "type": "org.xml.sax.helpers.DefaultHandlerCustomizer"
         },
         {
             "type": "probe",
@@ -493,7 +858,7 @@
             ]
         },
         {
-            "type": "probe$_run_closure10$_closure11",
+            "type": "probe$_run_closure10$_closure15",
             "methods": [
                 {
                     "name": "doCall",
@@ -504,13 +869,13 @@
             ]
         },
         {
-            "type": "probe$_run_closure10$_closure11BeanInfo"
+            "type": "probe$_run_closure10$_closure15BeanInfo"
         },
         {
-            "type": "probe$_run_closure10$_closure11Customizer"
+            "type": "probe$_run_closure10$_closure15Customizer"
         },
         {
-            "type": "probe$_run_closure10$_closure12",
+            "type": "probe$_run_closure10$_closure16",
             "methods": [
                 {
                     "name": "doCall",
@@ -521,16 +886,108 @@
             ]
         },
         {
-            "type": "probe$_run_closure10$_closure12BeanInfo"
+            "type": "probe$_run_closure10$_closure16BeanInfo"
         },
         {
-            "type": "probe$_run_closure10$_closure12Customizer"
+            "type": "probe$_run_closure10$_closure16Customizer"
         },
         {
             "type": "probe$_run_closure10BeanInfo"
         },
         {
             "type": "probe$_run_closure10Customizer"
+        },
+        {
+            "type": "probe$_run_closure11",
+            "methods": [
+                {
+                    "name": "doCall",
+                    "parameterTypes": [
+                        
+                    ]
+                },
+                {
+                    "name": "doCall",
+                    "parameterTypes": [
+                        "java.lang.Object"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "probe$_run_closure11BeanInfo"
+        },
+        {
+            "type": "probe$_run_closure11Customizer"
+        },
+        {
+            "type": "probe$_run_closure12",
+            "methods": [
+                {
+                    "name": "doCall",
+                    "parameterTypes": [
+                        
+                    ]
+                },
+                {
+                    "name": "doCall",
+                    "parameterTypes": [
+                        "java.lang.Object"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "probe$_run_closure12BeanInfo"
+        },
+        {
+            "type": "probe$_run_closure12Customizer"
+        },
+        {
+            "type": "probe$_run_closure13",
+            "methods": [
+                {
+                    "name": "doCall",
+                    "parameterTypes": [
+                        
+                    ]
+                },
+                {
+                    "name": "doCall",
+                    "parameterTypes": [
+                        "java.lang.Object"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "probe$_run_closure13BeanInfo"
+        },
+        {
+            "type": "probe$_run_closure13Customizer"
+        },
+        {
+            "type": "probe$_run_closure14",
+            "methods": [
+                {
+                    "name": "doCall",
+                    "parameterTypes": [
+                        
+                    ]
+                },
+                {
+                    "name": "doCall",
+                    "parameterTypes": [
+                        "java.lang.Object"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "probe$_run_closure14BeanInfo"
+        },
+        {
+            "type": "probe$_run_closure14Customizer"
         },
         {
             "type": "probe$_run_closure1BeanInfo"
@@ -709,6 +1166,37 @@
             "type": "probeCustomizer"
         },
         {
+            "type": "sun.nio.fs.UnixPath"
+        },
+        {
+            "type": "sun.nio.fs.UnixPathBeanInfo"
+        },
+        {
+            "type": "sun.nio.fs.UnixPathCustomizer"
+        },
+        {
+            "type": "sun.security.provider.NativePRNG",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "java.security.SecureRandomParameters"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "sun.security.provider.SHA",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        
+                    ]
+                }
+            ]
+        },
+        {
             "type": {
                 "proxy": [
                     "java.util.Comparator"
@@ -728,6 +1216,9 @@
                     "java.util.function.Function"
                 ]
             }
+        },
+        {
+            "type": "java.nio.file.WatchEvent$Modifier"
         }
     ]
 }


### PR DESCRIPTION
Put the three module jars on the probe classpath, union their shipped metadata in the drift check, and exercise Path extensions, the XML parsers and builder, and JSON output and parsing. The strict-mode image found three gaps: groovy-xml's FactorySupport needs its JAXP ServiceLoader lookups and default implementations registered (generator gains a resources section), groovy-json needs its ServiceLoader-loaded string service (hand-written module metadata), and the Introspector's by-name resolution of Path's parameter types needs a hand-listed entry the JVM agent cannot record, now preserved across updateProbeMetadata.