### PR TITLE
GROOVY-12405: jump-table dispatch for statically compiled switch stat…

### DIFF
--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesStatementWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesStatementWriter.java
@@ -25,7 +25,9 @@ import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.CaseStatement;
 import org.codehaus.groovy.ast.stmt.ForStatement;
+import org.codehaus.groovy.ast.stmt.SwitchStatement;
 import org.codehaus.groovy.ast.tools.GeneralUtils;
 import org.codehaus.groovy.classgen.AsmClassGenerator;
 import org.codehaus.groovy.classgen.asm.BytecodeVariable;
@@ -37,8 +39,17 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Objects;
 
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.enumConstantName;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.intConstant;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.isIntegralType;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.isOptimizedIntSwitch;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.isOptimizedStringSwitch;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.stringConstant;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.unwrapEnumType;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.maybeFallsThrough;
 import static org.objectweb.asm.Opcodes.AALOAD;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ARRAYLENGTH;
@@ -79,6 +90,104 @@ public class StaticTypesStatementWriter extends StatementWriter {
         controller.switchToFastPath();
         super.writeBlockStatement(statement);
         controller.switchToSlowPath();
+    }
+
+    /**
+     * Emits a jump table when the selector and labels are constants of a type
+     * {@code javac} would switch on, matching what a statically compiled switch
+     * expression already gets (GROOVY-12405). Anything else, including repeated
+     * labels, falls back to the sequential {@code isCase} chain.
+     */
+    @Override
+    public void writeSwitch(final SwitchStatement statement) {
+        List<CaseStatement> caseStatements = statement.getCaseStatements();
+        ClassNode selectorType = controller.getTypeChooser()
+                .resolveType(statement.getExpression(), controller.getClassNode());
+        if (!SwitchDispatchWriter.isDispatchable(selectorType, caseStatements)) {
+            super.writeSwitch(statement);
+            return;
+        }
+        writeDispatchSwitch(statement, caseStatements, selectorType);
+    }
+
+    /**
+     * The kind of dispatch is chosen once, from the type the type checker
+     * inferred, because that is what {@code isDispatchable} agreed to. Code
+     * generation can leave something wider on the operand stack, so a
+     * reference selector is coerced to the inferred type before it is stored.
+     */
+    private void writeDispatchSwitch(final SwitchStatement statement, final List<CaseStatement> caseStatements,
+            final ClassNode inferredType) {
+        AsmClassGenerator acg = controller.getAcg();
+        acg.onLineNumber(statement, "visitSwitch");
+        writeStatementLabel(statement);
+
+        statement.getExpression().visit(acg);
+        OperandStack operandStack = controller.getOperandStack();
+        boolean intSwitch = isOptimizedIntSwitch(inferredType, caseStatements);
+        ClassNode selectorType;
+        if (intSwitch) {
+            // unlike the sequential path the selector is not boxed: the jump
+            // table wants the primitive, and a wrapper is unboxed below
+            selectorType = operandStack.getTopOperand();
+        } else {
+            operandStack.doGroovyCast(inferredType);
+            selectorType = inferredType;
+        }
+
+        CompileStack compileStack = controller.getCompileStack();
+        // switch does not have a continue label; use enclosing continue label
+        Label breakLabel = compileStack.pushSwitch(statement.getStatementLabels());
+        int selectorIndex = compileStack.defineTemporaryVariable("switch", selectorType, true);
+
+        SwitchDispatchWriter dispatch = new SwitchDispatchWriter(controller);
+        Label defaultTarget = new Label();
+        ClassNode enumType = unwrapEnumType(inferredType);
+        int scratch = -1;
+        List<Label> targets;
+
+        if (intSwitch) {
+            SwitchDispatchWriter.ArmGroup<Integer> group = dispatch.groupArms(
+                    caseStatements, cs -> intConstant(cs.getExpression()), defaultTarget);
+            targets = group.targets;
+            int intSelector = selectorIndex;
+            if (!isIntegralType(selectorType)) {
+                dispatch.jumpIfNull(selectorIndex, selectorType, defaultTarget);
+                operandStack.load(selectorType, selectorIndex);
+                operandStack.doGroovyCast(ClassHelper.int_TYPE);
+                scratch = intSelector = compileStack.defineTemporaryVariable("$switchInt", ClassHelper.int_TYPE, true);
+            }
+            dispatch.emitIntSwitch(group.keys, targets, defaultTarget, intSelector);
+        } else if (isOptimizedStringSwitch(inferredType, caseStatements)) {
+            SwitchDispatchWriter.ArmGroup<String> group = dispatch.groupArms(
+                    caseStatements, cs -> stringConstant(cs.getExpression()), defaultTarget);
+            targets = group.targets;
+            dispatch.jumpIfNull(selectorIndex, selectorType, defaultTarget);
+            dispatch.emitStringHashDispatch(selectorIndex, group.keys, targets, defaultTarget);
+        } else {
+            SwitchDispatchWriter.ArmGroup<String> group = dispatch.groupArms(
+                    caseStatements, cs -> enumConstantName(cs.getExpression(), enumType), defaultTarget);
+            targets = group.targets;
+            // a null selector matches no constant label, so it takes the default
+            dispatch.jumpIfNull(selectorIndex, selectorType, defaultTarget);
+            scratch = dispatch.loadEnumName(selectorIndex, selectorType);
+            dispatch.emitStringHashDispatch(scratch, group.keys, targets, defaultTarget);
+        }
+
+        // arms are laid out in source order, so one without a jump falls into
+        // the next and then into the default, as the sequential path does
+        dispatch.emitArmCode(caseStatements, targets);
+        controller.getMethodVisitor().visitLabel(defaultTarget);
+        statement.getDefaultStatement().visit(acg);
+
+        if (maybeFallsThrough(statement) || statement.getStatementLabels() != null) {
+            controller.getMethodVisitor().visitLabel(breakLabel);
+        }
+        if (scratch != -1) {
+            compileStack.removeVar(scratch);
+        }
+        compileStack.removeVar(selectorIndex);
+        compileStack.pop();
     }
 
     //--------------------------------------------------------------------------

