### PR TITLE
GROOVY-12383: VM plugin: fall back to Java 8 accessibility rules when…

### DIFF
--- a/src/main/java/org/codehaus/groovy/vmplugin/v9/Java9.java
+++ b/src/main/java/org/codehaus/groovy/vmplugin/v9/Java9.java
@@ -219,6 +219,7 @@ public class Java9 extends Java8 {
     /** {@inheritDoc} */
     @Override
     public boolean trySetAccessible(final AccessibleObject ao) {
+        if (!MODULES_AVAILABLE) return super.trySetAccessible(ao);
         return ao.trySetAccessible();
     }
 
@@ -239,6 +240,7 @@ public class Java9 extends Java8 {
     public boolean checkCanSetAccessible(final AccessibleObject accessibleObject, final Class<?> callerClass) {
 
         if (!super.checkCanSetAccessible(accessibleObject, callerClass)) return false;
+        if (!MODULES_AVAILABLE) return true;
 
         if (callerClass == MethodHandle.class) {
             throw new IllegalCallerException(); // should not happen
@@ -263,6 +265,7 @@ public class Java9 extends Java8 {
     /** {@inheritDoc} */
     @Override
     public boolean checkAccessible(final Class<?> accessingClass, final Class<?> declaringClass, final int memberModifiers, final boolean allowIllegalAccess) {
+        if (!MODULES_AVAILABLE) return super.checkAccessible(accessingClass, declaringClass, memberModifiers, allowIllegalAccess);
         Module accessingModule = accessingClass.getModule();
         Module declaringModule = declaringClass.getModule();
         String packageName = declaringClass.getPackageName();
@@ -294,25 +297,46 @@ public class Java9 extends Java8 {
     private static final Map<String, Set<String>> CONCEALED_PACKAGES_TO_OPEN;
     private static final Map<String, Set<String>> EXPORTED_PACKAGES_TO_OPEN;
 
-    static {
-        ModuleFinder finder = ModuleFinder.ofSystem();
-        Map<String, ModuleDescriptor> packages = new HashMap<>(1024);
-        finder.findAll().stream()
-                .map(ModuleReference::descriptor)
-                .forEach(md -> md.packages().forEach(pn -> packages.putIfAbsent(pn, md)));
+    /**
+     * Whether the running VM has the Java Platform Module System. Runtimes built
+     * on the JDK class library without it (Android's ART) lack {@code Module},
+     * {@code ModuleFinder} and {@code trySetAccessible}; there the Java 8
+     * accessibility rules apply and the package tables below stay empty
+     * (GROOVY-12383).
+     */
+    private static final boolean MODULES_AVAILABLE = modulesAvailable();
 
+    static boolean modulesAvailable() {
+        try {
+            // every JPMS API this class relies on, not just the one it uses first
+            Class.class.getMethod("getModule");
+            AccessibleObject.class.getMethod("trySetAccessible");
+            Class.forName("java.lang.module.ModuleFinder", false, Java9.class.getClassLoader());
+            return true;
+        } catch (ReflectiveOperationException | LinkageError | SecurityException e) {
+            return false;
+        }
+    }
+
+    static {
         Map<String, Set<String>> concealedPackagesToOpen = new ConcurrentHashMap<>(64);
         Map<String, Set<String>> exportedPackagesToOpen = new ConcurrentHashMap<>(64);
+        if (MODULES_AVAILABLE) {
+            ModuleFinder finder = ModuleFinder.ofSystem();
+            Map<String, ModuleDescriptor> packages = new HashMap<>(1024);
+            finder.findAll().stream()
+                    .map(ModuleReference::descriptor)
+                    .forEach(md -> md.packages().forEach(pn -> packages.putIfAbsent(pn, md)));
 
-        for (String j8pn : JAVA8_PACKAGES()) {
-            ModuleDescriptor descriptor = packages.get(j8pn);
-            if (descriptor == null || isOpen(descriptor, j8pn)) continue;
+            for (String j8pn : JAVA8_PACKAGES()) {
+                ModuleDescriptor descriptor = packages.get(j8pn);
+                if (descriptor == null || isOpen(descriptor, j8pn)) continue;
 
-            Map<String, Set<String>> packagesToOpen =
-                isExported(descriptor, j8pn) ? exportedPackagesToOpen : concealedPackagesToOpen;
-            packagesToOpen.computeIfAbsent(descriptor.name(), k -> new HashSet<>(128)).add(j8pn);
+                Map<String, Set<String>> packagesToOpen =
+                    isExported(descriptor, j8pn) ? exportedPackagesToOpen : concealedPackagesToOpen;
+                packagesToOpen.computeIfAbsent(descriptor.name(), k -> new HashSet<>(128)).add(j8pn);
+            }
         }
-
         CONCEALED_PACKAGES_TO_OPEN = concealedPackagesToOpen;
         EXPORTED_PACKAGES_TO_OPEN = exportedPackagesToOpen;
     }

--- a/src/test/groovy/org/codehaus/groovy/vmplugin/v9/Java9AccessibilityTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/vmplugin/v9/Java9AccessibilityTest.groovy
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.vmplugin.v9
+
+import org.codehaus.groovy.vmplugin.VMPlugin
+import org.codehaus.groovy.vmplugin.VMPluginFactory
+import org.junit.jupiter.api.Test
+
+import java.lang.reflect.Modifier
+
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * GROOVY-12383: the module-system accessibility rules apply on a JVM, and the
+ * plugin initialises with them; where the module system is absent the Java 8
+ * rules take over, which only a runtime such as Android's ART can exercise.
+ */
+final class Java9AccessibilityTest {
+
+    private final VMPlugin plugin = VMPluginFactory.plugin
+
+    @Test
+    void moduleSystemIsDetectedOnAJvm() {
+        assertTrue(Java9.modulesAvailable())
+        assertTrue(plugin instanceof Java9)
+    }
+
+    @Test
+    void publicMemberOfAnExportedJdkPackageIsAccessible() {
+        def method = ArrayList.getMethod('size')
+        assertTrue(plugin.checkCanSetAccessible(method, Java9AccessibilityTest))
+        assertTrue(plugin.checkAccessible(Java9AccessibilityTest, ArrayList, method.modifiers, false))
+    }
+
+    @Test
+    void concealedJdkMemberIsNotAccessibleWithoutIllegalAccess() {
+        // jdk.internal.misc is in java.base and not exported to the unnamed module on any release since 9
+        def concealed = Class.forName('jdk.internal.misc.Unsafe')
+        assertFalse(plugin.checkAccessible(Java9AccessibilityTest, concealed, Modifier.PUBLIC | Modifier.STATIC, false))
+    }
+
+    @Test
+    void classConstructorIsNeverMadeAccessible() {
+        def constructors = Class.declaredConstructors
+        assertTrue(constructors.length > 0)
+        constructors.each { ctor ->
+            assertFalse(plugin.checkCanSetAccessible(ctor, Java9AccessibilityTest), ctor.toString())
+        }
+    }
+}


### PR DESCRIPTION
… the module system is absent