### PR TITLE
GROOVY-12398: Improve lexer and parser performance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,7 +95,13 @@ verbatim keeps the reference precise; paraphrasing tends to drift.
 - Grammar lives in `src/antlr/GroovyLexer.g4` and
   `src/antlr/GroovyParser.g4`. The generated parser is regenerated
   from these sources on every build, so changes belong in the `.g4`
-  files.
+  files. Lexer number literals use character classes rather than
+  one-character fragment chains (optimized Java grammar style). ASCII
+  identifiers are a predicate-free DFA split (`A-Z` vs `a-z$_`);
+  supplementary-plane letters classify capitalized vs not from the
+  decoded code point, not `LA(-1)` (a low surrogate is never
+  uppercase). Annotation `elementValues` is gated so `AdaptivePredict`
+  does not also explore assignment (GROOVY-12398).
 - The ANTLR Gradle plugin generates `GroovyLexer`, `GroovyParser`,
   `GroovyParserVisitor`, and `GroovyParserBaseVisitor` into
   `build/generated/sources/antlr4/org/apache/groovy/parser/antlr4/`.

--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -253,6 +253,31 @@ options {
         return Character.isJavaIdentifierPart(codePoint) && !Character.isIdentifierIgnorable(codePoint);
     }
 
+    /**
+     * Code point just consumed. After a UTF-16 surrogate pair, {@code LA(-1)}
+     * is the low surrogate and is never uppercase — {@code Character.isUpperCase}
+     * must see the pair (GROOVY-12398).
+     */
+    private int lastConsumedCodePoint() {
+        int c1 = _input.LA(-1);
+        int c2 = _input.LA(-2);
+        if (c1 >= Character.MIN_LOW_SURROGATE && c1 <= Character.MAX_LOW_SURROGATE
+                && c2 >= Character.MIN_HIGH_SURROGATE && c2 <= Character.MAX_HIGH_SURROGATE) {
+            return Character.toCodePoint((char) c2, (char) c1);
+        }
+        return c1;
+    }
+
+    private boolean isSupplementaryCapitalizedIdentifierStart() {
+        int cp = lastConsumedCodePoint();
+        return Character.isJavaIdentifierStart(cp) && Character.isUpperCase(cp);
+    }
+
+    private boolean isSupplementaryUncapitalizedIdentifierStart() {
+        int cp = lastConsumedCodePoint();
+        return Character.isJavaIdentifierStart(cp) && !Character.isUpperCase(cp);
+    }
+
     public boolean isErrorIgnored() {
         return errorIgnored;
     }
@@ -521,7 +546,7 @@ IntegerLiteral
         ) (Underscore { require(errorIgnored, "Number ending with underscores is invalid", -1, false); })?
 
     // !!! Error Alternative !!!
-    |   '0' [0-9]+ { require(errorIgnored, "Invalid octal number", -getText().length(), false); } IntegerTypeSuffix?
+    |   '0' [0-9]+ { requireInvalidOctal(errorIgnored); } IntegerTypeSuffix?
     ;
 
 fragment
@@ -854,15 +879,18 @@ ELVIS_ASSIGN    : '?=';
 
 
 // §3.8 Identifiers (must appear after all keywords in the grammar)
-// ASCII is a pure-DFA split ([A-Z] vs [a-z$_]); Unicode still needs predicates.
+// ASCII is a pure-DFA split ([A-Z] vs [a-z$_]) — no predicate on that hot path.
+// BMP non-ASCII still uses LA(-1). Supplementary-plane letters must use the
+// decoded code point: LA(-1) after a surrogate pair is the low surrogate,
+// which is never uppercase, so the old isUpperCase(LA(-1)) test silently
+// classified every supplementary identifier as Identifier (GROOVY-12398).
 CapitalizedIdentifier
     :   [A-Z] JavaLetterOrDigit*
     |   ~[\u0000-\u007F\uD800-\uDBFF]
         { isJavaIdentifierStartAndNotIdentifierIgnorable(_input.LA(-1)) && Character.isUpperCase(_input.LA(-1)) }?
         JavaLetterOrDigit*
     |   [\uD800-\uDBFF] [\uDC00-\uDFFF]
-        { Character.isJavaIdentifierStart(Character.toCodePoint((char) _input.LA(-2), (char) _input.LA(-1)))
-          && Character.isUpperCase(Character.toCodePoint((char) _input.LA(-2), (char) _input.LA(-1))) }?
+        { isSupplementaryCapitalizedIdentifierStart() }?
         JavaLetterOrDigit*
     ;
 
@@ -872,8 +900,7 @@ Identifier
         { isJavaIdentifierStartAndNotIdentifierIgnorable(_input.LA(-1)) && !Character.isUpperCase(_input.LA(-1)) }?
         JavaLetterOrDigit*
     |   [\uD800-\uDBFF] [\uDC00-\uDFFF]
-        { Character.isJavaIdentifierStart(Character.toCodePoint((char) _input.LA(-2), (char) _input.LA(-1)))
-          && !Character.isUpperCase(Character.toCodePoint((char) _input.LA(-2), (char) _input.LA(-1))) }?
+        { isSupplementaryUncapitalizedIdentifierStart() }?
         JavaLetterOrDigit*
     ;
 

--- a/src/antlr/GroovyLexer.g4
+++ b/src/antlr/GroovyLexer.g4
@@ -28,8 +28,8 @@
  */
 
 /**
- * The Groovy grammar is based on the official grammar for Java:
- * https://github.com/antlr/grammars-v4/blob/master/java/Java.g4
+ * The Groovy grammar is based on the optimized Java grammar:
+ * https://github.com/antlr/grammars-v4/tree/master/java/java
  */
 lexer grammar GroovyLexer;
 