--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesSwitchExpressionWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/StaticTypesSwitchExpressionWriter.java
@@ -35,23 +35,14 @@ import org.codehaus.groovy.transform.stc.StaticTypesMarker;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.function.Function;
 
 import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.callX;
 import static org.objectweb.asm.Opcodes.GOTO;
 import static org.objectweb.asm.Opcodes.ICONST_0;
 import static org.objectweb.asm.Opcodes.ICONST_1;
-import static org.objectweb.asm.Opcodes.IFEQ;
 import static org.objectweb.asm.Opcodes.IFNULL;
-import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 
 /**
  * Static-compilation writer for {@link SwitchExpression}. Emits
@@ -70,7 +61,10 @@ public class StaticTypesSwitchExpressionWriter extends SwitchExpressionWriter {
      */
     public StaticTypesSwitchExpressionWriter(final StaticTypesWriterController controller) {
         super(controller);
+        this.dispatch = new SwitchDispatchWriter(controller);
     }
+
+    private final SwitchDispatchWriter dispatch;
 
     /**
      * Keeps the selector as visited — boxing is deferred until a path actually
@@ -164,7 +158,7 @@ public class StaticTypesSwitchExpressionWriter extends SwitchExpressionWriter {
         if (!primitive && !isIntegralWrapper(selectorType)) return false;
 
         Label defaultTarget = new Label();
-        ArmGroup<Integer> group = groupArms(expression.getCaseStatements(),
+        SwitchDispatchWriter.ArmGroup<Integer> group = dispatch.groupArms(expression.getCaseStatements(),
                 cs -> intConstant(cs.getExpression()), defaultTarget);
         if (group.keys == null) return false;
 
@@ -173,59 +167,19 @@ public class StaticTypesSwitchExpressionWriter extends SwitchExpressionWriter {
 
         int intSelector = selectorIndex;
         if (!primitive) {
-            jumpIfNull(selectorIndex, selectorType, defaultTarget);
+            dispatch.jumpIfNull(selectorIndex, selectorType, defaultTarget);
             operandStack.load(selectorType, selectorIndex);
             operandStack.doGroovyCast(ClassHelper.int_TYPE);
             intSelector = compileStack.defineTemporaryVariable("$switchInt", ClassHelper.int_TYPE, true);
         }
 
-        emitIntSwitch(group.keys, group.targets, defaultTarget, intSelector);
+        dispatch.emitIntSwitch(group.keys, group.targets, defaultTarget, intSelector);
         finishArms(expression, group.targets, defaultTarget, selectorIndex, selectorType, false);
 
         if (!primitive) {
             compileStack.removeVar(intSelector);
         }
         return true;
-    }
-
-    private void emitIntSwitch(final List<Integer> keys, final List<Label> targets,
-            final Label defaultTarget, final int intSelector) {
-        TreeMap<Integer, Label> sorted = new TreeMap<>();
-        for (int i = 0; i < keys.size(); i += 1) {
-            sorted.put(keys.get(i), targets.get(i));
-        }
-        int n = sorted.size();
-        int[] keyArray = new int[n];
-        Label[] targetArray = new Label[n];
-        int i = 0;
-        for (var entry : sorted.entrySet()) {
-            keyArray[i] = entry.getKey();
-            targetArray[i] = entry.getValue();
-            i += 1;
-        }
-
-        OperandStack operandStack = controller.getOperandStack();
-        operandStack.load(ClassHelper.int_TYPE, intSelector);
-        operandStack.remove(1);
-
-        int min = keyArray[0];
-        int max = keyArray[n - 1];
-        long span = (long) max - (long) min + 1L;
-        // classfile payload, padding omitted (JVMS §6.5): tableswitch ≈ 12+4*span,
-        // lookupswitch ≈ 8+8*n. Prefer tableswitch when it is no larger.
-        long tableSize = 12L + 4L * span;
-        long lookupSize = 8L + 8L * n;
-        MethodVisitor mv = controller.getMethodVisitor();
-        if (span > 0 && span <= Integer.MAX_VALUE && tableSize <= lookupSize) {
-            Label[] table = new Label[(int) span];
-            Arrays.fill(table, defaultTarget);
-            for (int k = 0; k < n; k += 1) {
-                table[(int) ((long) keyArray[k] - min)] = targetArray[k];
-            }
-            mv.visitTableSwitchInsn(min, max, defaultTarget, table);
-        } else {
-            mv.visitLookupSwitchInsn(defaultTarget, keyArray, targetArray);
-        }
     }
 
     private boolean writeStringSwitch(final SwitchExpression expression,
@@ -235,12 +189,12 @@ public class StaticTypesSwitchExpressionWriter extends SwitchExpressionWriter {
         }
 
         Label defaultTarget = new Label();
-        ArmGroup<String> group = groupArms(expression.getCaseStatements(),
+        SwitchDispatchWriter.ArmGroup<String> group = dispatch.groupArms(expression.getCaseStatements(),
                 cs -> stringConstant(cs.getExpression()), defaultTarget);
         if (group.keys == null) return false;
 
-        jumpIfNull(selectorIndex, selectorType, defaultTarget);
-        emitStringHashDispatch(selectorIndex, group.keys, group.targets, defaultTarget);
+        dispatch.jumpIfNull(selectorIndex, selectorType, defaultTarget);
+        dispatch.emitStringHashDispatch(selectorIndex, group.keys, group.targets, defaultTarget);
         finishArms(expression, group.targets, defaultTarget, selectorIndex, selectorType, false);
         return true;
     }
@@ -256,7 +210,7 @@ public class StaticTypesSwitchExpressionWriter extends SwitchExpressionWriter {
         if (enumType == null || !enumType.isEnum()) return false;
 
         Label defaultTarget = new Label();
-        ArmGroup<String> group = groupArms(expression.getCaseStatements(),
+        SwitchDispatchWriter.ArmGroup<String> group = dispatch.groupArms(expression.getCaseStatements(),
                 cs -> enumConstantName(cs.getExpression(), enumType), defaultTarget);
         if (group.keys == null) return false;
 
@@ -270,14 +224,11 @@ public class StaticTypesSwitchExpressionWriter extends SwitchExpressionWriter {
         // a null selector matches no constant label; with no default it must
         // throw ISE, never the complete-enum ICCE
         Label nullTarget = complete ? new Label() : defaultTarget;
-        jumpIfNull(selectorIndex, selectorType, nullTarget);
+        dispatch.jumpIfNull(selectorIndex, selectorType, nullTarget);
 
-        operandStack.load(selectorType, selectorIndex);
-        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Enum", "name", "()Ljava/lang/String;", false);
-        operandStack.replace(ClassHelper.STRING_TYPE);
-        int nameLocal = compileStack.defineTemporaryVariable("$switchEnumName", ClassHelper.STRING_TYPE, true);
+        int nameLocal = dispatch.loadEnumName(selectorIndex, selectorType);
 
-        emitStringHashDispatch(nameLocal, group.keys, group.targets, defaultTarget);
+        dispatch.emitStringHashDispatch(nameLocal, group.keys, group.targets, defaultTarget);
         finishArms(expression, group.targets, defaultTarget, selectorIndex, selectorType, complete);
         if (nullTarget != defaultTarget) {
             mv.visitLabel(nullTarget);
@@ -288,129 +239,12 @@ public class StaticTypesSwitchExpressionWriter extends SwitchExpressionWriter {
         return true;
     }
 
-    /**
-     * Emits {@code lookupswitch} on {@code hashCode()} plus {@code equals},
-     * jumping straight to the shared arm label. Fall-through keys already
-     * share that label, so a second index tableswitch is unnecessary.
-     */
-    private void emitStringHashDispatch(final int stringLocal, final List<String> keys,
-            final List<Label> targets, final Label defaultTarget) {
-        Map<Integer, List<Integer>> hashToIndexes = new TreeMap<>();
-        for (int i = 0; i < keys.size(); i += 1) {
-            hashToIndexes.computeIfAbsent(keys.get(i).hashCode(), h -> new ArrayList<>()).add(i);
-        }
-        MethodVisitor mv = controller.getMethodVisitor();
-        OperandStack operandStack = controller.getOperandStack();
-
-        operandStack.load(ClassHelper.STRING_TYPE, stringLocal);
-        operandStack.doGroovyCast(ClassHelper.STRING_TYPE);
-        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "hashCode", "()I", false);
-        operandStack.replace(ClassHelper.int_TYPE);
-        operandStack.remove(1);
-
-        int[] hashes = hashToIndexes.keySet().stream().mapToInt(Integer::intValue).toArray();
-        Label[] hashTargets = new Label[hashes.length];
-        for (int i = 0; i < hashes.length; i += 1) {
-            hashTargets[i] = new Label();
-        }
-        mv.visitLookupSwitchInsn(defaultTarget, hashes, hashTargets);
-
-        for (int i = 0; i < hashes.length; i += 1) {
-            mv.visitLabel(hashTargets[i]);
-            for (int index : hashToIndexes.get(hashes[i])) {
-                operandStack.load(ClassHelper.STRING_TYPE, stringLocal);
-                mv.visitLdcInsn(keys.get(index));
-                operandStack.push(ClassHelper.STRING_TYPE);
-                mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
-                operandStack.replace(ClassHelper.boolean_TYPE, 2);
-                Label next = operandStack.jump(IFEQ);
-                mv.visitJumpInsn(GOTO, targets.get(index));
-                mv.visitLabel(next);
-            }
-            mv.visitJumpInsn(GOTO, defaultTarget);
-        }
-    }
-
-    /**
-     * Forward pass extracts every constant key (or skips the optimizer).
-     * Backward pass gives empty colon prefixes the following body's label,
-     * or {@code defaultTarget} when the empty suffix falls into default.
-     * Duplicate keys also skip the optimizer: the type checker reports them
-     * as an error (GROOVY-12289), so reaching here with one means checking
-     * was bypassed ({@code TypeCheckingMode.SKIP} or an extension), where
-     * sequential first-match-wins dispatch preserves dynamic semantics.
-     */
-    private <K> ArmGroup<K> groupArms(final List<CaseStatement> caseStatements,
-            final Function<CaseStatement, K> keyFn, final Label defaultTarget) {
-        int n = caseStatements.size();
-        if (n == 0) return ArmGroup.skip();
-
-        List<K> keys = new ArrayList<>(n);
-        Set<K> seen = new HashSet<>();
-        for (CaseStatement caseStatement : caseStatements) {
-            K key = keyFn.apply(caseStatement);
-            if (key == null || !seen.add(key)) return ArmGroup.skip();
-            keys.add(key);
-        }
-
-        Label[] targets = new Label[n];
-        Label current = defaultTarget;
-        for (int i = n - 1; i >= 0; i -= 1) {
-            if (!caseStatements.get(i).getCode().isEmpty()) {
-                current = new Label();
-            }
-            targets[i] = current;
-        }
-        return ArmGroup.of(keys, Arrays.asList(targets));
-    }
-
-    private void emitArmCode(final List<CaseStatement> caseStatements, final List<Label> targets) {
-        AsmClassGenerator acg = controller.getAcg();
-        MethodVisitor mv = controller.getMethodVisitor();
-        for (int i = 0; i < caseStatements.size(); i += 1) {
-            CaseStatement caseStatement = caseStatements.get(i);
-            if (caseStatement.getCode().isEmpty()) {
-                continue;
-            }
-            mv.visitLabel(targets.get(i));
-            caseStatement.getCode().visit(acg);
-        }
-    }
-
     private void finishArms(final SwitchExpression expression, final List<Label> targets,
             final Label defaultTarget, final int selectorIndex, final ClassNode selectorType,
             final boolean completeEnum) {
-        emitArmCode(expression.getCaseStatements(), targets);
+        dispatch.emitArmCode(expression.getCaseStatements(), targets);
         controller.getMethodVisitor().visitLabel(defaultTarget);
         writeDefaultOrThrow(expression, selectorIndex, selectorType, completeEnum);
     }
 
-    private void jumpIfNull(final int selectorIndex, final ClassNode selectorType, final Label target) {
-        OperandStack operandStack = controller.getOperandStack();
-        operandStack.load(selectorType, selectorIndex);
-        operandStack.remove(1);
-        controller.getMethodVisitor().visitJumpInsn(IFNULL, target);
-    }
-
-    /**
-     * {@code keys == null} means "not an optimizable constant switch, try the
-     * next optimizer (or fall back to sequential dispatch)".
-     */
-    private static final class ArmGroup<K> {
-        final List<K> keys;
-        final List<Label> targets;
-
-        private ArmGroup(final List<K> keys, final List<Label> targets) {
-            this.keys = keys;
-            this.targets = targets;
-        }
-
-        static <K> ArmGroup<K> skip() {
-            return new ArmGroup<>(null, null);
-        }
-
-        static <K> ArmGroup<K> of(final List<K> keys, final List<Label> targets) {
-            return new ArmGroup<>(keys, targets);
-        }
-    }
 }

--- a/src/main/java/org/codehaus/groovy/classgen/asm/sc/SwitchDispatchWriter.java
+++ b/src/main/java/org/codehaus/groovy/classgen/asm/sc/SwitchDispatchWriter.java
@@ -1,0 +1,285 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.classgen.asm.sc;
+
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.stmt.CaseStatement;
+import org.codehaus.groovy.classgen.AsmClassGenerator;
+import org.codehaus.groovy.classgen.asm.OperandStack;
+import org.codehaus.groovy.classgen.asm.WriterController;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.enumConstantName;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.intConstant;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.isOptimizedEnumSwitch;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.isOptimizedIntSwitch;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.isOptimizedStringSwitch;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.stringConstant;
+import static org.apache.groovy.ast.tools.SwitchExpressionUtils.unwrapEnumType;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.IFEQ;
+import static org.objectweb.asm.Opcodes.IFNULL;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+
+/**
+ * Emits the JVM dispatch shared by statically compiled switch statements and
+ * switch expressions: {@code tableswitch} or {@code lookupswitch} for int-family
+ * labels, {@code lookupswitch} on {@code hashCode} plus {@code equals} for
+ * strings, and the latter over {@code Enum.name()} for enums.
+ * <p>
+ * Callers own everything around the dispatch: evaluating the selector into a
+ * local, laying out the arm bodies with {@link #emitArmCode}, and deciding what
+ * happens when nothing matches, which differs between a statement and an
+ * expression.
+ *
+ * @since 7.0.0
+ */
+class SwitchDispatchWriter {
+
+    private final WriterController controller;
+
+    SwitchDispatchWriter(final WriterController controller) {
+        this.controller = controller;
+    }
+
+    /**
+     * Whether the selector and labels support a jump table: every label is a
+     * constant of a type {@code javac} would switch on, and no key repeats.
+     * <p>
+     * Duplicate keys cannot be expressed in a jump table, so they fall back to
+     * sequential first-match-wins dispatch, which preserves the behaviour of a
+     * switch the type checker did not reject (GROOVY-12289).
+     */
+    static boolean isDispatchable(final ClassNode selectorType, final List<CaseStatement> caseStatements) {
+        if (isOptimizedIntSwitch(selectorType, caseStatements)) {
+            return hasDistinctKeys(caseStatements, cs -> intConstant(cs.getExpression()));
+        }
+        if (isOptimizedStringSwitch(selectorType, caseStatements)) {
+            return hasDistinctKeys(caseStatements, cs -> stringConstant(cs.getExpression()));
+        }
+        if (isOptimizedEnumSwitch(selectorType, caseStatements)) {
+            ClassNode enumType = unwrapEnumType(selectorType);
+            return hasDistinctKeys(caseStatements, cs -> enumConstantName(cs.getExpression(), enumType));
+        }
+        return false;
+    }
+
+    private static <K> boolean hasDistinctKeys(final List<CaseStatement> caseStatements,
+            final Function<CaseStatement, K> keyFn) {
+        Set<K> seen = new HashSet<>();
+        for (CaseStatement caseStatement : caseStatements) {
+            if (!seen.add(keyFn.apply(caseStatement))) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Forward pass extracts every constant key (or skips the optimizer).
+     * Backward pass gives empty colon prefixes the following body's label,
+     * or {@code defaultTarget} when the empty suffix falls into default.
+     * Duplicate keys also skip the optimizer: the type checker reports them
+     * as an error for a switch expression (GROOVY-12289), so reaching here
+     * with one means checking was bypassed ({@code TypeCheckingMode.SKIP} or
+     * an extension), where sequential dispatch preserves dynamic semantics.
+     */
+    <K> ArmGroup<K> groupArms(final List<CaseStatement> caseStatements,
+            final Function<CaseStatement, K> keyFn, final Label defaultTarget) {
+        int n = caseStatements.size();
+        if (n == 0) return ArmGroup.skip();
+
+        List<K> keys = new ArrayList<>(n);
+        Set<K> seen = new HashSet<>();
+        for (CaseStatement caseStatement : caseStatements) {
+            K key = keyFn.apply(caseStatement);
+            if (key == null || !seen.add(key)) return ArmGroup.skip();
+            keys.add(key);
+        }
+
+        Label[] targets = new Label[n];
+        Label current = defaultTarget;
+        for (int i = n - 1; i >= 0; i -= 1) {
+            if (!caseStatements.get(i).getCode().isEmpty()) {
+                current = new Label();
+            }
+            targets[i] = current;
+        }
+        return ArmGroup.of(keys, Arrays.asList(targets));
+    }
+
+    /**
+     * Emits {@code tableswitch} or {@code lookupswitch}, whichever has the
+     * smaller classfile payload, over an int-typed local.
+     */
+    void emitIntSwitch(final List<Integer> keys, final List<Label> targets,
+            final Label defaultTarget, final int intSelector) {
+        TreeMap<Integer, Label> sorted = new TreeMap<>();
+        for (int i = 0; i < keys.size(); i += 1) {
+            sorted.put(keys.get(i), targets.get(i));
+        }
+        int n = sorted.size();
+        int[] keyArray = new int[n];
+        Label[] targetArray = new Label[n];
+        int i = 0;
+        for (var entry : sorted.entrySet()) {
+            keyArray[i] = entry.getKey();
+            targetArray[i] = entry.getValue();
+            i += 1;
+        }
+
+        OperandStack operandStack = controller.getOperandStack();
+        operandStack.load(ClassHelper.int_TYPE, intSelector);
+        operandStack.remove(1);
+
+        int min = keyArray[0];
+        int max = keyArray[n - 1];
+        long span = (long) max - (long) min + 1L;
+        // classfile payload, padding omitted (JVMS §6.5): tableswitch ≈ 12+4*span,
+        // lookupswitch ≈ 8+8*n. Prefer tableswitch when it is no larger.
+        long tableSize = 12L + 4L * span;
+        long lookupSize = 8L + 8L * n;
+        MethodVisitor mv = controller.getMethodVisitor();
+        if (span > 0 && span <= Integer.MAX_VALUE && tableSize <= lookupSize) {
+            Label[] table = new Label[(int) span];
+            Arrays.fill(table, defaultTarget);
+            for (int k = 0; k < n; k += 1) {
+                table[(int) ((long) keyArray[k] - min)] = targetArray[k];
+            }
+            mv.visitTableSwitchInsn(min, max, defaultTarget, table);
+        } else {
+            mv.visitLookupSwitchInsn(defaultTarget, keyArray, targetArray);
+        }
+    }
+
+    /**
+     * Emits {@code lookupswitch} on {@code hashCode()} plus {@code equals},
+     * jumping straight to the shared arm label. Fall-through keys already
+     * share that label, so a second index tableswitch is unnecessary.
+     */
+    void emitStringHashDispatch(final int stringLocal, final List<String> keys,
+            final List<Label> targets, final Label defaultTarget) {
+        Map<Integer, List<Integer>> hashToIndexes = new TreeMap<>();
+        for (int i = 0; i < keys.size(); i += 1) {
+            hashToIndexes.computeIfAbsent(keys.get(i).hashCode(), h -> new ArrayList<>()).add(i);
+        }
+        MethodVisitor mv = controller.getMethodVisitor();
+        OperandStack operandStack = controller.getOperandStack();
+
+        operandStack.load(ClassHelper.STRING_TYPE, stringLocal);
+        operandStack.doGroovyCast(ClassHelper.STRING_TYPE);
+        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "hashCode", "()I", false);
+        operandStack.replace(ClassHelper.int_TYPE);
+        operandStack.remove(1);
+
+        int[] hashes = hashToIndexes.keySet().stream().mapToInt(Integer::intValue).toArray();
+        Label[] hashTargets = new Label[hashes.length];
+        for (int i = 0; i < hashes.length; i += 1) {
+            hashTargets[i] = new Label();
+        }
+        mv.visitLookupSwitchInsn(defaultTarget, hashes, hashTargets);
+
+        for (int i = 0; i < hashes.length; i += 1) {
+            mv.visitLabel(hashTargets[i]);
+            for (int index : hashToIndexes.get(hashes[i])) {
+                operandStack.load(ClassHelper.STRING_TYPE, stringLocal);
+                mv.visitLdcInsn(keys.get(index));
+                operandStack.push(ClassHelper.STRING_TYPE);
+                mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
+                operandStack.replace(ClassHelper.boolean_TYPE, 2);
+                Label next = operandStack.jump(IFEQ);
+                mv.visitJumpInsn(GOTO, targets.get(index));
+                mv.visitLabel(next);
+            }
+            mv.visitJumpInsn(GOTO, defaultTarget);
+        }
+    }
+
+    /**
+     * Replaces the enum selector in {@code selectorIndex} with its
+     * {@code name()} in a fresh local, and returns that local. Constant names
+     * are stable when a separately compiled enum adds or reorders constants,
+     * so arms are never silently retargeted.
+     */
+    int loadEnumName(final int selectorIndex, final ClassNode selectorType) {
+        OperandStack operandStack = controller.getOperandStack();
+        operandStack.load(selectorType, selectorIndex);
+        controller.getMethodVisitor().visitMethodInsn(
+                INVOKEVIRTUAL, "java/lang/Enum", "name", "()Ljava/lang/String;", false);
+        operandStack.replace(ClassHelper.STRING_TYPE);
+        return controller.getCompileStack().defineTemporaryVariable(
+                "$switchEnumName", ClassHelper.STRING_TYPE, true);
+    }
+
+    /** Lays out the arm bodies in source order, so an arm without a jump falls into the next. */
+    void emitArmCode(final List<CaseStatement> caseStatements, final List<Label> targets) {
+        AsmClassGenerator acg = controller.getAcg();
+        MethodVisitor mv = controller.getMethodVisitor();
+        for (int i = 0; i < caseStatements.size(); i += 1) {
+            CaseStatement caseStatement = caseStatements.get(i);
+            if (caseStatement.getCode().isEmpty()) {
+                continue;
+            }
+            mv.visitLabel(targets.get(i));
+            caseStatement.getCode().visit(acg);
+        }
+    }
+
+    /** Branches to {@code target} when the selector is null; a primitive selector never is. */
+    void jumpIfNull(final int selectorIndex, final ClassNode selectorType, final Label target) {
+        if (ClassHelper.isPrimitiveType(selectorType)) {
+            return;
+        }
+        OperandStack operandStack = controller.getOperandStack();
+        operandStack.load(selectorType, selectorIndex);
+        operandStack.remove(1);
+        controller.getMethodVisitor().visitJumpInsn(IFNULL, target);
+    }
+
+    /**
+     * {@code keys == null} means "not an optimizable constant switch, try the
+     * next optimizer (or fall back to sequential dispatch)".
+     */
+    static final class ArmGroup<K> {
+        final List<K> keys;
+        final List<Label> targets;
+
+        private ArmGroup(final List<K> keys, final List<Label> targets) {
+            this.keys = keys;
+            this.targets = targets;
+        }
+
+        static <K> ArmGroup<K> skip() {
+            return new ArmGroup<>(null, null);
+        }
+
+        static <K> ArmGroup<K> of(final List<K> keys, final List<Label> targets) {
+            return new ArmGroup<>(keys, targets);
+        }
+    }
+}

--- a/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/SwitchStatementStaticCompileTest.groovy
+++ b/src/test/groovy/org/codehaus/groovy/classgen/asm/sc/SwitchStatementStaticCompileTest.groovy
@@ -1,0 +1,357 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.codehaus.groovy.classgen.asm.sc
+
+import org.codehaus.groovy.classgen.asm.AbstractBytecodeTestCase
+import org.junit.jupiter.api.Test
+
+import static groovy.test.GroovyAssert.assertScript
+
+/**
+ * Static-compilation bytecode and runtime shape of switch <em>statements</em>
+ * (GROOVY-12405): the same {@code tableswitch} / {@code lookupswitch} dispatch
+ * a switch expression gets, with statement fall-through preserved, and the
+ * sequential {@code isCase} chain everywhere else.
+ */
+final class SwitchStatementStaticCompileTest extends AbstractBytecodeTestCase {
+
+    @Test
+    void staticDenseIntStatementUsesTableSwitch() {
+        def bytecode = compile(method: 'm', '''\
+            @groovy.transform.CompileStatic
+            String m(int n) {
+                String r = 'none'
+                switch (n) {
+                    case 1: r = 'one'; break
+                    case 2: r = 'two'; break
+                    case 3: r = 'three'; break
+                    default: r = 'many'
+                }
+                r
+            }
+        ''')
+        assert bytecode.hasSequence(['TABLESWITCH'])
+        assert !bytecode.toString().contains('isCase')
+    }
+
+    @Test
+    void staticSparseIntStatementUsesLookupSwitch() {
+        def bytecode = compile(method: 'm', '''\
+            @groovy.transform.CompileStatic
+            String m(int n) {
+                String r = 'none'
+                switch (n) {
+                    case -100:    r = 'a'; break
+                    case 0:       r = 'b'; break
+                    case 1000000: r = 'c'; break
+                }
+                r
+            }
+        ''')
+        assert bytecode.hasSequence(['LOOKUPSWITCH'])
+        assert !bytecode.hasSequence(['TABLESWITCH'])
+        assert !bytecode.toString().contains('isCase')
+    }
+
+    @Test
+    void staticStringStatementUsesLookupSwitch() {
+        def bytecode = compile(method: 'm', '''\
+            @groovy.transform.CompileStatic
+            String m(String s) {
+                String r = 'none'
+                switch (s) {
+                    case 'Foo': r = 'a'; break
+                    case 'Bar': r = 'b'; break
+                }
+                r
+            }
+        ''')
+        assert bytecode.hasSequence(['LOOKUPSWITCH'])
+        assert bytecode.hasSequence(['INVOKEVIRTUAL java/lang/String.equals'])
+        assert !bytecode.toString().contains('isCase')
+    }
+
+    @Test
+    void staticEnumStatementDispatchesByName() {
+        def bytecode = compile(method: 'm', '''\
+            enum Color { RED, GREEN, BLUE }
+            @groovy.transform.CompileStatic
+            String m(Color c) {
+                String r = 'none'
+                switch (c) {
+                    case Color.RED:   r = 'r'; break
+                    case Color.GREEN: r = 'g'; break
+                }
+                r
+            }
+        ''')
+        assert bytecode.hasSequence(['INVOKEVIRTUAL java/lang/Enum.name'])
+        assert bytecode.hasSequence(['LOOKUPSWITCH'])
+        assert !bytecode.toString().contains('isCase')
+    }
+
+    @Test
+    void staticNonConstantLabelKeepsIsCase() {
+        def bytecode = compile(method: 'm', '''\
+            @groovy.transform.CompileStatic
+            String m(Object o, Object label) {
+                String r = 'none'
+                switch (o) {
+                    case label: r = 'hit'; break
+                }
+                r
+            }
+        ''')
+        assert !bytecode.hasSequence(['TABLESWITCH'])
+        assert !bytecode.hasSequence(['LOOKUPSWITCH'])
+    }
+
+    @Test
+    void duplicateLabelsKeepFirstMatchWins() {
+        // a jump table cannot hold a repeated key, so the dispatcher declines
+        // and the sequential chain is kept. Deliberately not statically
+        // compiled: a duplicate constant label is a type-checking error
+        // (GROOVY-12289 for expressions, GROOVY-12406 for statements), so the
+        // guard only ever matters where that check has not run
+        assertScript '''
+            String m(int n) {
+                String r = 'none'
+                switch (n) {
+                    case 1: r = 'first'; break
+                    case 1: r = 'second'; break
+                }
+                r
+            }
+            assert m(1) == 'first'
+            assert m(2) == 'none'
+        '''
+    }
+
+    @Test
+    void dispatchedStatementStillFallsThrough() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            String m(int n) {
+                def r = new StringBuilder()
+                switch (n) {
+                    case 1: r << 'a'
+                    case 2: r << 'b'; break
+                    case 3: r << 'c'
+                    case 4: r << 'd'
+                }
+                r.toString()
+            }
+            assert m(1) == 'ab'
+            assert m(2) == 'b'
+            assert m(3) == 'cd'
+            assert m(4) == 'd'
+            assert m(5) == ''
+        '''
+    }
+
+    @Test
+    void dispatchedStatementHonoursEmptyCasesAndDefault() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            String m(int n) {
+                String r = 'none'
+                switch (n) {
+                    case 1:
+                    case 2: r = 'low'; break
+                    case 3:
+                    case 4: r = 'high'; break
+                    default: r = 'other'
+                }
+                r
+            }
+            assert m(1) == 'low' && m(2) == 'low'
+            assert m(3) == 'high' && m(4) == 'high'
+            assert m(9) == 'other'
+        '''
+    }
+
+    @Test
+    void dispatchedStatementHonoursBreakContinueAndLabels() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            String loop() {
+                def r = new StringBuilder()
+                for (int x = 0; x < 4; x++) {
+                    switch (x) {
+                        case 1: continue
+                        case 2: r << 'two'; break
+                        case 3: break
+                        default: r << x
+                    }
+                    r << '.'
+                }
+                r.toString()
+            }
+            @groovy.transform.CompileStatic
+            String labelled() {
+                def r = new StringBuilder()
+                outer: for (int x = 0; x < 3; x++) {
+                    switch (x) {
+                        case 1: break outer
+                        default: r << x
+                    }
+                }
+                r.toString()
+            }
+            assert loop() == '0.two..'
+            assert labelled() == '0'
+        '''
+    }
+
+    @Test
+    void dispatchedStatementTakesDefaultForNullSelector() {
+        assertScript '''
+            enum Color { RED, GREEN }
+            @groovy.transform.CompileStatic
+            String forString(String s) {
+                String r = 'none'
+                switch (s) {
+                    case 'a': r = 'A'; break
+                    default: r = 'other'
+                }
+                r
+            }
+            @groovy.transform.CompileStatic
+            String forEnum(Color c) {
+                String r = 'none'
+                switch (c) {
+                    case Color.RED: r = 'r'; break
+                }
+                r
+            }
+            @groovy.transform.CompileStatic
+            String forWrapper(Integer i) {
+                String r = 'none'
+                switch (i) {
+                    case 1: r = 'one'; break
+                }
+                r
+            }
+            assert forString(null) == 'other'
+            assert forEnum(null) == 'none'
+            assert forWrapper(null) == 'none'
+        '''
+    }
+
+    @Test
+    void dispatchedStatementSupportsNarrowerIntegralSelectors() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            String forChar(char c) {
+                String r = 'none'
+                switch (c) {
+                    case 'a' as char: r = 'A'; break
+                    case 'b' as char: r = 'B'; break
+                }
+                r
+            }
+            @groovy.transform.CompileStatic
+            String forByte(byte b) {
+                String r = 'none'
+                switch (b) {
+                    case 1: r = 'one'; break
+                    case 2: r = 'two'; break
+                }
+                r
+            }
+            assert forChar('a' as char) == 'A' && forChar('z' as char) == 'none'
+            assert forByte((byte) 2) == 'two' && forByte((byte) 9) == 'none'
+        '''
+    }
+
+    @Test
+    void dispatchedStatementHandlesHashCollisions() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            String m(String s) {
+                String r = 'none'
+                switch (s) {
+                    case 'Aa': r = 'x'; break
+                    case 'BB': r = 'y'; break
+                }
+                r
+            }
+            assert 'Aa'.hashCode() == 'BB'.hashCode()
+            assert m('Aa') == 'x'
+            assert m('BB') == 'y'
+            assert m('Cc') == 'none'
+        '''
+    }
+
+    @Test
+    void dispatchedStatementSupportsReturnAndThrowArms() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            String m(int n) {
+                switch (n) {
+                    case 1: return 'one'
+                    case 2: throw new IllegalStateException('two')
+                }
+                'none'
+            }
+            assert m(1) == 'one'
+            assert m(3) == 'none'
+            try { m(2); assert false } catch (IllegalStateException e) { assert e.message == 'two' }
+        '''
+    }
+
+    @Test
+    void dispatchedStatementNests() {
+        assertScript '''
+            @groovy.transform.CompileStatic
+            String m(int i, int j) {
+                String r = 'none'
+                switch (i) {
+                    case 1:
+                        switch (j) {
+                            case 9: r = 'nine'; break
+                            default: r = 'other'
+                        }
+                        break
+                    case 2: r = 'two'; break
+                }
+                r
+            }
+            assert m(1, 9) == 'nine'
+            assert m(1, 5) == 'other'
+            assert m(2, 0) == 'two'
+            assert m(3, 0) == 'none'
+        '''
+    }
+
+    @Test
+    void dynamicStatementIsUnaffected() {
+        def bytecode = compile(method: 'm', '''\
+            String m(int n) {
+                String r = 'none'
+                switch (n) {
+                    case 1: r = 'one'; break
+                }
+                r
+            }
+        ''')
+        assert !bytecode.hasSequence(['TABLESWITCH'])
+        assert !bytecode.hasSequence(['LOOKUPSWITCH'])
+    }
+}