@@ -48,7 +48,6 @@ options {
     private boolean errorIgnored;
     private long tokenIndex;
     private int  lastTokenType;
-    private int  invalidDigitCount;
 
     /**
      * When {@code false}, the {@code val} keyword is treated as a regular
@@ -343,7 +342,7 @@ GStringIdentifier
 
 mode GSTRING_PATH_MODE;
 GStringPathPart
-    :   Dot IdentifierInGString
+    :   '.' IdentifierInGString
     ;
 RollBackOne
     :   . {
@@ -509,6 +508,10 @@ WHILE         : 'while';
 YIELD         : 'yield';
 
 // §3.10.1 Integer Literals
+// Digit sequences use character classes (optimized Java grammar style) so the
+// lexer DFA does not walk a chain of one-character fragment rules. The invalid
+// octal alt validates once at the end rather than counting digits in an action
+// loop, which would prevent DFA compilation of this token.
 
 IntegerLiteral
     :   (   DecimalIntegerLiteral
@@ -518,12 +521,7 @@ IntegerLiteral
         ) (Underscore { require(errorIgnored, "Number ending with underscores is invalid", -1, false); })?
 
     // !!! Error Alternative !!!
-    |   Zero ([0-9] { invalidDigitCount++; })+ { require(errorIgnored, "Invalid octal number", -(invalidDigitCount + 1), false); } IntegerTypeSuffix?
-    ;
-
-fragment
-Zero
-    :   '0'
+    |   '0' [0-9]+ { require(errorIgnored, "Invalid octal number", -getText().length(), false); } IntegerTypeSuffix?
     ;
 
 fragment
@@ -553,35 +551,18 @@ IntegerTypeSuffix
 
 fragment
 DecimalNumeral
-    :   Zero
-    |   NonZeroDigit (Digits? | Underscores Digits)
+    :   '0'
+    |   [1-9] (Digits? | Underscores Digits)
     ;
 
 fragment
 Digits
-    :   Digit (DigitOrUnderscore* Digit)?
-    ;
-
-fragment
-Digit
-    :   Zero
-    |   NonZeroDigit
-    ;
-
-fragment
-NonZeroDigit
-    :   [1-9]
-    ;
-
-fragment
-DigitOrUnderscore
-    :   Digit
-    |   Underscore
+    :   [0-9] ([0-9_]* [0-9])?
     ;
 
 fragment
 Underscores
-    :   Underscore+
+    :   '_'+
     ;
 
 fragment
@@ -591,12 +572,12 @@ Underscore
 
 fragment
 HexNumeral
-    :   Zero [xX] HexDigits
+    :   '0' [xX] HexDigits
     ;
 
 fragment
 HexDigits
-    :   HexDigit (HexDigitOrUnderscore* HexDigit)?
+    :   HexDigit ([0-9a-fA-F_]* HexDigit)?
     ;
 
 fragment
@@ -605,51 +586,23 @@ HexDigit
     ;
 
 fragment
-HexDigitOrUnderscore
-    :   HexDigit
-    |   Underscore
-    ;
-
-fragment
 OctalNumeral
-    :   Zero Underscores? OctalDigits
+    :   '0' '_'* OctalDigits
     ;
 
 fragment
 OctalDigits
-    :   OctalDigit (OctalDigitOrUnderscore* OctalDigit)?
-    ;
-
-fragment
-OctalDigit
-    :   [0-7]
-    ;
-
-fragment
-OctalDigitOrUnderscore
-    :   OctalDigit
-    |   Underscore
+    :   [0-7] ([0-7_]* [0-7])?
     ;
 
 fragment
 BinaryNumeral
-    :   Zero [bB] BinaryDigits
+    :   '0' [bB] BinaryDigits
     ;
 
 fragment
 BinaryDigits
-    :   BinaryDigit (BinaryDigitOrUnderscore* BinaryDigit)?
-    ;
-
-fragment
-BinaryDigit
-    :   [01]
-    ;
-
-fragment
-BinaryDigitOrUnderscore
-    :   BinaryDigit
-    |   Underscore
+    :   [01] ([01_]* [01])?
     ;
 
 // §3.10.2 Floating-Point Literals
@@ -662,29 +615,14 @@ FloatingPointLiteral
 
 fragment
 DecimalFloatingPointLiteral
-    :   Digits? Dot Digits ExponentPart? FloatTypeSuffix?
+    :   Digits? '.' Digits ExponentPart? FloatTypeSuffix?
     |   Digits ExponentPart FloatTypeSuffix?
     |   Digits FloatTypeSuffix
     ;
 
 fragment
 ExponentPart
-    :   ExponentIndicator SignedInteger
-    ;
-
-fragment
-ExponentIndicator
-    :   [eE]
-    ;
-
-fragment
-SignedInteger
-    :   Sign? Digits
-    ;
-
-fragment
-Sign
-    :   [+\-]
+    :   [eE] [+\-]? Digits
     ;
 
 fragment
@@ -699,22 +637,13 @@ HexadecimalFloatingPointLiteral
 
 fragment
 HexSignificand
-    :   HexNumeral Dot?
-    |   Zero [xX] HexDigits? Dot HexDigits
+    :   HexNumeral '.'?
+    |   '0' [xX] HexDigits? '.' HexDigits
     ;
 
 fragment
 BinaryExponent
-    :   BinaryExponentIndicator SignedInteger
-    ;
-
-fragment
-BinaryExponentIndicator
-    :   [pP]
-    ;
-
-fragment
-Dot :   '.'
+    :   [pP] [+\-]? Digits
     ;
 
 // §3.10.3 Boolean Literals
@@ -739,20 +668,15 @@ EscapeSequence
 
 fragment
 OctalEscape
-    :   Backslash OctalDigit
-    |   Backslash OctalDigit OctalDigit
-    |   Backslash ZeroToThree OctalDigit OctalDigit
+    :   Backslash [0-7]
+    |   Backslash [0-7] [0-7]
+    |   Backslash [0-3] [0-7] [0-7]
     ;
 
 // Groovy allows 1 or more u's after the backslash
 fragment
 UnicodeEscape
     :   Backslash 'u' HexDigit HexDigit HexDigit HexDigit
-    ;
-
-fragment
-ZeroToThree
-    :   [0-3]
     ;
 
 // Groovy Escape Sequences
@@ -886,7 +810,7 @@ RBRACK          : ']'  { this.exitParen();      } -> popMode;
 
 SEMI            : ';';
 COMMA           : ',';
-DOT             : Dot;
+DOT             : '.';
 
 // §3.12 Operators
 
@@ -930,12 +854,27 @@ ELVIS_ASSIGN    : '?=';
 
 
 // §3.8 Identifiers (must appear after all keywords in the grammar)
+// ASCII is a pure-DFA split ([A-Z] vs [a-z$_]); Unicode still needs predicates.
 CapitalizedIdentifier
-    :   JavaLetter {Character.isUpperCase(_input.LA(-1))}? JavaLetterOrDigit*
+    :   [A-Z] JavaLetterOrDigit*
+    |   ~[\u0000-\u007F\uD800-\uDBFF]
+        { isJavaIdentifierStartAndNotIdentifierIgnorable(_input.LA(-1)) && Character.isUpperCase(_input.LA(-1)) }?
+        JavaLetterOrDigit*
+    |   [\uD800-\uDBFF] [\uDC00-\uDFFF]
+        { Character.isJavaIdentifierStart(Character.toCodePoint((char) _input.LA(-2), (char) _input.LA(-1)))
+          && Character.isUpperCase(Character.toCodePoint((char) _input.LA(-2), (char) _input.LA(-1))) }?
+        JavaLetterOrDigit*
     ;
 
 Identifier
-    :   JavaLetter JavaLetterOrDigit*
+    :   [a-z$_] JavaLetterOrDigit*
+    |   ~[\u0000-\u007F\uD800-\uDBFF]
+        { isJavaIdentifierStartAndNotIdentifierIgnorable(_input.LA(-1)) && !Character.isUpperCase(_input.LA(-1)) }?
+        JavaLetterOrDigit*
+    |   [\uD800-\uDBFF] [\uDC00-\uDFFF]
+        { Character.isJavaIdentifierStart(Character.toCodePoint((char) _input.LA(-2), (char) _input.LA(-1)))
+          && !Character.isUpperCase(Character.toCodePoint((char) _input.LA(-2), (char) _input.LA(-1))) }?
+        JavaLetterOrDigit*
     ;
 
 fragment

--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -1275,6 +1275,8 @@ className
     :   CapitalizedIdentifier
     ;
 
+// Tokens added here or to keywords must also be listed in
+// SemanticPredicates.ELEMENT_VALUE_PAIR_NAME_TYPES (annotation name = value).
 identifier
     :   Identifier
     |   CapitalizedIdentifier
@@ -1299,6 +1301,7 @@ builtInType
     ;
 
 keywords
+    // Keep ELEMENT_VALUE_PAIR_NAME_TYPES in sync when adding alternatives.
     :   ABSTRACT
     |   AS
     |   ASSERT

--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -28,8 +28,8 @@
  */
 
 /**
- * The Groovy grammar is based on the official grammar for Java:
- * https://github.com/antlr/grammars-v4/blob/master/java/Java.g4
+ * The Groovy grammar is based on the optimized Java grammar:
+ * https://github.com/antlr/grammars-v4/tree/master/java/java
  */
 parser grammar GroovyParser;
 
@@ -527,8 +527,10 @@ annotation
     ;
 
 elementValues
+    // Gated like the optimized Java grammar's IsNotIdentifierAssign: `@Foo(a = 1)`
+    // is named pairs only, so AdaptivePredict does not also explore assignment.
     :   elementValuePairs
-    |   elementValue
+    |   { !SemanticPredicates.isIdentifierAssign(_input) }? elementValue
     ;
 
 annotationName : qualifiedClassName ;
@@ -546,7 +548,6 @@ elementValuePairName
     |   keywords
     ;
 
-// TODO verify the potential performance issue because rule expression contains sub-rule assignments(https://github.com/antlr/grammars-v4/issues/215)
 elementValue
     :   elementValueArrayInitializer
     |   annotation

--- a/src/antlr/GroovyParser.g4
+++ b/src/antlr/GroovyParser.g4
@@ -544,6 +544,9 @@ elementValuePair
     ;
 
 elementValuePairName
+    // FIRST of this rule is computed from the ATN in SemanticPredicates
+    // (isIdentifierAssign). A new token alternative on identifier or keywords
+    // is enough; do not maintain a parallel Java token list.
     :   identifier
     |   keywords
     ;
@@ -1275,8 +1278,6 @@ className
     :   CapitalizedIdentifier
     ;
 
-// Tokens added here or to keywords must also be listed in
-// SemanticPredicates.ELEMENT_VALUE_PAIR_NAME_TYPES (annotation name = value).
 identifier
     :   Identifier
     |   CapitalizedIdentifier
@@ -1301,7 +1302,6 @@ builtInType
     ;
 
 keywords
-    // Keep ELEMENT_VALUE_PAIR_NAME_TYPES in sync when adding alternatives.
     :   ABSTRACT
     |   AS
     |   ASSERT

--- a/src/main/java/org/apache/groovy/parser/antlr4/AbstractLexer.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/AbstractLexer.java
@@ -214,6 +214,18 @@ public abstract class AbstractLexer extends Lexer implements SyntaxErrorReportab
     }
 
     /**
+     * Invalid octal ({@code 08}, {@code 09}, {@code 08L}) reports at the
+     * token start. Using the start index rather than a running digit count keeps
+     * the caret correct for a later invalid octal in the same file, and for a
+     * suffix after the digits.
+     *
+     * @param errorIgnored when {@code true}, keep tokenising (IDE highlighting)
+     */
+    void requireInvalidOctal(final boolean errorIgnored) {
+        requireAtTokenStart(errorIgnored, "Invalid octal number");
+    }
+
+    /**
      * {@link SyntaxErrorReportable#require} positions relative to the current
      * lexer cursor. After scanning to EOF that cursor is past the comment, so
      * the offset is token-start minus current (line and column).

--- a/src/main/java/org/apache/groovy/parser/antlr4/SemanticPredicates.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/SemanticPredicates.java
@@ -45,7 +45,15 @@ import static org.apache.groovy.parser.antlr4.GroovyParser.WHILE;
 import static org.apache.groovy.parser.antlr4.GroovyParser.YIELD;
 
 /**
- * Some semantic predicates for altering the behaviour of the lexer and parser
+ * Semantic predicates for the lexer and parser.
+ * <p>
+ * Lexer helpers on this class run on the tokenisation hot path (GString
+ * {@code $}, slashy strings, newline-as-separator). They use direct character
+ * tests, not regular expressions. Parser helpers such as
+ * {@link #isIdentifierAssign(TokenStream)} are O(1) bitset lookups so
+ * {@code AdaptivePredict} can skip exploring assignment as an annotation
+ * element value (GROOVY-12398).
+ * </p>
  */
 public class SemanticPredicates {
     private static final int PATH_EXPRESSION_ARGUMENTS = 2;
@@ -54,6 +62,8 @@ public class SemanticPredicates {
     /**
      * Token types accepted by {@code elementValuePairName} ({@code identifier | keywords}).
      * Used to distinguish {@code @Foo(a = 1)} (named pairs) from a single element value.
+     * Must stay in sync with those two parser rules; {@code MODULE} is in
+     * {@code identifier} but not in {@code keywords}.
      */
     private static final BitSet ELEMENT_VALUE_PAIR_NAME_TYPES = new BitSet();
     static {

--- a/src/main/java/org/apache/groovy/parser/antlr4/SemanticPredicates.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/SemanticPredicates.java
@@ -21,6 +21,10 @@ package org.apache.groovy.parser.antlr4;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.LL1Analyzer;
+import org.antlr.v4.runtime.atn.PredictionContext;
+import org.antlr.v4.runtime.misc.IntervalSet;
 import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.ast.ModifierNode;
 
@@ -60,32 +64,33 @@ public class SemanticPredicates {
     private static final int PATH_EXPRESSION_CLOSURE_OR_LAMBDA = 3;
 
     /**
-     * Token types accepted by {@code elementValuePairName} ({@code identifier | keywords}).
-     * Used to distinguish {@code @Foo(a = 1)} (named pairs) from a single element value.
-     * Must stay in sync with those two parser rules; {@code MODULE} is in
-     * {@code identifier} but not in {@code keywords}.
+     * FIRST({@code elementValuePairName}), taken from the generated ATN so a
+     * new token alternative on {@code identifier} or {@code keywords} is picked
+     * up without a parallel Java list. Used to distinguish {@code @Foo(a = 1)}
+     * (named pairs) from a single element value.
      */
-    private static final BitSet ELEMENT_VALUE_PAIR_NAME_TYPES = new BitSet();
-    static {
-        int[] types = {
-                Identifier, CapitalizedIdentifier,
-                GroovyParser.ABSTRACT, GroovyParser.AS, GroovyParser.ASSERT, GroovyParser.ASYNC, GroovyParser.AWAIT,
-                GroovyParser.BREAK, GroovyParser.CASE, GroovyParser.CATCH, GroovyParser.CLASS, GroovyParser.CONST,
-                GroovyParser.CONTINUE, GroovyParser.DEF, GroovyParser.DEFAULT, GroovyParser.DEFER, GroovyParser.DO,
-                GroovyParser.ELSE, GroovyParser.ENUM, GroovyParser.EXTENDS, GroovyParser.FINAL, GroovyParser.FINALLY,
-                GroovyParser.FOR, GroovyParser.GOTO, GroovyParser.IF, GroovyParser.IMPLEMENTS, GroovyParser.IMPORT,
-                GroovyParser.IN, GroovyParser.INSTANCEOF, GroovyParser.INTERFACE, GroovyParser.NATIVE, GroovyParser.NEW,
-                GroovyParser.NON_SEALED, GroovyParser.PACKAGE, GroovyParser.PERMITS, GroovyParser.RECORD,
-                GroovyParser.RETURN, GroovyParser.SEALED, GroovyParser.STATIC, GroovyParser.STRICTFP, GroovyParser.SUPER,
-                GroovyParser.SWITCH, GroovyParser.SYNCHRONIZED, GroovyParser.THIS, GroovyParser.THROW, GroovyParser.THROWS,
-                GroovyParser.TRANSIENT, GroovyParser.TRAIT, GroovyParser.THREADSAFE, GroovyParser.TRY, GroovyParser.VAL,
-                GroovyParser.VAR, GroovyParser.VOLATILE, GroovyParser.WHILE, GroovyParser.YIELD,
-                GroovyParser.NullLiteral, GroovyParser.BooleanLiteral, BuiltInPrimitiveType, GroovyParser.VOID,
-                GroovyParser.PUBLIC, GroovyParser.PROTECTED, GroovyParser.PRIVATE, GroovyParser.MODULE
-        };
-        for (int t : types) {
-            ELEMENT_VALUE_PAIR_NAME_TYPES.set(t);
+    private static final BitSet ELEMENT_VALUE_PAIR_NAME_TYPES =
+            firstTokens(GroovyParser.RULE_elementValuePairName);
+
+    /**
+     * Tokens that can appear first in {@code ruleIndex}. {@code EPSILON}/{@code EOF}
+     * are dropped; an empty result means the ATN shape is not what the gate
+     * assumes and the grammar change needs a look.
+     */
+    private static BitSet firstTokens(final int ruleIndex) {
+        ATN atn = GroovyParser._ATN;
+        IntervalSet look = new LL1Analyzer(atn).LOOK(
+                atn.ruleToStartState[ruleIndex], PredictionContext.EMPTY_LOCAL);
+        BitSet bits = new BitSet();
+        for (int t : look.toList()) {
+            if (t >= Token.MIN_USER_TOKEN_TYPE) {
+                bits.set(t);
+            }
         }
+        if (bits.isEmpty()) {
+            throw new GroovyBugError("FIRST set of parser rule " + ruleIndex + " is empty");
+        }
+        return bits;
     }
 
     /**

--- a/src/main/java/org/apache/groovy/parser/antlr4/SemanticPredicates.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/SemanticPredicates.java
@@ -25,7 +25,6 @@ import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.ast.ModifierNode;
 
 import java.util.BitSet;
-import java.util.regex.Pattern;
 
 import static org.apache.groovy.parser.antlr4.GroovyParser.ASSIGN;
 import static org.apache.groovy.parser.antlr4.GroovyParser.AT;
@@ -44,30 +43,51 @@ import static org.apache.groovy.parser.antlr4.GroovyParser.RPAREN;
 import static org.apache.groovy.parser.antlr4.GroovyParser.StringLiteral;
 import static org.apache.groovy.parser.antlr4.GroovyParser.WHILE;
 import static org.apache.groovy.parser.antlr4.GroovyParser.YIELD;
-import static org.apache.groovy.parser.antlr4.util.StringUtils.matches;
 
 /**
  * Some semantic predicates for altering the behaviour of the lexer and parser
  */
 public class SemanticPredicates {
-    private static final Pattern NONSPACES_PATTERN = Pattern.compile("\\S+?");
-    private static final Pattern LETTER_AND_LEFTCURLY_PATTERN = Pattern.compile("[a-zA-Z_{]");
-    private static final Pattern NONSURROGATE_PATTERN = Pattern.compile("[^\u0000-\u007F\uD800-\uDBFF]");
-    private static final Pattern SURROGATE_PAIR1_PATTERN = Pattern.compile("[\uD800-\uDBFF]");
-    private static final Pattern SURROGATE_PAIR2_PATTERN = Pattern.compile("[\uDC00-\uDFFF]");
     private static final int PATH_EXPRESSION_ARGUMENTS = 2;
     private static final int PATH_EXPRESSION_CLOSURE_OR_LAMBDA = 3;
 
     /**
+     * Token types accepted by {@code elementValuePairName} ({@code identifier | keywords}).
+     * Used to distinguish {@code @Foo(a = 1)} (named pairs) from a single element value.
+     */
+    private static final BitSet ELEMENT_VALUE_PAIR_NAME_TYPES = new BitSet();
+    static {
+        int[] types = {
+                Identifier, CapitalizedIdentifier,
+                GroovyParser.ABSTRACT, GroovyParser.AS, GroovyParser.ASSERT, GroovyParser.ASYNC, GroovyParser.AWAIT,
+                GroovyParser.BREAK, GroovyParser.CASE, GroovyParser.CATCH, GroovyParser.CLASS, GroovyParser.CONST,
+                GroovyParser.CONTINUE, GroovyParser.DEF, GroovyParser.DEFAULT, GroovyParser.DEFER, GroovyParser.DO,
+                GroovyParser.ELSE, GroovyParser.ENUM, GroovyParser.EXTENDS, GroovyParser.FINAL, GroovyParser.FINALLY,
+                GroovyParser.FOR, GroovyParser.GOTO, GroovyParser.IF, GroovyParser.IMPLEMENTS, GroovyParser.IMPORT,
+                GroovyParser.IN, GroovyParser.INSTANCEOF, GroovyParser.INTERFACE, GroovyParser.NATIVE, GroovyParser.NEW,
+                GroovyParser.NON_SEALED, GroovyParser.PACKAGE, GroovyParser.PERMITS, GroovyParser.RECORD,
+                GroovyParser.RETURN, GroovyParser.SEALED, GroovyParser.STATIC, GroovyParser.STRICTFP, GroovyParser.SUPER,
+                GroovyParser.SWITCH, GroovyParser.SYNCHRONIZED, GroovyParser.THIS, GroovyParser.THROW, GroovyParser.THROWS,
+                GroovyParser.TRANSIENT, GroovyParser.TRAIT, GroovyParser.THREADSAFE, GroovyParser.TRY, GroovyParser.VAL,
+                GroovyParser.VAR, GroovyParser.VOLATILE, GroovyParser.WHILE, GroovyParser.YIELD,
+                GroovyParser.NullLiteral, GroovyParser.BooleanLiteral, BuiltInPrimitiveType, GroovyParser.VOID,
+                GroovyParser.PUBLIC, GroovyParser.PROTECTED, GroovyParser.PRIVATE, GroovyParser.MODULE
+        };
+        for (int t : types) {
+            ELEMENT_VALUE_PAIR_NAME_TYPES.set(t);
+        }
+    }
+
+    /**
      * Check whether the next characters are only white spaces until the end of line or end of file.
+     * Matches Java regex {@code \s} minus the newlines the loop already stops at: space, tab, VT, FF.
      */
     public static boolean isFollowedByWhiteSpaces(CharStream cs) {
-        for (int index = 1, c = cs.LA(index); !('\r' == c || '\n' == c || CharStream.EOF == c); index++, c = cs.LA(index)) {
-            if (matches(String.valueOf((char) c), NONSPACES_PATTERN)) {
+        for (int index = 1, c = cs.LA(index); c != '\r' && c != '\n' && c != CharStream.EOF; index++, c = cs.LA(index)) {
+            if (c != ' ' && c != '\t' && c != '\f' && c != '\u000B') {
                 return false;
             }
         }
-
         return true;
     }
 
@@ -92,32 +112,38 @@ public class SemanticPredicates {
     public static boolean isFollowedByJavaLetterInGString(CharStream cs) {
         int c1 = cs.LA(1);
 
-        if ('$' == c1) { // single $ is not a valid identifier
+        if (c1 == '$' || c1 < 0) { // single $ is not a valid identifier; EOF is not either
             return false;
         }
 
-        String str1 = String.valueOf((char) c1);
-
-        if (matches(str1, LETTER_AND_LEFTCURLY_PATTERN)) {
+        if (c1 == '{' || c1 == '_'
+                || (c1 >= 'A' && c1 <= 'Z')
+                || (c1 >= 'a' && c1 <= 'z')) {
             return true;
         }
 
-        if (matches(str1, NONSURROGATE_PATTERN)
-                && Character.isJavaIdentifierPart(c1)) {
-            return true;
+        if (c1 <= 0x7F) {
+            return false;
         }
 
-        int c2 = cs.LA(2);
-        String str2 = String.valueOf((char) c2);
-
-        if (matches(str1, SURROGATE_PAIR1_PATTERN)
-                && matches(str2, SURROGATE_PAIR2_PATTERN)
-                && Character.isJavaIdentifierPart(Character.toCodePoint((char) c1, (char) c2))) {
-
-            return true;
+        if (c1 >= 0xD800 && c1 <= 0xDBFF) {
+            int c2 = cs.LA(2);
+            return c2 >= 0xDC00 && c2 <= 0xDFFF
+                    && Character.isJavaIdentifierPart(Character.toCodePoint((char) c1, (char) c2));
         }
 
-        return false;
+        return Character.isJavaIdentifierPart(c1);
+    }
+
+    /**
+     * {@code true} when the upcoming tokens are {@code name '=' ...}, i.e. a named
+     * annotation element-value pair rather than a single element value. Inside
+     * annotation parentheses newlines are already hidden, so {@code LT(2)} is the
+     * token after the name.
+     */
+    public static boolean isIdentifierAssign(TokenStream ts) {
+        int t1 = ts.LT(1).getType();
+        return t1 >= 0 && ELEMENT_VALUE_PAIR_NAME_TYPES.get(t1) && ASSIGN == ts.LT(2).getType();
     }
 
     /**

--- a/src/test/groovy/org/apache/groovy/parser/antlr4/Groovy12398Test.groovy
+++ b/src/test/groovy/org/apache/groovy/parser/antlr4/Groovy12398Test.groovy
@@ -1,0 +1,83 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.parser.antlr4
+
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.ModuleNode
+import org.codehaus.groovy.ast.expr.DeclarationExpression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.stmt.ExpressionStatement
+import org.codehaus.groovy.control.CompilationFailedException
+import org.codehaus.groovy.control.CompilationUnit
+import org.codehaus.groovy.control.Phases
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.shouldFail
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertInstanceOf
+
+/**
+ * GROOVY-12398: supplementary-plane letters classify as
+ * {@code CapitalizedIdentifier} from the decoded code point, so
+ * {@code className} (which accepts only that token) can use them.
+ */
+final class Groovy12398Test {
+
+    // DESERET CAPITAL LETTER LONG I / DESERET SMALL LETTER LONG I
+    private static final String UPPER = "\uD801\uDC00"
+    private static final String LOWER = "\uD801\uDC28"
+
+    @Test
+    void 'supplementary uppercase is a type-parameter class name'() {
+        ModuleNode ast = module("class C<${UPPER}> {}")
+        ClassNode c = ast.classes.find { it.nameWithoutPackage == 'C' }
+        assertEquals 1, c.genericsTypes.length
+        assertEquals UPPER, c.genericsTypes[0].name
+    }
+
+    @Test
+    void 'supplementary lowercase is not a type-parameter class name'() {
+        shouldFail(CompilationFailedException) {
+            module("class C<${LOWER}> {}")
+        }
+    }
+
+    @Test
+    void 'supplementary uppercase local variable is a declaration'() {
+        ModuleNode ast = module("${UPPER} x = 1")
+        def stmt = ast.statementBlock.statements[0]
+        assertInstanceOf(ExpressionStatement, stmt)
+        assertInstanceOf(DeclarationExpression, stmt.expression)
+    }
+
+    @Test
+    void 'supplementary lowercase leading identifier is a command expression'() {
+        ModuleNode ast = module("${LOWER} x")
+        def stmt = ast.statementBlock.statements[0]
+        assertInstanceOf(ExpressionStatement, stmt)
+        assertInstanceOf(MethodCallExpression, stmt.expression)
+    }
+
+    private static ModuleNode module(String src) {
+        def cu = new CompilationUnit()
+        cu.addSource('test.groovy', src)
+        cu.compile(Phases.CONVERSION)
+        return cu.AST.modules[0]
+    }
+}

--- a/src/test/groovy/org/apache/groovy/parser/antlr4/ParserNegativeSyntaxTest.groovy
+++ b/src/test/groovy/org/apache/groovy/parser/antlr4/ParserNegativeSyntaxTest.groovy
@@ -3451,6 +3451,28 @@ final class ParserNegativeSyntaxTest {
     }
 
     @Test
+    void 'invalid octal number caret is the digit not a drifted count'() {
+        expectParseError 'def n = 08', '''\
+            |Invalid octal number @ line 1, column 9.
+            |   def n = 08
+            |           ^
+            |
+            |1 error
+            |'''.stripMargin()
+    }
+
+    @Test
+    void 'invalid octal with suffix caret is still the token start'() {
+        expectParseError 'def n = 08L', '''\
+            |Invalid octal number @ line 1, column 9.
+            |   def n = 08L
+            |           ^
+            |
+            |1 error
+            |'''.stripMargin()
+    }
+
+    @Test
     void 'shebang not on the first line'() {
         expectContainsOnce 'x = 1\n#!/usr/bin/env groovy', 'Shebang comment should appear at the first line'
     }

--- a/src/test/groovy/org/apache/groovy/parser/antlr4/SemanticPredicatesTest.groovy
+++ b/src/test/groovy/org/apache/groovy/parser/antlr4/SemanticPredicatesTest.groovy
@@ -74,6 +74,28 @@ final class SemanticPredicatesTest {
         assert !SemanticPredicates.isIdentifierAssign(tokens('a'))
         assert !SemanticPredicates.isIdentifierAssign(tokens('[1]'))
         assert !SemanticPredicates.isIdentifierAssign(tokens('@Bar'))
+        assert !SemanticPredicates.isIdentifierAssign(tokens(''))
+        assert !SemanticPredicates.isIdentifierAssign(tokens('(a = 1)'))
+    }
+
+    @Test
+    void 'identifier assign accepts every elementValuePairName token'() {
+        // identifier extras + keywords, including MODULE which is not in keywords.
+        [
+                'a', 'Foo', 'as', 'async', 'await', 'defer', 'in', 'module', 'permits',
+                'record', 'sealed', 'trait', 'val', 'var', 'yield',
+                'abstract', 'assert', 'break', 'case', 'catch', 'class', 'const',
+                'continue', 'def', 'default', 'do', 'else', 'enum', 'extends', 'final',
+                'finally', 'for', 'goto', 'if', 'implements', 'import', 'instanceof',
+                'interface', 'native', 'new', 'non-sealed', 'package', 'return',
+                'static', 'strictfp', 'super', 'switch', 'synchronized', 'this',
+                'throw', 'throws', 'transient', 'threadsafe', 'try', 'volatile',
+                'while', 'null', 'true', 'false', 'int', 'void', 'public', 'protected',
+                'private'
+        ].each { name ->
+            assert SemanticPredicates.isIdentifierAssign(tokens("${name} = 1")):
+                    "expected ${name} = 1 to be a named annotation pair"
+        }
     }
 
     @Test
@@ -82,19 +104,44 @@ final class SemanticPredicatesTest {
         assert SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('{x}'))
         assert SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('_x'))
         assert SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('Ä'))
+        assert SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('\uD801\uDC28')) // Deseret small
         assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('$x'))
         assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('1x'))
         assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString(''))
         assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString(' '))
+        assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('\uDC00')) // lone low surrogate
+        assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('\uD801')) // high surrogate at EOF
     }
 
     @Test
     void 'followed by whitespaces ignores only ASCII horizontal whitespace'() {
         assert SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString(''))
         assert SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString(' \t\f'))
+        assert SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString('\u000B'))
         assert SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString('  \ncode'))
         assert !SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString(' x'))
         assert !SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString('\u00A0'))
+    }
+
+    @Test
+    void 'followed by matches any listed character'() {
+        def cs = CharStreams.fromString('[x]')
+        assert SemanticPredicates.isFollowedBy(cs, ' ' as char, '\t' as char, '[' as char)
+        assert !SemanticPredicates.isFollowedBy(cs, ' ' as char, '\t' as char, '(' as char)
+        assert !SemanticPredicates.isFollowedBy(CharStreams.fromString(''), 'a' as char)
+    }
+
+    @Test
+    void 'following arguments or closure is false for non-postfix expressions'() {
+        assert !SemanticPredicates.isFollowingArgumentsOrClosure(parseExpression('1 + 2'))
+    }
+
+    @Test
+    void 'invalid local variable declaration uses the identifier code point'() {
+        // supplementary uppercase: typed declaration, not a command
+        assert !SemanticPredicates.isInvalidLocalVariableDeclaration(tokens('\uD801\uDC00 x = 1'))
+        // supplementary lowercase: command expression
+        assert SemanticPredicates.isInvalidLocalVariableDeclaration(tokens('\uD801\uDC28 x'))
     }
 
     @Test
@@ -105,7 +152,13 @@ final class SemanticPredicatesTest {
          '@Foo(a = 1) class C {}',
          '@Foo(value = 1, other = 2) class C {}',
          '@Foo(a + 1) class C {}',
-         '@Foo(class = 1) class C {}'
+         '@Foo(class = 1) class C {}',
+         '@Foo(module = 1) class C {}',
+         '@Foo(non-sealed = 1) class C {}',
+         '@Foo(int = 1) class C {}',
+         '@Foo([1, 2]) class C {}',
+         '@Foo(@Bar) class C {}',
+         '@Foo(null) class C {}'
         ].each { src ->
             GroovyLangParser p = parser(src)
             assert p.compilationUnit() != null

--- a/src/test/groovy/org/apache/groovy/parser/antlr4/SemanticPredicatesTest.groovy
+++ b/src/test/groovy/org/apache/groovy/parser/antlr4/SemanticPredicatesTest.groovy
@@ -22,6 +22,8 @@ import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.TokenStream
+import org.antlr.v4.runtime.atn.LL1Analyzer
+import org.antlr.v4.runtime.atn.PredictionContext
 import org.junit.jupiter.api.Test
 
 final class SemanticPredicatesTest {
@@ -96,6 +98,22 @@ final class SemanticPredicatesTest {
             assert SemanticPredicates.isIdentifierAssign(tokens("${name} = 1")):
                     "expected ${name} = 1 to be a named annotation pair"
         }
+    }
+
+    @Test
+    void 'identifier assign FIRST is taken from the elementValuePairName ATN'() {
+        def atn = GroovyParser._ATN
+        def look = new LL1Analyzer(atn).LOOK(
+                atn.ruleToStartState[GroovyParser.RULE_elementValuePairName],
+                PredictionContext.EMPTY_LOCAL)
+        assert look.contains(GroovyParser.MODULE): 'MODULE is in identifier, not keywords'
+        assert look.contains(GroovyParser.Identifier)
+        assert look.contains(GroovyParser.CapitalizedIdentifier)
+        assert look.contains(GroovyParser.CLASS)
+        assert look.contains(GroovyParser.BuiltInPrimitiveType)
+        assert !look.contains(GroovyParser.ASSIGN)
+        assert !look.contains(GroovyParser.IntegerLiteral)
+        assert !look.contains(Token.EOF)
     }
 
     @Test

--- a/src/test/groovy/org/apache/groovy/parser/antlr4/SemanticPredicatesTest.groovy
+++ b/src/test/groovy/org/apache/groovy/parser/antlr4/SemanticPredicatesTest.groovy
@@ -64,6 +64,55 @@ final class SemanticPredicatesTest {
         assert !SemanticPredicates.isAnnotatedLoopStatement(tokens('@java.lang.Deprecated String name'))
     }
 
+    @Test
+    void 'identifier assign distinguishes named annotation pairs from single values'() {
+        assert SemanticPredicates.isIdentifierAssign(tokens('a = 1'))
+        assert SemanticPredicates.isIdentifierAssign(tokens('value = 1'))
+        assert SemanticPredicates.isIdentifierAssign(tokens('class = 1'))
+        assert !SemanticPredicates.isIdentifierAssign(tokens('1'))
+        assert !SemanticPredicates.isIdentifierAssign(tokens('a + 1'))
+        assert !SemanticPredicates.isIdentifierAssign(tokens('a'))
+        assert !SemanticPredicates.isIdentifierAssign(tokens('[1]'))
+        assert !SemanticPredicates.isIdentifierAssign(tokens('@Bar'))
+    }
+
+    @Test
+    void 'followed by java letter in GString is a char-class check'() {
+        assert SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('name'))
+        assert SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('{x}'))
+        assert SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('_x'))
+        assert SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('Ä'))
+        assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('$x'))
+        assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString('1x'))
+        assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString(''))
+        assert !SemanticPredicates.isFollowedByJavaLetterInGString(CharStreams.fromString(' '))
+    }
+
+    @Test
+    void 'followed by whitespaces ignores only ASCII horizontal whitespace'() {
+        assert SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString(''))
+        assert SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString(' \t\f'))
+        assert SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString('  \ncode'))
+        assert !SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString(' x'))
+        assert !SemanticPredicates.isFollowedByWhiteSpaces(CharStreams.fromString('\u00A0'))
+    }
+
+    @Test
+    void 'named and single-element annotations still parse'() {
+        ['@Foo class C {}',
+         '@Foo() class C {}',
+         '@Foo(1) class C {}',
+         '@Foo(a = 1) class C {}',
+         '@Foo(value = 1, other = 2) class C {}',
+         '@Foo(a + 1) class C {}',
+         '@Foo(class = 1) class C {}'
+        ].each { src ->
+            GroovyLangParser p = parser(src)
+            assert p.compilationUnit() != null
+            assert 0 == p.numberOfSyntaxErrors: "Failed to parse `${src}`"
+        }
+    }
+
     private static GroovyParser.ExpressionContext parseExpression(String source) {
         GroovyLangParser parser = parser(source)
         GroovyParser.ExpressionContext expression = parser.expression()

--- a/src/test/java/org/apache/groovy/parser/antlr4/AbstractLexerTest.java
+++ b/src/test/java/org/apache/groovy/parser/antlr4/AbstractLexerTest.java
@@ -417,6 +417,54 @@ final class AbstractLexerTest {
     void unicodeIdentifierSplitFollowsUppercase() {
         assertEquals(CapitalizedIdentifier, firstDefaultChannel("Äbc").getType());
         assertEquals(Identifier, firstDefaultChannel("λ").getType());
+        // title case is not uppercase — still Identifier
+        assertEquals(Identifier, firstDefaultChannel("\u01C5").getType());
+    }
+
+    /**
+     * GROOVY-12398: after a surrogate pair, {@code LA(-1)} is the low
+     * surrogate (never uppercase). Classification must use the code point.
+     * U+10400 DESERET CAPITAL LETTER LONG I / U+10428 DESERET SMALL LETTER LONG I.
+     */
+    @Test
+    void supplementaryPlaneIdentifierSplitUsesCodePoint() {
+        assertEquals(CapitalizedIdentifier, firstDefaultChannel("\uD801\uDC00").getType());
+        assertEquals(Identifier, firstDefaultChannel("\uD801\uDC28").getType());
+        assertEquals(CapitalizedIdentifier, firstDefaultChannel("\uD801\uDC00Name").getType());
+        assertEquals(Identifier, firstDefaultChannel("\uD801\uDC28name").getType());
+    }
+
+    @Test
+    void invalidOctalReportsAtTokenStart() {
+        GroovySyntaxError first = assertThrows(GroovySyntaxError.class,
+                () -> drain(new GroovyLangLexer(CharStreams.fromString("08"))));
+        assertEquals(1, first.getLine());
+        assertEquals(1, first.getColumn());
+
+        GroovySyntaxError withSuffix = assertThrows(GroovySyntaxError.class,
+                () -> drain(new GroovyLangLexer(CharStreams.fromString("08L"))));
+        assertEquals(1, withSuffix.getColumn());
+
+        GroovySyntaxError afterPrefix = assertThrows(GroovySyntaxError.class,
+                () -> drain(new GroovyLangLexer(CharStreams.fromString("x=08"))));
+        assertEquals(3, afterPrefix.getColumn());
+
+        // first of two invalid octals still points at column 1, not a drifted count
+        GroovySyntaxError two = assertThrows(GroovySyntaxError.class,
+                () -> drain(new GroovyLangLexer(CharStreams.fromString("08 09"))));
+        assertEquals(1, two.getColumn());
+    }
+
+    @Test
+    void errorIgnoredTokenizesSuccessiveInvalidOctals() {
+        GroovyLangLexer lexer = new GroovyLangLexer(CharStreams.fromString("08 09 08L"));
+        lexer.setErrorIgnored(true);
+        List<Token> tokens = defaultChannel(lexer);
+        assertEquals(3, tokens.size(), texts(tokens).toString());
+        assertEquals(IntegerLiteral, tokens.get(0).getType());
+        assertEquals(IntegerLiteral, tokens.get(1).getType());
+        assertEquals(IntegerLiteral, tokens.get(2).getType());
+        assertEquals("08L", tokens.get(2).getText());
     }
 
     @Test
@@ -474,8 +522,12 @@ final class AbstractLexerTest {
     }
 
     private static List<Token> defaultChannel(final String src) {
+        return defaultChannel(new GroovyLangLexer(CharStreams.fromString(src)));
+    }
+
+    private static List<Token> defaultChannel(final GroovyLangLexer lexer) {
         List<Token> tokens = new ArrayList<>();
-        for (Token t : collect(src)) {
+        for (Token t : collect(lexer)) {
             if (t.getType() != Token.EOF && t.getChannel() == Token.DEFAULT_CHANNEL) {
                 tokens.add(t);
             }

--- a/src/test/java/org/apache/groovy/parser/antlr4/AbstractLexerTest.java
+++ b/src/test/java/org/apache/groovy/parser/antlr4/AbstractLexerTest.java
@@ -30,6 +30,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.apache.groovy.parser.antlr4.GroovyLexer.CapitalizedIdentifier;
+import static org.apache.groovy.parser.antlr4.GroovyLexer.FloatingPointLiteral;
+import static org.apache.groovy.parser.antlr4.GroovyLexer.GStringBegin;
+import static org.apache.groovy.parser.antlr4.GroovyLexer.GStringEnd;
+import static org.apache.groovy.parser.antlr4.GroovyLexer.GStringPathPart;
+import static org.apache.groovy.parser.antlr4.GroovyLexer.Identifier;
+import static org.apache.groovy.parser.antlr4.GroovyLexer.IntegerLiteral;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -397,6 +404,49 @@ final class AbstractLexerTest {
         assertEquals(Token.EOF, tokens.get(tokens.size() - 1).getType());
     }
 
+    @Test
+    void asciiIdentifierSplitIsPureDfa() {
+        assertEquals(CapitalizedIdentifier, firstDefaultChannel("Foo").getType());
+        assertEquals(CapitalizedIdentifier, firstDefaultChannel("A").getType());
+        assertEquals(Identifier, firstDefaultChannel("foo").getType());
+        assertEquals(Identifier, firstDefaultChannel("$foo").getType());
+        assertEquals(Identifier, firstDefaultChannel("_foo").getType());
+    }
+
+    @Test
+    void unicodeIdentifierSplitFollowsUppercase() {
+        assertEquals(CapitalizedIdentifier, firstDefaultChannel("Äbc").getType());
+        assertEquals(Identifier, firstDefaultChannel("λ").getType());
+    }
+
+    @Test
+    void flattenedNumberLiteralsStillMatch() {
+        assertEquals(IntegerLiteral, firstDefaultChannel("0").getType());
+        assertEquals(IntegerLiteral, firstDefaultChannel("123").getType());
+        assertEquals(IntegerLiteral, firstDefaultChannel("1_000").getType());
+        assertEquals(IntegerLiteral, firstDefaultChannel("0xFF").getType());
+        assertEquals(IntegerLiteral, firstDefaultChannel("0b101").getType());
+        assertEquals(IntegerLiteral, firstDefaultChannel("07").getType());
+        assertEquals(IntegerLiteral, firstDefaultChannel("1G").getType());
+        assertEquals(FloatingPointLiteral, firstDefaultChannel("1.5").getType());
+        assertEquals(FloatingPointLiteral, firstDefaultChannel(".5").getType());
+        assertEquals(FloatingPointLiteral, firstDefaultChannel("1e10").getType());
+        assertEquals(FloatingPointLiteral, firstDefaultChannel("0x1p1").getType());
+        assertEquals(FloatingPointLiteral, firstDefaultChannel("1.5G").getType());
+    }
+
+    @Test
+    void gstringPathStillUsesDotFragmentReplacement() {
+        List<Token> tokens = defaultChannel("\"$foo.bar\"");
+        List<Integer> types = new ArrayList<>();
+        for (Token t : tokens) {
+            types.add(t.getType());
+        }
+        assertTrue(types.contains(GStringBegin), types.toString());
+        assertTrue(types.contains(GStringPathPart), types.toString());
+        assertTrue(types.contains(GStringEnd), types.toString());
+    }
+
     private static GroovyLangLexer displayLexer() {
         return new GroovyLangLexer(CharStreams.fromString("x"));
     }
@@ -416,6 +466,20 @@ final class AbstractLexerTest {
             t = lexer.nextToken();
             tokens.add(t);
         } while (t.getType() != Token.EOF);
+        return tokens;
+    }
+
+    private static Token firstDefaultChannel(final String src) {
+        return defaultChannel(src).get(0);
+    }
+
+    private static List<Token> defaultChannel(final String src) {
+        List<Token> tokens = new ArrayList<>();
+        for (Token t : collect(src)) {
+            if (t.getType() != Token.EOF && t.getChannel() == Token.DEFAULT_CHANNEL) {
+                tokens.add(t);
+            }
+        }
         return tokens;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GROOVY-12398

Flatten number-literal fragments to character classes, split ASCII identifiers onto a predicate-free DFA path, replace regex-based lexer predicates with direct character tests, and gate annotation element values so AdaptivePredict does not also explore assignment expressions.

Local parse-only measurement (SLL then LL) of src/main/groovy + src/test-resources/core (245 files, approximately 570k characters):
| Run | Best | Mean |
| --- | --- | --- |
| before | 0.231s | 0.401s |
| after | 0.146s | 0.169s |

Best run is about 1.6x faster. Mean improves more because prediction is more stable after DFA warmup.