### PR DESCRIPTION
…ements

A statically compiled switch expression already emits tableswitch or lookupswitch when the selector and labels are constants of a type javac would switch on. A switch statement never has, in any Groovy release, so the colon form compiles to a chain of isCase calls that is linear in the number of arms:

    @CompileStatic
    String m(int i) {
        String r = 'many'
        switch (i) {
            case 1: r = 'one'; break
            case 2: r = 'two'; break
            case 3: r = 'three'; break
        }
        r
    }
    // was: 3 x ScriptBytecodeAdapter.isCase, now: tableswitch

javac emits a jump table for the statement form as readily as for the expression form, so this is Java alignment as much as an optimisation.

The emitters are shared rather than copied: SwitchDispatchWriter now holds the arm grouping, the int and string dispatch and the arm layout that StaticTypesSwitchExpressionWriter used to own, and both writers drive it. Only what differs stays with each caller, which for a statement is that nothing is thrown when no arm matches.

Statement semantics are preserved. Arms are laid out in source order, so one that does not jump falls into the next and then into the default, exactly as the sequential chain does. Labelled and unlabelled break, continue, return and throw are unaffected because they compile the same way in either layout. A null selector takes the default.

The dispatch applies only where the type checker's inferred type and every label agree; anything else keeps the sequential chain, including repeated labels, which a jump table cannot express and which the type checker does not reject for a statement.